### PR TITLE
heif: send on both codecs; route HEIF correctly to Telegram/ntfy

### DIFF
--- a/bin/ntfy.sh
+++ b/bin/ntfy.sh
@@ -35,11 +35,13 @@ fi
 filename="$(hostname -s | tr ' ' '-')"-"$(date +'%Y%m%d-%H%M%S')"
 
 # Format verification (HEIF or JPG)
-if [ "$ntfy_heif" = "true" ] && [ "$(yaml-cli -g .video0.codec)" = "h265" ]; then
+if [ "$ntfy_heif" = "true" ]; then
     snapshot=/tmp/${filename}.heif
+    content_type="image/heif"
     wget -q -T1 localhost/image.heif -O "$snapshot"
 else
     snapshot=/tmp/${filename}.jpg
+    content_type="image/jpeg"
     wget -q -T1 localhost/image.jpg -O "$snapshot"
 fi
 
@@ -76,6 +78,7 @@ command="${command} -H 'Priority: ${ntfy_priority}'"
 command="${command} -H 'Tags: warning,rotating_light'"
 command="${command} -H 'Message: ${ntfy_message}'"
 command="${command} -H 'Filename: $(basename $snapshot)'"
+command="${command} -H 'Content-Type: ${content_type}'"
 
 # Sending a file
 command="${command} -T '${snapshot}'"

--- a/sbin/openwall
+++ b/sbin/openwall
@@ -27,9 +27,11 @@ fi
 
 if [ "$openwall_heif" = "true" ]; then
 	snapshot=/tmp/snapshot.heif
+	content_type="image/heif"
 	wget -q -T1 localhost/image.heif -O "$snapshot"
 else
 	snapshot=/tmp/snapshot.jpg
+	content_type="image/jpeg"
 	wget -q -T1 localhost/image.jpg -O "$snapshot"
 fi
 
@@ -64,7 +66,7 @@ command="${command} -F 'soc=${soc}'"
 command="${command} -F 'soc_temperature=${temperature}'"
 command="${command} -F 'streamer=${streamer}'"
 command="${command} -F 'uptime=${uptime}'"
-command="${command} -F 'file=@${snapshot}'"
+command="${command} -F 'file=@${snapshot};type=${content_type}'"
 
 echo "$command"
 eval "$command"

--- a/sbin/openwall
+++ b/sbin/openwall
@@ -25,7 +25,7 @@ if [ "$openwall_enabled" != "true" ]; then
 	exit 1
 fi
 
-if [ "$openwall_heif" = "true"  ] && [ "$(yaml-cli -g .video0.codec)" = "h265" ]; then
+if [ "$openwall_heif" = "true" ]; then
 	snapshot=/tmp/snapshot.heif
 	wget -q -T1 localhost/image.heif -O "$snapshot"
 else

--- a/sbin/telegram
+++ b/sbin/telegram
@@ -23,7 +23,7 @@ else
 fi
 
 filename="$(hostname -s | tr ' ' '-')"-"$(date +'%Y%m%d-%H%M%S')"
-if [ "$telegram_heif" = "true"  ] && [ "$(yaml-cli -g .video0.codec)" = "h265" ]; then
+if [ "$telegram_heif" = "true" ]; then
 	snapshot=/tmp/${filename}.heif
 	wget -q -T1 localhost/image.heif -O "$snapshot"
 else
@@ -52,7 +52,9 @@ if [ -n "$telegram_thread_id" ]; then
 fi 
 command="${command} --url https://api.telegram.org/bot${telegram_token}"
 
-if [ "$telegram_document" = "true" ]; then
+# HEIF is not a valid sendPhoto format (Telegram only accepts JPEG/PNG/GIF/WEBP),
+# so always send it via sendDocument.
+if [ "$telegram_document" = "true" ] || [ "${snapshot##*.}" = "heif" ]; then
 	command="${command}/sendDocument"
 	command="${command} -F 'document=@${snapshot}'"
 	command="${command} -F 'caption=${telegram_message}'"

--- a/www/cgi-bin/ext-ntfy.cgi
+++ b/www/cgi-bin/ext-ntfy.cgi
@@ -70,7 +70,7 @@ fi
 				<div class="text-uppercase x-small text-secondary mt-3 mb-2">Message</div>
 				<% field_text "ntfy_caption" "Caption" "Supports %hostname, %datetime, %soctemp." %>
 				<% field_string "ntfy_priority" "Priority" "eval" "1 2 3 4 5" "1 = min, 5 = max (urgent)." %>
-				<% field_switch "ntfy_heif" "Use HEIF format" "eval" "Smaller files than JPEG." %>
+				<% field_switch "ntfy_heif" "Use HEIF format" "eval" "Smaller files (best with H265)." %>
 				<% button_submit %>
 			</form>
 		</div></div>

--- a/www/cgi-bin/ext-openwall.cgi
+++ b/www/cgi-bin/ext-openwall.cgi
@@ -50,7 +50,7 @@ fi
 				<% field_switch "openwall_crontab" "Add to crontab" "eval" "Send pictures timed by interval." %>
 				<% field_text "openwall_caption" "Caption" "Location or short description." %>
 				<div class="text-uppercase x-small text-secondary mt-3 mb-2">Options</div>
-				<% field_switch "openwall_heif" "Use HEIF format" "eval" "Smaller files than JPEG." %>
+				<% field_switch "openwall_heif" "Use HEIF format" "eval" "Smaller files (best with H265)." %>
 				<% field_switch "openwall_proxy" "Use SOCKS5" "eval" "<a href=\"ext-proxy.cgi\">Configure proxy access.</a>" %>
 				<% button_submit %>
 			</form>

--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -64,7 +64,7 @@ fi
 				<% field_text "telegram_caption" "Caption" "Location or short description." %>
 				<div class="text-uppercase x-small text-secondary mt-3 mb-2">Options</div>
 				<% field_switch "telegram_document" "Send as document" "eval" "Attach picture as general file." %>
-				<% field_switch "telegram_heif" "Use HEIF format" "eval" "Smaller files than JPEG." %>
+				<% field_switch "telegram_heif" "Use HEIF format" "eval" "Smaller files (best with H265); sent as a document." %>
 				<% field_switch "telegram_proxy" "Use SOCKS5" "eval" "<a href=\"ext-proxy.cgi\">Configure proxy access.</a>" %>
 				<% button_submit %>
 			</form>


### PR DESCRIPTION
## Why

Follow-up to #93. That PR un-greyed the HEIF switches in the UI, but the **sender scripts still gated HEIF on `Video0 == h265`**, so on an H.264 camera the toggle silently fell back to JPEG. A recent majestic update makes HEIF conformant on **both** codecs, so the gate can go.

While widening the rollout, two real delivery bugs surfaced:

- **Telegram:** `sendPhoto` only accepts JPEG/PNG/GIF/WEBP — a HEIF pushed that way is rejected (*"Unsupported image format"*). The script sent HEIF via `sendPhoto` unless *Send as document* was also ticked, so `telegram_heif` alone was broken.
- **ntfy:** the file was PUT with no `Content-Type`, so the attachment wasn't typed as an image.

## Changes

- Drop `&& [ "$(yaml-cli -g .video0.codec)" = "h265" ]` in `sbin/telegram`, `sbin/openwall`, `bin/ntfy.sh`.
- `sbin/telegram`: always use `sendDocument` when the snapshot is `.heif`.
- `bin/ntfy.sh`: send `Content-Type: image/heif` (or `image/jpeg`).
- Hints → "Smaller files (best with H265)." (the size win is mainly an HEVC story); Telegram note: sent as a document.

## Verification (hi3516av300, H264)

| sender | HEIF | JPEG |
|---|---|---|
| Telegram | builds `/sendDocument`, `document=@….heif` | `/sendPhoto`, `photo=@….jpg` |
| ntfy | `Content-Type: image/heif`, `-T ….heif` | `Content-Type: image/jpeg`, `-T ….jpg` |

`/image.heif` is ~28% smaller than `/image.jpg` on H.264 (414 KB vs 579 KB); larger gain on H.265.

> Note: HEIF previews inline only in Safari/Apple and the mobile Telegram/ntfy apps; Chrome/Firefox and Telegram **desktop** show it as a downloadable file. JPEG remains the default for universal compatibility.