### PR TITLE
fw-interface: redesign — cards + Light/Dark/Auto theme with live preview

### DIFF
--- a/www/a/fw-interface.js
+++ b/www/a/fw-interface.js
@@ -1,0 +1,13 @@
+// Web-UI settings: live theme preview (Auto follows the OS color scheme).
+(function () {
+	function resolve(t) {
+		return t === 'auto'
+			? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+			: t;
+	}
+	$$('#theme-choice input[name="webui_theme"]').forEach(el => {
+		el.addEventListener('change', () => {
+			if (el.checked) document.documentElement.setAttribute('data-bs-theme', resolve(el.value));
+		});
+	});
+})();

--- a/www/cgi-bin/fw-interface.cgi
+++ b/www/cgi-bin/fw-interface.cgi
@@ -23,8 +23,11 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 			;;
 
 		theme)
-			eval webui_theme=\$POST_webui_theme
-			echo webui_theme=\"$webui_theme\" >  $config_file
+			case "$POST_webui_theme" in
+				light|dark|auto) webui_theme="$POST_webui_theme";;
+				*) webui_theme="dark";;
+			esac
+			echo "webui_theme=\"$webui_theme\"" > "$config_file"
 			update_caminfo
 			redirect_back "success" "Settings updated."
 			;;
@@ -36,33 +39,50 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 fi
 
 ui_username="$USER"
+tcur=${webui_theme:-dark}
 %>
 
 <%in p/header.cgi %>
 
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
-	<div class="col">
-		<h3>Access</h3>
-		<form action="<%= $SCRIPT_NAME %>" method="post">
-			<% field_hidden "action" "access" %>
-			<p class="string">
-				<label for="ui_username" class="form-label">Username</label>
-				<input type="text" id="ui_username" name="ui_username" value="<%= $ui_username %>" class="form-control" autocomplete="username" disabled>
-			</p>
-			<% field_password "password_default" "Password" %>
-			<% field_password "password_confirm" "Confirm Password" %>
-			<% button_submit %>
-		</form>
+<div class="row g-4">
+	<div class="col-12 col-md-6">
+		<div class="card h-100"><div class="card-body">
+			<h3>Admin password</h3>
+			<form action="<%= $SCRIPT_NAME %>" method="post">
+				<% field_hidden "action" "access" %>
+				<p class="string">
+					<label for="ui_username" class="form-label">Username</label>
+					<input type="text" id="ui_username" name="ui_username" value="<%= $ui_username %>" class="form-control" autocomplete="username" disabled>
+				</p>
+				<% field_password "password_default" "Password" %>
+				<% field_password "password_confirm" "Confirm password" %>
+				<p class="hint text-secondary">This is the camera's <strong>root</strong> password — it secures the web UI and SSH.</p>
+				<% button_submit %>
+			</form>
+		</div></div>
 	</div>
 
-	<div class="col">
-		<h3>Theme</h3>
-		<form action="<%= $SCRIPT_NAME %>" method="post">
-			<% field_hidden "action" "theme" %>
-			<% field_string "webui_theme" "Theme" "eval" "dark light" %>
-			<% button_submit %>
-		</form>
+	<div class="col-12 col-md-6">
+		<div class="card h-100"><div class="card-body">
+			<h3>Appearance</h3>
+			<form action="<%= $SCRIPT_NAME %>" method="post">
+				<% field_hidden "action" "theme" %>
+				<label class="form-label d-block">Theme</label>
+				<div class="btn-group" role="group" aria-label="Theme" id="theme-choice">
+					<input type="radio" class="btn-check" name="webui_theme" id="theme-light" value="light" autocomplete="off" <% [ "$tcur" = "light" ] && echo checked %>>
+					<label class="btn btn-outline-primary" for="theme-light">☀ Light</label>
+					<input type="radio" class="btn-check" name="webui_theme" id="theme-dark" value="dark" autocomplete="off" <% [ "$tcur" = "dark" ] && echo checked %>>
+					<label class="btn btn-outline-primary" for="theme-dark">🌙 Dark</label>
+					<input type="radio" class="btn-check" name="webui_theme" id="theme-auto" value="auto" autocomplete="off" <% [ "$tcur" = "auto" ] && echo checked %>>
+					<label class="btn btn-outline-primary" for="theme-auto">Auto</label>
+				</div>
+				<p class="hint text-secondary mt-2">Auto follows your device's light/dark setting. Changes preview instantly.</p>
+				<% button_submit "Save" %>
+			</form>
+		</div></div>
 	</div>
 </div>
+
+<script src="/a/fw-interface.js" defer></script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -9,6 +9,7 @@ Pragma: no-cache
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title><% html_title %></title>
+	<script>if(document.documentElement.getAttribute('data-bs-theme')==='auto')document.documentElement.setAttribute('data-bs-theme',matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');</script>
 	<link rel="stylesheet" href="/a/bootstrap.min.css">
 	<link rel="stylesheet" href="/a/bootstrap.override.css">
 	<script src="/a/bootstrap.bundle.min.js"></script>

--- a/www/cgi-bin/p/header_fpv.cgi
+++ b/www/cgi-bin/p/header_fpv.cgi
@@ -9,6 +9,7 @@ Pragma: no-cache
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title><% html_title %></title>
+	<script>if(document.documentElement.getAttribute('data-bs-theme')==='auto')document.documentElement.setAttribute('data-bs-theme',matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');</script>
 	<link rel="stylesheet" href="/a/bootstrap.min.css">
 	<link rel="stylesheet" href="/a/bootstrap.override.css">
 	<script src="/a/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## What

The Web-UI settings page (Firmware ▸ Interface) was two bare `<h3>` + form sections
(change root password; a dark/light theme `<select>`). Modernized to the now-standard
card idiom, with a nicer theme control.

## How

- **Two neutral cards** — *Admin password* (read-only username, masked password +
  confirm, a hint that this is the camera's **root** password — web UI **and** SSH) and
  *Appearance*.
- **Appearance**: a Bootstrap segmented control **☀ Light / 🌙 Dark / Auto** (current
  value pre-selected) that **previews instantly** — `www/a/fw-interface.js` applies the
  chosen `data-bs-theme` on change (resolving Auto via `prefers-color-scheme`) — and
  persists on Save.
- **"Auto" support**: `header.cgi` / `header_fpv.cgi` get one tiny early-`<head>` inline
  script that resolves `data-bs-theme="auto"` → light/dark **before CSS paints** (no
  FOUC). It's a **no-op for any non-auto value**, so the `dark` default and existing
  behaviour are unchanged.
- **Hardening**: dropped the `eval $POST_webui_theme` and now validate the value to
  `light|dark|auto` before writing `webui.conf` (the password handler is unchanged).

No CSS or majestic changes.

## Testing (hi3516av300)

Clean two-card layout (screenshot); the segmented control shows the saved theme. Saving
updates `webui.conf` (303). With `webui_theme="auto"`, the header resolves `<html
data-bs-theme>` to a concrete `light`/`dark`. A malicious theme value
(`evil; rm -rf /`) is **rejected** (defaults to dark) and **not executed** (the unsafe
`eval` is gone). The root password was **not** changed during testing; the conf was
restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)