### PR TITLE
mj-settings: surface the USB camera settings tab

### DIFF
--- a/www/cgi-bin/j/locale.cgi
+++ b/www/cgi-bin/j/locale.cgi
@@ -16,6 +16,7 @@ mj_rtsp=RTSP
 mj_system=System
 mj_video0=Main stream
 mj_video1=Sub stream
+mj_usbcam=USB camera
 mj_watchdog=Watchdog
 mj_sip=SIP
 mj_cloud=Cloud (WebRTC)

--- a/www/cgi-bin/j/locale_fpv.cgi
+++ b/www/cgi-bin/j/locale_fpv.cgi
@@ -17,5 +17,6 @@ mj_rtsp=RTSP
 mj_system=System
 mj_video0=Video0
 mj_video1=Video1
+mj_usbcam=USB camera
 mj_watchdog=Watchdog
 # mj_youtube=Youtube


### PR DESCRIPTION
majestic ships a `usbcam` config section (USB UVC webcam as a second camera, merged in majestic), but the Majestic settings form **hides any schema section without an `mj_<section>` label** (the same mechanism that suppresses `youtube`/`cloud`). Add `mj_usbcam=USB camera` to both `j/locale.cgi` and `j/locale_fpv.cgi` so a **USB camera** tab appears.

No JS change is needed — `mj-settings.js` builds the form dynamically from majestic's `/api/v1/config.schema.json`, and its `renderField`/`renderProps` already handle every usbcam field: enum→`<select>` (codec, transcode.codec), `x-resolution`→resolution picker (size), the nested `transcode` object (recursed), and `visibleWhen` (rows hidden until `enabled`). Those annotations are added on the majestic side (companion PR).

Structural usbcam changes take effect through the **existing** "Apply now" pipeline-reload banner: usbcam fields aren't `x-live`, so `onSubmit` already shows the banner, and `applyReload()`→`j/mj-apply.cgi` SIGHUPs majestic, which re-inits usbcam. No new restart hint required.

## Verification
Schema-driven, correct by construction: the majestic companion PR's live schema exposes the annotated `usbcam.*` fields (verified on a gk7205v200 + C920), and the tab strip in `mj-settings.cgi` renders one `<li>` per schema section that has an `mj_<section>` label. (This minimal FPV test rig doesn't have the webui installed, so a live browser render wasn't captured here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)