### PR TITLE
mj-settings: let section cards size to content (drop h-100)

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -221,7 +221,7 @@
 			const props = ((state.schema.properties || {})[section] || {}).properties;
 			if (!props) continue;
 			const col = el('div', colCls);
-			const card = el('div', 'card h-100');
+			const card = el('div', 'card');
 			const body = el('div', 'card-body');
 			const h = el('h3');
 			h.textContent = label(section);
@@ -273,7 +273,7 @@
 			col.id = id;
 			col.className = 'col-12 col-lg-6';
 			col.innerHTML =
-				'<div class="card h-100"><div class="card-body">' +
+				'<div class="card"><div class="card-body">' +
 				'<h3>Visual editor</h3>' +
 				'<iframe id="mj-roi-iframe" src="/m/img.html" frameborder="0" class="mj-roi-iframe"></iframe>' +
 				'<button type="button" class="btn btn-outline-secondary mt-2" id="mj-roi-clear">Clear all regions</button>' +


### PR DESCRIPTION
Follow-up polish to the section-card settings redesign (#92).

With `card h-100`, a sparse section card (e.g. **HLS** = a single toggle, or **Watchdog** = two fields) was stretched to match the dense card beside it, becoming a tall, mostly-empty bordered box. Dropping `h-100` lets each card size to its content; the flex column still keeps each row aligned, so dense/paired cards (Main/Sub stream, RTSP/ONVIF) stay even while sparse cards stay compact. Visual-only, no behaviour change.

Verified on a hi3516av300 lab cam across all tabs (Image / Video & Audio / Events / Recording / Network & Integrations / System): sparse cards now read as small panels rather than empty boxes; the grid stays balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)