### PR TITLE
webui: cap number-input width so small integers don't stretch full-width

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -46,6 +46,11 @@
 	text-align: center;
 }
 
+/* small integers (ports, timeouts, sizes…) don't need the full card width */
+.number .input-group {
+	max-width: 10rem;
+}
+
 .x-small {
 	font-size: 0.8125rem;
 }


### PR DESCRIPTION
Follow-up polish to the settings redesign. Number fields (ports, timeouts, sizes — `<p class=\"number\">`) were rendered at full card width, so a 2-digit port or a timeout sat right-aligned in a ~440px box ("no designer" look).

Cap `.number .input-group` at `10rem` so small integers get a sensibly small box. Text inputs (paths, addresses) and selects (which can hold long values such as the `isp.sensorConfig` file path) stay full-width. Global rule, so it also tidies static `field_integer` fields. Visual-only, no behaviour change.

Verified on a hi3516av300 lab cam: System (ports 80/443, buffer 1024, watchdog timeout 300) and Video & Audio (frame rate 20, bitrate 4096/1024) number boxes are now compact; resolution text field and codec/rate/profile selects remain full-width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)