### PR TITLE
logs: configurable syslog buffer size + full-dmesg button

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -43,6 +43,7 @@
     │   ├── info-logs.cgi                # Unified live log viewer (Majestic / Kernel / Everything)
     │   ├── info-overlay.cgi
     │   ├── j
+    │   │   ├── dmesg.cgi                 # Full kernel ring buffer (dmesg) for the Logs page
     │   │   ├── locale.cgi
     │   │   ├── locale_fpv.cgi            # FPV version of majestic menu
     │   │   ├── pulse.cgi

--- a/www/cgi-bin/info-logs.cgi
+++ b/www/cgi-bin/info-logs.cgi
@@ -1,6 +1,24 @@
 #!/usr/bin/haserl
 <%in p/common.cgi %>
-<% page_title="Logs" %>
+<%
+page_title="Logs"
+syslog_defaults=/etc/default/syslogd
+
+if [ "$REQUEST_METHOD" = "POST" ]; then
+	size=$POST_syslog_size
+	if echo "$size" | grep -qE '^[0-9]+$' && [ "$size" -ge 16 ] && [ "$size" -le 4096 ]; then
+		mkdir -p /etc/default
+		echo "SYSLOG_SIZE=$size" > "$syslog_defaults"
+		/etc/init.d/S01syslogd restart >/dev/null 2>&1
+		redirect_to "$SCRIPT_NAME" "success" "Log buffer set to ${size} KiB (existing buffer cleared)."
+	else
+		redirect_to "$SCRIPT_NAME" "danger" "Invalid buffer size."
+	fi
+fi
+
+SYSLOG_SIZE=64
+[ -r "$syslog_defaults" ] && . "$syslog_defaults"
+%>
 <%in p/header.cgi %>
 <style>
 #log { height: 70vh; overflow-y: auto; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-all; }
@@ -24,8 +42,20 @@
 		<button id="log-pause" type="button" class="btn btn-sm btn-secondary">⏸ Pause</button>
 		<button id="log-clear" type="button" class="btn btn-sm btn-outline-secondary">Clear</button>
 		<button id="log-download" type="button" class="btn btn-sm btn-outline-secondary">⬇ Download</button>
+		<a href="/cgi-bin/j/dmesg.cgi" target="_blank" class="btn btn-sm btn-outline-secondary" title="Full kernel ring buffer (dmesg)">dmesg</a>
 	</div>
 </div>
 <div id="log" class="border rounded bg-body-tertiary"></div>
+<details class="mt-2">
+	<summary class="text-secondary small">Log buffer size — currently <%= $SYSLOG_SIZE %> KiB</summary>
+	<form action="<%= $SCRIPT_NAME %>" method="post" class="row g-2 align-items-end mt-1" style="max-width:30rem">
+		<div class="col">
+			<% field_string "syslog_size" "In-RAM syslog buffer (KiB)" "$SYSLOG_SIZE" "64 128 256 512 1024" "More backlog but more RAM. Default 64. Applies immediately and clears the current buffer." %>
+		</div>
+		<div class="col-auto">
+			<% button_submit "Apply" "secondary" %>
+		</div>
+	</form>
+</details>
 <script src="/a/logs.js"></script>
 <%in p/footer.cgi %>

--- a/www/cgi-bin/j/dmesg.cgi
+++ b/www/cgi-bin/j/dmesg.cgi
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "HTTP/1.1 200 OK
+Content-Type: text/plain; charset=UTF-8
+Cache-Control: no-store
+"
+dmesg


### PR DESCRIPTION
Follow-ups to the live Logs page (#61):

- **Configurable syslog buffer.** A "Log buffer size" control on Information > Logs writes `SYSLOG_SIZE` to `/etc/default/syslogd` and restarts syslogd. Lets users raise the in-RAM log ring for more backlog; **default stays 64 KiB so stock cameras spend no extra memory**. Requires the firmware S01syslogd that sources `/etc/default/syslogd` (OpenIPC/firmware PR).
- **dmesg button.** `j/dmesg.cgi` opens the full kernel ring buffer (pre-syslog-ring boot history), which the live Kernel filter can't show once it rotates out of the syslog ring.

Verified on hi3516av300: default → `syslogd -C64`; apply 256 → `/etc/default/syslogd` written, `syslogd -C256`, logread intact; dmesg.cgi → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)