### PR TITLE
Support PTZ for motor profile (ptz=) and GPIO steppers

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -44,6 +44,7 @@
     │   │   ├── locale.cgi
     │   │   ├── locale_fpv.cgi            # FPV version of majestic menu
     │   │   ├── pulse.cgi
+    │   │   ├── ptz.cgi                   # PTZ step (gpio-motors or motor + U-Boot ptz=)
     │   │   ├── run.cgi
     │   │   └── time.cgi
     │   ├── mj-configuration.cgi

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -1,0 +1,32 @@
+#!/bin/sh
+# PTZ step handler: GPIO stepper (gpio-motors) or profile motor (/usr/bin/motor + U-Boot ptz=).
+
+echo "HTTP/1.1 200 OK
+Content-type: text/plain; charset=UTF-8
+Cache-Control: no-store
+Pragma: no-cache
+
+"
+
+HORIZONTAL=0
+VERTICAL=0
+for param in $(echo "$QUERY_STRING" | tr '&' ' '); do
+	case "$param" in
+		h=*) HORIZONTAL="${param#*=}" ;;
+		v=*) VERTICAL="${param#*=}" ;;
+	esac
+done
+
+if command -v gpio-motors >/dev/null 2>&1 && [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; then
+	gpio-motors "$HORIZONTAL" "$VERTICAL" 10
+	exit $?
+fi
+
+ptz=$(fw_printenv -n ptz 2>/dev/null)
+if [ -x /usr/bin/motor ] && [ -n "$ptz" ]; then
+	/usr/bin/motor "$ptz" "$HORIZONTAL" "$VERTICAL"
+	exit $?
+fi
+
+echo "PTZ not available on this device."
+exit 1

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -449,7 +449,13 @@ update_caminfo() {
 
 	# WebUI
 	ui_password=$(grep root /etc/shadow | cut -d: -f2)
-	ptz_support=$(fw_printenv -n gpio_motors)
+	# PTZ preview controls: GPIO motors (gpio_motors + gpio-motors) or motor profile (ptz + /usr/bin/motor).
+	if { [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && command -v gpio-motors >/dev/null 2>&1; } ||
+		{ [ -x /usr/bin/motor ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; }; then
+		ptz_support="1"
+	else
+		ptz_support=""
+	fi
 
 	# Network
 	network_interface=$(ip route | awk '/default/ {print $5}' | head -n1)

--- a/www/cgi-bin/p/motor.cgi
+++ b/www/cgi-bin/p/motor.cgi
@@ -21,7 +21,7 @@
 function control(dir) {
 	let x = dir.includes("l") ? -5 : dir.includes("r") ? 5 : 0;
 	let y = dir.includes("d") ? -5 : dir.includes("u") ? 5 : 0;
-	fetch('/cgi-bin/j/run.cgi?web=' + btoa('gpio-motors ' + x + ' ' + y + ' 10'));
+	fetch('/cgi-bin/j/ptz.cgi?h=' + encodeURIComponent(x) + '&v=' + encodeURIComponent(y), { credentials: 'same-origin' });
 }
 
 $$(".motor button").forEach(el => {


### PR DESCRIPTION
## Summary
Preview PTZ controls only considered `gpio_motors` and always invoked `gpio-motors` via `run.cgi`. Several OpenIPC boards (e.g. SigmaStar Foscam X3/X5, `ssc337de-foscam`) expose PTZ through `/usr/bin/motor` and the U-Boot variable `ptz=`, without `gpio-motors` or `gpio_motors`.

## Changes
- Add `www/cgi-bin/j/ptz.cgi`: given `h` and `v` query parameters, run **gpio-motors** when `gpio_motors` is set and the binary exists, otherwise run **motor** with `$(fw_printenv -n ptz)` when configured.
- Update `common.cgi` so `ptz_support` is enabled when either backend is available (preview shows the motor pad).
- Update `p/motor.cgi` to call `j/ptz.cgi` with `credentials: 'same-origin'` so HTTP basic auth is reused.
- Document `j/ptz.cgi` in `structure.md`.

## Testing
- [ ] GPIO PTZ camera with `gpio_motors` set (existing behaviour).
- [x] Foscam-style `motor` + `ptz=ssc337de-foscam` (manual check on SSC337DE).

## Notes
This restores the pre–`52c930c` `motor $ptz` path while keeping the `gpio-motors` path for devices that switched to GPIO steppers.