### PR TITLE
fw-update: render the progress meter as one line, not a smear

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -52,13 +52,54 @@
 	function resumeHeartbeat() {
 		if (typeof startHeartbeat === 'function') startHeartbeat();
 	}
+	// This pane is a <pre>, but everything writing into it assumes a terminal:
+	// curl's download meter and flashcp's progress both redraw one line in place
+	// with a bare \r. Appended verbatim, each redraw lands after the last instead
+	// of replacing it, and the bar smears across the pane in unreadable columns
+	// (issue #134). Stripping ANSI does not help — \r is a control character, not
+	// an escape sequence, so it survives the regex above.
+	//
+	// So be just enough of a terminal for that: \n commits the line, \r returns
+	// the cursor to column 0, anything else overwrites at the cursor. Overwriting
+	// rather than clearing matters — a redraw shorter than the one before it
+	// leaves the tail of the longer line visible, which is what a real terminal
+	// does and what makes curl's meter look right as it shrinks.
+	//
+	// Two text nodes keep it cheap: finished lines are appended once and never
+	// touched again, and only the line still being drawn is rewritten. The
+	// console page has an actual terminal (xterm.js) and needs none of this.
+	const doneNode = document.createTextNode('');
+	const lineNode = document.createTextNode('');
+	out.appendChild(doneNode);
+	out.appendChild(lineNode);
+	let line = '';   // the line currently being drawn, after the last \n
+	let col = 0;     // cursor position within it
+
 	// Markers can straddle two frames, so match against a rolling window of the
 	// recent stream rather than each chunk in isolation.
 	let recent = '';
 	function append(t) {
 		const s = t.replace(ansi, '');
-		out.textContent += s;
+		let commit = '';
+		for (let i = 0; i < s.length; i++) {
+			const ch = s[i];
+			if (ch === '\n') {
+				commit += line + '\n';
+				line = '';
+				col = 0;
+			} else if (ch === '\r') {
+				col = 0;
+			} else {
+				line = line.slice(0, col) + ch + line.slice(col + 1);
+				col++;
+			}
+		}
+		if (commit) doneNode.appendData(commit);
+		lineNode.data = line;
 		out.scrollTop = out.scrollHeight;
+		// Deliberately still the raw stream: the markers below are whole-line
+		// messages, and matching them on what was received rather than on what
+		// survived the redraws keeps this decoupled from the rendering.
 		recent = (recent + s).slice(-512);
 		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
 		if (!aborted && abortMarker.test(recent)) {


### PR DESCRIPTION
Fixes #134.

### What was wrong

The upgrade pane is a `<pre>`, but everything writing into it assumes a terminal. `curl`'s download meter redraws a single line in place with a bare `\r`, and so does `flashcp`'s progress. Appended verbatim, each redraw lands *after* the previous one instead of replacing it, so at the pane's width the bar wraps into unreadable columns — @usa-'s screenshot in #134. Over SSH the same upgrade looks fine, because there a terminal is interpreting the control characters.

Stripping ANSI never helped: `\r` is a control **character**, not an escape sequence, so it went straight through the regex and into the DOM.

### Fix

Be just enough of a terminal for it: `\n` commits the line, `\r` returns the cursor to column 0, anything else overwrites at the cursor.

Overwriting rather than clearing is deliberate — a redraw shorter than the one before leaves the tail of the longer line visible, which is exactly what a real terminal does and what makes a shrinking meter look right.

Two text nodes keep the cost down: finished lines are appended once and never touched again, and only the line still being drawn is rewritten. A naive `textContent = everything` would rebuild the whole log on every frame.

Nothing else changes. The flash/abort markers still match on the **raw stream** rather than on what survived the redraws, so the rendering stays decoupled from the logic deciding whether an upgrade worked.

### Verification

Tested by extracting the real `append()` out of the shipped file (so the test exercises the code, not a paraphrase) and feeding it `curl -#` bytes captured off a camera:

```
1. real curl -# bytes off the camera
  ok   chunk=1: collapses 2 redraws onto 1 line
  ok   chunk=1: no CR survives into the DOM
  ok   chunk=7 / 64 / 4096: same
2. terminal semantics on a synthetic curl-style meter
  ok   last redraw is what renders
3. a shorter redraw leaves the longer tail (real terminal behaviour)
  ok   tail preserved
4. ordinary multi-line output is untouched
  ok   three lines, in order
5. CRLF must not eat the line
  ok   CRLF behaves as a newline

12 passed, 0 failed
```

Four chunk sizes because the input arrives in WebSocket frames — the result must not depend on where a frame happens to split a redraw.

### Notes

- Cosmetic only; no functional effect on upgrades.
- **Not** related to the sysupgrade work in OpenIPC/firmware#2249 / #2252, though it was *surfaced* by an earlier one: OpenIPC/firmware#2225 swapped the download from `curl -s` to `curl -#` so the WebUI would have something to show during the silent phase. Before that the pane never received `\r`-heavy output, so the gap was invisible.
- It should improve the **flash** phase too — busybox `flashcp` drives its `Erasing block` / `Writing kb` / `Verifying kb` progress through the same single-line rewrite. I could not confirm that byte-for-byte without a real flash, so treat it as expected rather than proven.
- The console page (`tool-console.cgi`) is unaffected: it runs a real terminal emulator (xterm.js 5.5.0) and needs none of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)