### PR TITLE
ui: modern "soft & elevated" theme refresh + brand fonts + Dark Reader compat

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -67,6 +67,22 @@
 	text-align: center;
 }
 
+/* A range slider is itself a `.form-control`, so Bootstrap boxes the track (and
+   its value chip) in a bordered "pill". That reads heavy for a slider — drop the
+   box so it's a bare track + plain value. The thumb still shows focus. */
+.range .form-range {
+	border: 0;
+	background-color: transparent;
+	box-shadow: none;
+}
+
+.range .input-group > .show-value {
+	border: 0;
+	background-color: transparent;
+	color: var(--bs-secondary-color);
+	padding-left: 0.25rem;
+}
+
 /* small integers (ports, timeouts, sizes…) don't need the full card width */
 .number .input-group {
 	max-width: 10rem;

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1,6 +1,27 @@
 :root {
-	--bs-font-sans-serif: 'Montserrat', sans-serif;
-	--bs-font-monospace: 'PT Mono', monospace;
+	/* brand fonts first (loaded from the CDN <link> in header.cgi), with a
+	   modern system fallback for offline/LAN cameras that can't reach the CDN */
+	--bs-font-sans-serif: 'Montserrat', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+	--bs-font-monospace: 'PT Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+
+	/* ── modern "soft & elevated" theme tokens ─────────────────────────────
+	   Everything here is a Bootstrap 5.3 custom property, so the refresh is a
+	   pure token layer that applies to every page. Softer corners: */
+	--bs-border-radius: 0.5rem;
+	--bs-border-radius-sm: 0.375rem;
+	--bs-border-radius-lg: 0.75rem;
+	--bs-border-radius-xl: 1rem;
+
+	/* layered elevation scale (cards/buttons float above the page) */
+	--bs-box-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.12);
+	--bs-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+	--bs-box-shadow-lg: 0 8px 28px rgba(0, 0, 0, 0.22);
+
+	/* accent-tinted focus ring (indigo brand colour) */
+	--bs-focus-ring-color: rgba(76, 96, 216, 0.35);
+	--bs-focus-ring-width: 0.2rem;
+
+	--mj-ease: 140ms ease;
 }
 
 .col > h3 {
@@ -338,16 +359,66 @@ pre#output[data-cmd] {
 }
 
 [data-bs-theme=light] {
+	color-scheme: light;
 	--bs-primary: rgb(76, 96, 216);
+	--bs-primary-rgb: 76, 96, 216;
 	--bs-secondary: rgb(76, 96, 216);
+	/* soft off-white page so white cards visibly lift off it */
+	--bs-body-bg: #f4f5f9;
+	--bs-body-color: #1f2430;
+	--bs-secondary-bg: #eceef4;
+	--bs-card-bg: #ffffff;
+	--bs-border-color: #e2e5ee;
 }
 
 [data-bs-theme=dark] {
-	--bs-primary: rgb(76, 96, 216);
+	color-scheme: dark;
+	/* accent nudged a touch brighter for contrast on dark surfaces */
+	--bs-primary: rgb(92, 112, 232);
+	--bs-primary-rgb: 92, 112, 232;
 	--bs-secondary: rgb(138, 159, 208);
+	/* cool, layered neutrals (not pure black) so cards float above the page */
+	--bs-body-bg: #14161c;
+	--bs-body-color: #e6e8ee;
+	--bs-secondary-bg: #1c1f27;
+	--bs-tertiary-bg: #232734;
+	--bs-card-bg: #1c1f27;
+	--bs-border-color: #2c313d;
+	--bs-focus-ring-color: rgba(92, 112, 232, 0.4);
 }
 
+/* solid accent primary button in dark (replaces the old washed-out translucent
+   generic blue), with a brighter hover */
 [data-bs-theme=dark] .btn-primary {
-	--bs-btn-bg: rgba(13, 110, 253, 0.5);
-	--bs-btn-border-color: rgba(13, 110, 253, 0.5);
+	--bs-btn-bg: var(--bs-primary);
+	--bs-btn-border-color: var(--bs-primary);
+	--bs-btn-hover-bg: rgb(110, 130, 245);
+	--bs-btn-hover-border-color: rgb(110, 130, 245);
+	--bs-btn-active-bg: rgb(78, 98, 218);
+	--bs-btn-active-border-color: rgb(78, 98, 218);
+}
+
+/* ── soft & elevated components (token-driven, applies to every page) ───── */
+.card {
+	border-radius: var(--bs-border-radius-lg);
+	box-shadow: var(--bs-box-shadow-sm);
+	transition: box-shadow var(--mj-ease);
+}
+
+.card:hover {
+	box-shadow: var(--bs-box-shadow);
+}
+
+.btn {
+	transition: background-color var(--mj-ease), border-color var(--mj-ease),
+		box-shadow var(--mj-ease), filter var(--mj-ease);
+}
+
+.btn-primary {
+	box-shadow: var(--bs-box-shadow-sm);
+}
+
+.form-control,
+.form-select {
+	transition: border-color var(--mj-ease), box-shadow var(--mj-ease);
 }

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -301,6 +301,14 @@ pre#output[data-cmd] {
 	column-gap: 1.5rem;
 }
 
+/* separate the masonry from whatever sits above it (the live-preview / live-
+   adjust row on the Image tab, or the page heading on plain tabs) so the first
+   card doesn't butt up against it. :not(:empty) avoids a phantom gap on the
+   motion/lone tabs where the masonry container is created but unused. */
+.mj-cards:not(:empty) {
+	margin-top: 1.5rem;
+}
+
 .mj-cards > .card {
 	break-inside: avoid;
 	margin-bottom: 1.5rem;

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -8,8 +8,13 @@ Pragma: no-cache
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<!-- the page ships its own light/dark theme; tell Dark Reader to leave colours alone -->
+	<meta name="darkreader-lock">
 	<title><% html_title %></title>
 	<script>if(document.documentElement.getAttribute('data-bs-theme')==='auto')document.documentElement.setAttribute('data-bs-theme',matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');</script>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=PT+Mono&display=swap">
 	<link rel="stylesheet" href="/a/bootstrap.min.css">
 	<link rel="stylesheet" href="/a/bootstrap.override.css">
 	<script src="/a/bootstrap.bundle.min.js"></script>

--- a/www/cgi-bin/status.cgi
+++ b/www/cgi-bin/status.cgi
@@ -119,8 +119,8 @@
 			<script type="application/json" id="overlay-data">{"total":<%= ${ov_total:-0} %>,"used":<%= ${ov_used:-0} %>,"avail":<%= ${ov_avail:-0} %>,"cats":[<%= $ov_cats %>]}</script>
 			<% if [ -n "$sd_rows" ]; then %>
 				<% echo "$sd_rows" | while IFS='|' read mnt use pct; do %>
-					<div class="d-flex justify-content-between x-small">
-						<span class="badge text-bg-success">SD</span>
+					<div class="d-flex align-items-center gap-2 x-small">
+						<span class="badge text-bg-success flex-shrink-0">SD</span>
 						<span class="text-secondary"><%= "$mnt — $use ($pct)" %></span>
 					</div>
 				<% done %>


### PR DESCRIPTION
The settings UI read as **stock Bootstrap 5.3**: flat cards (1px border, no elevation), tight default radius, default focus rings, almost no transitions. Two latent issues on top: the branded fonts (`Montserrat`/`PT Mono`) were *declared but never loaded* (so browsers fell back to a system font), and **Dark Reader** re-tinted the already-dark UI.

This is a **token-only** refresh — everything lives in `bootstrap.override.css` as Bootstrap 5.3 custom properties (no build step), so it applies to every page at once and is fully reversible.

## Soft & elevated look
- Softer corner radius (`--bs-border-radius*`) and a layered `--bs-box-shadow*` scale.
- Refined palettes: cooler **layered dark neutrals** (page `#14161c`, cards `#1c1f27` — not near-black) and a **soft off-white light** page (`#f4f5f9`) so white cards lift off it.
- `.card` gains subtle elevation + a gentle hover; accent-tinted focus ring; transitions on buttons/inputs.
- Fixed the dark `.btn-primary` hack (was a washed-out translucent *generic* blue → now the solid indigo accent).

## Brand fonts, wired up
- Added a Google Fonts `<link>` (preconnect + `display=swap`) for Montserrat/PT Mono in `header.cgi`. The `--bs-font-*` stacks keep a modern **system-font fallback**, so offline/LAN cameras (no internet) degrade gracefully.

## Dark Reader compatibility
- `color-scheme: dark|light` per theme + `<meta name="darkreader-lock">` so Dark Reader leaves the page's own theme untouched.

No HTML/JS structural changes; all existing custom classes (masonry `.mj-cards`, dirty `.mj-row`, sticky toolbar, storage bar, live panel, log console…) are preserved.

## Verification
Deployed to an hi3516av300 lab cam; screenshotted Video & Audio and fw-settings (and others) in **dark + light**: Montserrat loads from the CDN, cards show soft corners + subtle elevation, the accent is consistent (dark primary button fixed), and there are no layout regressions. Confirmed `darkreader-lock` + `color-scheme` in the served output.