### PR TITLE
fw-editor: frame the text editor in a card

### DIFF
--- a/www/cgi-bin/fw-editor.cgi
+++ b/www/cgi-bin/fw-editor.cgi
@@ -42,11 +42,14 @@ fi
 %>
 
 <%in p/header.cgi %>
-<form action="<%= $SCRIPT_NAME %>" method="post">
-	<% field_hidden "action" "save" %>
-	<% field_hidden "editor_file" "$editor_file" %>
-	<% field_textedit "editor_text" "File content" "$editor_file" %>
-	<% button_submit %>
-</form>
+<div class="card"><div class="card-body">
+	<h3 class="text-break">Text editor<% [ -n "$editor_file" ] && echo " — <code>${editor_file}</code>" %></h3>
+	<form action="<%= $SCRIPT_NAME %>" method="post">
+		<% field_hidden "action" "save" %>
+		<% field_hidden "editor_file" "$editor_file" %>
+		<% field_textedit "editor_text" "File content" "$editor_file" %>
+		<% button_submit %>
+	</form>
+</div></div>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
Wrap the field_textedit form in a neutral card with an <h3> showing the file being edited. Pure presentation; the save handler and field names are unchanged.

Verified on a hi3516av300 lab cam (?f=/etc/majestic.yaml): card present, filename in the heading, textarea + hidden action/editor_file intact, single btn-primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)