### PR TITLE
Preview: green outline toggles so on/off is readable (fixes #54)

### DIFF
--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -17,13 +17,13 @@
 
 		<div class="d-grid gap-3">
 			<input type="checkbox" class="btn-check" id="toggle-night">
-			<label class="btn btn-primary" for="toggle-night">Night</label>
+			<label class="btn btn-outline-success" for="toggle-night">Night</label>
 
 			<input type="checkbox" class="btn-check" id="toggle-ircut">
-			<label class="btn btn-primary" for="toggle-ircut">IRcut</label>
+			<label class="btn btn-outline-success" for="toggle-ircut">IRcut</label>
 
 			<input type="checkbox" class="btn-check" id="toggle-light">
-			<label class="btn btn-primary" for="toggle-light">Light</label>
+			<label class="btn btn-outline-success" for="toggle-light">Light</label>
 
 			<% if [ -n "$ptz_support" ]; then %>
 				<%in p/motor.cgi %>
@@ -41,9 +41,9 @@
 <% echo "\$('#toggle-ircut').disabled = $(get_night lightMonitor) || !$(get_night irCutPin1);" %>
 <% echo "\$('#toggle-light').disabled = $(get_night lightMonitor) || !$(get_night backlightPin);" %>
 
-$("#toggle-night").addEventListener("click", ev => {
+$("#toggle-night").addEventListener("click", () => {
 	fetch('/night/toggle').then(api => api.json()).then(data => {
-		ev.checked = data;
+		$('#toggle-night').checked = data;
 		if (!$('#toggle-ircut').disabled) {
 			$('#toggle-ircut').checked = data;
 		}
@@ -53,15 +53,15 @@ $("#toggle-night").addEventListener("click", ev => {
 	});
 });
 
-$("#toggle-ircut").addEventListener("click", ev => {
+$("#toggle-ircut").addEventListener("click", () => {
 	fetch('/night/ircut').then(api => api.json()).then(data => {
-		ev.checked = data;
+		$('#toggle-ircut').checked = data;
 	});
 });
 
-$("#toggle-light").addEventListener("click", ev => {
+$("#toggle-light").addEventListener("click", () => {
 	fetch('/night/light').then(api => api.json()).then(data => {
-		ev.checked = data;
+		$('#toggle-light').checked = data;
 	});
 });
 </script>


### PR DESCRIPTION
## Summary

Fixes #54 — on the **preview page**, the Night / IRcut / Light toggles were `btn btn-primary`, so Bootstrap rendered **OFF as light blue** (`--bs-btn-bg`) and **ON as dark blue** (`--bs-btn-active-bg`) — two near-identical shades. You couldn't tell a toggle's state at a glance, which is worst exactly when hunting for the correct GPIO pin on a fresh camera.

- **Color.** The three labels now use `btn btn-outline-success`: **OFF = hollow green outline, ON = solid green fill.** The state cue is *fill + hue*, not hue alone, so it survives both light/dark themes and red-green colour blindness. No CSS added — Bootstrap's `.btn-check:checked + .btn-outline-success` already styles the filled state.
- **State-sync fix.** The click handlers reconciled the optimistic toggle with the daemon's reply via `ev.checked = data`, which is a no-op — `ev` is the click `Event`, not the checkbox (and `ev.currentTarget` is `null` by the time the async `.then()` runs). So a button never corrected itself when the device disagreed — it could show "on" when the pin did nothing, compounding the very ambiguity this issue is about. Each handler now references its checkbox by id (`$('#toggle-…').checked = data`), matching how the night handler already updates its siblings.

Scope is one file — `www/cgi-bin/preview.cgi`. A repo-wide grep for `btn-check` / `toggle-night|ircut|light` returns only this file, so no other page (FPV included) is affected. Orthogonal to the #58 mj-settings refactor, which never touched `preview.cgi` or the `/night/*` endpoints.

## Test plan

Verified on a Hi3516AV300 **lite** camera (the build named in the issue):

- [x] Deployed file confirmed — all three labels `btn-outline-success`, all three handlers fixed, no stray `ev.checked`.
- [x] Change is parse-neutral: original vs edited behave byte-identically under bare `haserl`; zero `<%…%>` tags touched.
- [x] `btn-outline-success` is defined in the camera's `bootstrap.min.css`.
- [ ] **Reviewer, in a browser:** open Camera Preview, click **Night** — button goes hollow → solid green and back; confirm in both light and dark themes. (On a camera with no `nightMode` pins set, IRcut/Light stay disabled as before; set `irCutPin1` / `backlightPin` to exercise them.)
- [ ] Toggle, then reload — the button's fill matches the live `get_metrics` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)