### PR TITLE
heif: drop the H265-only gate from HEIF format switches

### DIFF
--- a/www/a/ext-ntfy.js
+++ b/www/a/ext-ntfy.js
@@ -1,9 +1,7 @@
-// Ntfy extension page: gate the HEIF switch and send a test notification
+// Ntfy extension page: send a test notification
 // (via ?send=test, which runs /usr/bin/ntfy.sh against the saved config).
-// `$` and mjHeifGate are globals from main.js.
+// `$` is a global from main.js.
 (function () {
-	mjHeifGate('#ntfy_heif');
-
 	const btn = $('#ntfy-test');
 	const out = $('#ntfy-status');
 	if (!btn) return;

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -26,15 +26,6 @@ function mjGet(cfg, dot) {
 	return dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg);
 }
 
-function mjHeifGate(sel) {
-	mjConfig().then(cfg => {
-		if (mjGet(cfg, 'video0.codec') !== 'h265') {
-			const el = $(sel);
-			if (el) { el.checked = false; el.disabled = true; }
-		}
-	});
-}
-
 function setProgressBar(id, value, name) {
 	$(id).setAttribute('aria-valuenow', value);
 	$(id).title = name + ': ' + value + '%'

--- a/www/cgi-bin/ext-ntfy.cgi
+++ b/www/cgi-bin/ext-ntfy.cgi
@@ -70,7 +70,7 @@ fi
 				<div class="text-uppercase x-small text-secondary mt-3 mb-2">Message</div>
 				<% field_text "ntfy_caption" "Caption" "Supports %hostname, %datetime, %soctemp." %>
 				<% field_string "ntfy_priority" "Priority" "eval" "1 2 3 4 5" "1 = min, 5 = max (urgent)." %>
-				<% field_switch "ntfy_heif" "Use HEIF format" "eval" "Requires H265 codec on Video0." %>
+				<% field_switch "ntfy_heif" "Use HEIF format" "eval" "Smaller files than JPEG." %>
 				<% button_submit %>
 			</form>
 		</div></div>

--- a/www/cgi-bin/ext-openwall.cgi
+++ b/www/cgi-bin/ext-openwall.cgi
@@ -50,7 +50,7 @@ fi
 				<% field_switch "openwall_crontab" "Add to crontab" "eval" "Send pictures timed by interval." %>
 				<% field_text "openwall_caption" "Caption" "Location or short description." %>
 				<div class="text-uppercase x-small text-secondary mt-3 mb-2">Options</div>
-				<% field_switch "openwall_heif" "Use HEIF format" "eval" "Requires H265 codec on Video0." %>
+				<% field_switch "openwall_heif" "Use HEIF format" "eval" "Smaller files than JPEG." %>
 				<% field_switch "openwall_proxy" "Use SOCKS5" "eval" "<a href=\"ext-proxy.cgi\">Configure proxy access.</a>" %>
 				<% button_submit %>
 			</form>
@@ -65,7 +65,5 @@ fi
 		<% ex "grep openwall /etc/crontabs/root" %>
 	</div>
 </details>
-
-<script>mjHeifGate('#openwall_heif');</script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -64,7 +64,7 @@ fi
 				<% field_text "telegram_caption" "Caption" "Location or short description." %>
 				<div class="text-uppercase x-small text-secondary mt-3 mb-2">Options</div>
 				<% field_switch "telegram_document" "Send as document" "eval" "Attach picture as general file." %>
-				<% field_switch "telegram_heif" "Use HEIF format" "eval" "Requires H265 codec on Video0." %>
+				<% field_switch "telegram_heif" "Use HEIF format" "eval" "Smaller files than JPEG." %>
 				<% field_switch "telegram_proxy" "Use SOCKS5" "eval" "<a href=\"ext-proxy.cgi\">Configure proxy access.</a>" %>
 				<% button_submit %>
 			</form>
@@ -90,7 +90,5 @@ fi
 		<% ex "grep telegram /etc/crontabs/root" %>
 	</div>
 </details>
-
-<script>mjHeifGate('#telegram_heif');</script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
## What

A recent majestic update makes HEIF snapshots work on **both** AVC (H264) and HEVC (H265). The UI still carried the old "Requires H265 codec on Video0." constraint, which:

- showed an obsolete hint on the **Use HEIF format** switch (OpenWall, Telegram, ntfy), and
- actively **unchecked + disabled** that switch via `mjHeifGate()` whenever Video0 wasn't H265.

## Change

- Remove the now-dead `mjHeifGate` helper from `main.js` and its three call sites.
- Replace the hint text with the actual benefit: **"Smaller files than JPEG."**

`mjConfig`/`mjGet` are kept — they're used by other pages.

No behavioural change beyond the HEIF switch now being usable on H264 too.