### PR TITLE
Add a 1 second delay for sensor info

### DIFF
--- a/sbin/openwall
+++ b/sbin/openwall
@@ -15,7 +15,7 @@ else
 	soc=$(ipcinfo --chip-name)
 fi
 
-sensor=$(ipcinfo --short-sensor)
+sensor=$(ipcinfo --short-sensor && sleep 1)
 streamer=$(basename $(ipcinfo --streamer))
 temperature=$(ipcinfo --temp)
 uptime=$(uptime | sed -r 's/^.+ up ([^,]+), .+$/\1/')


### PR DESCRIPTION
`ipcinfo --short-sensor` causes blinking/white snapshots for some cameras/sensors*. Adding a 1 second delay seems to mitigate this issue for OpenWall.
*CMSXJ25A [SSC325 + GC2053]


To be honest, I think the better thing would be to fix this in some way in ipcinfo itself, but this does the job too. Atleast for now. Feel free to find a better solution.