### PR TITLE
mj-settings: fix Visual editor iframe overflowing its card

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -337,18 +337,32 @@ pre#output[data-cmd] {
 }
 
 .mj-live-video {
+	display: block; /* avoid the inline baseline gap below the <video> */
 	width: 100%;
 	max-width: 640px;
 	aspect-ratio: 16/9;
 	background: #000;
 	border: 1px solid var(--bs-primary);
-	border-radius: 4px;
+	border-radius: var(--bs-border-radius);
+}
+
+/* Responsive-embed wrapper: a plain block div sizes width:100% correctly to the
+   card-body content box, whereas the iframe (a replaced element with
+   aspect-ratio) mis-resolves it and overflows. The iframe absolutely fills the
+   wrapper. */
+.mj-roi-wrap {
+	position: relative;
+	width: 100%;
+	aspect-ratio: 16/9;
 }
 
 .mj-roi-iframe {
+	position: absolute;
+	inset: 0;
 	width: 100%;
-	aspect-ratio: 16/9;
+	height: 100%;
 	border: 1px solid var(--bs-primary);
+	border-radius: var(--bs-border-radius);
 	padding: 0;
 	margin: 0;
 }

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -355,7 +355,7 @@
 			col.innerHTML =
 				'<div class="card"><div class="card-body">' +
 				'<h3>Visual editor</h3>' +
-				'<iframe id="mj-roi-iframe" src="/m/img.html" frameborder="0" class="mj-roi-iframe"></iframe>' +
+				'<div class="mj-roi-wrap"><iframe id="mj-roi-iframe" src="/m/img.html" frameborder="0" class="mj-roi-iframe"></iframe></div>' +
 				'<button type="button" class="btn btn-outline-secondary mt-2" id="mj-roi-clear">Clear all regions</button>' +
 				'</div></div>';
 			grid.appendChild(col);


### PR DESCRIPTION
On **Events**, the ROI **Visual editor** image overflowed its card — spilling past the right and bottom edges (obvious now that cards carry a border + shadow).

**Cause:** the iframe is a replaced element with `aspect-ratio`, and Chromium resolves its `width:100%` against the card-body's *padding* box, not the content box — measured 447 px in a 417 px content box (~30 px too wide). A plain block `<div style="width:100%">` in the same card-body correctly measures 417 px, confirming it's an iframe/replaced-element quirk, not the card.

**Fix:** the standard responsive-embed wrapper — wrap the iframe in a block `div.mj-roi-wrap` (which sizes correctly) and let the iframe absolutely fill it. Also rounded the iframe + `.mj-live-video` corners to match the cards and set `display:block` (drops the inline baseline gap).

Verified on an hi3516av300: iframe now 415 px, fully inside the card (no right/bottom overflow), image centered with even padding.