### PR TITLE
tool-sdcard: redesign as a modern JSON-driven SD-card page

### DIFF
--- a/www/a/sdcard.js
+++ b/www/a/sdcard.js
@@ -1,0 +1,146 @@
+// SD-card page: JSON status + format/mount/fsck ops + recording integration.
+(function () {
+	const SD = $('#sd');
+	let state = null, cfg = {}, timer = null;
+
+	function esc(s) { return String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c])); }
+	function humanBytes(n) {
+		n = +n || 0;
+		if (n >= 1073741824) return (n / 1073741824).toFixed(1) + ' GB';
+		if (n >= 1048576) return (n / 1048576).toFixed(0) + ' MB';
+		if (n >= 1024) return (n / 1024).toFixed(0) + ' KB';
+		return n + ' B';
+	}
+	function recPrefix() { return (mjGet(cfg, 'records.path') || '').split('%')[0].replace(/\/+$/, ''); }
+
+	function api(qs) { return fetch('/cgi-bin/j/sdcard.cgi' + (qs ? '?' + qs : ''), { credentials: 'same-origin' }).then(r => r.json()); }
+	function op(p) {
+		return fetch('/cgi-bin/j/sdcard.cgi', {
+			method: 'POST', credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams(p).toString(),
+		}).then(r => r.json());
+	}
+	function setConfig(obj) {
+		return fetch('/api/v1/config', {
+			method: 'POST', credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(obj),
+		}).then(r => r.ok);
+	}
+
+	function load() {
+		// fetch config fresh each time (so record-toggle changes show immediately)
+		return fetch('/api/v1/config.json', { credentials: 'same-origin' })
+			.then(r => r.ok ? r.json() : {}).catch(() => ({}))
+			.then(c => { cfg = c; const rp = recPrefix(); return api(rp ? 'rec=' + encodeURIComponent(rp) : ''); })
+			.then(d => { state = d; render(); })
+			.catch(() => { SD.innerHTML = '<div class="alert alert-danger">Failed to read SD-card status.</div>'; });
+	}
+
+	function badge(d) {
+		if (!d.present) return '<span class="badge text-bg-secondary">No card</span>';
+		if (d.mounted) return '<span class="badge text-bg-success">Mounted</span>';
+		if (d.fs) return '<span class="badge text-bg-warning">Not mounted</span>';
+		return '<span class="badge text-bg-danger">Unformatted</span>';
+	}
+
+	function storageBar(d) {
+		if (!d.mounted || !d.totalKb) return '';
+		const total = d.totalKb * 1024, used = d.usedKb * 1024;
+		const rec = Math.min(d.recBytes || 0, used), other = Math.max(0, used - rec), free = Math.max(0, total - used);
+		const segs = [];
+		if (rec > 0) segs.push({ name: 'Recordings', b: rec, c: '#4c60d8' });
+		if (other > 0) segs.push({ name: 'Other', b: other, c: '#e08a3c' });
+		const bar = segs.map(s => '<div class="seg" style="width:' + (s.b / total * 100).toFixed(2) + '%;background:' + s.c + '" title="' + s.name + ' ' + humanBytes(s.b) + '"></div>').join('');
+		const leg = segs.map(s => '<span><i class="dot" style="background:' + s.c + '"></i>' + s.name + ' <span class="text-secondary">' + humanBytes(s.b) + '</span></span>').join('')
+			+ '<span><i class="dot dot-free"></i>Free <span class="text-secondary">' + humanBytes(free) + '</span></span>';
+		return '<div class="d-flex justify-content-between x-small mb-1"><span class="fw-semibold">Storage</span><span class="text-secondary">' + humanBytes(used) + ' of ' + humanBytes(total) + ' used</span></div>'
+			+ '<div class="storage-bar mb-2">' + bar + '</div><div class="storage-legend x-small mb-2">' + leg + '</div>';
+	}
+
+	function render() {
+		const d = state;
+		const head = '<div class="d-flex align-items-center gap-3 mb-4 mt-n3"><h2 class="text-primary m-0">SD Card</h2>' + badge(d || {}) + '</div>';
+		if (!d || !d.present) {
+			SD.innerHTML = head + '<div class="alert alert-secondary">No SD card detected. Insert a card and reload.</div>';
+			return;
+		}
+		const rp = recPrefix(), recEnabled = mjGet(cfg, 'records.enabled') === true;
+		const onThisCard = d.mounted && rp === d.mountpoint;
+
+		let acts = '<button class="btn btn-sm btn-outline-primary" data-act="browse"' + (d.mounted ? '' : ' disabled') + '>Browse files</button>';
+		if (d.mounted) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="unmount">Unmount</button>';
+		else if (d.fs) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="mount">Mount</button>';
+		if (d.canFsck) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="fsck">Check</button>';
+		acts += '<button class="btn btn-sm btn-outline-danger" data-act="format">Format…</button>';
+
+		SD.innerHTML = head + '<div class="row g-4">'
+			+ '<div class="col-12 col-lg-7"><div class="card h-100"><div class="card-body">'
+			+ '<dl class="small list mb-3">'
+			+ '<dt>Model</dt><dd>' + esc(d.model || '—') + ' <span class="text-secondary">(' + esc(d.cardtype || 'SD') + ')</span></dd>'
+			+ '<dt>Capacity</dt><dd>' + humanBytes(d.sizeBytes) + '</dd>'
+			+ '<dt>Filesystem</dt><dd>' + (d.fs ? esc(d.fs) : '<span class="text-danger">unformatted</span>') + '</dd>'
+			+ '<dt>Mount</dt><dd>' + (d.mounted ? esc(d.mountpoint) : 'not mounted') + '</dd>'
+			+ '<dt>Manufactured</dt><dd class="text-secondary">' + esc(d.date || '—') + '</dd>'
+			+ '</dl>'
+			+ storageBar(d)
+			+ '<div class="d-flex flex-wrap gap-2 mt-2" id="sd-actions">' + acts + '</div>'
+			+ '</div></div></div>'
+			+ '<div class="col-12 col-lg-5"><div class="card h-100"><div class="card-body">'
+			+ '<div class="d-flex align-items-center mb-3"><h3 class="m-0 me-auto">Recording</h3>'
+			+ '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="sd-rec-toggle"' + (recEnabled ? ' checked' : '') + '></div></div>'
+			+ '<dl class="small list mb-3">'
+			+ '<dt>Status</dt><dd>' + (recEnabled ? '<span class="badge text-bg-success">Enabled</span>' : '<span class="badge text-bg-secondary">Disabled</span>') + '</dd>'
+			+ '<dt>Path</dt><dd class="text-break">' + esc(mjGet(cfg, 'records.path') || '—') + '</dd>'
+			+ '<dt>Split</dt><dd>' + (mjGet(cfg, 'records.split') || '—') + ' min</dd>'
+			+ '<dt>Max usage</dt><dd>' + (mjGet(cfg, 'records.maxUsage') || '—') + ' %</dd>'
+			+ '</dl>'
+			+ (d.mounted && !onThisCard ? '<button class="btn btn-sm btn-primary mb-3" id="sd-use">Use this card for recording</button>'
+				: (onThisCard ? '<div class="x-small text-success mb-3">✓ Recording to this card</div>' : ''))
+			+ '<div><a class="small" href="mj-settings.cgi?tab=records">Recording settings →</a></div>'
+			+ '</div></div></div></div>';
+
+		wire();
+	}
+
+	function busy(btn) { if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>'; } }
+	function after(r) { if (r && r.ok === false) alert('Failed: ' + (r.error || '')); load(); }
+
+	function wire() {
+		const acts = $('#sd-actions');
+		if (acts) acts.addEventListener('click', e => {
+			const b = e.target.closest('[data-act]'); if (!b) return;
+			const act = b.dataset.act;
+			if (act === 'browse') { location = 'tool-files.cgi?cd=' + encodeURIComponent(state.mountpoint); return; }
+			if (act === 'format') { openFormat(); return; }
+			if (act === 'fsck' && !confirm('Unmount and check the filesystem?')) return;
+			busy(b); op({ op: act }).then(after);
+		});
+		const tog = $('#sd-rec-toggle');
+		if (tog) tog.addEventListener('change', () => { tog.disabled = true; setConfig({ records: { enabled: tog.checked } }).then(load); });
+		const use = $('#sd-use');
+		if (use) use.addEventListener('click', () => { busy(use); setConfig({ records: { path: state.mountpoint + '/%F', enabled: true } }).then(load); });
+	}
+
+	function openFormat() {
+		const sel = $('#sd-format-fs'), log = $('#sd-format-log'), st = $('#sd-format-status'), go = $('#sd-format-go');
+		const fss = (state.mkfs && state.mkfs.length) ? state.mkfs : ['vfat'];
+		sel.innerHTML = fss.map(f => '<option value="' + f + '">' + f.toUpperCase() + (f === 'vfat' ? ' (FAT32)' : '') + '</option>').join('');
+		log.classList.add('d-none'); log.textContent = ''; st.textContent = '';
+		go.disabled = false; go.textContent = 'Format';
+		const modal = bootstrap.Modal.getOrCreateInstance('#sd-format');
+		go.onclick = () => {
+			if (!confirm('Erase ALL data and format the card as ' + sel.value + '?')) return;
+			go.disabled = true; st.textContent = 'Formatting… do not power off';
+			op({ op: 'format', fs: sel.value }).then(r => {
+				st.textContent = r.ok ? 'Done' : ('Failed: ' + (r.error || ''));
+				if (r.log) { log.classList.remove('d-none'); log.textContent = r.log; }
+				if (r.ok) { setTimeout(() => { modal.hide(); load(); }, 800); } else { go.disabled = false; }
+			}).catch(() => { st.textContent = 'Request failed'; go.disabled = false; });
+		};
+		modal.show();
+	}
+
+	load().then(() => { clearInterval(timer); timer = setInterval(() => { if (!document.hidden) load(); }, 5000); });
+})();

--- a/www/cgi-bin/j/sdcard.cgi
+++ b/www/cgi-bin/j/sdcard.cgi
@@ -1,0 +1,137 @@
+#!/bin/sh
+# SD-card backend: JSON status (GET) + management ops (POST).
+# GET  ?rec=<dir>  -> {present,device,target,model,...,sizeBytes,fs,mounted,
+#                      mountpoint,totalKb,usedKb,availKb,recBytes,mkfs:[...]}
+# POST op=format|mount|unmount|fsck [fs=vfat] -> {ok,error,log}
+
+DEV=/dev/mmcblk0
+SYS=/sys/block/mmcblk0
+
+json_hdr() { printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Control: no-store\n\n'; }
+json_str() { printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+json_log() { printf '%s' "$1" | tr -d '\000-\010\013-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | awk 'BEGIN{ORS=""}{print (NR>1?"\\n":"") $0}'; }
+sysf() { cat "$SYS/device/$1" 2>/dev/null; }
+
+# the active target partition/device and its conventional mount point
+target() { if [ -b "${DEV}p1" ]; then printf '%sp1' "$DEV"; else printf '%s' "$DEV"; fi; }
+
+mkfs_list() {
+	out=""
+	for fs in vfat ext4 exfat; do
+		command -v "mkfs.$fs" >/dev/null 2>&1 && out="$out${out:+,}\"$fs\""
+	done
+	printf '%s' "$out"
+}
+
+get_info() {
+	if [ ! -b "$DEV" ]; then printf '{"present":false,"mkfs":[%s]}' "$(mkfs_list)"; return; fi
+	t=$(target); base=${t##*/}
+	[ -b "${DEV}p1" ] && partd=true || partd=false
+	size=$(( $(cat "$SYS/size" 2>/dev/null || echo 0) * 512 ))
+	mp=$(awk -v d="$t" '$1==d{print $2; exit}' /proc/mounts)
+	# busybox blkid only reports UUID, so take the fs type from the mount table
+	# when mounted; otherwise probe blkid (formatted vs unformatted).
+	if [ -n "$mp" ]; then
+		fs=$(awk -v d="$t" '$1==d{print $3; exit}' /proc/mounts)
+	else
+		bt=$(blkid "$t" 2>/dev/null)
+		fs=$(printf '%s' "$bt" | sed -n 's/.*TYPE="\([^"]*\)".*/\1/p')
+		[ -z "$fs" ] && [ -n "$bt" ] && fs="formatted"
+	fi
+	mounted=false; total=0; used=0; avail=0; rec=0
+	if [ -n "$mp" ]; then
+		mounted=true
+		set -- $(df -k "$mp" 2>/dev/null | awk 'NR==2{print $2, $3, $4}')
+		total=${1:-0}; used=${2:-0}; avail=${3:-0}
+		if [ -n "$GET_rec" ] && [ -d "$GET_rec" ]; then
+			case "$GET_rec" in "$mp"|"$mp"/*) rec=$(( $(du -sk "$GET_rec" 2>/dev/null | cut -f1) * 1024 ));; esac
+		fi
+	fi
+	printf '{"present":true,"device":"%s","target":"%s","mountpoint":"%s","mounted":%s,"partitioned":%s,' \
+		"$DEV" "$t" "$(json_str "${mp:-/mnt/$base}")" "$mounted" "$partd"
+	printf '"model":"%s","cardtype":"%s","manfid":"%s","oemid":"%s","date":"%s","serial":"%s",' \
+		"$(json_str "$(sysf name)")" "$(json_str "$(sysf type)")" "$(json_str "$(sysf manfid)")" \
+		"$(json_str "$(sysf oemid)")" "$(json_str "$(sysf date)")" "$(json_str "$(sysf serial)")"
+	canfsck=false; command -v "fsck.$fs" >/dev/null 2>&1 && canfsck=true
+	printf '"sizeBytes":%s,"fs":"%s","totalKb":%s,"usedKb":%s,"availKb":%s,"recBytes":%s,"canFsck":%s,"mkfs":[%s]}' \
+		"$size" "$(json_str "$fs")" "$total" "$used" "$avail" "$rec" "$canfsck" "$(mkfs_list)"
+}
+
+# Ensure the /dev/mmcblk0p1 node exists: the kernel may know the partition
+# (in /proc/partitions) before mdev has created the device node. mdev -s makes
+# it (and fires the OpenIPC SD automount rule).
+ensure_node() {
+	[ -b "${DEV}p1" ] && return 0
+	i=0
+	while [ ! -b "${DEV}p1" ] && [ "$i" -lt 10 ]; do
+		mdev -s 2>/dev/null
+		[ -b "${DEV}p1" ] && break
+		sleep 1; i=$((i + 1))
+	done
+	[ -b "${DEV}p1" ]
+}
+
+do_format() {
+	fs="${POST_fs:-vfat}"
+	case "$fs" in vfat|ext4|exfat) ;; *) err="unsupported filesystem"; return;; esac
+	command -v "mkfs.$fs" >/dev/null 2>&1 || { err="mkfs.$fs not installed"; return; }
+	umount /mnt/mmcblk0p1 2>/dev/null; umount "${DEV}p1" 2>/dev/null; umount "$DEV" 2>/dev/null
+	if ! grep -q 'mmcblk0p1$' /proc/partitions; then
+		L="${L}# partition ${DEV}\n"
+		L="${L}$(printf 'o\nn\np\n1\n\n\nw\n' | fdisk "$DEV" 2>&1)\n"
+		partprobe "$DEV" 2>/dev/null
+	fi
+	ensure_node || { err="partition node mmcblk0p1 was not created"; return; }
+	umount "${DEV}p1" 2>/dev/null   # automount may have grabbed it
+	L="${L}# mkfs.$fs ${DEV}p1\n"
+	L="${L}$(mkfs.$fs "${DEV}p1" 2>&1)\n"
+	blkid "${DEV}p1" >/dev/null 2>&1 || { err="format failed"; return; }
+	mkdir -p /mnt/mmcblk0p1
+	mount "${DEV}p1" /mnt/mmcblk0p1 2>/dev/null
+	mountpoint -q /mnt/mmcblk0p1 || err="mount after format failed"
+}
+
+do_mount() {
+	ensure_node
+	t=$(target); base=${t##*/}; mkdir -p "/mnt/$base"
+	mount "$t" "/mnt/$base" 2>/dev/null
+	mountpoint -q "/mnt/$base" || err="mount failed"
+}
+
+do_unmount() {
+	t=$(target)
+	umount "$t" 2>/dev/null || err="unmount failed (in use?)"
+}
+
+do_fsck() {
+	t=$(target)
+	fs=$(awk -v d="$t" '$1==d{print $3; exit}' /proc/mounts)
+	[ -z "$fs" ] && fs=$(blkid "$t" 2>/dev/null | sed -n 's/.*TYPE="\([^"]*\)".*/\1/p')
+	command -v "fsck.$fs" >/dev/null 2>&1 || { err="no fsck tool for ${fs:-this filesystem}"; return; }
+	umount "$t" 2>/dev/null
+	L="${L}# fsck.$fs $t\n"
+	o=$(fsck -t "$fs" -y "$t" 2>&1); rc=$?
+	L="${L}${o}\n"
+	[ "$rc" -le 1 ] || err="fsck reported errors"
+}
+
+if [ "$REQUEST_METHOD" = "POST" ]; then
+	json_hdr
+	L=""; err=""
+	case "$POST_op" in
+		format) do_format;;
+		mount) do_mount;;
+		unmount) do_unmount;;
+		fsck) do_fsck;;
+		*) err="unknown op";;
+	esac
+	if [ -z "$err" ]; then
+		printf '{"ok":true,"log":"%s"}' "$(json_log "$L")"
+	else
+		printf '{"ok":false,"error":"%s","log":"%s"}' "$(json_str "$err")" "$(json_log "$L")"
+	fi
+	exit 0
+fi
+
+json_hdr
+get_info

--- a/www/cgi-bin/tool-sdcard.cgi
+++ b/www/cgi-bin/tool-sdcard.cgi
@@ -1,105 +1,22 @@
 #!/usr/bin/haserl
 <%in p/common.cgi %>
-
-<% page_title="SDcard" %>
+<% page_title="SD Card" %>
+<% hide_title=1 %>
 <%in p/header.cgi %>
 
-<% if [ ! -e /dev/mmcblk0 ]; then %>
+<div id="sd"><div class="text-secondary small">loading…</div></div>
 
-<div class="alert alert-danger">
-	<h4>SDcard is not available.</h4>
-	<p>Make sure the card is correctly inserted.</p>
-</div>
+<div class="modal fade" id="sd-format" tabindex="-1"><div class="modal-dialog"><div class="modal-content">
+	<div class="modal-header"><h5 class="modal-title text-danger">Format SD card</h5><button class="btn-close" data-bs-dismiss="modal"></button></div>
+	<div class="modal-body">
+		<div class="alert alert-danger mb-3"><strong>This erases everything on the card.</strong> Make a backup first.</div>
+		<label class="form-label" for="sd-format-fs">Filesystem</label>
+		<select id="sd-format-fs" class="form-select mb-3"></select>
+		<pre id="sd-format-log" class="small d-none mb-0" style="max-height:30vh;overflow:auto"></pre>
+	</div>
+	<div class="modal-footer"><span class="small text-secondary me-auto" id="sd-format-status"></span><button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button><button class="btn btn-danger" id="sd-format-go" type="button">Format</button></div>
+</div></div></div>
 
-<% else %>
-
-<%
-	card_device="/dev/mmcblk0"
-	card_partition="${card_device}p1"
-	mount_point="${card_partition//dev/mnt}"
-	error=""
-	_o=""
-%>
-
-<% if [ -n "$POST_doFormatCard" ]; then %>
-
-<div class="alert alert-danger">
-	<h4>SDcard formatting takes time.</h4>
-	<p>Please do not refresh this page. Wait until partition formatting is finished!</p>
-</div>
-
-<%
-	if [ "$(grep $card_partition /etc/mtab)" ]; then
-		_c="umount $card_partition"
-		_o="${_o}\n${_c}\n$($_c 2>&1)"
-		[ $? -ne 0 ] && error="Cannot unmount SDcard partition."
-	fi
-
-	if [ -z "$error" ]; then
-		_c="mkfs.vfat $card_partition"
-		_o="${_o}\n${_c}\n$($_c 2>&1)"
-		[ $? -ne 0 ] && error="Cannot format SDcard partition."
-	fi
-
-	if [ -z "$error" ] && [ ! -d "$mount_point" ]; then
-		_c="mkdir -p $mount_point"
-		_o="${_o}\n${_c}\n$($_c 2>&1)"
-		[ $? -ne 0 ] && error="Cannot create SDcard mount point."
-	fi
-
-	if [ -z "$error" ]; then
-		_c="mount -t vfat $card_partition $mount_point"
-		_o="${_o}\n${_c}\n$($_c 2>&1)"
-		[ $? -ne 0 ] && error="Cannot remount SDcard partition."
-	fi
-
-	if [ -n "$error" ]; then
-		report_error "$error"
-		[ -n "$_c" ] && report_command "$_c" "$_o"
-	else
-		report_log "$_o"
-	fi
-%>
-
-<a class="btn btn-primary" href="/">Return</a>
-
-<% else %>
-
-<h4>SDcard partitions</h4>
-<%
-	partitions=$(df -h | grep 'dev/mmc')
-	echo "<pre class=\"small\">${partitions}</pre>"
-%>
-
-<% if [ -n "$partitions" ]; then %>
-
-<h4>Browse files on these partitions</h4>
-<div class="mb-4">
-<%
-	IFS=$'\n'
-	for i in $partitions; do
-		_mount=$(echo $i | awk '{print $6}')
-		echo "<a href=\"tool-files.cgi?cd=${_mount}\" class=\"btn btn-primary\">${_mount}</a>"
-		unset _mount
-	done
-	IFS=$IFS_ORIG
-	unset _partitions
-%>
-</div>
-
-<% fi %>
-
-<h4>Format SDcard</h4>
-<div class="alert alert-danger">
-	<h4>ATTENTION! Formatting will destroy all data on the SDcard.</h4>
-	<p>Make sure you have a backup copy if you are going to use the data in the future.</p>
-	<form action="<%= $SCRIPT_NAME %>" method="post">
-	<% field_hidden "doFormatCard" "true" %>
-	<% button_submit "Format SDcard" "danger" %>
-	</form>
-</div>
-
-<% fi %>
-<% fi %>
+<script src="/a/sdcard.js" defer></script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
## What

The old SD-card page dumped `df | grep mmc` into a `<pre>`, hardcoded
`/dev/mmcblk0p1` (so it was **broken for whole-device cards** — the common case
of a blank card with no partition table), formatted vfat-only with concatenated
shell output, and had unescaped-output XSS holes. This rebuilds it card-based and
JS-driven, matching the status dashboard and file manager.

## How

- **`j/sdcard.cgi`** (new, `#!/bin/sh`, the `j/` JSON convention): GET returns card
  identity (model/type/manufacture-date from `/sys/block/mmcblk0/device/*`),
  capacity, filesystem, mount state, df usage, a recordings-dir size, the available
  `mkfs.*` list, and whether `fsck` is possible. POST ops `format`/`mount`/
  `unmount`/`fsck` (quoted, **no `eval`**) return `{ok,error,log}`.
- **Format = partition-then-format:** busybox `fdisk` creates `mmcblk0p1`, **`mdev -s`**
  realises the device node (the kernel can know the partition before mdev makes the
  `/dev` node), `mkfs.<fs>`, then mount `/mnt/mmcblk0p1` — handling the whole-device
  card the old page couldn't. Adapts to an existing partition. Offers only the
  filesystems whose `mkfs.*` exist; "Check" only when an `fsck.<fs>` helper exists
  (honest about busybox's missing helpers).
- fs type comes from the **mount table** (busybox `blkid` only reports UUID).
- **`sdcard.js`** (new): a Card-info card + the **segmented storage bar** (reused
  from `status.js`) split **Recordings / Other / Free**, and a **Recording** card
  with a record on/off toggle, a **"Use this card for recording"** button (points
  `records.path` at the mounted card via `/api/v1/config`) and a link to Record
  settings; plus Browse / Mount / Unmount / Check / Format (danger-confirm modal
  with a live log). Light 5 s refresh.
- `tool-sdcard.cgi` becomes a thin shell + format modal; the `[ -e /dev/mmcblk0 ]`
  nav guard stays.

No majestic changes.

## Testing (hi3516av300, real 29 GiB SD32G card)

Detect (SD32G, 29.1 GB, vfat, 05/2021); **format** (partition + vfat + mount of the
previously-unpartitioned card); mount/unmount; the storage bar's **Recordings**
split; and **"Use this card for recording"** (sets `records.path=/mnt/mmcblk0p1/%F`
+ `enabled`, shown live). Screenshots: clean two-card layout consistent with the
status page; `canFsck=false` correctly hides Check on this card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)