### PR TITLE
fw-time: redesign — cards, live clock, externalized JS, set-from-browser

### DIFF
--- a/www/a/fw-time.js
+++ b/www/a/fw-time.js
@@ -1,0 +1,89 @@
+// Time Settings page: timezone autocomplete (over the bundled TZ table from
+// timezone.js), NTP "Sync now" / offline "Set from browser", and a live device
+// clock in the summary card. `$`/`$$` are the helpers from main.js.
+(function () {
+	function findTimezone(tz) {
+		return tz.n === $('#tz_name').value;
+	}
+	function updateTimezone() {
+		const m = TZ.filter(findTimezone);
+		$('#tz_data').value = m.length ? m[0].v : '';
+	}
+	function useBrowserTimezone() {
+		$('#tz_name').value = Intl.DateTimeFormat().resolvedOptions().timeZone.replaceAll('_', ' ');
+		updateTimezone();
+	}
+
+	// Sync now / Set from browser — both report into #time-status.
+	function call(url, btn) {
+		const s = $('#time-status');
+		btn.disabled = true;
+		s.className = 'small text-secondary';
+		s.textContent = 'working…';
+		fetch(url)
+			.then(r => r.json())
+			.then(j => {
+				s.className = 'small alert alert-' + j.result + ' py-1 px-2 mb-0';
+				s.textContent = j.message;
+			})
+			.catch(() => {
+				s.className = 'small alert alert-danger py-1 px-2 mb-0';
+				s.textContent = 'Request failed.';
+			})
+			.finally(() => { btn.disabled = false; });
+	}
+
+	// Live device clock: grab the device epoch once, keep the offset to the
+	// browser clock, then tick locally (no second 2s poller vs the header).
+	let skew = 0, zone = '';
+	function tick() {
+		const el = $('#tz-now');
+		if (el) el.textContent = new Date(Date.now() + skew).toLocaleString() + (zone ? ' ' + zone : '');
+	}
+
+	function init() {
+		const tzn = $('#tz_name');
+		if (tzn) {
+			if (navigator.userAgent.includes('Android') && navigator.userAgent.includes('Firefox')) {
+				const sel = document.createElement('select');
+				sel.classList.add('form-select');
+				sel.name = 'tz_name';
+				sel.id = 'tz_name';
+				sel.options.add(new Option());
+				TZ.forEach(tz => {
+					const opt = new Option(tz.n);
+					opt.selected = (tz.n === tzn.value);
+					sel.options.add(opt);
+				});
+				tzn.replaceWith(sel);
+			} else {
+				const el = $('#tz_list');
+				el.innerHTML = '';
+				TZ.forEach(tz => {
+					const o = document.createElement('option');
+					o.value = tz.n;
+					el.appendChild(o);
+				});
+			}
+			const field = $('#tz_name');
+			field.addEventListener('focus', ev => ev.target.select());
+			field.addEventListener('selectionchange', updateTimezone);
+			field.addEventListener('change', updateTimezone);
+			$('#frombrowser').addEventListener('click', useBrowserTimezone);
+		}
+
+		const sync = $('#sync-time');
+		if (sync) sync.addEventListener('click', e => call('/cgi-bin/j/time.cgi', e.currentTarget));
+		const set = $('#set-time');
+		if (set) set.addEventListener('click', e => call('/cgi-bin/j/time.cgi?set=' + Math.floor(Date.now() / 1000), e.currentTarget));
+
+		fetch('/cgi-bin/j/pulse.cgi')
+			.then(r => r.json())
+			.then(j => { skew = (Number(j.time_now) * 1000) - Date.now(); zone = j.timezone || ''; })
+			.catch(() => {})
+			.finally(() => { tick(); setInterval(tick, 1000); });
+	}
+
+	if (document.readyState !== 'loading') init();
+	else document.addEventListener('DOMContentLoaded', init);
+})();

--- a/www/cgi-bin/fw-time.cgi
+++ b/www/cgi-bin/fw-time.cgi
@@ -24,114 +24,80 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 				eval ntp="\$POST_server_${i}"
 				[ -n "$ntp" ] && echo "server $ntp iburst" >> /etc/ntp.conf
 			done
+			update_caminfo
 			redirect_back "success" "Configuration updated."
 			;;
 	esac
-
-	update_caminfo
-	redirect_to "$SCRIPT_NAME" "success" "Timezone updated."
 fi
+
+for i in $(seq 0 3); do
+	eval server_${i}=$(sed -n $((i + 1))p /etc/ntp.conf | awk '{print $2}')
+done
+ntp_summary=$(echo $server_0 $server_1 $server_2 $server_3 | sed 's/ /, /g')
 %>
 
 <%in p/header.cgi %>
+
+<div class="row g-4">
+	<div class="col-12">
+		<div class="card h-100"><div class="card-body">
+			<h3>Current</h3>
+			<dl class="small list mb-0">
+				<dt>Device time</dt><dd id="tz-now">—</dd>
+				<dt>Zone name</dt><dd><%= $tz_name %></dd>
+				<dt>POSIX string</dt><dd class="text-break"><%= $tz_data %></dd>
+				<dt>NTP servers</dt><dd><%= "${ntp_summary:-—}" %></dd>
+			</dl>
+		</div></div>
+	</div>
+</div>
+
 <form action="<%= $SCRIPT_NAME %>" method="post">
 	<% field_hidden "action" "update" %>
-	<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
-		<div class="col">
-			<h3>Time Zone</h3>
-			<datalist id="tz_list"></datalist>
-			<p class="string">
-				<label for="tz_name" class="form-label">Zone name</label>
-				<input type="text" id="tz_name" name="tz_name" value="<%= $tz_name %>" class="form-control" list="tz_list">
-				<span class="hint text-secondary">Type the name of the nearest large city.</span>
-			</p>
-			<p class="string">
-				<label for="tz_data" class="form-label">Zone string</label>
-				<input type="text" id="tz_data" name="tz_data" value="<%= $tz_data %>" class="form-control" readonly>
-				<span class="hint text-secondary">Control string of the timezone selected above.</span>
-			</p>
-			<p><a href="#" id="frombrowser">Pick up timezone from browser</a></p>
+	<div class="row g-4 mt-0">
+		<div class="col-12 col-lg-6">
+			<div class="card h-100"><div class="card-body">
+				<h3>Time zone</h3>
+				<datalist id="tz_list"></datalist>
+				<p class="string" id="tz_name_wrap">
+					<label for="tz_name" class="form-label">Zone name</label>
+					<input type="text" id="tz_name" name="tz_name" value="<%= $tz_name %>" class="form-control" list="tz_list">
+					<span class="hint text-secondary">Type the name of the nearest large city.</span>
+				</p>
+				<p class="string" id="tz_data_wrap">
+					<label for="tz_data" class="form-label">Zone string</label>
+					<input type="text" id="tz_data" name="tz_data" value="<%= $tz_data %>" class="form-control" readonly>
+					<span class="hint text-secondary">Control string of the timezone selected above.</span>
+				</p>
+				<button type="button" class="btn btn-sm btn-outline-secondary" id="frombrowser">Use browser timezone</button>
+			</div></div>
 		</div>
 
-		<div class="col">
-		<h3>Synchronization</h3>
-			<%
-			for i in $(seq 0 3); do
-				eval server_${i}=$(sed -n $((i + 1))p /etc/ntp.conf | awk '{print $2}')
-				field_text "server_${i}" "Server $((i + 1))"
-			done
-			%>
-			<p id="sync-time-wrapper"><a href="#" id="sync-time">Sync time</a></p>
-		</div>
-
-		<div class="col">
-		<h3>Configuration</h3>
-			<% ex "cat /etc/timezone" %>
-			<% ex "cat /etc/TZ" %>
-			<% ex "cat /etc/ntp.conf" %>
+		<div class="col-12 col-lg-6">
+			<div class="card h-100"><div class="card-body">
+				<h3>Network time (NTP)</h3>
+				<% for i in $(seq 0 3); do field_text "server_${i}" "Server $((i + 1))"; done %>
+				<div class="my-2 d-flex gap-2 flex-wrap">
+					<button type="button" class="btn btn-sm btn-outline-secondary" id="sync-time">Sync now</button>
+					<button type="button" class="btn btn-sm btn-outline-secondary" id="set-time">Set from browser</button>
+				</div>
+				<div id="time-status" class="small text-secondary"></div>
+			</div></div>
 		</div>
 	</div>
+
 	<% button_submit %>
 </form>
 
+<details class="mt-4">
+	<summary class="text-secondary small">Advanced — raw configuration</summary>
+	<div class="mt-3">
+		<% ex "cat /etc/timezone" %>
+		<% ex "cat /etc/TZ" %>
+		<% ex "cat /etc/ntp.conf" %>
+	</div>
+</details>
+
 <script src="/a/timezone.js"></script>
-<script>
-	function findTimezone(tz) {
-		return tz.n == $("#tz_name").value;
-	}
-
-	function updateTimezone() {
-		const tz = TZ.filter(findTimezone);
-		$("#tz_data").value = (tz.length == 0) ? "" : tz[0].v;
-	}
-
-	function useBrowserTimezone(event) {
-		event.preventDefault();
-		$("#tz_name").value = Intl.DateTimeFormat().resolvedOptions().timeZone.replaceAll('_', ' ');
-		updateTimezone();
-	}
-
-	window.addEventListener('load', () => {
-		const tzn = $("#tz_name");
-		if (navigator.userAgent.includes("Android") && navigator.userAgent.includes("Firefox")) {
-			const sel = document.createElement("select");
-			sel.classList.add("form-select");
-			sel.name = "tz_name";
-			sel.id = "tz_name";
-			sel.options.add(new Option());
-			let opt;
-			TZ.forEach(function (tz) {
-				opt = new Option(tz.n);
-				opt.selected = (tz.n == tzn.value);
-				sel.options.add(opt);
-			});
-			tzn.replaceWith(sel);
-		} else {
-			const el = $("#tz_list");
-				el.innerHTML = "";
-				TZ.forEach(function (tz) {
-				const o = document.createElement("option");
-				o.value = tz.n;
-				el.appendChild(o);
-			});
-		}
-		tzn.addEventListener("focus", ev => ev.target.select());
-		tzn.addEventListener("selectionchange", updateTimezone);
-		tzn.addEventListener("change", updateTimezone);
-		$("#frombrowser").addEventListener("click", useBrowserTimezone);
-	});
-
-	$('#sync-time').addEventListener('click', event => {
-		event.preventDefault();
-		fetch('/cgi-bin/j/time.cgi')
-			.then((response) => response.json())
-			.then((json) => {
-				p = document.createElement('p');
-				p.classList.add('alert', 'alert-' + json.result);
-				p.textContent = json.message;
-				$('#sync-time-wrapper').replaceWith(p);
-			})
-	});
-</script>
-
+<script src="/a/fw-time.js" defer></script>
 <%in p/footer.cgi %>

--- a/www/cgi-bin/j/time.cgi
+++ b/www/cgi-bin/j/time.cgi
@@ -1,9 +1,28 @@
 #!/bin/sh
-if ntpd -n -q -N; then
-	payload='{"result":"success","message":"Camera time synchronized with NTP server."}'
-else
-	payload='{"result":"danger","message":"Synchronization failed!"}'
-fi
+# Time helper. Default: sync via NTP (ntpd -n -q -N).
+# With ?set=<epoch>: set the system clock from the caller's Unix time (used by
+# the "Set from browser" button for offline cameras; no RTC, so this is volatile
+# across reboots). Always returns {"result":"success|danger","message":"..."}.
+
+case "$QUERY_STRING" in
+	*set=*)
+		set_val=$(printf '%s' "$QUERY_STRING" | sed -n 's/.*\(^\|&\)set=\([^&]*\).*/\2/p')
+		if echo "$set_val" | grep -qE '^[0-9]+$' && date -s @"$set_val" >/dev/null 2>&1; then
+			payload='{"result":"success","message":"Camera clock set from browser."}'
+		elif echo "$set_val" | grep -qE '^[0-9]+$'; then
+			payload='{"result":"danger","message":"Failed to set clock."}'
+		else
+			payload='{"result":"danger","message":"Invalid timestamp."}'
+		fi
+		;;
+	*)
+		if ntpd -n -q -N; then
+			payload='{"result":"success","message":"Camera time synchronized with NTP server."}'
+		else
+			payload='{"result":"danger","message":"Synchronization failed!"}'
+		fi
+		;;
+esac
 
 echo "HTTP/1.1 200 OK
 Content-type: application/json


### PR DESCRIPTION
Brings the **Firmware ▸ Time** page into the modern web-UI idiom shared by `status` / `fw-network` / `fw-interface` / `fw-update`.

## What changed

**`www/cgi-bin/fw-time.cgi`** — rebuilt the body:
- The three bare columns (Time Zone / Synchronization / Configuration) become neutral cards: a read-only **Current** summary (live device clock, zone name, POSIX string, NTP servers via `dl.list`), a **Time zone** form card, and a **Network time (NTP)** form card — all inside one `<form>`, so a single **Save** still persists timezone + NTP servers together.
- The redundant raw `/etc/TZ`, `/etc/timezone`, `/etc/ntp.conf` dumps move into an **Advanced — raw configuration** `<details>`.
- Fixes a latent bug: `update_caminfo` was dead code after the `case` (the `update)` branch `redirect_back`-exits first), so `sysinfo` kept a stale timezone after a save. It now runs inside the branch before the redirect.

**`www/a/fw-time.js`** (new) — the old inline `<script>` externalized (loaded after the `timezone.js` table). Keeps the datalist autocomplete, the `tz_name`→`tz_data` POSIX mapping, and the Android/Firefox `<select>` fallback. The old "Pick up timezone from browser" / "Sync time" anchors become real buttons, and Sync/Set results report into a stable status line. The **Device time** in the Current card ticks from a one-shot `pulse.cgi` epoch + captured skew, so it shows *device* time (not the browser's) without adding a second poller alongside the header heartbeat.

**`www/cgi-bin/j/time.cgi`** — gains an offline **Set from browser** path: a validated `?set=<epoch>` branch (`grep -qE '^[0-9]+$'` then `date -s @epoch`) that the new button calls with the browser's Unix time. NTP (`ntpd -n -q -N`) stays the default when no `set` param is given. No `hwclock` — these boards have no battery RTC, so a manual set is volatile across reboots (expected/acceptable).

Single primary accent (Save); secondary actions are `btn-outline-secondary`; color only on the transient sync/set result alerts. No backend (C) or CSS changes.

## Verification

Deployed all three files to a hi3516av300 lab camera; checked rendered DOM + screenshots in light and dark themes:
- All ids present; `timezone.js`+`fw-time.js` load; the datalist is populated with 451 zones (JS ran); only one `btn-primary` (Save), the rest `btn-outline-secondary`; no permanent `alert-*` blocks; raw dumps live inside the Advanced `<details>`.
- The live **Device time** visibly ticks ahead of the static header clock.
- `j/time.cgi?set=<now>` → `result:success` and the device epoch matched exactly; `?set=abc` and `?set=` → `result:danger` "Invalid timestamp"; plain (no param) still does NTP.
- The timezone-change POST (which nags a reboot) was deliberately **not** exercised — the form/handler were code-reviewed and only the read-only + `j/` paths were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)