### PR TITLE
webui: fix blue background on log/output panels in light theme

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -311,10 +311,17 @@ pre#output[data-cmd] {
 	--bs-nav-link-color: white;
 }
 
+/* Brand the navbar blue in light theme with an explicit colour (dark theme keeps
+   Bootstrap's default dark bar). Doing it here instead of via --bs-tertiary-bg-rgb
+   keeps .bg-body-tertiary neutral for the log/output console panels — otherwise
+   those panels rendered dark text on a blue background in light theme. */
+[data-bs-theme=light] .navbar.bg-body-tertiary {
+	background-color: var(--bs-primary) !important;
+}
+
 [data-bs-theme=light] {
 	--bs-primary: rgb(76, 96, 216);
 	--bs-secondary: rgb(76, 96, 216);
-	--bs-tertiary-bg-rgb: 76, 96, 216;
 }
 
 [data-bs-theme=dark] {


### PR DESCRIPTION
Bug (reported): on info-logs in **light theme** the log console showed dark text on a **blue** background (unreadable); dark theme was fine.

Root cause: the light-theme override set `--bs-tertiary-bg-rgb` to the brand blue purely to colour the navbar, but Bootstrap's `.bg-body-tertiary` uses that same variable — so the info-logs console (`#log`) and the fw-update progress `<pre>` (`#fw-output`) inherited a blue background in light theme. Dark theme never overrode the variable, so it looked correct there.

Fix: brand the navbar blue with an explicit rule (`[data-bs-theme=light] .navbar.bg-body-tertiary`) and drop the `--bs-tertiary-bg-rgb` override, so `.bg-body-tertiary` returns to its neutral grey for the console panels. The navbar is unchanged (blue in light, dark bar in dark).

Verified on a hi3516av300: light-theme log console now neutral grey with readable text (severity colours intact) and the navbar still blue; dark theme identical to before. Same fix also corrects the fw-update progress panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)