### PR TITLE
console: interactive xterm.js terminal (replaces one-shot command runner)

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -63,7 +63,7 @@
     │   │   └── roi.cgi
     │   ├── preview.cgi
     │   ├── status.cgi
-    │   ├── tool-console.cgi
+    │   ├── tool-console.cgi             # Interactive shell terminal (xterm.js over majestic /ws/terminal)
     │   ├── tool-files.cgi
     │   └── tool-sdcard.cgi
     ├── favicon.ico

--- a/www/cgi-bin/tool-console.cgi
+++ b/www/cgi-bin/tool-console.cgi
@@ -5,37 +5,35 @@ page_title="Console"
 %>
 
 <%in p/header.cgi %>
-<form>
-<div class="row">
-	<div class="col-10">
-		<% field_text "command" "Enter command:" %>
-	</div>
-	<div class="col align-self-center">
-		<% button_submit "Run" "secondary" %>
-	</div>
-	<div class="col-10">
-		<div id="output-wrapper"></div>
-	</div>
-</div>
-</form>
-
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<div id="terminal" class="border rounded mb-3" style="height:72vh"></div>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
 <script>
-$('form').addEventListener('submit', event => {
-	event.preventDefault();
-	$('form input[type=submit]').disabled = true;
-	cmd = $('#command').value;
+(function () {
+	const term = new Terminal({ cursorBlink: true, fontSize: 13, scrollback: 5000 });
+	const fit = new FitAddon.FitAddon();
+	term.loadAddon(fit);
+	term.open(document.getElementById('terminal'));
+	fit.fit();
 
-	el = document.createElement('pre')
-	el.id = "output";
-	el.dataset['cmd'] = cmd;
+	const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+	const ws = new WebSocket(proto + '://' + location.host + '/ws/terminal');
+	ws.binaryType = 'arraybuffer';
+	const enc = new TextEncoder();
+	const sendResize = () =>
+		ws.readyState === 1 &&
+		ws.send(JSON.stringify({ resize: { cols: term.cols, rows: term.rows } }));
 
-	h6 = document.createElement('h6')
-	$('#output-wrapper').innerHTML = '';
-	$('#output-wrapper').appendChild(h6);
-	$('#output-wrapper').appendChild(el);
+	ws.onopen = () => { sendResize(); term.focus(); };
+	ws.onmessage = e => term.write(new Uint8Array(e.data));
+	ws.onclose = () => term.write('\r\n\x1b[31m[session closed]\x1b[0m\r\n');
+	ws.onerror = () => term.write('\r\n\x1b[31m[connection error]\x1b[0m\r\n');
 
-	runCmd("web")
-});
+	term.onData(d => ws.readyState === 1 && ws.send(enc.encode(d)));
+	term.onResize(sendResize);
+	addEventListener('resize', () => fit.fit());
+})();
 </script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
Replaces the **Tools → Console** page — previously a fire-and-forget command form (`runCmd` → `/cgi-bin/j/run.cgi`, `timeout 3`, no TTY, ANSI stripped client-side) — with a real interactive terminal.

`tool-console.cgi` now hosts an **xterm.js** terminal that connects to majestic's `/ws/terminal` WebSocket: binary frames carry raw stdin/stdout, a `{"resize":{"cols":N,"rows":M}}` text frame resizes the PTY. Same-origin, so the browser's cached HTTP Basic credentials authorize the WS handshake. The camera spawns an interactive **login** shell (banner, `$HOME`, prompt — just like SSH).

- xterm.js + addon-fit load from the **jsDelivr CDN** (pinned `@xterm/xterm@5.5.0`, `@xterm/addon-fit@0.10.0`) — no flash cost on the camera.
- `runCmd()` (`www/a/main.js`) and `j/run.cgi` are **kept** — `fw-system.cgi` still streams firmware-upgrade output through them.

Requires a majestic build with the `/ws/terminal` endpoint (widgetii/majestic#192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)