### PR TITLE
fw-update: robust upgrade over WebSocket (+ fix #44 post-flash clock)

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -15,6 +15,7 @@
     │   ├── bootstrap.bundle.min.js
     │   ├── bootstrap.min.css
     │   ├── bootstrap.override.css
+    │   ├── fw-update.js                 # Firmware update over majestic /ws/upgrade WebSocket (fw-update.cgi)
     │   ├── logo.svg
     │   ├── logs.js                      # Live log viewer (majestic /ws/logs WebSocket) for info-logs.cgi
     │   ├── main.js

--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -1,0 +1,76 @@
+// Firmware update over the robust /ws/upgrade WebSocket.
+// majestic stops video (frees RAM), streams download+verify here, then is
+// killed at the flash step; the page switches to "rebooting" and polls until
+// the camera returns. A local .tgz is first POSTed to /upload, then flashed via
+// sysupgrade --archive. Vanilla JS; `$` is the querySelector helper from main.js.
+(function () {
+	const out = $('#fw-output');
+	const ansi = /[][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+	const dec = new TextDecoder('utf-8');
+
+	function status(cls, msg) {
+		const s = $('#fw-status');
+		s.className = 'alert alert-' + cls;
+		s.textContent = msg;
+	}
+	function append(t) {
+		out.textContent += t.replace(ansi, '');
+		out.scrollTop = out.scrollHeight;
+	}
+	function showProgress() {
+		$('#fw-controls').style.display = 'none';
+		$('#fw-progress').style.display = '';
+	}
+	function params(source) {
+		const on = id => { const el = $('#' + id); return !!(el && el.checked); };
+		return { source, kernel: on('fw_kernel'), rootfs: on('fw_rootfs'),
+			reset: on('fw_reset'), force: on('fw_force') };
+	}
+
+	function startUpgrade(source) {
+		const p = params(source);
+		if (!p.kernel && !p.rootfs) { status('danger', 'Select kernel and/or rootfs.'); return; }
+		showProgress();
+		status('warning', 'Preparing — freeing memory…');
+		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
+		ws.binaryType = 'arraybuffer';
+		ws.onopen = () => { ws.send(JSON.stringify(p)); status('warning', 'Upgrading — do not power off…'); };
+		ws.onmessage = e => append(dec.decode(new Uint8Array(e.data), { stream: true }));
+		ws.onclose = () => { status('warning', 'Flashing & rebooting — do not power off. Waiting for the camera…'); pollBack(); };
+		ws.onerror = () => {};
+	}
+
+	// After the WS drops (majestic killed at flash) poll until the camera is back.
+	function pollBack() {
+		let tries = 0;
+		const t = setInterval(() => {
+			if (++tries > 150) { clearInterval(t); status('danger', 'The camera has not returned. Check it manually.'); return; }
+			const ctl = new AbortController();
+			setTimeout(() => ctl.abort(), 2500);
+			fetch('/?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal })
+				.then(() => { clearInterval(t); status('success', 'Camera is back online.'); setTimeout(() => location.href = 'status.cgi', 1500); })
+				.catch(() => {});
+		}, 3000);
+	}
+
+	const g = $('#fw-install-github');
+	if (g) g.addEventListener('click', e => { e.preventDefault(); startUpgrade('github'); });
+
+	const u = $('#fw-install-upload');
+	if (u) u.addEventListener('click', async e => {
+		e.preventDefault();
+		const f = $('#fw-file').files[0];
+		if (!f) { status('danger', 'Choose a firmware .tgz first.'); return; }
+		showProgress();
+		status('warning', 'Uploading firmware…');
+		try {
+			const r = await fetch('/upload', { method: 'POST', headers: { 'File-Location': '/tmp/firmware.tgz' }, body: f });
+			if (!r.ok) { status('danger', 'Upload failed (' + r.status + ').'); return; }
+			append('Uploaded ' + f.name + ' (' + f.size + ' bytes)\n');
+			startUpgrade('/tmp/firmware.tgz');
+		} catch (err) {
+			status('danger', 'Upload error: ' + err);
+		}
+	});
+})();

--- a/www/cgi-bin/fw-update.cgi
+++ b/www/cgi-bin/fw-update.cgi
@@ -2,15 +2,22 @@
 <%in p/common.cgi %>
 <%
 	page_title="Firmware Update"
-	if [ -n "$network_gateway" ]; then
-		fw_soc=$soc
-		if [ "$soc_vendor" = "ingenic" ]; then
-			fw_soc=$soc_family
-		fi
 
+	github_ver() {
+		[ -z "$network_gateway" ] && return
+		fw_soc=$soc
+		[ "$soc_vendor" = "ingenic" ] && fw_soc=$soc_family
 		builder=$(fw_printenv -n upgrade)
-		url="https://github.com/openipc/firmware/releases/download/latest/openipc.${fw_soc}-${flash_type}-${fw_variant}.tgz"
-		ver=$(curl -m5 -ILs "${builder:-$url}" | grep Last-Modified | cut -d' ' -f2-)
+		fw_url="${builder:-https://github.com/openipc/firmware/releases/download/latest/openipc.${fw_soc}-${flash_type}-${fw_variant}.tgz}"
+		curl -m5 -ILs "$fw_url" | grep -i last-modified | cut -d' ' -f2-
+	}
+
+	ver=$(github_ver)
+	# Issue #44: a fresh flash boots with a stale clock so the HTTPS check
+	# fails; sync time once (NTP, else HTTP Date header) and retry.
+	if [ -z "$ver" ] && [ -n "$network_gateway" ]; then
+		synctime
+		ver=$(github_ver)
 	fi
 
 	if [ -n "$ver" ]; then
@@ -18,39 +25,45 @@
 	else
 		fw_date="<span class=\"text-danger\">- no access to GitHub -</span>"
 	fi
-
 	fw_kernel="true"
 	fw_rootfs="true"
-	fw_reboot="true"
 %>
 <%in p/header.cgi %>
 
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
-	<div class="col">
-		<h3>Version</h3>
-			<dl class="list small">
-			<dt>Installed</dt>
-			<dd><%= $fw_version %></dd>
-			<dt>On GitHub</dt>
-			<dd id="firmware-master-ver"><%= $fw_date %></dd>
-		</dl>
+<div id="fw-status" class="alert alert-secondary">
+	Installed <b><%= $fw_version %></b> &middot; On GitHub <span id="firmware-master-ver"><%= $fw_date %></span>
+</div>
+
+<div id="fw-controls">
+	<div class="alert alert-warning">The camera stops video and reboots to upgrade. <b>Do not power off</b> during the process.</div>
+
+	<div class="mb-3" style="max-width:32rem">
+		<% field_switch "fw_kernel" "Upgrade kernel" "true" %>
+		<% field_switch "fw_rootfs" "Upgrade rootfs" "true" %>
+		<% field_switch "fw_reset" "Reset config (wipe overlay)" "false" %>
+		<% field_switch "fw_force" "Reflash even if the same version" "false" %>
 	</div>
 
-	<div class="col">
-		<h3>Upgrade</h3>
-		<% if [ -n "$ver" ]; then %>
-			<form action="fw-system.cgi" method="post">
-				<% field_switch "fw_kernel" "Upgrade kernel." "eval" %>
-				<% field_switch "fw_rootfs" "Upgrade rootfs." "eval" %>
-				<% field_switch "fw_reboot" "Restart after upgrade." "eval" %>
-				<% field_switch "fw_reset" "Reset firmware." "eval" %>
-				<% field_switch "fw_force" "Reflash installed version." "eval" %>
-				<% button_submit "Install update from GitHub" "warning" %>
-			</form>
-		<% else %>
-			<p class="alert alert-danger">Updating requires access to GitHub.</p>
-		<% fi %>
+	<div class="row row-cols-1 row-cols-md-2 g-4">
+		<div class="col">
+			<h5>From GitHub</h5>
+			<% if [ -n "$ver" ]; then %>
+				<button id="fw-install-github" type="button" class="btn btn-warning">Install update from GitHub</button>
+			<% else %>
+				<p class="text-danger mb-0">Requires access to GitHub.</p>
+			<% fi %>
+		</div>
+		<div class="col">
+			<h5>From file</h5>
+			<input id="fw-file" type="file" accept=".tgz,.gz" class="form-control mb-2">
+			<button id="fw-install-upload" type="button" class="btn btn-warning">Upload &amp; install</button>
+		</div>
 	</div>
 </div>
 
+<div id="fw-progress" style="display:none">
+	<pre id="fw-output" class="border rounded p-2 bg-body-tertiary" style="height:60vh;overflow:auto;white-space:pre-wrap;font-size:12px"></pre>
+</div>
+
+<script src="/a/fw-update.js"></script>
 <%in p/footer.cgi %>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -268,6 +268,22 @@ get_config() {
 	echo ${1}/etc/majestic.yaml
 }
 
+# Best-effort clock fix for HTTPS (issue #44): a fresh flash boots with the
+# stale build timestamp until ntpd converges, so HTTPS to GitHub fails
+# ("certificate not yet valid"). Try a quick blocking NTP sync; if that is
+# unreachable, set the clock from a plain-HTTP Date header (no TLS needed).
+synctime() {
+	timeout 8 ntpd -n -q -N >/dev/null 2>&1 && return 0
+	local h d e
+	for h in http://github.com http://deb.debian.org; do
+		d=$(curl -m5 -sI "$h" | sed -n 's/^[Dd]ate: //p' | head -1 | tr -d '\r')
+		[ -z "$d" ] && continue
+		e=$(date -D "%a, %d %b %Y %T GMT" -d "$d" +%s 2>/dev/null)
+		[ -n "$e" ] && date -s @"$e" >/dev/null 2>&1 && return 0
+	done
+	return 1
+}
+
 get_metrics() {
 	local m=$(pidof majestic)
 	if [ -z "$m" ]; then


### PR DESCRIPTION
Redesigns **Firmware → Update** to be robust (the long-standing concern that the upgrade is served by majestic, which `sysupgrade` kills up front, so the progress stream dies immediately).

- `fw-update.cgi` + new `fw-update.js`: open majestic's `/ws/upgrade`, stream download+verify, then on the flash-step socket close show **"flashing & rebooting"** and poll until the camera returns. Adds **local .tgz upload** (POST `/upload` → `sysupgrade --archive`) next to the GitHub source.
- **Fixes #44**: a fresh flash boots with the stale build timestamp so the HTTPS GitHub check fails until manual time sync. New `synctime()` in `common.cgi` (blocking `ntpd`, else a plain-HTTP `Date` header) runs before the check and the page retries.

Needs majestic with `/ws/upgrade` (widgetii/majestic#194) and `sysupgrade --web` (OpenIPC/firmware#2190). Verified live on hi3516av300 incl. a real flash; #44 verified by forcing the clock to 2020 → page synced + resolved GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)