### PR TITLE
preview: redesign into the modern card idiom

### DIFF
--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -1,0 +1,82 @@
+// Camera Preview page glue: night/IRcut/light toggles (via the /night and
+// /metrics/night APIs) and the low-latency MSE player attach (MajesticVideo
+// from preview.js, with an MJPEG/no-signal fallback). `$`, mjConfig and mjGet
+// are globals from main.js; this file loads after preview.js.
+(function () {
+	// --- Night / IRcut / Light toggles ---
+	mjConfig().then(cfg => {
+		const active = v => v !== false && v != null;
+		const lm = active(mjGet(cfg, 'nightMode.lightMonitor'));
+		$('#toggle-night').disabled = lm;
+		$('#toggle-ircut').disabled = lm || !active(mjGet(cfg, 'nightMode.irCutPin1'));
+		$('#toggle-light').disabled = lm || !active(mjGet(cfg, 'nightMode.backlightPin'));
+		if (lm) $('#mj-lightmon').hidden = false;
+	});
+
+	['night', 'ircut', 'light'].forEach(n =>
+		fetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
+			.then(r => r.text()).then(v => { $('#toggle-' + n).checked = +v > 0; })
+			.catch(() => {}));
+
+	$('#toggle-night').addEventListener('click', () => {
+		fetch('/night/toggle').then(api => api.json()).then(data => {
+			$('#toggle-night').checked = data;
+			if (!$('#toggle-ircut').disabled) $('#toggle-ircut').checked = data;
+			if (!$('#toggle-light').disabled) $('#toggle-light').checked = data;
+		});
+	});
+	$('#toggle-ircut').addEventListener('click', () => {
+		fetch('/night/ircut').then(api => api.json()).then(data => { $('#toggle-ircut').checked = data; });
+	});
+	$('#toggle-light').addEventListener('click', () => {
+		fetch('/night/light').then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
+	});
+
+	// --- Live MSE player (with MJPEG / no-signal fallback) ---
+	const initial = $('#live-video');
+	if (!initial || !window.MajesticVideo) return;
+	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
+	let jpegOn = false;
+	mjConfig().then(cfg => {
+		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
+		if (mjGet(cfg, 'video1.enabled') === true) $('#mj-sub').hidden = false;
+	});
+	const cur = () => $('#live-video');
+
+	const BARS = '#000 url(/a/preview.svg)';
+	function showVideo() {
+		const v = cur();
+		if (v) { v.style.display = ''; v.style.background = '#000'; }
+		if (img) { img.style.display = 'none'; img.src = ''; }
+		if (note) note.style.display = 'none';
+	}
+	function showNoSignal() {
+		const v = cur();
+		if (v) { v.style.display = ''; v.style.background = BARS; }
+		if (img) { img.style.display = 'none'; img.src = ''; }
+		if (note) note.style.display = 'none';
+		if (badge) badge.textContent = 'no signal';
+	}
+	function showFallback() {
+		const v = cur();
+		if (v) v.style.display = 'none';
+		if (jpegOn && img) { img.src = '/mjpeg'; img.style.display = ''; if (note) note.style.display = 'none'; }
+		else if (note) note.style.display = '';
+		if (badge) badge.textContent = 'MJPEG';
+	}
+
+	const player = MajesticVideo.attach(initial, {
+		stream: 0,
+		onState: (s, d) => {
+			if (s === 'playing') showVideo();
+			else if (s === 'nosignal') showNoSignal();
+			else if (s === 'mjpeg') showFallback();
+			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+		},
+		onCodec: (codec, cs, w, h) => { if (badge) badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h; },
+	});
+
+	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
+	if (s0) s0.addEventListener('change', () => player.setStream(0));
+	if (s1) s1.addEventListener('change', () => player.setStream(1));
+})();

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -4,121 +4,37 @@
 <% page_title="Camera Preview" %>
 <%in p/header.cgi %>
 
-<div class="row preview">
-	<div class="col">
-		<% preview %>
-		<p class="small"><a href="mj-endpoints.cgi">Majestic Endpoints</a></p>
+<div class="row g-4">
+	<div class="col-12 col-lg-9">
+		<div class="card h-100"><div class="card-body">
+			<% preview %>
+			<p class="small mb-0"><a href="mj-endpoints.cgi">Majestic endpoints</a></p>
+		</div></div>
 	</div>
 
-	<div class="col-auto">
-		<p class="small" id="mj-lightmon" hidden><a href="mj-settings.cgi?tab=nightMode">Light monitor active</a></p>
+	<div class="col-12 col-lg-3">
+		<div class="card h-100"><div class="card-body">
+			<h3>Controls</h3>
+			<p class="small" id="mj-lightmon" hidden><a href="mj-settings.cgi?tab=nightMode">Light monitor active</a></p>
+			<div class="d-grid gap-2">
+				<input type="checkbox" class="btn-check" id="toggle-night">
+				<label class="btn btn-outline-primary" for="toggle-night">Night</label>
 
-		<div class="d-grid gap-3">
-			<input type="checkbox" class="btn-check" id="toggle-night">
-			<label class="btn btn-outline-success" for="toggle-night">Night</label>
+				<input type="checkbox" class="btn-check" id="toggle-ircut">
+				<label class="btn btn-outline-primary" for="toggle-ircut">IRcut</label>
 
-			<input type="checkbox" class="btn-check" id="toggle-ircut">
-			<label class="btn btn-outline-success" for="toggle-ircut">IRcut</label>
+				<input type="checkbox" class="btn-check" id="toggle-light">
+				<label class="btn btn-outline-primary" for="toggle-light">Light</label>
 
-			<input type="checkbox" class="btn-check" id="toggle-light">
-			<label class="btn btn-outline-success" for="toggle-light">Light</label>
-
-			<% if [ -n "$ptz_support" ]; then %>
-				<%in p/motor.cgi %>
-			<% fi %>
-		</div>
+				<% if [ -n "$ptz_support" ]; then %>
+					<%in p/motor.cgi %>
+				<% fi %>
+			</div>
+		</div></div>
 	</div>
 </div>
 
-<script>
-mjConfig().then(cfg => {
-	const active = v => v !== false && v != null;
-	const lm = active(mjGet(cfg, 'nightMode.lightMonitor'));
-	$('#toggle-night').disabled = lm;
-	$('#toggle-ircut').disabled = lm || !active(mjGet(cfg, 'nightMode.irCutPin1'));
-	$('#toggle-light').disabled = lm || !active(mjGet(cfg, 'nightMode.backlightPin'));
-	if (lm) $('#mj-lightmon').hidden = false;
-});
-['night', 'ircut', 'light'].forEach(n =>
-	fetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
-		.then(r => r.text()).then(v => { $('#toggle-' + n).checked = +v > 0; })
-		.catch(() => {}));
-
-$("#toggle-night").addEventListener("click", () => {
-	fetch('/night/toggle').then(api => api.json()).then(data => {
-		$('#toggle-night').checked = data;
-		if (!$('#toggle-ircut').disabled) {
-			$('#toggle-ircut').checked = data;
-		}
-		if (!$('#toggle-light').disabled) {
-			$('#toggle-light').checked = data;
-		}
-	});
-});
-
-$("#toggle-ircut").addEventListener("click", () => {
-	fetch('/night/ircut').then(api => api.json()).then(data => {
-		$('#toggle-ircut').checked = data;
-	});
-});
-
-$("#toggle-light").addEventListener("click", () => {
-	fetch('/night/light').then(api => api.json()).then(data => {
-		$('#toggle-light').checked = data;
-	});
-});
-</script>
-
 <script src="/a/preview.js"></script>
-<script>
-(function () {
-	const initial = $('#live-video');
-	if (!initial || !window.MajesticVideo) return;
-	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
-	let jpegOn = false;
-	mjConfig().then(cfg => {
-		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
-		if (mjGet(cfg, 'video1.enabled') === true) $('#mj-sub').hidden = false;
-	});
-	const cur = () => $('#live-video');
-
-	const BARS = '#000 url(/a/preview.svg)';
-	function showVideo() {
-		const v = cur();
-		if (v) { v.style.display = ''; v.style.background = '#000'; }
-		if (img) { img.style.display = 'none'; img.src = ''; }
-		if (note) note.style.display = 'none';
-	}
-	function showNoSignal() {
-		const v = cur();
-		if (v) { v.style.display = ''; v.style.background = BARS; }
-		if (img) { img.style.display = 'none'; img.src = ''; }
-		if (note) note.style.display = 'none';
-		if (badge) badge.textContent = 'no signal';
-	}
-	function showFallback() {
-		const v = cur();
-		if (v) v.style.display = 'none';
-		if (jpegOn && img) { img.src = '/mjpeg'; img.style.display = ''; if (note) note.style.display = 'none'; }
-		else if (note) note.style.display = '';
-		if (badge) badge.textContent = 'MJPEG';
-	}
-
-	const player = MajesticVideo.attach(initial, {
-		stream: 0,
-		onState: (s, d) => {
-			if (s === 'playing') showVideo();
-			else if (s === 'nosignal') showNoSignal();
-			else if (s === 'mjpeg') showFallback();
-			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
-		},
-		onCodec: (codec, cs, w, h) => { if (badge) badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h; },
-	});
-
-	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
-	if (s0) s0.addEventListener('change', () => player.setStream(0));
-	if (s1) s1.addEventListener('change', () => player.setStream(1));
-})();
-</script>
+<script src="/a/preview-page.js"></script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
Reframe the row preview shell into a row g-4 of two cards (live video + Controls), recolor the Night/IRcut/Light toggles from outline-success to the single outline-primary accent, and externalize both inline <script> blocks (night/IRcut/light wiring + the MajesticVideo MSE attach/fallback) into www/a/preview-page.js (loaded after preview.js). The preview() partial, the player and the night/metrics APIs are unchanged.

Verified on a hi3516av300 lab cam: screenshot shows the live MSE stream decoding inside a framed card with the Controls card; 2 cards, no outline-success, 5 outline-primary, both JS files loaded, all toggle ids intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)