### PR TITLE
ext-backuper: drop the dead restore stub

### DIFF
--- a/www/cgi-bin/ext-backuper.cgi
+++ b/www/cgi-bin/ext-backuper.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/haserl --upload-limit=200 --upload-dir=/tmp
+#!/usr/bin/haserl
 <%in p/common.cgi %>
 <%
 config_file=/etc/webui/backup.conf
@@ -24,9 +24,7 @@ if [ "$GET_backup" = "create" ]; then
 	exit 0
 fi
 
-if [ "$GET_backup" = "restore" ]; then
-	# temporary stub, until file upload is fixed
-	redirect_back
-	exit 0
-fi
+# This endpoint only serves the backup download; send any other request back to
+# the page that owns the backuper configuration.
+redirect_to "fw-settings.cgi"
 %>


### PR DESCRIPTION
The `?backup=restore` branch was a never-finished stub ("temporary stub, until file upload is fixed") that nothing calls. Remove it, along with the `--upload-limit`/`--upload-dir` haserl flags that only existed for that upload path. Any non-create request now 303-redirects to `fw-settings.cgi` (which owns the backuper config) instead of falling through to a 500.

The working `?backup=create` download path (used by the fw-settings "Create backup" button) is unchanged.

Verified on a hi3516av300 lab cam: ?backup=create still returns 200 application/tar+gzip (valid gzip); ?backup=restore and a bare hit now 303 -> fw-settings.cgi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)