### PR TITLE
Fix day/night badge stuck on Day, and default password in endpoint URLs

### DIFF
--- a/www/a/status.js
+++ b/www/a/status.js
@@ -32,8 +32,11 @@
 				else if (key === 'node_load1') m.load1 = val;
 				else if (key === 'node_time_seconds') m.nodeTime = val;
 				else if (key === 'node_boot_time_seconds') m.nodeBoot = val;
+				// night_enabled starts with 'n' too, so it has to be matched
+				// inside this branch — a metric caught by the charCode dispatch
+				// never reaches the tests below it.
+				else if (key === 'night_enabled') m.night = val;
 			} else if (key === 'hls_clients_total') m.hls = val;
-			else if (key === 'night_enabled') m.night = val;
 			else if (key === 'ircut_enabled') m.ircut = val;
 		}
 		return m;

--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -76,9 +76,9 @@ fi
 			<h3>Remote send</h3>
 			<dl class="small list mb-0">
 				<dt>Webhook</dt>
-				<dd class="text-break cp2cb">http://root:12345@<%= $network_address %>/cgi-bin/ext-telegram.cgi?send=image</dd>
+				<dd class="text-break cp2cb">http://root:PASSWORD@<%= $network_address %>/cgi-bin/ext-telegram.cgi?send=image</dd>
 			</dl>
-			<p class="small text-secondary mt-2">Call this URL to trigger an image send. Click to copy.</p>
+			<p class="small text-secondary mt-2">Call this URL to trigger an image send. Click to copy, then replace <code>PASSWORD</code> with your WebUI password.</p>
 		</div></div>
 	</div>
 </div>

--- a/www/cgi-bin/fw-settings.cgi
+++ b/www/cgi-bin/fw-settings.cgi
@@ -49,8 +49,8 @@ fi
 			<a class="btn btn-primary" href="ext-backuper.cgi?backup=create">Create backup</a>
 
 			<hr class="my-3">
-			<p class="small text-secondary mb-1">Or create one remotely (click to copy):</p>
-			<pre class="cp2cb small mb-0">wget --content-disposition http://root:12345@<%= $network_address %>/cgi-bin/ext-backuper.cgi?backup=create</pre>
+			<p class="small text-secondary mb-1">Or create one remotely (click to copy, then replace <code>PASSWORD</code> with your WebUI password):</p>
+			<pre class="cp2cb small mb-0">wget --content-disposition http://root:PASSWORD@<%= $network_address %>/cgi-bin/ext-backuper.cgi?backup=create</pre>
 
 			<details class="mt-3">
 				<summary class="small">Restore from a backup (manual)</summary>

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -1,18 +1,30 @@
 #!/usr/bin/haserl
 <%in p/common.cgi %>
-<% page_title="Majestic Endpoints" %>
+<% page_title="Majestic Endpoints"
+
+# system.unsafe switches authentication off for every HTTP and RTSP endpoint, so
+# the credentials note below would be wrong. Ask the live config rather than
+# majestic.yaml, which omits keys left at their default.
+mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilter -e '@.system.unsafe' 2>/dev/null)
+%>
 
 <%in p/header.cgi %>
+
+<% if [ "$mj_unsafe" = "true" ]; then %>
+<p class="small text-danger">Authentication is switched off for every endpoint (<code>system.unsafe</code>) — anyone who can reach the camera can open these URLs.</p>
+<% else %>
+<p class="small text-secondary">These endpoints authenticate as user <code>root</code> with the same password you use for this WebUI. Players such as VLC ask for it when you open a bare URL.</p>
+<% fi %>
 
 <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">
 	<div class="col">
 		<h3>Video</h3>
 		<dl>
-			<dt class="cp2cb">rtsp://root:12345@<%= $network_address %>/stream=0</dt>
+			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=0</dt>
 			<dd>RTSP main stream.</dd>
-			<dt class="cp2cb">rtsp://root:12345@<%= $network_address %>/stream=1</dt>
+			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=1</dt>
 			<dd>RTSP sub stream.</dd>
-			<dt class="cp2cb">rtsp://root:12345@<%= $network_address %>/stream=2</dt>
+			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=2</dt>
 			<dd>RTSP JPEG stream.</dd>
 			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=0</dt>
 			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview).</dd>


### PR DESCRIPTION
Fixes the two cosmetic bugs reported in OpenIPC/firmware#2235.

## Day/night badge always read "Day"

`parseMetrics()` in `www/a/status.js` dispatches on the first character of a metric name as a fast path for the `node_*` family. `night_enabled` also starts with `n`, so it was swallowed by that branch, matched none of the `node_*` prefixes, and fell out of the chain — leaving the later `key === 'night_enabled'` test unreachable. `m.night` stayed `0`, so the badge always rendered "Day".

`ircut_enabled` starts with `i` and was never affected, which is why IR-cut in the same badge stayed correct — exactly the asymmetry described in the report.

This needs no particular camera, sensor or version to reproduce: it is a parsing bug in the page's own JavaScript and happens everywhere.

## Endpoint URLs printed `root:12345`

Endpoints authenticate as `root` with the camera's system password. Only the hash of that password is kept on the device, so the WebUI has no way to render the real one — `12345` was a fixed guess at the factory default.

It was never merely stale, it was always wrong: `check_password` in `p/common.cgi` redirects to `fw-interface.cgi` until the password has been changed, so the endpoints page is only reachable once `12345` has stopped working.

The RTSP URLs now omit credentials. A bare `rtsp://` URL is better than a wrong one — players such as VLC prompt on 401, whereas a bad embedded password just fails — and a note above the list says which account and password to use. When `system.unsafe` is set there is no authentication at all, so the note would be misleading; the page reads the live config and shows a warning instead.

The backup and webhook URLs in `fw-settings.cgi` and `ext-telegram.cgi` are fetched by `wget`, which does not prompt, so those keep a credential slot with an explicit `root:PASSWORD@` placeholder and a note to substitute it.

## Testing

Verified on a hi3516ev300 camera.

Day/night badge, driven by the camera's real `/metrics` with night mode actually on:

| | badge |
|---|---|
| before | `☀️ Day · IR-cut on` |
| after | `🌙 Night · IR-cut on` |

Every other value the page parses (CPU, memory, temperature, load, uptime, HLS clients, network counters) is byte-identical before and after.

Also confirmed on the camera:

- endpoints page renders bare `rtsp://<ip>/stream=N`; no `12345` remains in any of the three rendered pages
- both branches of the `system.unsafe` note render correctly, checked by toggling the setting and reverting it
- `system.unsafe` is reported by the live config even when left at its default, so the lookup is reliable
- with the default password still in place the page 303s to `fw-interface.cgi`, confirming `12345` could never actually be displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)