### PR TITLE
info-logs: frame the live log console in a card; tidy CSS & accents

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -173,6 +173,32 @@ pre#output[data-cmd] {
 	color: rgba(170, 170, 170, 0.8);
 }
 
+/* live log console (info-logs.cgi) */
+#log {
+	height: 70vh;
+	overflow-y: auto;
+	font-family: var(--bs-font-monospace);
+	font-size: 12px;
+	white-space: pre-wrap;
+	word-break: break-all;
+}
+
+.log-line {
+	padding: 0 .25rem;
+}
+
+.log-err {
+	color: #dc3545;
+}
+
+.log-warn {
+	color: #fd7e14;
+}
+
+.log-debug {
+	opacity: .6;
+}
+
 .mj-row {
 	border-left: 2px solid transparent;
 	padding-left: 0.5rem;

--- a/www/cgi-bin/info-logs.cgi
+++ b/www/cgi-bin/info-logs.cgi
@@ -20,42 +20,37 @@ SYSLOG_SIZE=64
 [ -r "$syslog_defaults" ] && . "$syslog_defaults"
 %>
 <%in p/header.cgi %>
-<style>
-#log { height: 70vh; overflow-y: auto; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-all; }
-.log-line { padding: 0 .25rem; }
-.log-err { color: #dc3545; }
-.log-warn { color: #fd7e14; }
-.log-debug { opacity: .6; }
-</style>
-<div class="row g-2 align-items-center mb-2">
-	<div class="col-auto">
-		<select id="log-source" class="form-select form-select-sm">
-			<option value="all">Everything</option>
-			<option value="majestic">Majestic</option>
-			<option value="kernel">Kernel</option>
-		</select>
-	</div>
-	<div class="col">
-		<input id="log-filter" type="text" class="form-control form-control-sm" placeholder="filter…" autocomplete="off">
-	</div>
-	<div class="col-auto">
-		<button id="log-pause" type="button" class="btn btn-sm btn-secondary">⏸ Pause</button>
-		<button id="log-clear" type="button" class="btn btn-sm btn-outline-secondary">Clear</button>
-		<button id="log-download" type="button" class="btn btn-sm btn-outline-secondary">⬇ Download</button>
-		<a href="/cgi-bin/j/dmesg.cgi" target="_blank" class="btn btn-sm btn-outline-secondary" title="Full kernel ring buffer (dmesg)">dmesg</a>
-	</div>
-</div>
-<div id="log" class="border rounded bg-body-tertiary"></div>
-<details class="mt-2">
-	<summary class="text-secondary small">Log buffer size — currently <%= $SYSLOG_SIZE %> KiB</summary>
-	<form action="<%= $SCRIPT_NAME %>" method="post" class="row g-2 align-items-end mt-1" style="max-width:30rem">
+<div class="card"><div class="card-body">
+	<div class="row g-2 align-items-center mb-3">
+		<div class="col-auto">
+			<select id="log-source" class="form-select form-select-sm">
+				<option value="all">Everything</option>
+				<option value="majestic">Majestic</option>
+				<option value="kernel">Kernel</option>
+			</select>
+		</div>
 		<div class="col">
-			<% field_string "syslog_size" "In-RAM syslog buffer (KiB)" "$SYSLOG_SIZE" "64 128 256 512 1024" "More backlog but more RAM. Default 64. Applies immediately and clears the current buffer." %>
+			<input id="log-filter" type="text" class="form-control form-control-sm" placeholder="filter…" autocomplete="off">
 		</div>
 		<div class="col-auto">
-			<% button_submit "Apply" "secondary" %>
+			<button id="log-pause" type="button" class="btn btn-sm btn-outline-secondary">⏸ Pause</button>
+			<button id="log-clear" type="button" class="btn btn-sm btn-outline-secondary">Clear</button>
+			<button id="log-download" type="button" class="btn btn-sm btn-outline-secondary">⬇ Download</button>
+			<a href="/cgi-bin/j/dmesg.cgi" target="_blank" class="btn btn-sm btn-outline-secondary" title="Full kernel ring buffer (dmesg)">dmesg</a>
 		</div>
-	</form>
-</details>
+	</div>
+	<div id="log" class="border rounded bg-body-tertiary"></div>
+	<details class="mt-3">
+		<summary class="text-secondary small">Log buffer size — currently <%= $SYSLOG_SIZE %> KiB</summary>
+		<form action="<%= $SCRIPT_NAME %>" method="post" class="row g-2 align-items-end mt-1" style="max-width:30rem">
+			<div class="col">
+				<% field_string "syslog_size" "In-RAM syslog buffer (KiB)" "$SYSLOG_SIZE" "64 128 256 512 1024" "More backlog but more RAM. Default 64. Applies immediately and clears the current buffer." %>
+			</div>
+			<div class="col-auto">
+				<% button_submit "Apply" %>
+			</div>
+		</form>
+	</details>
+</div></div>
 <script src="/a/logs.js"></script>
 <%in p/footer.cgi %>


### PR DESCRIPTION
Brings the **Information ▸ Logs** page into the modern web-UI idiom shared by `status` / `fw-network` / `fw-update` / `fw-time`.

This page was already the cleanest of the suite — JS is externalized in `logs.js`, the per-line severity coloring is meaningful, and the buffer control is already in a `<details>`. So this is **presentation + CSS hygiene only**: no functional, `logs.js`, or backend change, and every id the console JS targets (`#log #log-source #log-filter #log-pause #log-clear #log-download`) is preserved.

## What changed

**`www/cgi-bin/info-logs.cgi`**
- Wrap the toolbar + `#log` console + buffer-size `<details>` in one neutral `card` / `card-body`, matching how the other pages frame their content.
- Remove the inline `<style>` block (moved to CSS, below).
- Make the toolbar uniformly neutral: **Pause** becomes `btn-outline-secondary` (its ⏸/▶ text toggle still shows state), alongside Clear / Download / dmesg.
- Give the page its single primary accent on the one real persisting action: the buffer-size **Apply** button is now `btn-primary` (was secondary).

**`www/a/bootstrap.override.css`**
- Relocate the console rules (`#log`, `.log-line`, `.log-err`/`.log-warn`/`.log-debug`) out of the CGI, using the site monospace font var. The err=red / warn=orange / debug=dim coloring is unchanged.

## Verification

Deployed both files to a hi3516av300 lab camera; checked rendered DOM + screenshots in light and dark themes:
- The served HTML has **no inline `<style>`**; the console rules now come from `bootstrap.override.css`.
- The console streams live over `/ws/logs` inside the framed card — a DOM dump showed 2000 lines with **146 `log-err`, 42 `log-warn`, 940 `log-debug`**, confirming the per-line severity coloring still applies to the live stream.
- All console ids present; `logs.js` loaded and untouched; Pause is outline, Apply is the single `btn-primary`; toolbar otherwise neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)