### PR TITLE
status: use MemAvailable for the header memory bar (was ~94%)

### DIFF
--- a/www/cgi-bin/j/pulse.cgi
+++ b/www/cgi-bin/j/pulse.cgi
@@ -10,9 +10,14 @@ if [ -n "$temp" ]; then
 	soc_temp="${temp%.*}°C"
 fi
 
-mem_total=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
-mem_free=$(awk '/MemFree/ {print $2}' /proc/meminfo)
-mem_used=$(( 100 - (mem_free / (mem_total / 100)) ))
+mem_total=$(awk '/^MemTotal/ {print $2}' /proc/meminfo)
+# MemAvailable counts reclaimable cache/buffers as available, so this is real
+# usage — not MemFree, which treats the kernel's page cache as "used" and reads
+# alarmingly high (~94%). Matches the status dashboard. Fall back to MemFree on
+# kernels too old to report MemAvailable.
+mem_avail=$(awk '/^MemAvailable/ {print $2}' /proc/meminfo)
+[ -z "$mem_avail" ] && mem_avail=$(awk '/^MemFree/ {print $2}' /proc/meminfo)
+mem_used=$(( 100 - (mem_avail * 100 / mem_total) ))
 overlay_used=$(df | grep /overlay | xargs | cut -d' ' -f5)
 uptime=$(awk '{m=$1/60; h=m/60; printf "%sd %sh %sm %ss\n", int(h/24), int(h%24), int(m%60), int($1%60) }' /proc/uptime)
 


### PR DESCRIPTION
The header's memory bar showed an alarming **~94%** while the status dashboard showed **~32%** for the same RAM.

**Cause:** `pulse.cgi` computed `100 − MemFree/MemTotal`. On Linux `MemFree` excludes the kernel's reclaimable page cache/buffers (here Cached ≈ 400 MB of 754 MB), so it counts cache as "used" and reads ~94%. The status page uses `MemAvailable` (free + reclaimable) → the real ~32%.

**Fix:** compute the header bar from `MemAvailable` too (`100 − MemAvailable/MemTotal`), matching the dashboard; fall back to `MemFree` on kernels without `MemAvailable`. Verified on an hi3516av300: header now 33% (vs status 32%, the gap is just poll timing).