### PR TITLE
settings: schema-driven form (all sections, hierarchical, conditional fields)

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -30,9 +30,38 @@
 	}
 
 	async function init() {
-		wireNav();
+		try {
+			state.schema = await fetchJson('/api/v1/config.schema.json');
+		} catch (e) {
+			const form = document.getElementById('mj-settings-form');
+			if (form) showFatal(form, 'Failed to load schema: ' + e.message);
+			return;
+		}
+		buildNav();
 		window.addEventListener('popstate', onPopState);
 		await load(state.tab, /*push*/ false);
+	}
+
+	function label(key) {
+		return (boot.labels && boot.labels[key]) ||
+			(key ? key.charAt(0).toUpperCase() + key.slice(1) : key);
+	}
+
+	function buildNav() {
+		const nav = document.getElementById('mj-settings-nav');
+		if (!nav) return;
+		nav.innerHTML = '';
+		for (const key of Object.keys(state.schema.properties || {})) {
+			const li = document.createElement('li');
+			li.className = 'nav-item';
+			const a = document.createElement('a');
+			a.className = 'nav-link';
+			a.href = 'mj-settings.cgi?tab=' + encodeURIComponent(key);
+			a.textContent = label(key);
+			li.appendChild(a);
+			nav.appendChild(li);
+		}
+		wireNav();
 	}
 
 	function wireNav() {
@@ -94,18 +123,7 @@
 
 		state.fields = [];
 		state.initial = {};
-		for (const key of Object.keys(props)) {
-			const dot = tab + '.' + key;
-			if (EXCLUDE.has(dot)) continue;
-
-			const sub = props[key];
-			const eff = getDotted(state.config, dot);
-			const field = renderField(form, dot, key, sub, eff);
-			if (field) {
-				state.fields.push(field);
-				state.initial[dot] = field.getValue();
-			}
-		}
+		renderProps(form, tab, props);
 
 		const toolbar = document.createElement('div');
 		toolbar.className = 'mj-toolbar d-flex align-items-center mt-3 gap-2';
@@ -115,6 +133,8 @@
 		form.appendChild(toolbar);
 
 		if (tab === 'motionDetect') toggleRoi(tab);
+
+		applyVisibility();
 
 		updateDirty();
 	}
@@ -131,10 +151,8 @@
 	}
 
 	function setTitle(tab) {
-		const h = document.querySelector('#mj-settings-form-col h3');
-		if (!h) return;
-		const active = document.querySelector('#mj-settings-nav .nav-link.active');
-		if (active) h.textContent = active.textContent.trim();
+		const h = document.getElementById('mj-settings-title');
+		if (h) h.textContent = label(tab);
 	}
 
 	function toggleRoi(tab) {
@@ -172,6 +190,51 @@
 
 	function hasDirty() {
 		return state.fields.some(f => f.getValue() !== state.initial[f.dot]);
+	}
+
+	function titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
+
+	function renderProps(form, basePath, props) {
+		for (const key of Object.keys(props)) {
+			const dot = basePath + '.' + key;
+			if (EXCLUDE.has(dot)) continue;
+			const sub = props[key];
+			if (sub && sub.type === 'object' && sub.properties) {
+				const h = el('h5', 'mt-4 mb-2 text-secondary');
+				h.textContent = sub.title || titleCase(key);
+				form.appendChild(h);
+				renderProps(form, dot, sub.properties);
+				continue;
+			}
+			const eff = getDotted(state.config, dot);
+			const field = renderField(form, dot, key, sub, eff);
+			if (field) {
+				state.fields.push(field);
+				state.initial[dot] = field.getValue();
+			}
+		}
+	}
+
+	function applyVisibility() {
+		state.visUpdaters = [];
+		const byDot = {};
+		for (const f of state.fields) byDot[f.dot] = f;
+		for (const f of state.fields) {
+			const vw = f.schema && f.schema.visibleWhen;
+			if (!vw || !vw.field) continue;
+			const parent = f.dot.slice(0, f.dot.lastIndexOf('.'));
+			const ctrl = byDot[parent + '.' + vw.field];
+			if (!ctrl) continue;
+			const update = () => { f.p.style.display = String(ctrl.getValue()) === String(vw.equals) ? '' : 'none'; };
+			ctrl.control.addEventListener('change', update);
+			ctrl.control.addEventListener('input', update);
+			state.visUpdaters.push(update);
+			update();
+		}
+	}
+
+	function runVisibility() {
+		(state.visUpdaters || []).forEach(u => u());
 	}
 
 	function renderField(form, dot, key, sub, eff) {
@@ -358,6 +421,7 @@
 			f.setValue(eff);
 			state.initial[f.dot] = f.getValue();
 		}
+		runVisibility();
 		updateDirty();
 	}
 

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -1,24 +1,7 @@
-// Low-latency H.264/H.265 live player over the majestic /ws/video WebSocket.
-// majestic re-wraps the encoded stream as fragmented MP4; this feeds it to a
-// <video> element via Media Source Extensions (MSE). MSE works over plain
-// http:// on a camera (unlike WebCodecs, which is secure-context-only), so this
-// is the path that actually plays on an IP camera with no TLS cert. Falls back
-// to MJPEG when MSE or the codec isn't supported. No third-party library.
-//
-// Reusable: MajesticVideo.attach(videoEl, opts) returns a small handle so the
-// Preview page (and later the motionDetect ROI editor) can share one player.
-//   opts.stream  : 0 main (default) | 1 sub
-//   opts.onState : (state, detail) => {}   // 'connecting'|'playing'|'mjpeg'|'error'
-//   opts.onCodec : (codec, codecString, width, height) => {}
-// handle: { setStream(n), requestIdr(), destroy(), supported }
-//
-// Wire format (see src/websrv/ws.c on_ws_video):
-//   text   : {type:"init",codec,codecString,mime,width,height,stream}
-//   binary : first frame = fMP4 init segment (ftyp+moov); then one moof+mdat
-//            fragment per access unit.
+// Low-latency H.264/H.265 MSE player over the majestic /ws/video WebSocket.
 window.MajesticVideo = (function () {
-	const MAX_QUEUE = 240;     // drop oldest fragments if the tab stalls
-	const LIVE_EDGE = 1.0;     // seconds of buffer ahead before we snap to live
+	const MAX_QUEUE = 240;
+	const LIVE_EDGE = 1.0;
 
 	function attach(video, opts) {
 		opts = opts || {};
@@ -31,7 +14,7 @@ window.MajesticVideo = (function () {
 		let gotSignal = false, signalTimer = null, failCount = 0;
 
 		const mseOk = ('MediaSource' in window);
-		const NO_SIGNAL_MS = 4000;  // WS open but no stream this long => no signal
+		const NO_SIGNAL_MS = 4000;
 
 		function armSignalTimer() {
 			clearTimeout(signalTimer);
@@ -65,19 +48,13 @@ window.MajesticVideo = (function () {
 			if (objUrl) { try { URL.revokeObjectURL(objUrl); } catch (e) {} objUrl = null; }
 		}
 
-		// Chrome wedges a <video>'s decoder when a new MediaSource with a
-		// different resolution/codec is bound to the SAME element (switching
-		// streams) -> MEDIA_ERR_DECODE that survives until the element is
-		// recreated. So hand each connection a brand-new element cloned from the
-		// original (preserving id / classes / inline style / autoplay attrs).
-		// The page re-queries #live-video for show/hide.
 		function onVideoError(e) {
 			if (!closed && e.target === video) reconnect();
 		}
 		function freshVideo() {
 			const old = video;
 			const nv = old.cloneNode(false);
-			nv.removeAttribute('src'); // don't inherit the old (revoked) blob: URL
+			nv.removeAttribute('src');
 			nv.muted = true;
 			if (old.parentNode) old.parentNode.replaceChild(nv, old);
 			old.removeEventListener('error', onVideoError);
@@ -87,8 +64,8 @@ window.MajesticVideo = (function () {
 		}
 
 		function onInit(info) {
-			markSignal(); /* a stream description means the camera has signal */
-			failCount = 0; /* a healthy connection resets the give-up counter */
+			markSignal();
+			failCount = 0;
 			onCodec(info.codec, info.codecString, info.width, info.height);
 			mime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
 			if (!mseOk || !MediaSource.isTypeSupported(mime)) {
@@ -111,11 +88,6 @@ window.MajesticVideo = (function () {
 			}, { once: true });
 		}
 
-		// Keep playback inside the live buffered range. Critically this also
-		// handles a stream switch: the new MediaSource's timeline starts near 0,
-		// but the <video>'s currentTime is still in the OLD stream's frame (e.g.
-		// 1s or 6s), so it lands outside the new buffer and stalls to black. Snap
-		// in whenever currentTime is before the buffer, past it, or drifting.
 		function syncLive() {
 			try {
 				if (!video.buffered.length) return;
@@ -137,7 +109,7 @@ window.MajesticVideo = (function () {
 
 		function open() {
 			if (closed) return;
-			freshVideo(); // clean decoder for every (re)connect / stream switch
+			freshVideo();
 			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 			onState('connecting');
 			ws = new WebSocket(proto + '://' + location.host + '/ws/video?stream=' + stream);
@@ -159,9 +131,6 @@ window.MajesticVideo = (function () {
 		function reconnect() {
 			teardownMse();
 			if (closed || reconnectTimer) return;
-			// Give up after a run of failures that never delivered a stream
-			// (server busy / 503, or endpoint unavailable) and fall back to MJPEG
-			// instead of storming the reconnect loop.
 			if (++failCount >= 6) { onState('mjpeg', 'live stream unavailable'); stop(); return; }
 			reconnectTimer = setTimeout(function () {
 				reconnectTimer = null;
@@ -187,9 +156,6 @@ window.MajesticVideo = (function () {
 			backoff = 1000;
 			failCount = 0;
 			stop();
-			// Let the old MediaSource/decoder fully release before binding a new
-			// one — Chrome decode-errors if a new (different-resolution) decoder
-			// spins up while the previous one is still being torn down.
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			reconnectTimer = setTimeout(function () { reconnectTimer = null; open(); }, 300);
 		}

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -6,25 +6,11 @@ page_title="Majestic Settings"
 label="$GET_tab"
 [ -z "$label" ] && label="system"
 
-include j/locale.cgi
-
-section=""
-if [ -f "$(get_schema)" ]; then
-	eval $(jsonfilter -e "section=@.properties" < $(get_schema) 2>/dev/null)
-fi
-
-title=""
-for key in $section; do
-	loc=$(eval echo \$mj_${key})
-	if [ -n "$loc" ] && [ "$label" = "$key" ]; then
-		title="$loc"
-		break
-	fi
-done
-
 mj_json_escape() {
 	sed 's/\\/\\\\/g; s/"/\\"/g'
 }
+
+labels=$(sed -n 's/^mj_\([A-Za-z0-9]*\)=\(.*\)/"\1":"\2"/p' j/locale.cgi 2>/dev/null | paste -sd,)
 
 boot_exclude=""
 if [ -e j/exclude.lst ]; then
@@ -58,45 +44,20 @@ fi
 
 <div class="row g-4 mb-4">
 	<div class="col-12 col-md-3 col-lg-2">
-		<ul class="nav nav-pills flex-column small sticky-md-top" id="mj-settings-nav">
-			<%
-			for key in $section; do
-				loc=$(eval echo \$mj_${key})
-				[ -z "$loc" ] && continue
-				c="class=\"nav-link\""
-				[ "$label" = "$key" ] && c="class=\"nav-link active\" aria-current=\"page\""
-				echo "<li class=\"nav-item\"><a ${c} href=\"mj-settings.cgi?tab=${key}\">${loc}</a></li>"
-			done
-			%>
-		</ul>
+		<ul class="nav nav-pills flex-column small sticky-md-top" id="mj-settings-nav"></ul>
 	</div>
 
-	<% if [ -n "$title" ]; then %>
-
 	<div class="col-12 col-md-9 col-lg-6" id="mj-settings-form-col">
-		<script type="application/json" id="mj-settings-boot">{"tab":"<%= $label %>","exclude":[<%= $boot_exclude %>],"sensors":[<%= $boot_sensors %>]}</script>
+		<script type="application/json" id="mj-settings-boot">{"tab":"<%= $label %>","labels":{<%= $labels %>},"exclude":[<%= $boot_exclude %>],"sensors":[<%= $boot_sensors %>]}</script>
 
-		<h3><%= $title %></h3>
+		<h3 id="mj-settings-title"></h3>
 		<form id="mj-settings-form" action="javascript:void(0)" autocomplete="off">
 			<p class="text-secondary small mb-0">Loading settings…</p>
 		</form>
 	</div>
-
-	<% else %>
-
-	<div class="col-12 col-md-9 col-lg-10">
-		<div class="alert alert-danger">
-			<h4>Setting is not available.</h4>
-			<p><a href="mj-settings.cgi">Majestic Settings</a></p>
-		</div>
-	</div>
-
-	<% fi %>
 </div>
 
-<% if [ -n "$title" ]; then %>
 <script src="/a/mj-settings.js" defer></script>
-<% fi %>
 
 <% fi %>
 

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -293,14 +293,6 @@ get_metrics() {
 	fi
 }
 
-get_schema() {
-	local m=/tmp/webui/schema.json
-	if [ ! -e "$m" ]; then
-		wget -q -T1 localhost/api/v1/config.schema.json -O "$m"
-	fi
-	echo "$m"
-}
-
 get_night() {
 	local m=$(pidof majestic)
 	local v=$(yaml-cli -g .nightMode.$1)
@@ -368,17 +360,9 @@ pre() {
 	tag "pre" "$(echo -e "$1" | sed "s/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g;s/\"/\&quot;/g")" "$2" "$3"
 }
 
-# Live preview player: low-latency H.264/H.265 over the /ws/video WebSocket,
-# played in a <video> via Media Source Extensions (see www/a/preview.js). Falls
-# back to an MJPEG <img> when MSE (or the codec) isn't supported; the wiring
-# lives in preview.cgi. The player needs only encoded video (always on), so it
-# renders regardless of jpeg.enabled — jpeg only gates the MJPEG fallback.
 preview() {
 	local jpeg_enabled="$(yaml-cli -g .jpeg.enabled)"
-	# Plain black while starting up; the colorbars test pattern (preview.svg) is
-	# applied by preview.js only on genuine "no signal".
 	local bg="background:#000; background-size:cover; width:100%"
-	# Only offer the Sub toggle when the sub stream is actually encoding.
 	local sub=""
 	if [ "true" = "$(yaml-cli -g .video1.enabled)" ]; then
 		sub='<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-1" autocomplete="off"><label class="btn btn-outline-primary" for="mj-stream-1">Sub</label>'

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -73,17 +73,16 @@ $("#toggle-light").addEventListener("click", () => {
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
 	const jpegOn = initial.closest('.mj-player').dataset.jpeg === 'true';
-	const cur = () => $('#live-video'); // preview.js swaps the element per connection
+	const cur = () => $('#live-video');
 
 	const BARS = '#000 url(/a/preview.svg)';
 	function showVideo() {
 		const v = cur();
-		if (v) { v.style.display = ''; v.style.background = '#000'; } // video paints over; no colorbars while live
+		if (v) { v.style.display = ''; v.style.background = '#000'; }
 		if (img) { img.style.display = 'none'; img.src = ''; }
 		if (note) note.style.display = 'none';
 	}
 	function showNoSignal() {
-		// genuine lack of signal from the camera: show the colorbars test pattern
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = BARS; }
 		if (img) { img.style.display = 'none'; img.src = ''; }


### PR DESCRIPTION
## What

Make Majestic Settings fully **schema-driven in the browser**, and surface the
new nested/conditional config (companion to the majestic `config_show_if` /
`isp.iris` change).

### Nav built client-side — no server schema cache
`mj-settings.cgi` was building the section tabs server-side from a **cached**
copy of the schema (`/tmp/webui/schema.json`, fetched once and never refreshed),
while the form fetched the live schema. After any majestic restart that changed
the schema, the nav went stale (e.g. an orphan `Iris` tab that errored on click).

Now the CGI is a thin shell; `mj-settings.js` fetches the live schema **once**
and builds **both** the nav and the form from it. Every schema section appears
automatically — `j/locale.cgi` is only a friendly-label override (JS falls back
to the capitalised key). `get_schema()`/the cache are removed.

### Hierarchy + conditional fields
- Nested `object` sections (e.g. `isp.iris`) render recursively under a
  sub-heading, mirroring the schema.
- Fields carrying `visibleWhen` (emitted by `config_show_if`) are shown only
  while a sibling control equals the value, re-evaluating on change **and** after
  a programmatic change (reset/save).

### Cleanup
First commit trims the verbose comments from the shipped `preview.js` /
`preview.cgi` (flash size).

## Testing

On hi3516av300, headless Chrome: nav built client-side (18 sections, no orphan
`Iris` tab, friendly labels), `ISP` shows a nested **Iris** sub-section, the DC
controls hide/show with `type`, and **reset** correctly collapses them. The
camera no longer recreates `/tmp/webui/schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)