### PR TITLE
fw-update: redesign — cards, single accent, advanced options collapsed

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -35,10 +35,13 @@
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
 		ws.binaryType = 'arraybuffer';
-		ws.onopen = () => { ws.send(JSON.stringify(p)); status('warning', 'Upgrading — do not power off…'); };
+		let opened = false;
+		ws.onopen = () => { opened = true; ws.send(JSON.stringify(p)); status('warning', 'Upgrading — do not power off…'); };
 		ws.onmessage = e => append(dec.decode(new Uint8Array(e.data), { stream: true }));
-		ws.onclose = () => { status('warning', 'Flashing & rebooting — do not power off. Waiting for the camera…'); pollBack(); };
-		ws.onerror = () => {};
+		// A flash only happens after the socket opened; a close without ever
+		// opening means the handshake failed (let onerror report it).
+		ws.onclose = () => { if (!opened) return; status('warning', 'Flashing & rebooting — do not power off. Waiting for the camera…'); pollBack(); };
+		ws.onerror = () => { if (!opened) status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); };
 	}
 
 	// After the WS drops (majestic killed at flash) poll until the camera is back.

--- a/www/cgi-bin/fw-update.cgi
+++ b/www/cgi-bin/fw-update.cgi
@@ -23,46 +23,73 @@
 	if [ -n "$ver" ]; then
 		fw_date=$(date -D "%a, %d %b %Y %T GMT" +"$(date +%y | sed 's/.$/.&/').%m.%d" --date "$ver")
 	else
-		fw_date="<span class=\"text-danger\">- no access to GitHub -</span>"
+		fw_date=""
 	fi
 	fw_kernel="true"
 	fw_rootfs="true"
 %>
 <%in p/header.cgi %>
 
-<div id="fw-status" class="alert alert-secondary">
-	Installed <b><%= $fw_version %></b> &middot; On GitHub <span id="firmware-master-ver"><%= $fw_date %></span>
+<div class="row g-4">
+	<div class="col-12">
+		<div class="card h-100"><div class="card-body">
+			<h3>Firmware</h3>
+			<dl class="small list mb-0">
+				<dt>Installed</dt><dd><%= "${fw_version}-${fw_variant}" %></dd>
+				<dt>Latest on GitHub</dt>
+				<dd><span id="firmware-master-ver"><% if [ -n "$fw_date" ]; then %><%= $fw_date %><% else %><span class="text-secondary">— no access to GitHub —</span><% fi %></span></dd>
+				<dt>SoC</dt><dd><%= $soc %> <span class="text-secondary">(<%= $soc_family %>)</span></dd>
+				<dt>Flash</dt><dd><%= $flash_type %></dd>
+			</dl>
+			<div id="fw-status" class="small text-secondary mt-2"></div>
+		</div></div>
+	</div>
 </div>
 
-<div id="fw-controls">
-	<div class="alert alert-warning">The camera stops video and reboots to upgrade. <b>Do not power off</b> during the process.</div>
+<div id="fw-controls" class="mt-4">
+	<div class="alert alert-warning py-2 small">The camera stops video and reboots to upgrade. <strong>Do not power off</strong> during the process.</div>
 
-	<div class="mb-3" style="max-width:32rem">
+	<div class="mb-4" style="max-width:32rem">
 		<% field_switch "fw_kernel" "Upgrade kernel" "true" %>
 		<% field_switch "fw_rootfs" "Upgrade rootfs" "true" %>
-		<% field_switch "fw_reset" "Reset config (wipe overlay)" "false" %>
-		<% field_switch "fw_force" "Reflash even if the same version" "false" %>
+		<details class="mt-2">
+			<summary class="text-secondary small">Advanced options</summary>
+			<div class="mt-2">
+				<% field_switch "fw_reset" "Reset config (wipe overlay)" "false" "Erases all your settings — equivalent to a fresh flash." %>
+				<% field_switch "fw_force" "Reflash even if the same version" "false" "Re-writes flash even when installed and target versions match." %>
+			</div>
+		</details>
 	</div>
 
-	<div class="row row-cols-1 row-cols-md-2 g-4">
-		<div class="col">
-			<h5>From GitHub</h5>
-			<% if [ -n "$ver" ]; then %>
-				<button id="fw-install-github" type="button" class="btn btn-warning">Install update from GitHub</button>
-			<% else %>
-				<p class="text-danger mb-0">Requires access to GitHub.</p>
-			<% fi %>
+	<div class="row g-4">
+		<div class="col-12 col-md-6">
+			<div class="card h-100"><div class="card-body">
+				<h3>From GitHub</h3>
+				<p class="small text-secondary">Download and flash the latest release for this board.</p>
+				<% if [ -n "$ver" ]; then %>
+					<button id="fw-install-github" type="button" class="btn btn-primary">Install update from GitHub</button>
+				<% else %>
+					<button id="fw-install-github" type="button" class="btn btn-primary" disabled>Install update from GitHub</button>
+					<p class="small text-danger mb-0 mt-2">No access to GitHub. <a href="fw-network.cgi">Check your network</a>.</p>
+				<% fi %>
+			</div></div>
 		</div>
-		<div class="col">
-			<h5>From file</h5>
-			<input id="fw-file" type="file" accept=".tgz,.gz" class="form-control mb-2">
-			<button id="fw-install-upload" type="button" class="btn btn-warning">Upload &amp; install</button>
+		<div class="col-12 col-md-6">
+			<div class="card h-100"><div class="card-body">
+				<h3>From file</h3>
+				<p class="small text-secondary">Upload a <code>.tgz</code> firmware image from your computer.</p>
+				<input id="fw-file" type="file" accept=".tgz,.gz" class="form-control mb-2">
+				<button id="fw-install-upload" type="button" class="btn btn-primary">Upload &amp; install</button>
+			</div></div>
 		</div>
 	</div>
 </div>
 
-<div id="fw-progress" style="display:none">
-	<pre id="fw-output" class="border rounded p-2 bg-body-tertiary" style="height:60vh;overflow:auto;white-space:pre-wrap;font-size:12px"></pre>
+<div id="fw-progress" class="mt-4" style="display:none">
+	<div class="card"><div class="card-body">
+		<h3>Progress</h3>
+		<pre id="fw-output" class="border rounded p-2 bg-body-tertiary mb-0" style="height:60vh;overflow:auto;white-space:pre-wrap;font-size:12px"></pre>
+	</div></div>
 </div>
 
 <script src="/a/fw-update.js"></script>


### PR DESCRIPTION
Brings the **Firmware ▸ Update** page into the modern web-UI idiom shared by `status` / `fw-network` / `fw-interface`, **without touching the upgrade backend** or the robust `/ws/upgrade` + `/upload` + poll-back flow.

## What changed

**`www/cgi-bin/fw-update.cgi`** — rebuilt the body (shell head untouched):
- The permanent `alert-secondary` status strip → a neutral **Firmware** summary card (Installed / Latest on GitHub / SoC / Flash via `dl.list`). `#fw-status` stays as a quiet status line the JS repaints transiently during the operation.
- Action buttons recoloured `btn-warning` → single **primary** accent.
- kernel/rootfs toggles stay visible; the power options (reset overlay, force reflash) move into an **Advanced options** `<details>` with explanatory hints.
- The two methods are now two neutral cards; the GitHub button renders **disabled** with a "check your network" hint when GitHub is unreachable (previously it was omitted entirely).
- The streaming console is wrapped in a card for consistency.

**`www/a/fw-update.js`** — every id it relies on is preserved, so the WebSocket/upload/poll logic is unchanged except for one robustness fix: track whether the socket opened, so a failed `/ws/upgrade` handshake (another session in progress → 503, or unreachable) surfaces a friendly message instead of silently polling for a reboot that never happened.

No backend, CSS, or header changes. Colour is reserved for meaning: the single retained `alert-warning` is the genuine "do not power off" caution; red/green only appear transiently for real error/success status.

## Verification

Deployed to a hi3516av300 lab camera and checked the rendered DOM + screenshots in both light and dark themes:
- All JS-referenced ids present exactly once; `btn-warning` gone, two `btn-primary`, the only `alert-*` in markup is the meaningful power-off caution.
- Summary card shows real values (Installed `2.6.06.07-lite`, Latest `2.6.06.13`, SoC, Flash); Advanced options collapses the reset/force switches.
- The actual `sysupgrade` flash was **not** triggered — that path is unchanged from the earlier upgrade redesign and only the presentation moved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)