### PR TITLE
webui: cap short enum selects UI-wide for consistent control sizes

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -51,13 +51,14 @@
 	max-width: 10rem;
 }
 
-/* moderate cap for short enum selects in Majestic settings; long-option
-   selects (e.g. the sensor-config file list) opt out via .mj-wide */
-.mj-row.select .form-select {
+/* moderate cap for short enum selects (field_string/mj-settings/fpv) so a short
+   value doesn't sit in a full-width box; long-option selects (e.g. the
+   sensor-config file list) opt out via .mj-wide */
+.select .form-select {
 	max-width: 16rem;
 }
 
-.mj-row.select.mj-wide .form-select {
+.select.mj-wide .form-select {
 	max-width: none;
 }
 


### PR DESCRIPTION
Final visual-consistency pass across every page. The UI was already consistent on fonts, headings, primary/utility button sizes, card framing, number caps and alert usage. The one real **input-control-size** inconsistency: the 16rem cap on short enum selects was scoped to mj-settings, so on the Extensions/Firmware/FPV pages selects (OpenWall Interval, Ntfy Priority, fw-network interface, WFB bandwidth, …) were still full card width — a short value in an oversized box, exactly the oversizing fixed earlier for number inputs.

Broaden the cap from `.mj-row.select` to `.select` so all field-helper / generated enum selects match. Long-option selects still opt out via `.mj-wide` (the mj-settings sensor-config file list). Verified the longest static select — fpv-wfb \"Channel 161 - 5805 MHz\" — still renders in full at 16rem (no truncation). Visual-only.

Verified on a hi3516av300 across all user-facing pages: selects now sit in consistent ~16rem boxes (OpenWall Interval, fw-network interface), the channel picker is not truncated, mj-settings selects unchanged, sensor-config select stays full-width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)