### PR TITLE
mj-configuration: redesign into the modern card idiom

### DIFF
--- a/www/cgi-bin/mj-configuration.cgi
+++ b/www/cgi-bin/mj-configuration.cgi
@@ -3,17 +3,25 @@
 <% page_title="Majestic Configuration" %>
 <%in p/header.cgi %>
 
-<div class="row row-cols-2">
-	<% ex "cat $(get_config)" %>
-	<div class="col">
-		<%
-			diff $(get_config /rom) $(get_config) > /tmp/majestic.patch
-			ex "cat /tmp/majestic.patch"
-		%>
-		<div class="row">
-			<p><a class="btn btn-secondary" href="fw-editor.cgi?f=<%= $(get_config) %>">Edit Configuration</a></p>
-			<p><a class="btn btn-danger" href="fw-restore.cgi?f=<%= $(get_config) %>">Reset Configuration</a></p>
-		</div>
+<div class="row g-4">
+	<div class="col-12 col-lg-7">
+		<div class="card h-100"><div class="card-body">
+			<h3>Running configuration</h3>
+			<% ex "cat $(get_config)" %>
+		</div></div>
+	</div>
+	<div class="col-12 col-lg-5">
+		<div class="card h-100"><div class="card-body">
+			<h3>Changes from defaults</h3>
+			<%
+				diff $(get_config /rom) $(get_config) > /tmp/majestic.patch
+				ex "cat /tmp/majestic.patch"
+			%>
+			<div class="d-flex gap-2 mt-3">
+				<a class="btn btn-outline-secondary" href="fw-editor.cgi?f=<%= $(get_config) %>">Edit</a>
+				<a class="btn btn-danger" href="fw-restore.cgi?f=<%= $(get_config) %>">Reset to defaults</a>
+			</div>
+		</div></div>
 	</div>
 </div>
 


### PR DESCRIPTION
Replace the row row-cols-2 raw layout with a row g-4 of two cards: "Running configuration" (the live majestic.yaml) and "Changes from defaults" (the diff vs /rom) with Edit (outline-secondary) and Reset-to-defaults (btn-danger, confirm-gated) actions. The config view is this page purpose, so it stays framed and visible. Diff generation unchanged.

Verified on a hi3516av300 lab cam: 2 cards in row g-4, config content shown, Edit + Reset links intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)