### PR TITLE
fw-update: confirm the version after the reboot, not that the camera answered

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -1,33 +1,81 @@
 // Firmware update over the robust /ws/upgrade WebSocket.
 // majestic stops video (frees RAM), streams download+verify here, then is
-// killed at the flash step; the page switches to "rebooting" and polls until
-// the camera returns. A local .tgz is first POSTed to /upload, then flashed via
-// sysupgrade --archive. Vanilla JS; `$` is the querySelector helper from main.js.
+// killed at the flash step; the page switches to "rebooting", polls until the
+// camera returns, and then checks the version it came back on — sysupgrade
+// reboots on failure too, so coming back is not by itself evidence of anything.
+// A local .tgz is first POSTed to /upload, then flashed via sysupgrade
+// --archive. Vanilla JS; `$` is the querySelector helper from main.js.
 (function () {
 	const out = $('#fw-output');
 	const ansi = /[][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 	const dec = new TextDecoder('utf-8');
 
-	// sysupgrade prints one of these only after the (silent) download, once it is
-	// into the point-of-no-return flash. Seeing one lets us tell a real flash
-	// apart from an idle-timeout disconnect during the quiet download/time-sync.
-	const flashMarker = /Received and unpacked|Kernel updated|RootFS updated|Unmounting|Unconditional reboot|Protected: flashing/i;
+	// sysupgrade prints "Protected: flashing continues…" at its point of no
+	// return, immediately before the first erase, and the "… updated" lines once a
+	// partition has been written. Seeing one tells a real flash apart from a
+	// socket that dropped during the quiet download.
+	//
+	// Nothing printed EARLIER belongs here. "Unmounting SD card" comes from
+	// check_sdcard and "Received and unpacked" from the end of the download —
+	// both run before the flash, so listing them meant sawFlash was already true
+	// before the download even started, and the "may have failed" diagnosis below
+	// was unreachable for the whole life of the feature (issue #120).
+	const flashMarker = /Protected: flashing|Stopping web server before flashing|Kernel updated|RootFS updated/i;
 	let sawFlash = false;
+
+	// sysupgrade's die() prints "<reason> Aborting.". For a failure before the
+	// first write it now exits without rebooting, which leaves this socket open on
+	// a `tail -F` that will never emit another line — so notice it here rather
+	// than sitting on "Upgrading…" forever.
+	const abortMarker = /Aborting\./;
+	let aborted = false;
+
+	// Whether --force_ver was requested. It reflashes the same version on purpose,
+	// so an unchanged version afterwards is a success, not a failure.
+	let forced = false;
+
+	// The version this page was rendered with, compared against the rebooted
+	// camera's. A failed sysupgrade reboots too, so "it answered again" is not
+	// evidence that anything was flashed (issue #120, t31x).
+	const installedEl = $('#fw-installed');
+	const installedBefore = installedEl ? installedEl.textContent.trim() : '';
 
 	function status(cls, msg) {
 		const s = $('#fw-status');
 		s.className = 'alert alert-' + cls;
 		s.textContent = msg;
 	}
+	// Markers can straddle two frames, so match against a rolling window of the
+	// recent stream rather than each chunk in isolation.
+	let recent = '';
 	function append(t) {
 		const s = t.replace(ansi, '');
-		if (!sawFlash && flashMarker.test(s)) sawFlash = true;
 		out.textContent += s;
 		out.scrollTop = out.scrollHeight;
+		recent = (recent + s).slice(-512);
+		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
+		if (!aborted && abortMarker.test(recent)) {
+			aborted = true;
+			if (sawFlash) {
+				// Already past the first erase. sysupgrade still reboots from here —
+				// the partition is written either way — so let pollBack run and
+				// report whatever the camera comes back as.
+				status('danger', 'The upgrade failed after flashing had started — see the log below. Waiting for the camera…');
+			} else {
+				// Nothing reached flash, so no reboot is coming and the log above is
+				// the whole story. Say so now instead of waiting out pollBack.
+				status('danger', 'The upgrade was aborted — see the log below. Nothing was written to flash, so the camera is unchanged.');
+			}
+		}
 	}
 	function showProgress() {
 		$('#fw-controls').style.display = 'none';
 		$('#fw-progress').style.display = '';
+		// The camera is about to spend minutes downloading and flashing, often on
+		// one core. Stop polling pulse.cgi at it — each tick forks a dozen
+		// processes and makes a loopback request into the majestic that is
+		// streaming this log (issue #120).
+		if (typeof stopHeartbeat === 'function') stopHeartbeat();
 	}
 	function params(source) {
 		const on = id => { const el = $('#' + id); return !!(el && el.checked); };
@@ -40,6 +88,9 @@
 		if (!p.kernel && !p.rootfs) { status('danger', 'Select kernel and/or rootfs.'); return; }
 		showProgress();
 		sawFlash = false;
+		aborted = false;
+		recent = '';
+		forced = p.force;
 		status('warning', 'Preparing — freeing memory…');
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
@@ -55,16 +106,60 @@
 		// server-side concern: majestic pings /ws/upgrade while the child is idle.)
 		ws.onclose = () => {
 			if (!opened) return;   // handshake failed → onerror reports it
+			if (aborted && !sawFlash) return;   // gave up before touching flash; no reboot is coming
 			status('warning', 'Waiting for the camera to reboot — do not power off…');
 			pollBack();
 		};
 		ws.onerror = () => { if (!opened) status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); };
 	}
 
+	// Read the version the camera is running NOW. Re-fetches this page instead of
+	// adding an endpoint — fw-update.cgi already renders it, and the value has to
+	// come from the rebooted camera rather than from this stale document.
+	// Returns null if it cannot be established (camera still coming up, or a
+	// --reset run bounced us to the password page), which callers treat as
+	// "unknown", not as "failed".
+	async function installedNow() {
+		const ctl = new AbortController();
+		const to = setTimeout(() => ctl.abort(), 5000);
+		try {
+			const r = await fetch('fw-update.cgi?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal });
+			if (!r.ok) return null;
+			const doc = new DOMParser().parseFromString(await r.text(), 'text/html');
+			const el = doc.getElementById('fw-installed');
+			return el ? el.textContent.trim() : null;
+		} catch (err) {
+			return null;
+		} finally {
+			clearTimeout(to);
+		}
+	}
+
+	// The camera answered again. Decide success on the version it came back on,
+	// not on the fact that it answered: sysupgrade's die() reboots on failure
+	// too, so down-then-up is exactly what a failed upgrade looks like as well
+	// (issue #120, t31x — "the page refreshes, but the firmware is not updated").
+	async function confirmUpgrade() {
+		status('warning', 'Camera is back — checking the installed version…');
+		// It answers / as soon as majestic is up, which can be before the CGI is
+		// ready, so give the version a few tries before settling for "unknown".
+		let now = null;
+		for (let i = 0; i < 5 && now === null; i++) {
+			if (i) await new Promise(r => setTimeout(r, 2000));
+			now = await installedNow();
+		}
+		if (now && installedBefore && now === installedBefore && !forced) {
+			status('danger', 'The camera rebooted but is still running ' + now +
+				' — the update did not apply. Check the log above and try again.');
+			return;
+		}
+		status('success', now ? 'Updated — now running ' + now + '.' : 'Camera is back online.');
+		setTimeout(() => location.href = 'status.cgi', 1500);
+	}
+
 	// Confirm a real reboot before reporting done: the camera must first go
-	// UNREACHABLE, then come back. A dropped socket alone is not proof — on a
-	// failed upgrade the camera stays up, and blindly reloading would report a
-	// success that never happened (issue #120, t31x).
+	// UNREACHABLE, then come back — and then confirmUpgrade checks what it came
+	// back as.
 	function pollBack() {
 		function ping() {
 			const ctl = new AbortController();
@@ -86,7 +181,7 @@
 					return;
 				}
 			} else {
-				if (up) { status('success', 'Camera is back online.'); setTimeout(() => location.href = 'status.cgi', 1500); return; }
+				if (up) { confirmUpgrade(); return; }
 				if (++tries > UP_TRIES) { status('danger', 'The camera has not returned. Check it manually.'); return; }
 			}
 			setTimeout(tick, 3000);

--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -45,6 +45,13 @@
 		s.className = 'alert alert-' + cls;
 		s.textContent = msg;
 	}
+	// Give the header widgets back to a page that is going to stay put. Called on
+	// every outcome that leaves the user on this page with a camera that is idle
+	// again — but deliberately NOT when we last saw it mid-flash, where polling it
+	// is the thing we were trying to avoid.
+	function resumeHeartbeat() {
+		if (typeof startHeartbeat === 'function') startHeartbeat();
+	}
 	// Markers can straddle two frames, so match against a rolling window of the
 	// recent stream rather than each chunk in isolation.
 	let recent = '';
@@ -65,6 +72,7 @@
 				// Nothing reached flash, so no reboot is coming and the log above is
 				// the whole story. Say so now instead of waiting out pollBack.
 				status('danger', 'The upgrade was aborted — see the log below. Nothing was written to flash, so the camera is unchanged.');
+				resumeHeartbeat();
 			}
 		}
 	}
@@ -110,7 +118,7 @@
 			status('warning', 'Waiting for the camera to reboot — do not power off…');
 			pollBack();
 		};
-		ws.onerror = () => { if (!opened) status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); };
+		ws.onerror = () => { if (!opened) { status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); resumeHeartbeat(); } };
 	}
 
 	// Read the version the camera is running NOW. Re-fetches this page instead of
@@ -151,6 +159,7 @@
 		if (now && installedBefore && now === installedBefore && !forced) {
 			status('danger', 'The camera rebooted but is still running ' + now +
 				' — the update did not apply. Check the log above and try again.');
+			resumeHeartbeat();
 			return;
 		}
 		status('success', now ? 'Updated — now running ' + now + '.' : 'Camera is back online.');
@@ -177,12 +186,12 @@
 				if (!up) { downSeen = true; tries = 0; status('warning', 'Camera is rebooting — waiting for it to come back…'); }
 				else if (++tries > DOWN_TRIES) {
 					if (sawFlash) status('warning', 'Still flashing — the camera has not rebooted yet. Give it a few minutes, then reload.');
-					else status('danger', 'The camera never rebooted — the update may have failed. Check the log above and try again.');
+					else { status('danger', 'The camera never rebooted — the update may have failed. Check the log above and try again.'); resumeHeartbeat(); }
 					return;
 				}
 			} else {
 				if (up) { confirmUpgrade(); return; }
-				if (++tries > UP_TRIES) { status('danger', 'The camera has not returned. Check it manually.'); return; }
+				if (++tries > UP_TRIES) { status('danger', 'The camera has not returned. Check it manually.'); resumeHeartbeat(); return; }
 			}
 			setTimeout(tick, 3000);
 		}
@@ -201,11 +210,12 @@
 		status('warning', 'Uploading firmware…');
 		try {
 			const r = await fetch('/upload', { method: 'POST', headers: { 'File-Location': '/tmp/firmware.tgz' }, body: f });
-			if (!r.ok) { status('danger', 'Upload failed (' + r.status + ').'); return; }
+			if (!r.ok) { status('danger', 'Upload failed (' + r.status + ').'); resumeHeartbeat(); return; }
 			append('Uploaded ' + f.name + ' (' + f.size + ' bytes)\n');
 			startUpgrade('/tmp/firmware.tgz');
 		} catch (err) {
 			status('danger', 'Upload error: ' + err);
+			resumeHeartbeat();
 		}
 	});
 })();

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -90,6 +90,19 @@ async function runCmd(msg) {
 	}
 }
 
+// Every tick spawns j/pulse.cgi, which forks a dozen more processes and makes a
+// loopback request to /metrics/isp. That is fine on an idle camera and ruinous
+// on one that is flashing itself, so pages that take the camera over can switch
+// it off (see fw-update.js, issue #120).
+let heartbeatStopped = false;
+let heartbeatTimer = null;
+
+function stopHeartbeat() {
+	heartbeatStopped = true;
+	clearTimeout(heartbeatTimer);
+	heartbeatTimer = null;
+}
+
 function heartbeat() {
 	fetch('/cgi-bin/j/pulse.cgi')
 		.then((response) => response.json())
@@ -128,7 +141,14 @@ function heartbeat() {
 				if (mj) mj.textContent = json.mj_uptime || '–';
 			}
 		})
-		.then(setTimeout(heartbeat, 2000));
+		.finally(() => {
+			// Re-arm once the poll has settled. The old `.then(setTimeout(...))`
+			// ran setTimeout immediately and passed .then the timer id, so ticks
+			// were scheduled 2s apart no matter how long the CGI took — they piled
+			// up on exactly the busy camera that could least afford it.
+			if (!heartbeatStopped)
+				heartbeatTimer = setTimeout(heartbeat, 2000);
+		});
 }
 
 function initAll() {

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -103,8 +103,19 @@ function stopHeartbeat() {
 	heartbeatTimer = null;
 }
 
+function startHeartbeat() {
+	if (!heartbeatStopped) return;
+	heartbeatStopped = false;
+	heartbeat();
+}
+
 function heartbeat() {
-	fetch('/cgi-bin/j/pulse.cgi')
+	// Bound the request. The next tick is armed when this one settles, so a
+	// fetch left hanging by a camera that is busy or half-rebooted would
+	// otherwise stop the heartbeat for the rest of the page's life.
+	const ctl = new AbortController();
+	const to = setTimeout(() => ctl.abort(), 5000);
+	fetch('/cgi-bin/j/pulse.cgi', { signal: ctl.signal })
 		.then((response) => response.json())
 		.then((json) => {
 			if (json.soc_temp !== '') {
@@ -142,6 +153,7 @@ function heartbeat() {
 			}
 		})
 		.finally(() => {
+			clearTimeout(to);
 			// Re-arm once the poll has settled. The old `.then(setTimeout(...))`
 			// ran setTimeout immediately and passed .then the timer id, so ticks
 			// were scheduled 2s apart no matter how long the CGI took — they piled

--- a/www/cgi-bin/fw-update.cgi
+++ b/www/cgi-bin/fw-update.cgi
@@ -34,7 +34,10 @@
 		<div class="card h-100"><div class="card-body">
 			<h3>Firmware</h3>
 			<dl class="small list mb-0">
-				<dt>Installed</dt><dd><%= "${fw_version}-${fw_variant}" %></dd>
+				<%# id is a contract with fw-update.js: after the camera reboots it
+				    re-fetches this page and compares the value to decide whether the
+				    upgrade actually applied (issue #120). %>
+				<dt>Installed</dt><dd id="fw-installed"><%= "${fw_version}-${fw_variant}" %></dd>
 				<dt>Latest on GitHub</dt>
 				<dd><span id="firmware-master-ver"><% if [ -n "$fw_date" ]; then %><%= $fw_date %><% else %><span class="text-secondary">— no access to GitHub —</span><% fi %></span></dd>
 				<dt>SoC</dt><dd><%= $soc %> <span class="text-secondary">(<%= $soc_family %>)</span></dd>


### PR DESCRIPTION
Fixes the part of #120 that survived the first pass. The reporter's 2026-07-29 build already had all three changes the issue was closed on — the `#` download bar in their screenshot proves firmware #2225 landed — so this is a remaining failure mode, not a regression.

### Reachability was never proof

`pollBack()` declared success as soon as the camera went unreachable and came back. That was meant to be evidence of a real flash (#123), reasoning that a failed upgrade leaves the camera up. But `sysupgrade`'s `die()` reboots on **every** failure path, so down-then-up is exactly what a failed upgrade looks like too — the page then redirected to `status.cgi` showing the version the user already had. That is the original **t31x** report verbatim: *"the page refreshes after several minutes, but the firmware is not updated"*.

Confirmed on hardware (lab hi3516av300, `busybox reboot` stubbed via `PATH`):

```
sysupgrade 1.0.56:  "File ... not found Aborting." -> "Unconditional reboot" -> REBOOTED
```

Now the version is compared instead. `fw-update.cgi` gains an `id` on the value it already renders; after the reboot the page is re-fetched from the camera, retrying while the CGI comes up, and falling back to "unknown" rather than "failed" when it genuinely cannot tell (a `--reset` run lands on the password page). `--force_ver` reflashes the same version on purpose, so it is exempt.

### The honest error message was dead code

`flashMarker` matched strings printed *before* the point of no return:

| marker | printed at | main flow |
|---|---|---|
| `Unmounting` | `check_sdcard` | line 685 |
| `Received and unpacked` | end of download | line 686 |
| `Protected: flashing` | — | line 693 ← actual point of no return |

`sawFlash` was therefore already true before the download started, so *"the camera never rebooted — the update may have failed"* could never fire; users always got *"Still flashing…"*. Now only markers at or after the first erase count, matched against a rolling window so one split across two frames is not missed.

### Two more

- **Report `Aborting.` immediately.** With OpenIPC/firmware#2249 a pre-flash failure no longer reboots, which leaves the socket open on a `tail -F` that will never emit another line. `pollBack` is only suppressed when nothing was flashed — a `die()` after the first erase still reboots and still needs following.
- **Stop the heartbeat during the upgrade.** The page kept polling `j/pulse.cgi` every 2 s through the download and flash; each tick spawns a shell that forks ~12 more processes and makes a loopback request to `/metrics/isp`, on a camera that is often single-core and busy unpacking firmware into tmpfs. The re-arm was also wrong — `.then(setTimeout(...))` invoked `setTimeout` immediately and passed `.then` a timer id, so ticks were scheduled 2 s apart regardless of how long the CGI took.

### Verification

Rendering checked on the lab hi3516av300 — `<dd id="fw-installed">2.6.08.09-lite</dd>`, exactly once. The reboot-reporting path needs sysupgrade ≥ 1.0.57 (OpenIPC/firmware#2249) to be exercised end to end; that has not been run against a real flash yet.

Related: OpenIPC/firmware#2249, and a majestic-side change guarding `/metrics` and `/cgi-bin` during upgrade mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)