### PR TITLE
common: detect the default password instead of inferring it

### DIFF
--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -125,10 +125,40 @@ button_submit() {
 	echo "<div class=\"mt-2\"><input type=\"submit\" class=\"btn btn-${c}\"${x} value=\"${t}\"></div>"
 }
 
+# Is root still on the password the firmware ships with?
+#
+# The stored hash is salted, so comparing it against a fixed string cannot
+# work — two hashes of "12345" differ by their salt. Re-hash the default with
+# the salt actually in use and compare that against the live hash.
+#
+# Stays quiet whenever the answer cannot be established (locked account, a
+# crypt scheme mkpasswd cannot reproduce, mkpasswd missing). A false positive
+# here redirects every page to the interface settings and locks the operator
+# out of their own camera, and this is advice rather than an access control.
+uses_default_password() {
+	local hash method salt
+	hash=$(sed -n 's/^root:\([^:]*\):.*/\1/p' /etc/shadow)
+
+	case "$hash" in
+		"") return 0;;		# no password at all is worse than the default
+		'$1$'*) method=md5;;
+		'$5$'*) method=sha256;;
+		'$6$'*) method=sha512;;
+		*) return 1;;		# locked (! or *), or a scheme we cannot rebuild
+	esac
+
+	salt=$(echo "$hash" | cut -d'$' -f3)
+	case "$salt" in
+		""|rounds=*) return 1;;	# mkpasswd has no way to set a round count
+	esac
+
+	[ "$(mkpasswd -m "$method" -S "$salt" 12345 2>/dev/null)" = "$hash" ]
+}
+
 check_password() {
 	local p="/cgi-bin/fw-interface.cgi"
 	[ -z "$SCRIPT_NAME" ] || [ "$SCRIPT_NAME" = "${p}" ] && return
-	if [ ! -f /etc/shadow- ] || [ -z $(grep root /etc/shadow- | cut -d: -f2) ]; then
+	if uses_default_password; then
 		redirect_to "${p}" "danger" "You must set your own secure password!"
 	fi
 }


### PR DESCRIPTION
## What the check actually tests

`check_password()` decided whether root was still on the shipped password by looking for `/etc/shadow-` and reading root's hash out of it:

```sh
if [ ! -f /etc/shadow- ] || [ -z $(grep root /etc/shadow- | cut -d: -f2) ]; then
```

`/etc/shadow-` is the backup `chpasswd` leaves behind, and the hash inside it is the **previous** password. So the condition answers *"has a password ever been changed on this box"* — a proxy — and never looks at the password actually in force.

**On the path the firmware ships, the proxy is right every time**, which is why this has held up for years. I confirmed that before changing anything, by running `firstboot` on a hi3516av300 and using only the interface settings form:

| step | `/etc/shadow` (current) | `/etc/shadow-` (what was read) | gate |
|---|---|---|---|
| after `firstboot` | `$1$jv4d1NpW$…` default | absent | **303** nag ✓ |
| set `S3cure!Pass` | `$1$k8EgiOtG$…` | `$1$jv4d1NpW$…` | **200** cleared ✓ |
| set back to `12345` | `$1$RlmP8TAn$…` default | `$1$k8EgiOtG$…` | **200** cleared ✗ |

The middle row shows the mechanism in plain sight: `/etc/shadow-` at that moment holds *the factory default hash itself*.

After the third step the camera is on the factory default password — `curl -u root:12345` returns 200 — and the webui says nothing. Restoring a config backup that carries a `shadow-`, or a support session that resets to the default for troubleshooting, lands in the same state.

## The fix

Ask the real question: take root's hash from `/etc/shadow`, re-hash `12345` with the salt in use, compare. A fixed comparison is not an option because the hash is salted — `$1$jv4d1NpW$…` and `$1$RlmP8TAn$…` are both `12345`.

Two smaller hazards go with it:

- `grep root` was unanchored and matched any line containing `root`, including another account's `/root` home directory.
- The unquoted `$(...)` meant two matches turned `[ -z a b ]` into `sh: [: !: binary operator expected`, exit status 2 — the `||` chain went false and the nag was **suppressed**. Malformed input failing open.

The check stays quiet when the answer cannot be established: a locked account (`!`/`*`), a crypt scheme `mkpasswd` cannot rebuild (`rounds=`), or no `mkpasswd`. A false positive here redirects *every* page to interface settings and locks the operator out of their own camera — worse than a missing hint, given this is advice rather than an access control.

Implementation note for reviewers: passing the whole hash as `-S` does **not** work on busybox — `mkpasswd -m md5 -S '$1$RlmP8TAn$KUlv…' 12345` returns `$1$$4e9eZx73…`, an empty salt. The salt field has to be extracted, hence the `cut -d'$' -f3`.

## Verification (hi3516av300)

End to end through the form, with the new code deployed:

```
A. factory default 12345, no /etc/shadow-       -> 303  (nag)      want 303
B. real password set                            -> 200  (cleared)  want 200
C. reverted to 12345, /etc/shadow- present      -> 303  (nag)      want 303
```

C is the case that defeats the current code.

Unit matrix against synthetic shadow files on the same busybox:

```
md5 hash of 12345                          -> NAG   ok
md5 hash of a real password                -> quiet ok
sha512 hash of 12345                       -> NAG   ok
sha512 of a real password                  -> quiet ok
empty hash (no password)                   -> NAG   ok
locked account (!)                         -> quiet ok
locked account (*)                         -> quiet ok
sha512 with rounds= (unrebuildable)        -> quiet ok
decoy line containing /root (anchor test)  -> NAG   ok
```

## Deliberately out of scope

- Still a redirect rather than a dismissible banner. `header.cgi` already has the banner pattern for the restart notice and it would suit this better, but that is a UX change and belongs on its own.
- The JSON endpoints under `j/` do not call `check_password` at all (0 of 13 include `common.cgi`), so a default-password camera remains fully driveable through them regardless of what this prompt says. Worth addressing, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)