### PR TITLE
mj-settings: moderate width cap on short enum selects

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -51,6 +51,16 @@
 	max-width: 10rem;
 }
 
+/* moderate cap for short enum selects in Majestic settings; long-option
+   selects (e.g. the sensor-config file list) opt out via .mj-wide */
+.mj-row.select .form-select {
+	max-width: 16rem;
+}
+
+.mj-row.select.mj-wide .form-select {
+	max-width: none;
+}
+
 .x-small {
 	font-size: 0.8125rem;
 }

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -389,13 +389,15 @@
 			control = p.querySelector('input');
 		} else if (type === 'string' && enumVals && enumVals.length) {
 			p = el('p', 'select mj-row');
+			// short enums get a moderate width cap; long-option enums stay full-width
+			if (enumVals.some(o => String(o).length > 14)) p.classList.add('mj-wide');
 			const opts = enumVals.map(o => option(o, String(eff) === String(o))).join('');
 			p.innerHTML =
 				'<label for="' + id + '" class="form-label">' + esc(desc) + '</label>' +
 				'<select class="form-select" id="' + id + '">' + opts + '</select>';
 			control = p.querySelector('select');
 		} else if (type === 'string' && isSensorPath) {
-			p = el('p', 'select mj-row');
+			p = el('p', 'select mj-row mj-wide');
 			const opts = '<option value=""></option>' + SENSORS.map(s => option(s, String(eff) === s)).join('');
 			p.innerHTML =
 				'<label for="' + id + '" class="form-label">' + esc(desc) + '</label>' +


### PR DESCRIPTION
Follow-up polish: now that number inputs are compact (#95), the short enum selects (codec, rate-control mode, profile, severity, anti-flicker, …) still stretched full card width. Cap them at `16rem` so they match.

Long-option selects **opt out** via `.mj-wide`: the renderer adds it to the `isp.sensorConfig` file-path select and to any enum whose options exceed 14 chars, so nothing truncates. The cap is scoped to `.mj-row` selects, so static and FPV server-rendered selects (e.g. fpv-wfb's long \"Channel 161 - 5805 MHz\" picker) are unaffected. Visual-only.

Verified on a hi3516av300 lab cam: Video codec/rate/profile selects now sit in tidy ~16rem boxes; the resolution text field stays full-width; on Image, the DOM shows 6 short enum selects capped and only the \"Sensor configuration file\" select carrying `.mj-wide` (full-width, no truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)