### PR TITLE
fix for "Memory usage" bar

### DIFF
--- a/www/cgi-bin/j/pulse.cgi
+++ b/www/cgi-bin/j/pulse.cgi
@@ -11,7 +11,8 @@ if [ -n "$temp" ]; then
 fi
 
 mem_total=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
-mem_free=$(awk '/MemFree/ {print $2}' /proc/meminfo)
+###mem_free=$(awk '/MemFree/ {print $2}' /proc/meminfo)
+mem_free=$(awk '/MemAvailable/ {print $2}' /proc/meminfo)
 mem_used=$(( 100 - (mem_free / (mem_total / 100)) ))
 overlay_used=$(df | grep /overlay | xargs | cut -d' ' -f5)
 uptime=$(awk '{m=$1/60; h=m/60; printf "%sd %sh %sm %ss\n", int(h/24), int(h%24), int(m%60), int($1%60) }' /proc/uptime)


### PR DESCRIPTION
Better use "**MemAvailable**" instead of "MemFree" in "Memory usage" bar.

	Info about "Available" vs "Free":

https://stackoverflow.com/questions/30869297/difference-between-memfree-and-memavailable
**MemAvailable**: The amount of memory, available for starting new applications, without swapping.
MemFree: The amount of physical RAM, in kibibytes, left unused by the system.

https://askubuntu.com/questions/867068/what-is-available-memory-while-using-free-command
Free memory is the amount of memory which is currently not used for anything. 
This number should be small, because memory which is not used is simply wasted.
**Available** memory is the amount of memory which is available for allocation to a new process or to existing processes.
