### PR TITLE
fw-network: redesign — clean card form + Wi-Fi scan + MAC editor

### DIFF
--- a/www/a/fw-network.js
+++ b/www/a/fw-network.js
@@ -1,0 +1,45 @@
+// Network settings: DHCP/interface field toggles + Wi-Fi scan.
+(function () {
+	const iface = $('#network_interface'), dhcp = $('#network_dhcp');
+
+	function esc(s) { return String(s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+	function toggleStatic() {
+		const on = dhcp && dhcp.checked;
+		['network_address', 'network_netmask', 'network_gateway', 'network_nameserver'].forEach(id => {
+			const inp = $('#' + id), wrap = $('#' + id + '_wrap');
+			if (inp) inp.disabled = on;
+			if (wrap) wrap.classList.toggle('d-none', on);
+		});
+	}
+
+	function toggleInterface() {
+		const sec = $('#wifi-section');
+		if (sec) sec.classList.toggle('d-none', !(iface && iface.value === 'wlan0'));
+	}
+
+	function scan() {
+		const btn = $('#wifi-scan'), st = $('#wifi-scan-status'), sel = $('#wifi-results');
+		btn.disabled = true; st.textContent = 'scanning…'; sel.classList.add('d-none'); sel.innerHTML = '';
+		fetch('/cgi-bin/j/network.cgi?scan=1', { credentials: 'same-origin' })
+			.then(r => r.json()).then(d => {
+				btn.disabled = false;
+				const nets = (d.networks || []).sort((a, b) => b.signal - a.signal);
+				if (!nets.length) { st.textContent = d.error || 'no networks found'; return; }
+				st.textContent = nets.length + ' found';
+				sel.innerHTML = '<option value="">— pick a network —</option>' + nets.map(n =>
+					'<option value="' + esc(n.ssid) + '">' + esc(n.ssid) + '  ·  ' + (n.signal | 0) + ' dBm  ·  ' + esc(n.security) + '</option>').join('');
+				sel.classList.remove('d-none');
+			}).catch(() => { btn.disabled = false; st.textContent = 'scan failed'; });
+	}
+
+	if (iface) iface.addEventListener('change', toggleInterface);
+	if (dhcp) dhcp.addEventListener('change', toggleStatic);
+	const scanBtn = $('#wifi-scan');
+	if (scanBtn) scanBtn.addEventListener('click', scan);
+	const sel = $('#wifi-results');
+	if (sel) sel.addEventListener('change', () => { const i = $('#network_wlan_ssid'); if (sel.value && i) i.value = sel.value; });
+
+	toggleInterface();
+	toggleStatic();
+})();

--- a/www/cgi-bin/fw-network.cgi
+++ b/www/cgi-bin/fw-network.cgi
@@ -43,7 +43,7 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 
 			[ -z "$network_interface" ] && set_error_flag "Default network interface cannot be empty."
 			if [ "$network_interface" = "wlan0" ]; then
-				[ -z "$network_wlan_ssid" ] && set_error_flag"WLAN SSID cannot be empty."
+				[ -z "$network_wlan_ssid" ] && set_error_flag "WLAN SSID cannot be empty."
 				[ -z "$network_wlan_password" ] && set_error_flag "WLAN Password cannot be empty."
 			fi
 
@@ -86,68 +86,91 @@ fi
 <%in p/header.cgi %>
 
 <div class="row g-4">
-	<div class="col col-md-6 col-lg-4 mb-4">
-		<form action="<%= $SCRIPT_NAME %>" method="post">
-			<% field_hidden "action" "update" %>
-			<% field_text "network_hostname" "Hostname" %>
-			<% field_string "network_interface" "Network interface" "eval" "$network_list" %>
-			<% field_text "network_wlan_ssid" "WLAN SSID" %>
-			<% field_text "network_wlan_password" "WLAN Password" %>
-
-			<% field_switch "network_dhcp" "Use DHCP" "eval" %>
-			<% field_text "network_address" "IP Address" %>
-			<% field_text "network_netmask" "IP Netmask" %>
-			<% field_text "network_gateway" "Gateway" %>
-			<% field_text "network_nameserver" "DNS" %>
-			<% button_submit %>
-		</form>
-
-		<div class="alert alert-danger mt-4">
-			<h5>Reset network configuration</h5>
-			<p>Restore the config file bundled with firmware. All changes to the default configuration will be lost!</p>
+	<div class="col-12 col-lg-7">
+		<div class="card h-100"><div class="card-body">
+			<h3>Network settings</h3>
 			<form action="<%= $SCRIPT_NAME %>" method="post">
-				<% field_hidden "action" "reset" %>
-				<% button_submit "Reset config" "danger" %>
+				<% field_hidden "action" "update" %>
+
+				<div class="text-uppercase x-small text-secondary mb-2">General</div>
+				<% field_text "network_hostname" "Hostname" %>
+				<% field_string "network_interface" "Network interface" "eval" "$network_list" %>
+
+				<div id="wifi-section">
+					<div class="text-uppercase x-small text-secondary mt-3 mb-2">Wi-Fi</div>
+					<% field_text "network_wlan_ssid" "WLAN SSID" %>
+					<div class="mb-3">
+						<button type="button" class="btn btn-sm btn-outline-secondary" id="wifi-scan">Scan for networks</button>
+						<span id="wifi-scan-status" class="small text-secondary ms-2"></span>
+						<select id="wifi-results" class="form-select form-select-sm mt-2 d-none"></select>
+					</div>
+					<% field_password "network_wlan_password" "WLAN Password" %>
+				</div>
+
+				<div class="text-uppercase x-small text-secondary mt-3 mb-2">IP</div>
+				<% field_switch "network_dhcp" "Use DHCP" "eval" %>
+				<% field_text "network_address" "IP Address" %>
+				<% field_text "network_netmask" "IP Netmask" %>
+				<% field_text "network_gateway" "Gateway" %>
+				<% field_text "network_nameserver" "DNS" %>
+				<% button_submit %>
 			</form>
-		</div>
+		</div></div>
 	</div>
 
-	<div class="col col-md-6 col-lg-8">
-		<% for dev in $network_list; do %>
-			<% ex "cat /etc/network/interfaces.d/$dev" %>
-		<% done %>
-		<% if [ -n "$(fw_printenv -n wlandev)" ]; then %>
-			<% ex "fw_printenv | grep wlan" %>
-		<% fi %>
-		<% ex "ifconfig" %>
+	<div class="col-12 col-lg-5">
+		<div class="card h-100"><div class="card-body">
+			<h3>Current connection</h3>
+			<dl class="small list mb-0">
+				<dt>Hostname</dt><dd><%= $network_hostname %></dd>
+				<dt>Interface</dt><dd><%= $network_interface %></dd>
+				<dt>Mode</dt><dd><%= $([ "$network_dhcp" = "true" ] && echo DHCP || echo Static) %></dd>
+				<dt>IP</dt><dd><%= $network_address %></dd>
+				<dt>Netmask</dt><dd><%= ${network_netmask:-—} %></dd>
+				<dt>Gateway</dt><dd><%= ${network_gateway:-—} %></dd>
+				<dt>DNS</dt><dd><%= ${network_nameserver:-—} %></dd>
+				<dt>MAC</dt><dd class="text-break"><%= $network_macaddr %></dd>
+			</dl>
+		</div></div>
 	</div>
 </div>
 
-<script>
-	function toggleStatic() {
-		const c = $('#network_dhcp').checked;
-		const ids = ['network_address','network_netmask','network_gateway','network_nameserver'];
-		ids.forEach(id => {
-			$('#' + id).disabled = c;
-			let el = $('#' + id + '_wrap');
-			c ? el.classList.add('d-none') : el.classList.remove('d-none');
-		});
-	}
+<details class="mt-4">
+	<summary>Advanced</summary>
+	<div class="row g-4 mt-1">
+		<div class="col-12 col-lg-6">
+			<div class="card"><div class="card-body">
+				<h3>Change MAC address</h3>
+				<p class="small text-secondary">Override the Ethernet MAC address. <span class="text-danger">Requires a reboot.</span></p>
+				<form action="<%= $SCRIPT_NAME %>" method="post">
+					<% field_hidden "action" "changemac" %>
+					<% field_string "mac_address" "MAC address" "$network_macaddr" %>
+					<% button_submit "Update MAC" "danger" %>
+				</form>
 
-	function toggleInterface() {
-		const ids = ['network_wlan_ssid','network_wlan_password'];
-		if ($('#network_interface').value == 'wlan0') {
-			ids.forEach(id => $('#' + id + '_wrap').classList.remove('d-none'));
-		} else {
-			ids.forEach(id => $('#' + id + '_wrap').classList.add('d-none'));
-		}
-	}
+				<hr class="my-3">
+				<h3 class="fs-6">Reset network configuration</h3>
+				<p class="small text-secondary">Restore the config bundled with the firmware. All changes are lost.</p>
+				<form action="<%= $SCRIPT_NAME %>" method="post">
+					<% field_hidden "action" "reset" %>
+					<% button_submit "Reset config" "outline-danger confirm" %>
+				</form>
+			</div></div>
+		</div>
 
-	$('#network_interface').addEventListener('change', toggleInterface);
-	$('#network_dhcp').addEventListener('change', toggleStatic);
+		<div class="col-12 col-lg-6">
+			<div class="card"><div class="card-body">
+				<h3>Diagnostics</h3>
+				<% for dev in $network_list; do %>
+					<% ex "cat /etc/network/interfaces.d/$dev" %>
+				<% done %>
+				<% [ -n "$(fw_printenv -n wlandev)" ] && ex "fw_printenv | grep wlan" %>
+				<% ex "ifconfig" %>
+			</div></div>
+		</div>
+	</div>
+</details>
 
-	toggleInterface();
-	toggleStatic();
-</script>
+<script src="/a/fw-network.js" defer></script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/j/network.cgi
+++ b/www/cgi-bin/j/network.cgi
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Wi-Fi scan: GET ?scan=1 -> {"networks":[{ssid,signal,security}],"error":""}
+# (signal is dBm; security is open/WEP/WPA/WPA2). Always returns valid JSON.
+DEV=wlan0
+
+printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Control: no-store\n\n'
+
+json_str() { printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+num() { printf '%s' "$1" | grep -oE '^-?[0-9]+' || printf '0'; }
+
+if [ ! -e "/sys/class/net/$DEV" ]; then
+	printf '{"networks":[],"error":"no Wi-Fi interface"}'
+	exit 0
+fi
+
+ip link set "$DEV" up 2>/dev/null
+
+# intermediate lines: "signal|security|ssid"
+raw=""
+
+# 1) wpa_cli (when wpa_supplicant runs with a control socket): scan + scan_results
+if command -v wpa_cli >/dev/null 2>&1; then
+	wpa_cli -i "$DEV" scan >/dev/null 2>&1
+	sleep 2
+	sr=$(wpa_cli -i "$DEV" scan_results 2>/dev/null)
+	raw=$(printf '%s\n' "$sr" | awk -F'\t' '
+		NR>1 && NF>=5 && $5!="" {
+			sec="open";
+			if ($4 ~ /WPA2/) sec="WPA2"; else if ($4 ~ /WPA/) sec="WPA"; else if ($4 ~ /WEP/) sec="WEP";
+			print $3"|"sec"|"$5
+		}')
+fi
+
+# 2) fallback to iwlist
+if [ -z "$raw" ] && command -v iwlist >/dev/null 2>&1; then
+	raw=$(iwlist "$DEV" scan 2>/dev/null | awk '
+		/Signal level/      { s=$0; sub(/.*Signal level[=:]/,"",s); sub(/[ ].*/,"",s); sig=s }
+		/Encryption key:on/  { enc=1 }
+		/Encryption key:off/ { enc=0 }
+		/IEEE 802.11i\/WPA2/ { sec="WPA2" }
+		/WPA Version 1/      { if (sec=="") sec="WPA" }
+		/ESSID:/ {
+			e=$0; sub(/.*ESSID:"/,"",e); sub(/"[ ]*$/,"",e);
+			if (e!="" && e!="<hidden>")
+				printf "%s|%s|%s\n", sig, (enc ? (sec ? sec : "WEP") : "open"), e;
+			sig=""; enc=0; sec=""
+		}')
+fi
+
+# dedup by ssid keeping the strongest signal (largest dBm)
+dedup=$(printf '%s\n' "$raw" | awk -F'|' '
+	$3!="" { if (!($3 in seen) || $1+0 > sig[$3]+0) { sig[$3]=$1; sec[$3]=$2; seen[$3]=1 } }
+	END { for (s in seen) print sig[s]"|"sec[s]"|"s }')
+
+networks=""
+OLDIFS=$IFS
+IFS='
+'
+for line in $dedup; do
+	[ -z "$line" ] && continue
+	sig=${line%%|*}; rest=${line#*|}; sec=${rest%%|*}; ssid=${rest#*|}
+	[ -z "$ssid" ] && continue
+	networks="$networks${networks:+,}{\"ssid\":\"$(json_str "$ssid")\",\"signal\":$(num "$sig"),\"security\":\"$(json_str "$sec")\"}"
+done
+IFS=$OLDIFS
+
+printf '{"networks":[%s],"error":""}' "$networks"


### PR DESCRIPTION
## What

The network page was a flat field list beside a right column of **raw `ex` dumps**
(`interfaces.d/*`, `ifconfig`, wlan env), with the **Wi-Fi password as plain text**,
an `alert-danger` colour box for Reset, and a `changemac` handler that had **no UI**.

Rebuilt with the status / SD / file-manager idiom — neutral cards, a single accent,
raw output behind a disclosure — keeping the value reads and the
`update`/`reset`/`changemac` POST handlers **unchanged** (only fixed one pre-existing
`set_error_flag` typo in the wlan path).

## How

- **Network settings** card: the form grouped *General / Wi-Fi / IP*; the Wi-Fi
  password is now **masked** (`field_password`, show toggle). A **Current connection**
  card shows a read-only `dl.list` summary while editing.
- **`j/network.cgi`** (new): `GET ?scan=1` lists nearby SSIDs (signal / security) via
  `wpa_cli`/`iwlist`, returning valid JSON and **degrading gracefully** (no wlan0 →
  `{"networks":[],"error":"no Wi-Fi interface"}`). A **Scan** button (`fw-network.js`)
  fills the SSID from the results.
- The previously-hidden **MAC editor** is exposed inside a collapsed **Advanced**
  section (validated, `fw_setenv`, reboot note), alongside the demoted diagnostics
  dumps and **Reset** (a small `outline-danger` with confirm — not a colour box).
- Page JS moved to `www/a/fw-network.js` (DHCP/interface toggles + scan).

No CSS or majestic changes.

## Testing (hi3516av300, eth0/DHCP — no disruptive changes applied)

Clean two-card layout, no colour blocks (screenshot). On load the Wi-Fi block and the
static-IP fields are correctly hidden; DHCP is on. The scan endpoint degrades
gracefully (this cam has no wlan0). MAC is prefilled in Advanced; Reset uses a
confirm. The `update`/`reset`/`changemac` backend is unchanged and was **not**
exercised against the live link. **Note:** the Wi-Fi scan parsing is code-reviewed
only — there's no wlan0 on the lab camera to exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)