### PR TITLE
fw-update: check updates via sysupgrade, not a verifying HTTPS HEAD (#121)

### DIFF
--- a/www/cgi-bin/fw-update.cgi
+++ b/www/cgi-bin/fw-update.cgi
@@ -3,25 +3,24 @@
 <%
 	page_title="Firmware Update"
 
-	github_ver() {
+	# Latest build available for THIS board, via sysupgrade — the same updater the
+	# Install button drives over /ws/upgrade. It reads OpenIPC's manifest.flat
+	# (firmware or builder repo, chosen by model) with `curl -k`, so unlike the old
+	# verifying HTTPS HEAD it is not defeated by a fresh flash's stale clock
+	# (issue #44/#121: BADCERT_FUTURE made curl fail while sysupgrade updated fine).
+	# `timeout` bounds it so a dead network cannot hang the page.
+	latest_build() {
 		[ -z "$network_gateway" ] && return
-		fw_soc=$soc
-		[ "$soc_vendor" = "ingenic" ] && fw_soc=$soc_family
-		builder=$(fw_printenv -n upgrade)
-		fw_url="${builder:-https://github.com/openipc/firmware/releases/download/latest/openipc.${fw_soc}-${flash_type}-${fw_variant}.tgz}"
-		curl -m5 -ILs "$fw_url" | grep -i last-modified | cut -d' ' -f2-
+		command -v sysupgrade >/dev/null 2>&1 || return
+		timeout 15 sysupgrade --list-builds 2>/dev/null \
+			| grep -Eo '[A-Za-z0-9._]+-[0-9]{8}-[0-9a-f]+' | head -1
 	}
 
-	ver=$(github_ver)
-	# Issue #44: a fresh flash boots with a stale clock so the HTTPS check
-	# fails; sync time once (NTP, else HTTP Date header) and retry.
-	if [ -z "$ver" ] && [ -n "$network_gateway" ]; then
-		synctime
-		ver=$(github_ver)
-	fi
-
+	ver=$(latest_build)
 	if [ -n "$ver" ]; then
-		fw_date=$(date -D "%a, %d %b %Y %T GMT" +"$(date +%y | sed 's/.$/.&/').%m.%d" --date "$ver")
+		# nightly-20260717-027aae1 -> 2026-07-17
+		fw_date=$(echo "$ver" | grep -Eo '[0-9]{8}' | head -1 | sed -E 's/(....)(..)(..)/\1-\2-\3/')
+		[ -z "$fw_date" ] && fw_date="$ver"
 	else
 		fw_date=""
 	fi


### PR DESCRIPTION
Closes #121

## Problem

`fw-update.cgi` shows **"— no access to GitHub —"** and disables the *Install update from GitHub* button, even when the camera has full GitHub access and `sysupgrade` updates fine from SSH. Reported on gk7205v200_lite / gk7205v210, reproduced on a hi3516ev300_lite.

## Root cause

The "Latest on GitHub" probe was a **separate, more fragile** code path than the actual updater:

- `github_ver()` did a **verifying** `curl -m5 -ILs …/releases/download/latest/openipc.<soc>-<flash>-<variant>.tgz | grep last-modified`.
- A fresh/rarely-rebooted flash boots with its **clock stuck at the build date** until NTP converges. Against that past clock GitHub's real TLS cert is "not yet valid", so curl fails instantly with `curl: (60) Cert verify failed: BADCERT_FUTURE` → empty result → "No access to GitHub" + disabled button. Same failure family as #44.
- The **real** updater (`fw-update.js` → `/ws/upgrade` → firmware `sysupgrade`) fetches OpenIPC's `manifest.flat` with `curl -k`, so it is immune to the stale clock — which is why `sysupgrade --list-builds` / `--build=…` work while the WebUI reports no access.

## Fix

Ask the same tool the updater uses, so the availability check and the updater share one source of truth:

```sh
latest_build() {
    [ -z "$network_gateway" ] && return
    command -v sysupgrade >/dev/null 2>&1 || return
    timeout 15 sysupgrade --list-builds 2>/dev/null \
        | grep -Eo '[A-Za-z0-9._]+-[0-9]{8}-[0-9a-f]+' | head -1
}
```

- Drops the bespoke `latest`-release-asset URL, the 5 s cap, the `ingenic` URL juggling, and the vestigial `fw_printenv -n upgrade` branch — `sysupgrade` already routes stock vs builder manifests by model.
- Keeps the `ver` (button gate) and `fw_date` (label) variables, so the rest of the page and `a/fw-update.js` are untouched. One file serves both the standard and FPV navs.
- "Latest on GitHub" now shows a clean `YYYY-MM-DD`.
- The `synctime` retry is no longer needed here (the check no longer depends on the clock); `synctime()` in `p/common.cgi` is left in place for a separate cleanup.

## Verification

Deployed to a hi3516ev300_lite whose clock was stuck at its build date and rendered over its real HTTP server:

| | "Latest on GitHub" | Install button |
|---|---|---|
| Before | `— no access to GitHub —` | disabled + no-access note |
| After | `2026-07-17` | **enabled** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)