### PR TITLE
ext-proxy: redesign into the modern card idiom

### DIFF
--- a/www/cgi-bin/ext-proxy.cgi
+++ b/www/cgi-bin/ext-proxy.cgi
@@ -19,21 +19,28 @@ fi
 
 <%in p/header.cgi %>
 
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
-	<div class="col">
-	<form action="<%= $SCRIPT_NAME %>" method="post">
-		<% field_hidden "action" "update" %>
-		<% field_text "socks5_host" "SOCKS5 host" %>
-		<% field_text "socks5_port" "SOCKS5 port" "1080" %>
-		<% field_text "socks5_username" "SOCKS5 username" %>
-		<% field_password "socks5_password" "SOCKS5 password" %>
-		<% button_submit %>
-	</form>
-	</div>
-
-	<div class="col">
-		<% [ -e "$config_file" ] && ex "cat $config_file" %>
+<div class="row g-4">
+	<div class="col-12 col-lg-6">
+		<div class="card h-100"><div class="card-body">
+			<h3>SOCKS5 proxy</h3>
+			<p class="small text-secondary">Route extension traffic (OpenWall, Telegram) through a SOCKS5 proxy.</p>
+			<form action="<%= $SCRIPT_NAME %>" method="post">
+				<% field_hidden "action" "update" %>
+				<% field_text "socks5_host" "SOCKS5 host" %>
+				<% field_text "socks5_port" "SOCKS5 port" "1080" %>
+				<% field_text "socks5_username" "SOCKS5 username" %>
+				<% field_password "socks5_password" "SOCKS5 password" %>
+				<% button_submit %>
+			</form>
+		</div></div>
 	</div>
 </div>
+
+<details class="mt-4">
+	<summary class="text-secondary small">Advanced — raw configuration</summary>
+	<div class="mt-3">
+		<% [ -e "$config_file" ] && ex "cat $config_file" %>
+	</div>
+</details>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
Frame the SOCKS5 proxy form in a neutral card with a short lead; demote the raw config dump into an Advanced <details>. No backend change — field names and the POST handler are unchanged.

Verified on a hi3516av300 lab cam: 1 card, raw dump in <details>, single btn-primary, no decorative alert blocks, all socks5_* field ids present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)