### PR TITLE
ci: gate pull requests on the minify build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,36 @@
+name: check
+
+# Gate pull requests on the same minification the release build runs: terser over
+# every hand-written .js followed by `node --check` on the result, plus clean-css
+# over the CSS.
+#
+# dist.yml only fires on push to master, so before this nothing ran on a PR at
+# all — a syntax error or a construct terser choked on reached master unnoticed
+# and broke the rolling dist release the firmware buildroot package fetches.
+#
+# This deliberately runs `npm run build:dist`, the very script dist.yml uses,
+# rather than reimplementing the terser invocation: a gate that duplicated the
+# build would be free to drift away from it. Node is pinned to the same version
+# for the same reason.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build:dist


### PR DESCRIPTION
Follow-up to #136, where this gap surfaced: that PR reported `statusCheckRollup: []` — **no CI ran on it at all.**

`dist.yml` only fires on `push` to `master`, so a syntax error or a construct terser chokes on reaches master unnoticed and breaks the rolling `dist` release the firmware buildroot package fetches. `tools/build-dist.sh` already runs terser plus `node --check` over every hand-written `.js` (and clean-css over the CSS) — it just never ran early enough to stop anything.

## What this does

Runs `npm run build:dist` on `pull_request`.

Deliberately the **same script** `dist.yml` uses, on the same pinned Node, rather than a reimplemented terser invocation — a gate that duplicated the build would be free to drift away from it. It doesn't publish anything; `permissions: contents: read` and no release step.

## Verification

`build-dist.sh` pipes `find` into a `while` loop, which runs in a subshell, so `set -e` propagation out of the loop is not obvious by inspection. Worth confirming rather than assuming:

```
=== control: unmodified tree ===
exit=0
=== inject a syntax error into www/a/status.js ===
exit=1
```

So a broken file does fail the run rather than being swallowed.

YAML parses; triggers `pull_request` + `workflow_dispatch`; single `build` job.

This PR is its own first test — the check should appear on it.

## Not included

No shell linting for the CGIs. Most are haserl templates (`<% %>`), so they aren't valid `sh` input, and the runner has no busybox `ash` anyway — that needs its own thought rather than being bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
