### PR TITLE
logs: live unified log viewer (replaces static Majestic/Kernel pages)

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -16,6 +16,7 @@
     │   ├── bootstrap.min.css
     │   ├── bootstrap.override.css
     │   ├── logo.svg
+    │   ├── logs.js                      # Live log viewer (majestic /ws/logs WebSocket) for info-logs.cgi
     │   ├── main.js
     │   ├── mj-settings.js               # Client-side renderer + saver for Majestic settings
     │   ├── preview.svg
@@ -39,8 +40,7 @@
     │   ├── fw-system.cgi
     │   ├── fw-time.cgi
     │   ├── fw-update.cgi
-    │   ├── info-kernel.cgi
-    │   ├── info-majestic.cgi
+    │   ├── info-logs.cgi                # Unified live log viewer (Majestic / Kernel / Everything)
     │   ├── info-overlay.cgi
     │   ├── j
     │   │   ├── locale.cgi

--- a/www/a/logs.js
+++ b/www/a/logs.js
@@ -1,0 +1,100 @@
+// Live log viewer for info-logs.cgi.
+// Streams majestic's /ws/logs WebSocket (a single `logread -f` over which klogd
+// has already merged kernel + application logs) and renders it with a source
+// selector, free-text filter, pause, clear and download. Vanilla JS, no deps.
+(function () {
+	const MAX_LINES = 2000;
+	const el = $('#log');
+	const elSource = $('#log-source');
+	const elFilter = $('#log-filter');
+	const elPause = $('#log-pause');
+	const elClear = $('#log-clear');
+	const elDownload = $('#log-download');
+
+	const lines = []; // ring buffer of raw syslog lines
+	let paused = false;
+
+	// Each syslog line is: "<Mon DD HH:MM:SS> <host> <facility>.<severity> <prog>[pid]: msg"
+	const SOURCES = {
+		all: () => true,
+		majestic: l => /\bmajestic[[:]/.test(l),
+		kernel: l => /\bkernel:|\bkern\./.test(l),
+	};
+	function matches(l) {
+		const src = SOURCES[elSource.value] || SOURCES.all;
+		if (!src(l)) return false;
+		const q = elFilter.value.trim().toLowerCase();
+		return !q || l.toLowerCase().includes(q);
+	}
+
+	function sevClass(l) {
+		const m = l.match(/^\S+\s+\d+\s+\S+\s+\S+\s+\w+\.(\w+)\s/);
+		switch (m && m[1]) {
+			case 'emerg': case 'alert': case 'crit': case 'err':
+				return 'log-err';
+			case 'warning': case 'warn':
+				return 'log-warn';
+			case 'debug':
+				return 'log-debug';
+			default:
+				return '';
+		}
+	}
+
+	function atBottom() {
+		return el.scrollHeight - el.clientHeight - el.scrollTop < 4;
+	}
+	function makeRow(l) {
+		const d = document.createElement('div');
+		d.className = 'log-line ' + sevClass(l);
+		d.textContent = l;
+		return d;
+	}
+	function render() {
+		const stick = atBottom();
+		el.textContent = '';
+		const frag = document.createDocumentFragment();
+		for (const l of lines) if (matches(l)) frag.appendChild(makeRow(l));
+		el.appendChild(frag);
+		if (stick) el.scrollTop = el.scrollHeight;
+	}
+	function pushLine(l) {
+		lines.push(l);
+		if (lines.length > MAX_LINES) lines.shift();
+		if (paused || !matches(l)) return;
+		const stick = atBottom();
+		el.appendChild(makeRow(l));
+		while (el.childElementCount > MAX_LINES) el.removeChild(el.firstChild);
+		if (stick) el.scrollTop = el.scrollHeight;
+	}
+
+	const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+	const ws = new WebSocket(proto + '://' + location.host + '/ws/logs');
+	ws.binaryType = 'arraybuffer';
+	const dec = new TextDecoder('utf-8');
+	let partial = '';
+	ws.onmessage = e => {
+		const parts = (partial + dec.decode(new Uint8Array(e.data), { stream: true })).split('\n');
+		partial = parts.pop();
+		for (const p of parts) if (p) pushLine(p);
+	};
+	ws.onclose = () => pushLine('--- log stream closed ---');
+	ws.onerror = () => pushLine('--- connection error ---');
+
+	elSource.addEventListener('change', render);
+	elFilter.addEventListener('input', render);
+	elPause.addEventListener('click', () => {
+		paused = !paused;
+		elPause.textContent = paused ? '▶ Resume' : '⏸ Pause';
+		if (!paused) render();
+	});
+	elClear.addEventListener('click', () => { lines.length = 0; render(); });
+	elDownload.addEventListener('click', () => {
+		const blob = new Blob([lines.join('\n') + '\n'], { type: 'text/plain' });
+		const a = document.createElement('a');
+		a.href = URL.createObjectURL(blob);
+		a.download = 'majestic-logs.txt';
+		a.click();
+		URL.revokeObjectURL(a.href);
+	});
+})();

--- a/www/cgi-bin/info-kernel.cgi
+++ b/www/cgi-bin/info-kernel.cgi
@@ -1,6 +1,0 @@
-#!/usr/bin/haserl
-<%in p/common.cgi %>
-<% page_title="Kernel Messages" %>
-<%in p/header.cgi %>
-<% ex "dmesg" %>
-<%in p/footer.cgi %>

--- a/www/cgi-bin/info-logs.cgi
+++ b/www/cgi-bin/info-logs.cgi
@@ -1,0 +1,31 @@
+#!/usr/bin/haserl
+<%in p/common.cgi %>
+<% page_title="Logs" %>
+<%in p/header.cgi %>
+<style>
+#log { height: 70vh; overflow-y: auto; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-all; }
+.log-line { padding: 0 .25rem; }
+.log-err { color: #dc3545; }
+.log-warn { color: #fd7e14; }
+.log-debug { opacity: .6; }
+</style>
+<div class="row g-2 align-items-center mb-2">
+	<div class="col-auto">
+		<select id="log-source" class="form-select form-select-sm">
+			<option value="all">Everything</option>
+			<option value="majestic">Majestic</option>
+			<option value="kernel">Kernel</option>
+		</select>
+	</div>
+	<div class="col">
+		<input id="log-filter" type="text" class="form-control form-control-sm" placeholder="filter…" autocomplete="off">
+	</div>
+	<div class="col-auto">
+		<button id="log-pause" type="button" class="btn btn-sm btn-secondary">⏸ Pause</button>
+		<button id="log-clear" type="button" class="btn btn-sm btn-outline-secondary">Clear</button>
+		<button id="log-download" type="button" class="btn btn-sm btn-outline-secondary">⬇ Download</button>
+	</div>
+</div>
+<div id="log" class="border rounded bg-body-tertiary"></div>
+<script src="/a/logs.js"></script>
+<%in p/footer.cgi %>

--- a/www/cgi-bin/info-majestic.cgi
+++ b/www/cgi-bin/info-majestic.cgi
@@ -1,6 +1,0 @@
-#!/usr/bin/haserl
-<%in p/common.cgi %>
-<% page_title="Majestic Messages" %>
-<%in p/header.cgi %>
-<% ex "logread | grep -o majestic.*" %>
-<%in p/footer.cgi %>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -29,8 +29,7 @@ Pragma: no-cache
 						<ul aria-labelledby="dropdownInformation" class="dropdown-menu">
 							<li><a class="dropdown-item" href="status.cgi">Status</a></li>
 							<li><hr class="dropdown-divider"></li>
-							<li><a class="dropdown-item" href="info-majestic.cgi">Majestic</a></li>
-							<li><a class="dropdown-item" href="info-kernel.cgi">Kernel</a></li>
+							<li><a class="dropdown-item" href="info-logs.cgi">Logs</a></li>
 							<li><a class="dropdown-item" href="info-overlay.cgi">Overlay</a></li>
 						</ul>
 					</li>


### PR DESCRIPTION
Information > Majestic (`logread | grep majestic`) and > Kernel (`dmesg`) were one-shot dumps that never updated after page load. This replaces both with a single **Information > Logs** page backed by a purpose-built viewer (`www/a/logs.js`) that streams majestic's `/ws/logs` WebSocket — one unified `logread -f` stream (klogd merges kernel + app logs) filtered client-side.

Features: source selector (Majestic / Kernel / Everything), free-text filter, pause, clear, download, severity colouring, a capped 2000-line ring, autoscroll. Same-origin, so the cached HTTP Basic creds authorise the handshake.

Requires a majestic build with the `/ws/logs` endpoint (widgetii/majestic#193). Verified live on hi3516av300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)