### PR TITLE
status: show Majestic's own uptime in the Uptime card

### DIFF
--- a/www/a/main.js
+++ b/www/a/main.js
@@ -121,6 +121,12 @@ function heartbeat() {
 			if (typeof(json.uptime) !== 'undefined' && json.uptime !== '') {
 				$('#uptime').textContent = 'Uptime:️ ' + json.uptime;
 			}
+
+			// Majestic's own uptime, shown in the status-page Uptime card (if present)
+			if (typeof(json.mj_uptime) !== 'undefined') {
+				const mj = $('#st-uptime-mj');
+				if (mj) mj.textContent = json.mj_uptime || '–';
+			}
 		})
 		.then(setTimeout(heartbeat, 2000));
 }

--- a/www/cgi-bin/j/pulse.cgi
+++ b/www/cgi-bin/j/pulse.cgi
@@ -15,8 +15,23 @@ mem_free=$(awk '/MemFree/ {print $2}' /proc/meminfo)
 mem_used=$(( 100 - (mem_free / (mem_total / 100)) ))
 overlay_used=$(df | grep /overlay | xargs | cut -d' ' -f5)
 uptime=$(awk '{m=$1/60; h=m/60; printf "%sd %sh %sm %ss\n", int(h/24), int(h%24), int(m%60), int($1%60) }' /proc/uptime)
-payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s"}' \
-	"${soc_temp}" "$(date +%s)" "$(cat /etc/timezone)" "${mem_used}" "${overlay_used//%/}" "${daynight_value:=-1}" "$uptime")
+
+# Majestic's own uptime: system uptime minus the process start time (field 22 of
+# /proc/<pid>/stat is starttime in clock ticks since boot). Computed live each
+# poll, so it stays correct even if majestic restarts on its own. Formatted
+# without seconds to match the status card's system-uptime line.
+mj_uptime=""
+mjpid=$(echo "$web" | awk '{print $1}')
+if [ -n "$mjpid" ] && [ -r "/proc/$mjpid/stat" ]; then
+	mj_uptime=$(awk -v hz="$(getconf CLK_TCK 2>/dev/null || echo 100)" \
+		-v up="$(awk '{print $1}' /proc/uptime)" \
+		'{ s = up - $22/hz; if (s<0) s=0;
+		   d=int(s/86400); h=int((s%86400)/3600); m=int((s%3600)/60);
+		   printf "%s%s%sm", (d? d"d ":""), (h||d? h"h ":""), m }' "/proc/$mjpid/stat")
+fi
+
+payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s","mj_uptime":"%s"}' \
+	"${soc_temp}" "$(date +%s)" "$(cat /etc/timezone)" "${mem_used}" "${overlay_used//%/}" "${daynight_value:=-1}" "$uptime" "$mj_uptime")
 
 echo "HTTP/1.1 200 OK
 Content-type: application/json

--- a/www/cgi-bin/status.cgi
+++ b/www/cgi-bin/status.cgi
@@ -53,7 +53,7 @@
 		<div class="card h-100"><div class="card-body py-2">
 			<div class="x-small text-uppercase text-secondary">Uptime</div>
 			<div class="lh-1 my-1"><span class="fs-5 fw-semibold" id="st-uptime">–</span></div>
-			<div class="x-small text-secondary mt-1">since boot</div>
+			<div class="x-small text-secondary mt-1">Majestic <span id="st-uptime-mj">–</span></div>
 		</div></div>
 	</div>
 </div>


### PR DESCRIPTION
Adds Majestic's process uptime next to the system uptime in the status dashboard's **Uptime** card — useful for spotting a majestic restart (e.g. a config reload/crash) that didn't reboot the box.

- **`pulse.cgi`** computes it live each poll from `/proc/<pid>/stat` (system uptime − process starttime), so it's correct *even across a majestic restart* (no stale page-load value). Added as `mj_uptime` in the JSON payload, formatted without seconds to match the card's system-uptime line.
- **`main.js`** fills a new `#st-uptime-mj` element from the existing 2 s heartbeat (no extra request).
- **`status.cgi`** Uptime card now reads: system uptime (large) + `Majestic <uptime>` beneath it.

Webui-only; reuses the existing pulse heartbeat. Verified on an hi3516av300: card shows e.g. system `2d 4h 53m` with `Majestic 2h 38m` (cross-checked against `/proc`).