### PR TITLE
settings: read config client-side via /api/v1/config.json, drop yaml-cli from pages

### DIFF
--- a/www/a/main.js
+++ b/www/a/main.js
@@ -14,6 +14,27 @@ function sleep(ms) {
 	return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+let _mjCfg;
+function mjConfig() {
+	if (!_mjCfg)
+		_mjCfg = fetch('/api/v1/config.json', { credentials: 'same-origin' })
+			.then(r => r.ok ? r.json() : {}).catch(() => ({}));
+	return _mjCfg;
+}
+
+function mjGet(cfg, dot) {
+	return dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg);
+}
+
+function mjHeifGate(sel) {
+	mjConfig().then(cfg => {
+		if (mjGet(cfg, 'video0.codec') !== 'h265') {
+			const el = $(sel);
+			if (el) { el.checked = false; el.disabled = true; }
+		}
+	});
+}
+
 function setProgressBar(id, value, name) {
 	$(id).setAttribute('aria-valuenow', value);
 	$(id).title = name + ': ' + value + '%'

--- a/www/cgi-bin/ext-ntfy.cgi
+++ b/www/cgi-bin/ext-ntfy.cgi
@@ -114,11 +114,7 @@ function sendTestNtfy() {
         });
 }
 
-// Logic for disabling HEIF if the codec is not h265
-<% if [ "$(yaml-cli -g .video0.codec)" != "h265" ]; then %>
-    $('#ntfy_heif').checked = false;
-    $('#ntfy_heif').disabled = true;
-<% fi %>
+mjHeifGate('#ntfy_heif');
 </script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/ext-openwall.cgi
+++ b/www/cgi-bin/ext-openwall.cgi
@@ -71,10 +71,7 @@ fi
 	$('#openwall_crontab').checked = true;
 <% fi %>
 
-<% if [ "$(yaml-cli -g .video0.codec)" != "h265" ]; then %>
-	$('#openwall_heif').checked = false;
-	$('#openwall_heif').disabled = true;
-<% fi %>
+mjHeifGate('#openwall_heif');
 </script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -84,10 +84,7 @@ fi
 	$('#telegram_crontab').checked = true;
 <% fi %>
 
-<% if [ "$(yaml-cli -g .video0.codec)" != "h265" ]; then %>
-	$('#telegram_heif').checked = false;
-	$('#telegram_heif').disabled = true;
-<% fi %>
+mjHeifGate('#telegram_heif');
 </script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -284,25 +284,6 @@ synctime() {
 	return 1
 }
 
-get_metrics() {
-	local m=$(pidof majestic)
-	if [ -z "$m" ]; then
-		echo 0
-	else
-		wget -q -T1 localhost/metrics/night?value=${1} -O -
-	fi
-}
-
-get_night() {
-	local m=$(pidof majestic)
-	local v=$(yaml-cli -g .nightMode.$1)
-	if [ -n "$m" ] && [ -n "$v" ] && [ "$v" != "false" ]; then
-		echo true
-	else
-		echo false
-	fi
-}
-
 log_create() {
 	echo "${1}:${2}" > "$log_file"
 }
@@ -361,18 +342,14 @@ pre() {
 }
 
 preview() {
-	local jpeg_enabled="$(yaml-cli -g .jpeg.enabled)"
 	local bg="background:#000; background-size:cover; width:100%"
-	local sub=""
-	if [ "true" = "$(yaml-cli -g .video1.enabled)" ]; then
-		sub='<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-1" autocomplete="off"><label class="btn btn-outline-primary" for="mj-stream-1">Sub</label>'
-	fi
 	cat <<EOF
-<div class="mj-player" data-jpeg="$jpeg_enabled">
+<div class="mj-player">
 	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Stream">
 		<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-0" autocomplete="off" checked>
 		<label class="btn btn-outline-primary" for="mj-stream-0">Main</label>
-		$sub
+		<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-1" autocomplete="off">
+		<label class="btn btn-outline-primary" for="mj-stream-1" id="mj-sub" hidden>Sub</label>
 		<span id="mj-badge" class="badge text-bg-secondary align-self-center ms-2">connecting…</span>
 	</div>
 	<video id="live-video" autoplay muted playsinline style="$bg"></video>

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -11,9 +11,7 @@
 	</div>
 
 	<div class="col-auto">
-		<% if [ "$(get_night lightMonitor)" = "true" ]; then %>
-			<p class="small"><a href="mj-settings.cgi?tab=nightMode">Light monitor active</a></p>
-		<% fi %>
+		<p class="small" id="mj-lightmon" hidden><a href="mj-settings.cgi?tab=nightMode">Light monitor active</a></p>
 
 		<div class="d-grid gap-3">
 			<input type="checkbox" class="btn-check" id="toggle-night">
@@ -33,13 +31,18 @@
 </div>
 
 <script>
-<% echo "\$('#toggle-night').checked = $(get_metrics night_enabled);" %>
-<% echo "\$('#toggle-ircut').checked = $(get_metrics ircut_enabled);" %>
-<% echo "\$('#toggle-light').checked = $(get_metrics light_enabled);" %>
-
-<% echo "\$('#toggle-night').disabled = $(get_night lightMonitor);" %>
-<% echo "\$('#toggle-ircut').disabled = $(get_night lightMonitor) || !$(get_night irCutPin1);" %>
-<% echo "\$('#toggle-light').disabled = $(get_night lightMonitor) || !$(get_night backlightPin);" %>
+mjConfig().then(cfg => {
+	const active = v => v !== false && v != null;
+	const lm = active(mjGet(cfg, 'nightMode.lightMonitor'));
+	$('#toggle-night').disabled = lm;
+	$('#toggle-ircut').disabled = lm || !active(mjGet(cfg, 'nightMode.irCutPin1'));
+	$('#toggle-light').disabled = lm || !active(mjGet(cfg, 'nightMode.backlightPin'));
+	if (lm) $('#mj-lightmon').hidden = false;
+});
+['night', 'ircut', 'light'].forEach(n =>
+	fetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
+		.then(r => r.text()).then(v => { $('#toggle-' + n).checked = +v > 0; })
+		.catch(() => {}));
 
 $("#toggle-night").addEventListener("click", () => {
 	fetch('/night/toggle').then(api => api.json()).then(data => {
@@ -72,7 +75,11 @@ $("#toggle-light").addEventListener("click", () => {
 	const initial = $('#live-video');
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
-	const jpegOn = initial.closest('.mj-player').dataset.jpeg === 'true';
+	let jpegOn = false;
+	mjConfig().then(cfg => {
+		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
+		if (mjGet(cfg, 'video1.enabled') === true) $('#mj-sub').hidden = false;
+	});
 	const cur = () => $('#live-video');
 
 	const BARS = '#000 url(/a/preview.svg)';


### PR DESCRIPTION
## What

A few pages still shelled out to `yaml-cli -g` at CGI render time to bake one
`majestic.yaml` value into the page (e.g. `$(yaml-cli -g .video1.enabled)`).
The schema-driven settings form already reads/writes config through majestic's
HTTP API; this does the same for the leftover **reads**, so those pages no longer
depend on the `yaml-cli` binary or block render on a config probe. All writes
already went through the API — this is reads only.

## Changes

`www/a/main.js` gains a tiny cached reader (`mjConfig`/`mjGet`) plus
`mjHeifGate()`, mirroring the `fetch('/api/v1/config.json')` pattern
`mj-settings.js` already uses. Then:

- **ext-ntfy / ext-telegram / ext-openwall**: the three identical
  `.video0.codec → HEIF` haserl gates collapse to one `mjHeifGate('#…_heif')`
  call each — now reflecting the *live* codec, not the value at render time.
- **`preview()`** (`p/common.cgi`): emits static markup — always renders the
  Sub radio (hidden) and drops the `data-jpeg` attribute.
- **`preview.cgi`**: the night/ircut/light toggle *disabled*+*checked* states,
  the light-monitor notice, and Sub visibility move client-side to `mjConfig()`
  + the live `/metrics/night` fetch; an `active()` helper reproduces the old
  `get_night` truthiness (incl. the pin-`0`-is-active quirk).
- dead `get_night()` / `get_metrics()` helpers removed from `p/common.cgi`.

## Not touched (out of scope)

- `bin/ntfy.sh` — a server-side notification script (no browser).
- `p/fpv_common.cgi` / `fpv-wfb.cgi` — operate on `/etc/wfb.yaml` (WifiBroadcast,
  a different daemon); majestic's API only serves `majestic.yaml`.

## Auth

No regression: `/api/v1/config.json` is root/session gated, but so are these
pages — the non-root media allowlist is only
`/image,/mjpeg,/night,/cgi-bin/v,/ws/video`, so anyone who can load the page
already carries the cookie that makes the fetch succeed (same path mj-settings
uses).

## Testing

On hi3516av300, headless Chromium against the live API (config:
`video1.enabled=true`, `video0.codec=h264`, `lightMonitor=false`, no IR/backlight
pins): **Sub** button revealed, **ircut/light** toggles disabled, **ntfy HEIF**
box disabled — all matching the prior server-rendered behavior. `grep` confirms
no `yaml-cli` left in the converted pages (only the FPV `wfb.yaml` path remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)