### PR TITLE
mj-settings: lay a lone section tab in two columns instead of a centred card

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -255,6 +255,23 @@ pre#output[data-cmd] {
 	flex: 1 1 auto;
 }
 
+/* a lone full-width section card (e.g. Recording) flows its fields in 2 columns */
+.mj-cols {
+	column-count: 2;
+	column-gap: 2.5rem;
+}
+
+.mj-cols .mj-row,
+.mj-cols h5 {
+	break-inside: avoid;
+}
+
+@media (max-width: 767.98px) {
+	.mj-cols {
+		column-count: 1;
+	}
+}
+
 .mj-live-video {
 	width: 100%;
 	max-width: 640px;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -237,7 +237,7 @@
 		// Multi-card groups flow 2-up; a lone card (e.g. Recording — no preview,
 		// no ROI mate) is centred so it reads as one panel, not a left-stranded half.
 		const lone = group.sections.length === 1 && !groupHasMotion(group) && !live;
-		const colCls = lone ? 'col-12 col-lg-8 mx-auto' : 'col-12 col-lg-6';
+		const colCls = lone ? 'col-12' : 'col-12 col-lg-6';
 		for (const section of group.sections) {
 			const props = ((state.schema.properties || {})[section] || {}).properties;
 			if (!props) continue;
@@ -247,12 +247,17 @@
 			const h = el('h3');
 			h.textContent = label(section);
 			body.appendChild(h);
+			// a lone full-width card flows its fields in two columns so it fills the
+			// width instead of stranding a half-card or stretching single-column inputs.
+			const target = lone ? el('div', 'mj-cols') : body;
+			if (lone) body.appendChild(target);
 			card.appendChild(body);
 			col.appendChild(card);
-			renderProps(body, section, props);
+			renderProps(target, section, props);
 			// a section whose only fields were x-live (moved to the panel) is empty
 			// apart from its heading — don't show an empty card.
-			if (body.childElementCount <= 1) continue;
+			const filled = lone ? target.childElementCount > 0 : body.childElementCount > 1;
+			if (!filled) continue;
 			grid.appendChild(col);
 		}
 


### PR DESCRIPTION
A single-section tab — Recording — rendered as one **centred** half-width card, which looked stranded/odd. Make a lone group a **full-width card whose fields flow in two columns** (`.mj-cols`, `column-count:2`, collapsing to 1 on small screens), so it fills the width like the multi-card tabs without stretching single-column inputs (the Recording path stays confined to its column; the number/select caps still apply).

Only single-section, non-motion, non-live groups take this path (today just Recording); everything else is unchanged. Visual-only.

Verified on a hi3516av300: Recording now shows a full-width Record card with its fields balanced across two columns — no centring, no stranded half-card, path input at a sensible width. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)