### PR TITLE
preview: low-latency H.264/H.265 live player over /ws/video (MSE)

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -20,6 +20,7 @@
     │   ├── logs.js                      # Live log viewer (majestic /ws/logs WebSocket) for info-logs.cgi
     │   ├── main.js
     │   ├── mj-settings.js               # Client-side renderer + saver for Majestic settings
+    │   ├── preview.js                   # Low-latency H.264/H.265 live player (MSE/fMP4 over majestic /ws/video) for preview.cgi
     │   ├── preview.svg
     │   └── timezone.js
     ├── cgi-bin

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -1,0 +1,213 @@
+// Low-latency H.264/H.265 live player over the majestic /ws/video WebSocket.
+// majestic re-wraps the encoded stream as fragmented MP4; this feeds it to a
+// <video> element via Media Source Extensions (MSE). MSE works over plain
+// http:// on a camera (unlike WebCodecs, which is secure-context-only), so this
+// is the path that actually plays on an IP camera with no TLS cert. Falls back
+// to MJPEG when MSE or the codec isn't supported. No third-party library.
+//
+// Reusable: MajesticVideo.attach(videoEl, opts) returns a small handle so the
+// Preview page (and later the motionDetect ROI editor) can share one player.
+//   opts.stream  : 0 main (default) | 1 sub
+//   opts.onState : (state, detail) => {}   // 'connecting'|'playing'|'mjpeg'|'error'
+//   opts.onCodec : (codec, codecString, width, height) => {}
+// handle: { setStream(n), requestIdr(), destroy(), supported }
+//
+// Wire format (see src/websrv/ws.c on_ws_video):
+//   text   : {type:"init",codec,codecString,mime,width,height,stream}
+//   binary : first frame = fMP4 init segment (ftyp+moov); then one moof+mdat
+//            fragment per access unit.
+window.MajesticVideo = (function () {
+	const MAX_QUEUE = 240;     // drop oldest fragments if the tab stalls
+	const LIVE_EDGE = 1.0;     // seconds of buffer ahead before we snap to live
+
+	function attach(video, opts) {
+		opts = opts || {};
+		const onState = opts.onState || function () {};
+		const onCodec = opts.onCodec || function () {};
+		let stream = opts.stream | 0;
+		let ws = null, ms = null, sb = null, objUrl = null;
+		let queue = [], started = false, mime = null;
+		let closed = false, reconnectTimer = null, backoff = 1000;
+		let gotSignal = false, signalTimer = null, failCount = 0;
+
+		const mseOk = ('MediaSource' in window);
+		const NO_SIGNAL_MS = 4000;  // WS open but no stream this long => no signal
+
+		function armSignalTimer() {
+			clearTimeout(signalTimer);
+			signalTimer = setTimeout(function () {
+				if (!gotSignal && !closed) onState('nosignal');
+			}, NO_SIGNAL_MS);
+		}
+		function markSignal() { gotSignal = true; clearTimeout(signalTimer); }
+
+		function pump() {
+			if (!sb || sb.updating || !queue.length) return;
+			try { sb.appendBuffer(queue.shift()); }
+			catch (e) { trim(); }
+		}
+		function trim() {
+			try {
+				if (sb && !sb.updating && sb.buffered.length) {
+					const end = sb.buffered.end(sb.buffered.length - 1);
+					if (end > 8) sb.remove(0, end - 4);
+				}
+			} catch (e) {}
+		}
+
+		function teardownMse() {
+			started = false; queue = [];
+			try { if (sb && sb.updating) sb.abort(); } catch (e) {}
+			try { if (sb && ms && ms.readyState === 'open') ms.removeSourceBuffer(sb); } catch (e) {}
+			sb = null;
+			try { if (ms && ms.readyState === 'open') ms.endOfStream(); } catch (e) {}
+			ms = null;
+			if (objUrl) { try { URL.revokeObjectURL(objUrl); } catch (e) {} objUrl = null; }
+		}
+
+		// Chrome wedges a <video>'s decoder when a new MediaSource with a
+		// different resolution/codec is bound to the SAME element (switching
+		// streams) -> MEDIA_ERR_DECODE that survives until the element is
+		// recreated. So hand each connection a brand-new element cloned from the
+		// original (preserving id / classes / inline style / autoplay attrs).
+		// The page re-queries #live-video for show/hide.
+		function onVideoError(e) {
+			if (!closed && e.target === video) reconnect();
+		}
+		function freshVideo() {
+			const old = video;
+			const nv = old.cloneNode(false);
+			nv.removeAttribute('src'); // don't inherit the old (revoked) blob: URL
+			nv.muted = true;
+			if (old.parentNode) old.parentNode.replaceChild(nv, old);
+			old.removeEventListener('error', onVideoError);
+			try { old.removeAttribute('src'); old.load(); } catch (e) {}
+			video = nv;
+			video.addEventListener('error', onVideoError);
+		}
+
+		function onInit(info) {
+			markSignal(); /* a stream description means the camera has signal */
+			failCount = 0; /* a healthy connection resets the give-up counter */
+			onCodec(info.codec, info.codecString, info.width, info.height);
+			mime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
+			if (!mseOk || !MediaSource.isTypeSupported(mime)) {
+				onState('mjpeg', 'codec ' + info.codec + ' not playable here');
+				stop();
+				return;
+			}
+			teardownMse();
+			ms = new MediaSource();
+			objUrl = URL.createObjectURL(ms);
+			video.src = objUrl;
+			ms.addEventListener('sourceopen', function () {
+				try { sb = ms.addSourceBuffer(mime); }
+				catch (e) { onState('mjpeg', 'addSourceBuffer failed'); stop(); return; }
+				try { sb.mode = 'segments'; } catch (e) {}
+				sb.addEventListener('updateend', pump);
+				started = true;
+				onState('playing', info.codec);
+				pump();
+			}, { once: true });
+		}
+
+		// Keep playback inside the live buffered range. Critically this also
+		// handles a stream switch: the new MediaSource's timeline starts near 0,
+		// but the <video>'s currentTime is still in the OLD stream's frame (e.g.
+		// 1s or 6s), so it lands outside the new buffer and stalls to black. Snap
+		// in whenever currentTime is before the buffer, past it, or drifting.
+		function syncLive() {
+			try {
+				if (!video.buffered.length) return;
+				const start = video.buffered.start(0);
+				const end = video.buffered.end(video.buffered.length - 1);
+				const ct = video.currentTime;
+				if (ct < start || ct > end + 0.25 || end - ct > LIVE_EDGE)
+					video.currentTime = Math.max(start, end - 0.1);
+			} catch (e) {}
+		}
+
+		function onBinary(buf) {
+			queue.push(new Uint8Array(buf));
+			if (queue.length > MAX_QUEUE) queue.splice(0, queue.length - MAX_QUEUE);
+			pump();
+			syncLive();
+			if (video.paused) video.play().catch(function () {});
+		}
+
+		function open() {
+			if (closed) return;
+			freshVideo(); // clean decoder for every (re)connect / stream switch
+			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+			onState('connecting');
+			ws = new WebSocket(proto + '://' + location.host + '/ws/video?stream=' + stream);
+			ws.binaryType = 'arraybuffer';
+			gotSignal = false;
+			ws.onopen = function () { backoff = 1000; armSignalTimer(); };
+			ws.onmessage = function (e) {
+				if (typeof e.data === 'string') {
+					let info; try { info = JSON.parse(e.data); } catch (_) { return; }
+					if (info && info.type === 'init') onInit(info);
+					return;
+				}
+				onBinary(e.data);
+			};
+			ws.onclose = function () { ws = null; if (!closed) reconnect(); };
+			ws.onerror = function () { try { ws.close(); } catch (e) {} };
+		}
+
+		function reconnect() {
+			teardownMse();
+			if (closed || reconnectTimer) return;
+			// Give up after a run of failures that never delivered a stream
+			// (server busy / 503, or endpoint unavailable) and fall back to MJPEG
+			// instead of storming the reconnect loop.
+			if (++failCount >= 6) { onState('mjpeg', 'live stream unavailable'); stop(); return; }
+			reconnectTimer = setTimeout(function () {
+				reconnectTimer = null;
+				backoff = Math.min(backoff * 2, 8000);
+				open();
+			}, backoff);
+		}
+
+		function stop() {
+			clearTimeout(signalTimer);
+			if (ws) { try { ws.close(); } catch (e) {} ws = null; }
+			teardownMse();
+		}
+
+		function requestIdr() {
+			if (ws && ws.readyState === 1) ws.send(JSON.stringify({ request: 'idr' }));
+		}
+
+		function setStream(n) {
+			n = n | 0;
+			if (n === stream) return;
+			stream = n;
+			backoff = 1000;
+			failCount = 0;
+			stop();
+			// Let the old MediaSource/decoder fully release before binding a new
+			// one — Chrome decode-errors if a new (different-resolution) decoder
+			// spins up while the previous one is still being torn down.
+			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+			reconnectTimer = setTimeout(function () { reconnectTimer = null; open(); }, 300);
+		}
+
+		function destroy() {
+			closed = true;
+			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+			stop();
+		}
+
+		if (!mseOk) {
+			onState('mjpeg', 'MSE unavailable');
+			return { setStream: function () {}, requestIdr: function () {}, destroy: function () {}, supported: false };
+		}
+
+		open();
+		return { setStream: setStream, requestIdr: requestIdr, destroy: destroy, supported: true };
+	}
+
+	return { attach: attach };
+})();

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -14,6 +14,10 @@
 			<dd>RTSP sub stream.</dd>
 			<dt class="cp2cb">rtsp://root:12345@<%= $network_address %>/stream=2</dt>
 			<dd>RTSP JPEG stream.</dd>
+			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=0</dt>
+			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview).</dd>
+			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=1</dt>
+			<dd>Low-latency H.264/H.265 sub stream (fMP4/MSE).</dd>
 			<dt class="cp2cb">http://<%= $network_address %>/mjpeg</dt>
 			<dd>MJPEG video stream.</dd>
 			<dt class="cp2cb">http://<%= $network_address %>/video.mp4</dt>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -368,12 +368,37 @@ pre() {
 	tag "pre" "$(echo -e "$1" | sed "s/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g;s/\"/\&quot;/g")" "$2" "$3"
 }
 
+# Live preview player: low-latency H.264/H.265 over the /ws/video WebSocket,
+# played in a <video> via Media Source Extensions (see www/a/preview.js). Falls
+# back to an MJPEG <img> when MSE (or the codec) isn't supported; the wiring
+# lives in preview.cgi. The player needs only encoded video (always on), so it
+# renders regardless of jpeg.enabled — jpeg only gates the MJPEG fallback.
 preview() {
-	if [ "true" = "$(yaml-cli -g .jpeg.enabled)" ]; then
-		echo "<video poster=\"/mjpeg\" style=\"background:url(/a/preview.svg); background-size:cover; width:100%\"></video>"
-	else
-		echo "<p class=\"alert alert-warning\"><a href=\"mj-settings.cgi?tab=jpeg\">Enable JPEG support</a> to see the preview.</p>"
+	local jpeg_enabled="$(yaml-cli -g .jpeg.enabled)"
+	# Plain black while starting up; the colorbars test pattern (preview.svg) is
+	# applied by preview.js only on genuine "no signal".
+	local bg="background:#000; background-size:cover; width:100%"
+	# Only offer the Sub toggle when the sub stream is actually encoding.
+	local sub=""
+	if [ "true" = "$(yaml-cli -g .video1.enabled)" ]; then
+		sub='<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-1" autocomplete="off"><label class="btn btn-outline-primary" for="mj-stream-1">Sub</label>'
 	fi
+	cat <<EOF
+<div class="mj-player" data-jpeg="$jpeg_enabled">
+	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Stream">
+		<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-0" autocomplete="off" checked>
+		<label class="btn btn-outline-primary" for="mj-stream-0">Main</label>
+		$sub
+		<span id="mj-badge" class="badge text-bg-secondary align-self-center ms-2">connecting…</span>
+	</div>
+	<video id="live-video" autoplay muted playsinline style="$bg"></video>
+	<img id="live-mjpeg" alt="" style="display:none; $bg">
+	<p id="mj-note" class="alert alert-warning" style="display:none">
+		Your browser can't play the live H.264/H.265 stream.
+		<a href="mj-settings.cgi?tab=jpeg">Enable JPEG</a> for an MJPEG fallback.
+	</p>
+</div>
+EOF
 }
 
 progressbar() {

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -66,4 +66,53 @@ $("#toggle-light").addEventListener("click", () => {
 });
 </script>
 
+<script src="/a/preview.js"></script>
+<script>
+(function () {
+	const initial = $('#live-video');
+	if (!initial || !window.MajesticVideo) return;
+	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
+	const jpegOn = initial.closest('.mj-player').dataset.jpeg === 'true';
+	const cur = () => $('#live-video'); // preview.js swaps the element per connection
+
+	const BARS = '#000 url(/a/preview.svg)';
+	function showVideo() {
+		const v = cur();
+		if (v) { v.style.display = ''; v.style.background = '#000'; } // video paints over; no colorbars while live
+		if (img) { img.style.display = 'none'; img.src = ''; }
+		if (note) note.style.display = 'none';
+	}
+	function showNoSignal() {
+		// genuine lack of signal from the camera: show the colorbars test pattern
+		const v = cur();
+		if (v) { v.style.display = ''; v.style.background = BARS; }
+		if (img) { img.style.display = 'none'; img.src = ''; }
+		if (note) note.style.display = 'none';
+		if (badge) badge.textContent = 'no signal';
+	}
+	function showFallback() {
+		const v = cur();
+		if (v) v.style.display = 'none';
+		if (jpegOn && img) { img.src = '/mjpeg'; img.style.display = ''; if (note) note.style.display = 'none'; }
+		else if (note) note.style.display = '';
+		if (badge) badge.textContent = 'MJPEG';
+	}
+
+	const player = MajesticVideo.attach(initial, {
+		stream: 0,
+		onState: (s, d) => {
+			if (s === 'playing') showVideo();
+			else if (s === 'nosignal') showNoSignal();
+			else if (s === 'mjpeg') showFallback();
+			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+		},
+		onCodec: (codec, cs, w, h) => { if (badge) badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h; },
+	});
+
+	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
+	if (s0) s0.addEventListener('change', () => player.setStream(0));
+	if (s1) s1.addEventListener('change', () => player.setStream(1));
+})();
+</script>
+
 <%in p/footer.cgi %>


### PR DESCRIPTION
## What

Replace the high-latency MJPEG preview with a **Media Source Extensions**
player fed **fragmented MP4** over majestic's new `/ws/video` WebSocket
(companion to the majestic `/ws/video` change).

WebCodecs is lower latency but **secure-context-only**, so it can't run over a
camera's plain-HTTP webui. **MSE plays fMP4 over `http://`**, so it actually
works on an IP camera with no TLS cert; it falls back to an MJPEG `<img>` when
the codec isn't playable in the browser.

## Highlights

- New reusable `www/a/preview.js` — `MajesticVideo.attach(videoEl, opts)` →
  `{ setStream, requestIdr, destroy }`. No third-party library.
- **Main / Sub** stream toggle; Sub shown only when `video1` is enabled.
- Colorbars test pattern appears only on genuine **signal loss**, not while
  the stream is just starting up.
- **Robust stream switching** — the part that took the most iteration:
  - fresh `<video>` element per connection (cloned without inheriting the
    stale `blob:` src),
  - `currentTime` snapped into the new live buffer (the new stream's timeline
    restarts near 0),
  - a short decoder-release delay before binding the new stream — Chrome
    otherwise throws `MEDIA_ERR_DECODE` when a new, different-resolution
    decoder spins up while the previous one is still tearing down.
- Reconnect backs off and falls back to MJPEG instead of storming when the
  endpoint is busy.

## Testing

On hi3516av300, driving **Main → Sub → Main → Sub** in headless Chrome: every
switch plays cleanly (buffer grows, `currentTime` advances, `readyState` 4, no
decode errors). H.264 and H.265 both validated end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)