### PR TITLE
fw-interface: sync /etc/onvif.passwd with the system password

### DIFF
--- a/www/cgi-bin/fw-interface.cgi
+++ b/www/cgi-bin/fw-interface.cgi
@@ -18,6 +18,8 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 			fi
 
 			echo "root:${password_default}" | chpasswd
+			printf "root:%s\n" "$password_default" > /etc/onvif.passwd
+			chmod 600 /etc/onvif.passwd
 			update_caminfo
 			redirect_to "/" "success" "Password updated."
 			;;


### PR DESCRIPTION
## Summary

When the operator changes the system password through the access form, also write the cleartext to `/etc/onvif.passwd` (mode 0600) so majestic's ONVIF WS-Security UsernameToken validator stays in sync.

## Why

Majestic's ONVIF SOAP layer enforces WS-Security UsernameToken (master+8956bbe8). ONVIF clients (Frigate, Axxon, ONVIF Device Test Tool, python-onvif-zeep, ODM) almost universally use the **PasswordDigest** flavour:

```
expected = base64(SHA1(decode_b64(Nonce) || Created || cleartext_password))
```

The device cannot validate that without the cleartext on hand — and `/etc/shadow` only stores the crypt() hash, so the system password file alone cannot answer WSSE PasswordDigest. Majestic therefore reads cleartext credentials from `/etc/onvif.passwd` (mode 0600, format `user:password\n`).

The firmware's `majestic` package seeds `/etc/onvif.passwd` at build time with `root:12345` matching the default `/etc/shadow` hash. This PR closes the loop: whenever the operator changes the password through the web UI, both `chpasswd` and `/etc/onvif.passwd` update together, so ONVIF clients stay aligned with the shell/RTSP/HTTP credentials without any operator intervention.

If `/etc/onvif.passwd` is missing (e.g., older firmware on cameras that haven't been re-imaged), majestic falls back to open-mode access — backward-compatible.

## Test plan

- [x] Built majestic master+8956bbe8 + cross-deployed to openipc-hi3516ev300
- [x] Set /etc/onvif.passwd to root:<live system pass>; ran onvif-tt with matching --user/--password → 43 PASS / 8 FAIL / 89 SKIP (was 35/12/93 without WSSE)
- [x] With mismatched passwords, every SOAP request returns wsse:FailedAuthentication on the wire
- [x] Web UI: changing password through fw-interface.cgi updates both /etc/shadow (via chpasswd) and /etc/onvif.passwd