### PR TITLE
motor.cgi: press-and-hold instead of one-step-per-click

### DIFF
--- a/www/cgi-bin/p/motor.cgi
+++ b/www/cgi-bin/p/motor.cgi
@@ -18,15 +18,47 @@
 </div>
 
 <script>
-function control(dir) {
-	let x = dir.includes("l") ? -5 : dir.includes("r") ? 5 : 0;
-	let y = dir.includes("d") ? -5 : dir.includes("u") ? 5 : 0;
-	fetch('/cgi-bin/j/run.cgi?web=' + btoa('gpio-motors ' + x + ' ' + y + ' 10'));
-}
+(function () {
+	const STEP = 5;
+	const PHASE_MS = 10;
+	const TICK_MS = 250;
 
-$$(".motor button").forEach(el => {
-	el.addEventListener("click", ev => {
-		control(ev.target.dataset.dir);
+	let inflight = false;
+	let holdTimer = null;
+
+	function fire(dir) {
+		if (inflight) return;
+		const x = dir.includes("l") ? -STEP : dir.includes("r") ? STEP : 0;
+		const y = dir.includes("d") ? -STEP : dir.includes("u") ? STEP : 0;
+		inflight = true;
+		fetch('/cgi-bin/j/run.cgi?web=' + btoa('gpio-motors ' + x + ' ' + y + ' ' + PHASE_MS))
+			.finally(() => { inflight = false; });
+	}
+
+	function startHold(dir) {
+		stopHold();
+		fire(dir);
+		holdTimer = setInterval(() => fire(dir), TICK_MS);
+	}
+
+	function stopHold() {
+		if (holdTimer) { clearInterval(holdTimer); holdTimer = null; }
+	}
+
+	$$(".motor button").forEach(el => {
+		const dir = el.dataset.dir;
+		if (dir === "cc") {
+			el.addEventListener("click", () => fire(dir));
+			return;
+		}
+		el.addEventListener("mousedown", e => { e.preventDefault(); startHold(dir); });
+		el.addEventListener("mouseup", stopHold);
+		el.addEventListener("mouseleave", stopHold);
+		el.addEventListener("touchstart", e => { e.preventDefault(); startHold(dir); }, { passive: false });
+		el.addEventListener("touchend", stopHold);
+		el.addEventListener("touchcancel", stopHold);
 	});
-});
+
+	window.addEventListener("blur", stopHold);
+})();
 </script>


### PR DESCRIPTION
## Summary

The current motor arrow buttons fire \`gpio-motors\` once per click, which is impractical on most motorized cameras — you have to repeatedly click an arrow to pan smoothly.

Replace with a mousedown/touchstart → \`setInterval(250 ms)\` loop that re-fires while the button is held, with mouseup / mouseleave / touchend / touchcancel / window-blur all stopping the loop. An inflight guard prevents queueing if a previous request hasn't returned yet (slow links, slow PTZ daemons).

Step size and phase timing preserved at the upstream defaults (5 steps, 10 ms phase). The 🆗 center button keeps its existing single-fire behaviour, so any board that maps \`gpio-motors 0 0 N\` to a "home" / "stop" / "no-op" in its wrapper keeps that behaviour.

## Test plan

- [x] Held arrows with mouse → pan/tilt motors continuously rotate at ~7°/sec pan, ~14°/sec tilt (TP-Link Kasa KC110, OV2735 + ULN2803 + 24BYJ48 steppers).
- [x] Released → motors stop within one tick.
- [x] Dragged finger off button on touch device → motors stop (touchcancel).
- [x] Switched tab away mid-hold → motors stop (window blur).
- [x] Center button still triggers \`gpio-motors 0 0 10\`.

## Context

Split out from the closed OpenIPC/firmware#2151 (KC110 board package, re-filed at OpenIPC/builder#99 per @widgetii's review). This particular change is fully generic — useful on any motorized camera using the upstream \`gpio-motors\` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)