### PR TITLE
webui: harmonise button styles and ext card widths for consistency

### DIFF
--- a/www/a/sdcard.js
+++ b/www/a/sdcard.js
@@ -69,7 +69,7 @@
 		const rp = recPrefix(), recEnabled = mjGet(cfg, 'records.enabled') === true;
 		const onThisCard = d.mounted && rp === d.mountpoint;
 
-		let acts = '<button class="btn btn-sm btn-outline-primary" data-act="browse"' + (d.mounted ? '' : ' disabled') + '>Browse files</button>';
+		let acts = '<button class="btn btn-sm btn-outline-secondary" data-act="browse"' + (d.mounted ? '' : ' disabled') + '>Browse files</button>';
 		if (d.mounted) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="unmount">Unmount</button>';
 		else if (d.fs) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="mount">Mount</button>';
 		if (d.canFsck) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="fsck">Check</button>';

--- a/www/cgi-bin/ext-proxy.cgi
+++ b/www/cgi-bin/ext-proxy.cgi
@@ -20,7 +20,7 @@ fi
 <%in p/header.cgi %>
 
 <div class="row g-4">
-	<div class="col-12 col-lg-6">
+	<div class="col-12 col-lg-8">
 		<div class="card h-100"><div class="card-body">
 			<h3>SOCKS5 proxy</h3>
 			<p class="small text-secondary">Route extension traffic (OpenWall, Telegram) through a SOCKS5 proxy.</p>

--- a/www/cgi-bin/ext-vtun.cgi
+++ b/www/cgi-bin/ext-vtun.cgi
@@ -27,7 +27,7 @@ fi
 <%in p/header.cgi %>
 
 <div class="row g-4">
-	<div class="col-12 col-lg-6">
+	<div class="col-12 col-lg-8">
 		<div class="card h-100"><div class="card-body">
 			<h3>VTun</h3>
 			<p class="small text-secondary">Virtual tunnel for remote access to the camera.</p>

--- a/www/cgi-bin/ext-wireguard.cgi
+++ b/www/cgi-bin/ext-wireguard.cgi
@@ -32,7 +32,7 @@ fi
 <%in p/header.cgi %>
 
 <div class="row g-4">
-	<div class="col-12 col-lg-7">
+	<div class="col-12 col-lg-8">
 		<div class="card h-100"><div class="card-body">
 			<h3>WireGuard</h3>
 			<p class="small text-secondary">WireGuard VPN tunnel for secure remote access.</p>

--- a/www/cgi-bin/fpv-wfb.cgi
+++ b/www/cgi-bin/fpv-wfb.cgi
@@ -447,7 +447,7 @@ update_wfbinfo
             </form>
             <hr class="my-3">
             <p class="small text-secondary mb-2">Reboot to apply new WFB settings.</p>
-            <a class="btn btn-sm btn-danger" href="fw-restart.cgi">Restart camera</a>
+            <a class="btn btn-sm btn-outline-secondary confirm" href="fw-restart.cgi">Restart camera</a>
         </div></div>
     </div>
 

--- a/www/cgi-bin/tool-files.cgi
+++ b/www/cgi-bin/tool-files.cgi
@@ -7,9 +7,9 @@
 	<div class="d-flex flex-wrap align-items-center gap-2 mb-2">
 		<nav id="fm-breadcrumb" aria-label="path" class="me-auto"><ol class="breadcrumb m-0"></ol></nav>
 		<div class="btn-group btn-group-sm">
-			<button id="fm-newfolder" class="btn btn-outline-primary" type="button">New folder</button>
-			<button id="fm-newfile" class="btn btn-outline-primary" type="button">New file</button>
-			<button id="fm-upload-btn" class="btn btn-outline-primary" type="button">Upload</button>
+			<button id="fm-newfolder" class="btn btn-outline-secondary" type="button">New folder</button>
+			<button id="fm-newfile" class="btn btn-outline-secondary" type="button">New file</button>
+			<button id="fm-upload-btn" class="btn btn-outline-secondary" type="button">Upload</button>
 		</div>
 	</div>
 


### PR DESCRIPTION
Tidy-ups from the full-UI screenshot/consistency pass:

- **Restart-camera styling**: fpv-wfb used `btn-danger` (red) while fw-settings uses a neutral outline. A reboot is not destructive, so fpv-wfb now matches (`btn-outline-secondary` + `confirm`). Red stays reserved for destructive actions.
- **Utility-button colour**: the File Manager (New folder / New file / Upload) and SD Card (Browse files) used `btn-outline-primary` (blue) while every other incidental button across the UI is `btn-outline-secondary` (gray). Unified to gray; destructive actions (Format / Delete) stay red, and the SD \"Use this card for recording\" stays the single solid-blue primary.
- **Extensions card widths**: the single-card pages (VTun / WireGuard / Proxy) used `col-lg-6`/`col-lg-7`; unified to `col-lg-8` to match OpenWall so the settings card is the same width across all Extensions pages.

Visual-only. Verified on a hi3516av300: File Manager + SD Card utility buttons now gray, fpv-wfb restart neutral, ext-proxy/vtun/wireguard cards at the OpenWall width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)