### PR TITLE
mj-settings: frame the schema-driven settings in section cards

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -214,6 +214,33 @@ pre#output[data-cmd] {
 	text-decoration: none;
 }
 
+.mj-live-video {
+	width: 100%;
+	max-width: 640px;
+	aspect-ratio: 16/9;
+	background: #000;
+	border: 1px solid var(--bs-primary);
+	border-radius: 4px;
+}
+
+.mj-roi-iframe {
+	width: 100%;
+	aspect-ratio: 16/9;
+	border: 1px solid var(--bs-primary);
+	padding: 0;
+	margin: 0;
+}
+
+.mj-toolbar {
+	position: sticky;
+	bottom: 0;
+	z-index: 5;
+	margin-top: 1rem;
+	padding: 0.75rem 0;
+	background: var(--bs-body-bg);
+	border-top: 1px solid var(--bs-border-color);
+}
+
 .btn-motor {
 	font-size: 2.3rem;
 	--bs-btn-border-width: 0;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -188,45 +188,58 @@
 		err.role = 'alert';
 		form.appendChild(err);
 
-		// Live preview pinned at the top so slider changes are visible as you
-		// drag — reuses the low-latency /ws/video MSE player (a/preview.js).
+		// Each section renders as its own card; the cards flow in a responsive
+		// 2-column grid that fills the page width.
+		const grid = el('div', 'row g-4');
+		grid.id = 'mj-settings-grid';
+		form.appendChild(grid);
+
+		// Live preview pinned full-width at the top so slider changes are visible
+		// as you drag — reuses the low-latency /ws/video MSE player (a/preview.js).
 		if (groupHasLive(group) && window.MajesticVideo) {
-			const pv = el('div', 'mb-3');
-			pv.id = 'mj-live-preview';
-			pv.innerHTML =
+			const col = el('div', 'col-12');
+			col.id = 'mj-live-preview';
+			col.innerHTML =
+				'<div class="card"><div class="card-body">' +
 				'<div class="text-secondary small mb-1">Live preview</div>' +
-				'<video id="mj-live-video" autoplay muted playsinline ' +
-				'style="width:100%;max-width:640px;border:1px solid rgb(76,96,216);' +
-				'border-radius:4px;aspect-ratio:16/9;background:#000;"></video>';
-			form.appendChild(pv);
+				'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
+				'</div></div>';
+			grid.appendChild(col);
 			state.previewPlayer =
-				window.MajesticVideo.attach(pv.querySelector('#mj-live-video'), { stream: 0 });
+				window.MajesticVideo.attach(col.querySelector('#mj-live-video'), { stream: 0 });
 		}
 
 		state.fields = [];
 		state.initial = {};
-		// Render each merged section. Multi-section groups get a subheader per
-		// section; a single-section group needs none (the tab title says it).
-		const multi = group.sections.length > 1;
+		// One card per merged section; renderProps fills the card body (nested
+		// object sub-properties still get an <h5> subheader inside the card).
+		// Multi-card groups flow 2-up; a lone card (e.g. Recording — no preview,
+		// no ROI mate) is centred so it reads as one panel, not a left-stranded half.
+		const lone = group.sections.length === 1 && !groupHasMotion(group) && !groupHasLive(group);
+		const colCls = lone ? 'col-12 col-lg-8 mx-auto' : 'col-12 col-lg-6';
 		for (const section of group.sections) {
 			const props = ((state.schema.properties || {})[section] || {}).properties;
 			if (!props) continue;
-			if (multi) {
-				const h = el('h5', 'mt-4 mb-2 text-secondary');
-				h.textContent = label(section);
-				form.appendChild(h);
-			}
-			renderProps(form, section, props);
+			const col = el('div', colCls);
+			const card = el('div', 'card h-100');
+			const body = el('div', 'card-body');
+			const h = el('h3');
+			h.textContent = label(section);
+			body.appendChild(h);
+			card.appendChild(body);
+			col.appendChild(card);
+			grid.appendChild(col);
+			renderProps(body, section, props);
 		}
 
+		if (groupHasMotion(group)) toggleRoi(group);
+
 		const toolbar = document.createElement('div');
-		toolbar.className = 'mj-toolbar d-flex align-items-center mt-3 gap-2';
+		toolbar.className = 'mj-toolbar d-flex align-items-center gap-2';
 		toolbar.innerHTML =
 			'<span class="me-auto text-secondary small" id="mj-dirty-count">No changes.</span>' +
 			'<button type="submit" class="btn btn-primary" id="mj-save" disabled>Save Changes</button>';
 		form.appendChild(toolbar);
-
-		if (groupHasMotion(group)) toggleRoi(group);
 
 		applyVisibility();
 
@@ -254,17 +267,18 @@
 		const existing = document.getElementById(id);
 		if (groupHasMotion(group)) {
 			if (existing) return;
-			const wrap = document.createElement('div');
-			wrap.id = id;
-			wrap.className = 'mt-4';
-			wrap.innerHTML =
+			const grid = document.getElementById('mj-settings-grid');
+			if (!grid) return;
+			const col = document.createElement('div');
+			col.id = id;
+			col.className = 'col-12 col-lg-6';
+			col.innerHTML =
+				'<div class="card h-100"><div class="card-body">' +
 				'<h3>Visual editor</h3>' +
-				'<iframe id="mj-roi-iframe" src="/m/img.html" frameborder="0" style="padding:0;margin:0;border:1px solid rgb(76,96,216);width:100%;aspect-ratio:16/9;"></iframe>' +
-				'<div class="row mb-3 mt-2 align-items-center">' +
-				'<div class="col"><input type="button" class="btn btn-primary" id="mj-roi-clear" value="Clear all regions"></div>' +
-				'</div>';
-			const col = document.getElementById('mj-settings-form-col');
-			if (col) col.appendChild(wrap);
+				'<iframe id="mj-roi-iframe" src="/m/img.html" frameborder="0" class="mj-roi-iframe"></iframe>' +
+				'<button type="button" class="btn btn-outline-secondary mt-2" id="mj-roi-clear">Clear all regions</button>' +
+				'</div></div>';
+			grid.appendChild(col);
 			const clearBtn = document.getElementById('mj-roi-clear');
 			if (clearBtn) {
 				clearBtn.addEventListener('click', () => {
@@ -286,7 +300,7 @@
 
 	function titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
 
-	function renderProps(form, basePath, props) {
+	function renderProps(container, basePath, props) {
 		for (const key of Object.keys(props)) {
 			const dot = basePath + '.' + key;
 			if (EXCLUDE.has(dot)) continue;
@@ -294,12 +308,12 @@
 			if (sub && sub.type === 'object' && sub.properties) {
 				const h = el('h5', 'mt-4 mb-2 text-secondary');
 				h.textContent = sub.title || titleCase(key);
-				form.appendChild(h);
-				renderProps(form, dot, sub.properties);
+				container.appendChild(h);
+				renderProps(container, dot, sub.properties);
 				continue;
 			}
 			const eff = getDotted(state.config, dot);
-			const field = renderField(form, dot, key, sub, eff);
+			const field = renderField(container, dot, key, sub, eff);
 			if (field) {
 				state.fields.push(field);
 				state.initial[dot] = field.getValue();
@@ -329,7 +343,7 @@
 		(state.visUpdaters || []).forEach(u => u());
 	}
 
-	function renderField(form, dot, key, sub, eff) {
+	function renderField(container, dot, key, sub, eff) {
 		const desc = sub.description || key;
 		const type = sub.type;
 		const id = 'mjf-' + dot.replace(/\./g, '-');
@@ -459,7 +473,7 @@
 		}
 		p.appendChild(reset);
 
-		form.appendChild(p);
+		container.appendChild(p);
 
 		control.addEventListener('input', updateDirty);
 		control.addEventListener('change', updateDirty);

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -47,7 +47,7 @@ fi
 		<ul class="nav nav-pills flex-column small sticky-md-top" id="mj-settings-nav"></ul>
 	</div>
 
-	<div class="col-12 col-md-9 col-lg-6" id="mj-settings-form-col">
+	<div class="col-12 col-md-9 col-lg-10" id="mj-settings-form-col">
 		<script type="application/json" id="mj-settings-boot">{"tab":"<%= $label %>","labels":{<%= $labels %>},"exclude":[<%= $boot_exclude %>],"sensors":[<%= $boot_sensors %>]}</script>
 
 		<h3 id="mj-settings-title"></h3>


### PR DESCRIPTION
The Majestic settings form is generated by `mj-settings.js` from the JSON schema. It looked "alien" next to the rest of the suite because of **framing**, not the controls (which already use the field_* Bootstrap classes): the form sat bare on the page, and sidebar `col-lg-2` + form `col-lg-6` used only 8/12 columns — a narrow middle strip with ~33% dead space on the right.

## What changed
- **Each config section is now its own neutral card**, flowing in a responsive `row g-4` / `col-lg-6` grid that fills the width. Multi-section tabs (Image, Video & Audio, Network, System) flow 2-up; the **live preview** and the **motionDetect ROI visual-editor** are grid cards (the editor sits beside the motion-detection card); a lone single-section tab (Recording) gets a centred `col-lg-8` card. A **sticky bottom bar** keeps the dirty-count + Save reachable on long tabs.
- Content column widened to `col-lg-10`; sidebar pill-nav unchanged.
- Live-video / ROI-iframe inline styles moved into CSS classes (`.mj-live-video`, `.mj-roi-iframe`, using `var(--bs-primary)`), plus a sticky `.mj-toolbar`.
- `renderProps`/`renderField` now append into the section card body.

**No backend change** and no change to the API calls (`config.schema.json` / `config.json` / `POST config` / `reset` / `x-live image`) or the dirty / reset / `visibleWhen` / live-preview logic — only the assembly in `load()`/`toggleRoi()` was reframed.

## Verification
On a hi3516av300 lab cam (runs majestic + the schema API), headless-rendered every tab in light + dark: Image (3 cards + live MSE preview), Video & Audio (5), Events (motion card + ROI editor with the regions drawn), Recording (centred panel), Network & Integrations (8 cards), System (2) — all fill the width as framed cards; sidebar pills + active state intact; `#mj-save`/`#mj-dirty-count`/`.mj-reset`/`.mj-row` all present; `node --check` clean. A real config Save was not triggered (it reloads the SDK / writes majestic.yaml); the submit path is unchanged and code-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)