### PR TITLE
fw-settings: preserve newlines in the backuper-config textarea

### DIFF
--- a/www/cgi-bin/fw-settings.cgi
+++ b/www/cgi-bin/fw-settings.cgi
@@ -83,7 +83,7 @@ fi
 			<p class="small text-secondary mb-2">Lines starting <code>#/</code> are files to back up; <code>cli -s …</code> lines run after a restore.</p>
 			<form action="<%= $SCRIPT_NAME %>" method="post">
 				<% field_hidden "action" "save" %>
-				<textarea name="editor_text" class="form-control font-monospace small" style="height:20rem;white-space:pre;overflow-wrap:normal" spellcheck="false"><%= $(sed 's/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g' "$config_file") %></textarea>
+				<textarea name="editor_text" class="form-control font-monospace small" style="height:20rem;white-space:pre;overflow-wrap:normal" spellcheck="false"><% sed 's/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g' "$config_file" %></textarea>
 				<% button_submit "Save configuration" %>
 			</form>
 		</div></div>


### PR DESCRIPTION
Bug (reported): the **Backuper configuration** textarea showed the whole config collapsed onto one very long line.

Root cause: the content was emitted with `<%= $(sed ... \"$config_file\") %>`, and haserl's `<%=` is an **unquoted `echo`** — so the shell word-split `sed`'s multi-line output and `echo` rejoined the tokens with single spaces, collapsing every newline.

Fix: emit `sed` directly via the `<% ... %>` form (its stdout goes straight to the page — no `echo`, no word-splitting), so the line breaks survive. HTML-escaping (`&`/`<`/`>`) and the save handler are unchanged.

Verified on a hi3516av300: the served `<textarea>` now contains the config across ~15 lines (comment block, `#/path` entries, then the `cli -s …` commands), and it renders multi-line in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)