### PR TITLE
fw-reset: frame the overlay-erase progress in a card

### DIFF
--- a/www/cgi-bin/fw-reset.cgi
+++ b/www/cgi-bin/fw-reset.cgi
@@ -7,8 +7,11 @@
 %>
 
 <%in p/header.cgi %>
-<h3 class="alert alert-warning">DO NOT CLOSE, REFRESH, OR NAVIGATE AWAY FROM THIS PAGE UNTIL THE PROCESS IS FINISHED!</h3>
-<pre id="output" data-cmd="<%= $c %>" data-reboot="<%= $r %>"></pre>
+<div class="alert alert-warning">Do not close, refresh, or navigate away from this page until the process finishes. The camera will reboot automatically.</div>
+<div class="card"><div class="card-body">
+	<h3>Progress</h3>
+	<pre id="output" class="mb-0" data-cmd="<%= $c %>" data-reboot="<%= $r %>"></pre>
+</div></div>
 
 <script>
 	const el = $('pre#output');


### PR DESCRIPTION
Replace the <h3 class=alert> heading with a compact alert-warning caution (meaningful — this erases the overlay and reboots) and frame the live runCmd <pre id=output> in a card, matching the fw-update progress view. The command (data-cmd), data-reboot flag and runCmd call are unchanged.

Verified by fetching the HTML on a hi3516av300 lab cam (NOT executed — the erase only fires from browser JS): card present, single meaningful warning, data-cmd=\"/usr/sbin/sysupgrade -s -n -x\", data-reboot=true, runCmd intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)