### PR TITLE
settings: array-native editor for MultiRect fields (roi/crop/privacyMasks)

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -174,8 +174,6 @@
 			const clearBtn = document.getElementById('mj-roi-clear');
 			if (clearBtn) {
 				clearBtn.addEventListener('click', () => {
-					const ifr = document.getElementById('mj-roi-iframe');
-					if (ifr) ifr.contentWindow.location.reload();
 					const roiField = state.fields.find(f => f.dot === 'motionDetect.roi');
 					if (roiField) {
 						roiField.setValue('');
@@ -302,6 +300,54 @@
 				'<label for="' + id + '" class="form-label">' + esc(desc) + '</label>' +
 				'<input type="text" id="' + id + '" class="form-control" value="' + esc(v) + '">';
 			control = p.querySelector('input');
+		} else if (type === 'array') {
+			// MultiRect fields (motionDetect.roi, crop, privacyMasks) are a list of
+			// "AxBxCxD" regions: render one editable row per region, not a single
+			// comma-joined string. The Visual editor (m/img.html) adds/reads rows
+			// through the window.mjRoi* hooks exposed below.
+			p = el('p', 'array mj-row');
+			p.innerHTML =
+				'<label class="form-label">' + esc(desc) + '</label>' +
+				'<div class="mj-array" id="' + id + '"></div>' +
+				'<button type="button" class="btn btn-sm btn-outline-secondary mt-1 mj-array-add">+ Add region</button>';
+			control = p.querySelector('.mj-array');
+			// Re-render the Visual editor's canvas whenever the list changes
+			// (add/delete/edit/reset), so drawn rectangles track the rows.
+			const syncEditor = () => {
+				if (dot !== 'motionDetect.roi') return;
+				const ifr = document.getElementById('mj-roi-iframe');
+				if (ifr && ifr.contentWindow && ifr.contentWindow.mjRoiRedraw)
+					ifr.contentWindow.mjRoiRedraw();
+			};
+			const onChange = () => { updateDirty(); syncEditor(); };
+			control._sync = syncEditor;
+			const addRow = (val) => {
+				const row = el('div', 'input-group input-group-sm mb-1 mj-array-row');
+				const inp = el('input', 'form-control');
+				inp.type = 'text';
+				inp.placeholder = 'XxYxWxH';
+				inp.value = val || '';
+				inp.addEventListener('input', onChange);
+				inp.addEventListener('change', onChange);
+				const del = el('button', 'btn btn-outline-danger mj-array-del');
+				del.type = 'button';
+				del.textContent = '×';
+				del.addEventListener('click', () => { row.remove(); onChange(); });
+				row.appendChild(inp);
+				row.appendChild(del);
+				control.appendChild(row);
+				return inp;
+			};
+			control._addRow = addRow;
+			control._rows = () => Array.from(control.querySelectorAll('.mj-array-row input'))
+				.map(i => i.value.trim()).filter(s => s.length);
+			(Array.isArray(eff) ? eff : (eff ? String(eff).split(/\s*,\s*/) : []))
+				.forEach(x => { if (x) addRow(x); });
+			p.querySelector('.mj-array-add').addEventListener('click', () => { addRow(''); onChange(); });
+			if (dot === 'motionDetect.roi') {
+				window.mjRoiAdd = (dim) => { if (dim) { addRow(dim); onChange(); } };
+				window.mjRoiList = () => control._rows();
+			}
 		} else {
 			return null;
 		}
@@ -324,13 +370,23 @@
 		control.addEventListener('input', updateDirty);
 		control.addEventListener('change', updateDirty);
 
+		// array fields canonicalise to a comma-joined string so dirty-tracking
+		// (a plain !== against state.initial) keeps working; onSubmit splits it
+		// back into a list before POSTing.
 		const getValue = type === 'boolean'
 			? () => control.checked ? 'true' : 'false'
+			: type === 'array'
+			? () => control._rows().join(', ')
 			: () => String(control.value);
 
 		const setValue = (v) => {
 			if (type === 'boolean') {
 				control.checked = toBool(v);
+			} else if (type === 'array') {
+				control.querySelectorAll('.mj-array-row').forEach(r => r.remove());
+				const arr = Array.isArray(v) ? v : (v ? String(v).split(/\s*,\s*/) : []);
+				arr.forEach(x => { if (x) control._addRow(x); });
+				if (control._sync) control._sync();
 			} else {
 				control.value = v !== undefined && v !== null ? String(v) : '';
 				const show = p.querySelector('.show-value');
@@ -360,7 +416,14 @@
 		if (!dirty.length) return;
 
 		const body = {};
-		for (const f of dirty) setDotted(body, f.dot, f.getValue());
+		for (const f of dirty) {
+			let val = f.getValue();
+			// array-typed schema fields (MultiRect: roi/crop/privacyMasks) post as a
+			// list of strings, not a comma-joined scalar.
+			if (f.schema && f.schema.type === 'array')
+				val = String(val).split(',').map(s => s.trim()).filter(s => s.length);
+			setDotted(body, f.dot, val);
+		}
 
 		const btn = document.getElementById('mj-save');
 		btn.disabled = true;

--- a/www/m/img.html
+++ b/www/m/img.html
@@ -13,7 +13,6 @@
 <div id="canvas"></div>
 
 <script>
-const ROI_INPUT_ID = 'mjf-motionDetect-roi';
 const IFRAME = window.frameElement;
 const HOST = IFRAME ? IFRAME.parentElement : null;
 const IMG_WIDTH = Math.round((HOST ? HOST.offsetWidth : window.innerWidth) * 0.99);
@@ -29,17 +28,37 @@ function _motion_size() {
 	return JSON.parse(xhr.responseText).video0.size.split('x');
 }
 
-function _roi_input() {
-	return parent.document.getElementById(ROI_INPUT_ID);
+// The settings form (a/mj-settings.js) renders motionDetect.roi as a list of
+// region rows and exposes these hooks; the editor adds/reads regions through
+// them rather than manipulating a string input.
+function _roi_list() {
+	return parent.mjRoiList ? parent.mjRoiList() : [];
 }
 
-function _update_roi_value(next) {
-	const input = _roi_input();
-	if (!input) return;
-	input.value = next;
-	input.dispatchEvent(new Event('input', { bubbles: true }));
-	input.dispatchEvent(new Event('change', { bubbles: true }));
+function _roi_add(dim) {
+	if (parent.mjRoiAdd) parent.mjRoiAdd(dim);
 }
+
+function draw_rectangle(s, color) {
+	const canvas = document.getElementById('canvas');
+	const e = document.createElement('div');
+	e.className = 'rectangle';
+	e.style.left = (s[0] / COEFF) + 'px'; e.style.top = (s[1] / COEFF) + 'px';
+	e.style.width = (s[2] / COEFF) + 'px'; e.style.height = (s[3] / COEFF) + 'px';
+	e.style.background = color;
+	canvas.appendChild(e);
+}
+
+// Re-render every region from the parent's current list. Exposed so the
+// settings form can re-sync the canvas after a row is added/deleted/reset/edited.
+function redraw_regions() {
+	const canvas = document.getElementById('canvas');
+	canvas.querySelectorAll('.rectangle').forEach(el => el.remove());
+	for (const v of _roi_list()) {
+		if (v) draw_rectangle(v.split('x'), GRN);
+	}
+}
+window.mjRoiRedraw = redraw_regions;
 
 function set_canvas_size() {
 	document.getElementById('canvas').style.width = IMG_WIDTH + 'px';
@@ -71,23 +90,9 @@ function initDraw(canvas) {
 	};
 
 	let element = null;
-	function draw_rectangle(s, color) {
-		e= document.createElement('div');
-		e.className = 'rectangle'
-		e.style.left = (s[0] / COEFF) + 'px'; e.style.top = (s[1] / COEFF) + 'px';
-		e.style.width = (s[2] / COEFF) + 'px'; e.style.height = (s[3] / COEFF) + 'px';
-		e.style.background = color;
-		canvas.appendChild(e)
-		e = null;
-	}
 
 	// draw current regions
-	const seed = _roi_input();
-	if (seed && seed.value) {
-		for (v of seed.value.split(', ')) {
-			draw_rectangle(v.split('x'), GRN);
-		}
-	}
+	redraw_regions();
 
 	canvas.onmousemove = function (e) {
 		setMousePosition(e);
@@ -121,10 +126,7 @@ function initDraw(canvas) {
 				rW = Math.round((rect.right - rect.left) * COEFF),
 				rH = Math.round((rect.bottom - rect.top) * COEFF);
 			rect = element = null;
-			const input = _roi_input();
-			if (!input) return;
-			let dimensions = rX + 'x' + rY + 'x' + rW + 'x' + rH;
-			_update_roi_value(input.value === '' ? dimensions : input.value + ',' + dimensions);
+			_roi_add(rX + 'x' + rY + 'x' + rW + 'x' + rH);
 		}
 	}
 }


### PR DESCRIPTION
Companion to widgetii/majestic#198, which stores `motionDetect.roi` / `video.crop` / `osd.privacyMasks` as a JSON **array** of `"AxBxCxD"` strings (was a comma-joined string).

The schema-driven form had no renderer for `type:"array"`, so the roi field stopped rendering: no region numbers, the Visual editor couldn't find its target, and Save Changes stayed disabled.

- `renderField`: render array fields as a **list** — one editable row per region with a remove (×) button and an "Add region" button — not a single comma-joined input.
- `getValue` canonicalises rows to a comma string so dirty-tracking keeps working; `onSubmit` splits it back into a list so the POST body is a real array.
- The Visual editor (`m/img.html`) adds/reads regions through `window.mjRoi*` hooks on the parent form, and re-renders its canvas on every list change (add/delete/edit/reset/clear) so rectangles always track the rows.

Verified end-to-end on hi3516av300: render, add/draw, delete, edit, reset (no longer 500s), and Save (posts an array → 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)