### PR TITLE
ci: lint the plain shell scripts too, and stop the locale files lying

### DIFF
--- a/tools/lint-templates.sh
+++ b/tools/lint-templates.sh
@@ -12,14 +12,17 @@
 # artifact rather than a haserl bug, but it does mean on-device linting is out.
 #
 # The cd and the mktemp below are checked rather than assumed: this is a gate,
-# and a gate that cannot run has to say so instead of reaching the "templates
-# ok" line. An unguarded cd would silently lint the wrong tree, or none at all,
+# and a gate that cannot run has to say so instead of reaching the success
+# line. An unguarded cd would silently lint the wrong tree, or none at all,
 # and an unguarded mktemp would drop every finding on the floor.
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd) || exit 1
 cd "$ROOT" || exit 1
 
 FAILS=$(mktemp) || exit 1
-trap 'rm -f "$FAILS"' EXIT
+# What actually got inspected, so the summary can report real counts. A gate
+# that checked nothing should not be indistinguishable from a gate that passed.
+SEEN=$(mktemp) || exit 1
+trap 'rm -f "$FAILS" "$SEEN"' EXIT
 
 # --- 1. syntax --------------------------------------------------------------
 # Shell constructs legally span <% %> blocks here: status.cgi opens `if ...;
@@ -48,6 +51,7 @@ if ! (
 	cd www/cgi-bin || exit 1
 	find . -name '*.cgi' | sed 's|^\./||' | sort | while IFS= read -r f; do
 		head -1 "$f" | grep -q haserl || continue
+		echo "t" >> "$SEEN"
 		if ! out=$(haserl -d "$f" < /dev/null 2>&1); then
 			printf 'www/cgi-bin/%s: haserl: %s\n' "$f" "$(printf '%s' "$out" | tail -1)" >> "$FAILS"
 			continue
@@ -69,7 +73,7 @@ fi
 #
 # grep exits 0 for a match, 1 for a clean run and 2+ for an error. `if
 # hits=$(grep ...)` conflates 1 and 2, so a grep that failed outright would look
-# exactly like "no violations" and the script would still print templates ok —
+# exactly like "no violations" and the script would still report success —
 # the guard silently disabling itself is the one outcome worse than not having
 # it. -r and --include are GNU extensions (CLAUDE.md rules them out), so the
 # file list comes from find; globbing is off because it is expanded unquoted.
@@ -99,13 +103,23 @@ esac
 # quotes would end up inside the label.
 find www sbin -type f 2>/dev/null | sort | while IFS= read -r s; do
 	head -1 "$s" | grep -qE '^#!.*/(sh|ash|dash)$' || continue
+	echo "s" >> "$SEEN"
 	if ! err=$(sh -n "$s" 2>&1); then
 		printf '%s: %s\n' "$s" "$err" >> "$FAILS"
 	fi
 done
 
+ntpl=$(grep -c '^t$' "$SEEN")
+nsh=$(grep -c '^s$' "$SEEN")
+
+# Nothing to check is a broken selector, not a clean tree — the repo always has
+# both kinds of file. Without this, a find or shebang test that stopped matching
+# would report a confident pass over zero files.
+[ "$ntpl" -gt 0 ] || echo "lint: no haserl templates matched, selection is broken" >> "$FAILS"
+[ "$nsh" -gt 0 ] || echo "lint: no shell scripts matched, selection is broken" >> "$FAILS"
+
 if [ -s "$FAILS" ]; then
 	cat "$FAILS"
 	exit 1
 fi
-echo "templates ok"
+echo "ok: $ntpl haserl templates, $nsh shell scripts"

--- a/tools/lint-templates.sh
+++ b/tools/lint-templates.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Validate the haserl CGI templates under www/cgi-bin.
+# Validate the haserl CGI templates under www/cgi-bin, plus the ordinary shell
+# scripts under www/ and sbin/.
 #
 # Run from CI (.github/workflows/check.yml); also fine by hand. Needs haserl on
 # PATH — Ubuntu ships it in universe, so `apt-get install haserl` is enough.
@@ -10,17 +11,12 @@
 # upstream 0.9.36 built on x86 has no such problem, so it is a buildroot
 # artifact rather than a haserl bug, but it does mean on-device linting is out.
 #
-# Runs from www/cgi-bin because <%in %> resolves relative to the CURRENT
-# WORKING DIRECTORY, not to the including file — undocumented in the manpage,
-# and the reason every page 404s its include if you invoke haserl from the repo
-# root. majestic execs the CGIs with that same cwd, so this matches production.
-#
-# Both of these are checked rather than assumed: this is a gate, and a gate that
-# cannot run has to say so instead of reaching the "templates ok" line. An
-# unguarded cd would silently lint the wrong directory (or none), and an
-# unguarded mktemp would drop every finding on the floor.
-DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../www/cgi-bin" && pwd) || exit 1
-cd "$DIR" || exit 1
+# The cd and the mktemp below are checked rather than assumed: this is a gate,
+# and a gate that cannot run has to say so instead of reaching the "templates
+# ok" line. An unguarded cd would silently lint the wrong tree, or none at all,
+# and an unguarded mktemp would drop every finding on the floor.
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd) || exit 1
+cd "$ROOT" || exit 1
 
 FAILS=$(mktemp) || exit 1
 trap 'rm -f "$FAILS"' EXIT
@@ -38,16 +34,32 @@ trap 'rm -f "$FAILS"' EXIT
 # so the obvious `haserl -d "$f" | sh -n` discards that status and then hands
 # the message to the shell, which finds it a perfectly valid command — leaving a
 # broken template reported as clean. Hence capturing the codegen first.
-find . -name '*.cgi' | sed 's|^\./||' | sort | while IFS= read -r f; do
-	head -1 "$f" | grep -q haserl || continue
-	if ! out=$(haserl -d "$f" < /dev/null 2>&1); then
-		printf '%s: haserl: %s\n' "$f" "$(printf '%s' "$out" | tail -1)" >> "$FAILS"
-		continue
-	fi
-	if ! err=$(printf '%s\n' "$out" | sh -n 2>&1); then
-		printf '%s: %s\n' "$f" "$err" >> "$FAILS"
-	fi
-done
+#
+# The subshell is because <%in %> resolves relative to the CURRENT WORKING
+# DIRECTORY rather than to the including file — undocumented in the manpage, and
+# the reason every page fails to find its include if haserl is invoked from the
+# repo root. majestic execs the CGIs with this same cwd, so it matches
+# production.
+#
+# The subshell's status is checked for the same reason as the cd above: `cd ...
+# || exit 1` inside it only leaves the subshell, so on its own it would skip
+# every template while the script carried on to report success.
+if ! (
+	cd www/cgi-bin || exit 1
+	find . -name '*.cgi' | sed 's|^\./||' | sort | while IFS= read -r f; do
+		head -1 "$f" | grep -q haserl || continue
+		if ! out=$(haserl -d "$f" < /dev/null 2>&1); then
+			printf 'www/cgi-bin/%s: haserl: %s\n' "$f" "$(printf '%s' "$out" | tail -1)" >> "$FAILS"
+			continue
+		fi
+		if ! err=$(printf '%s\n' "$out" | sh -n 2>&1); then
+			printf 'www/cgi-bin/%s: %s\n' "$f" "$err" >> "$FAILS"
+		fi
+	done
+	exit 0
+); then
+	echo "lint: could not enter www/cgi-bin, templates unchecked" >> "$FAILS"
+fi
 
 # --- 2. escaping ------------------------------------------------------------
 # CLAUDE.md: "Never <%= $userInput %> for anything that came from POST_/GET_."
@@ -62,7 +74,7 @@ done
 # it. -r and --include are GNU extensions (CLAUDE.md rules them out), so the
 # file list comes from find; globbing is off because it is expanded unquoted.
 set -f
-set -- $(find . -name '*.cgi' | sort)
+set -- $(find www/cgi-bin -name '*.cgi' | sort)
 set +f
 hits=$(grep -nE '<%=[^%]*\$\{?(POST|GET)_' /dev/null "$@")
 case $? in
@@ -73,6 +85,24 @@ case $? in
 1) ;;
 *) echo "lint: grep failed, escaping guard did not run" >> "$FAILS" ;;
 esac
+
+# --- 3. plain shell ---------------------------------------------------------
+# Everything that is not a template: the j/*.cgi JSON endpoints and the sbin
+# helpers. Worth checking because nothing else does — sbin/setnetwork writes
+# /etc/network/interfaces.d and sbin/updatewebui is the deploy path, so a syntax
+# error in either misconfigures or bricks the camera it runs on.
+#
+# Selection is by shebang. That is why j/locale.cgi and j/locale_fpv.cgi no
+# longer carry one: they are data files parsed with sed (mj-settings.cgi), never
+# sourced or executed, and `mj_cloud=Cloud (WebRTC)` is not valid shell. Quoting
+# that value would not help — the sed captures \(.*\) straight into JSON, so the
+# quotes would end up inside the label.
+find www sbin -type f 2>/dev/null | sort | while IFS= read -r s; do
+	head -1 "$s" | grep -qE '^#!.*/(sh|ash|dash)$' || continue
+	if ! err=$(sh -n "$s" 2>&1); then
+		printf '%s: %s\n' "$s" "$err" >> "$FAILS"
+	fi
+done
 
 if [ -s "$FAILS" ]; then
 	cat "$FAILS"

--- a/www/cgi-bin/j/locale.cgi
+++ b/www/cgi-bin/j/locale.cgi
@@ -1,4 +1,3 @@
-#!/bin/sh
 mj_audio=Audio
 mj_hls=HLS
 mj_image=Image

--- a/www/cgi-bin/j/locale_fpv.cgi
+++ b/www/cgi-bin/j/locale_fpv.cgi
@@ -1,4 +1,3 @@
-#!/bin/sh
 mj_audio=Audio
 mj_cloud=Cloud
 #mj_hls=HLS


### PR DESCRIPTION
Stacked on #138 — it edits `tools/lint-templates.sh`, which #138 introduces. GitHub will retarget this to `master` once #138 merges.

This is the follow-up to the "deliberately not in this PR" section of #138. On reflection that exclusion was the wrong call: it left the *device-side* scripts unchecked, which is the half where a syntax error actually costs something.

```
sbin/setnetwork    writes /etc/network/interfaces.d
sbin/updatewebui   the deploy path
sbin/telegram, sbin/openwall
www/cgi-bin/j/*.cgi   12 JSON endpoints, incl. pulse.cgi
```

Nothing else tests any of them.

## The blocker, and why an exclusion list was the wrong fix

`j/locale.cgi` carries `#!/bin/sh` but is not a script — it's a data file parsed with `sed` by `mj-settings.cgi:13`, never sourced, never executed. `mj_cloud=Cloud (WebRTC)` isn't valid shell, so it fails `sh -n` at line 22.

Rather than special-case it, **drop the shebang** from it and `locale_fpv.cgi` so shebang-based selection skips them for what they are. Verified inert: the sed output is **byte-identical** before and after, since the shebang line never matched `^mj_` anyway.

Quoting the value instead would *not* work — the sed captures `\(.*\)` straight into JSON, so `"Cloud (WebRTC)"` would put literal quote characters inside the label.

## Correction to something I said in #138

I claimed dropping the shebang would stop `/cgi-bin/j/locale.cgi` returning 500. **It doesn't** — I tested it on the lab camera. The file ships `0755` (`build-dist.sh:29` forces that on every `*.cgi`) and majestic still execs it; it now fails with `ENOEXEC` instead of a shell syntax error. Same 500.

Nothing requests it, so it's cosmetic, but getting the file out of the CGI tree is a genuinely separate change and I haven't made it.

## Mutation tested

Both halves, since a gate that never fires is worse than none:

| injected fault | result |
|---|---|
| stray `fi` in `sbin/setnetwork` | caught |
| unterminated `case` in `j/pulse.cgi` | caught |
| unterminated `while` in `sbin/updatewebui` | caught |
| unbalanced quote in `sbin/telegram` | caught |
| `locale.cgi` re-acquiring a shebang | caught (correctly — then it *claims* to be a script) |
| all four haserl cases from #138 | still caught after the refactor |
| *unmodified tree* | **passes** |

15 shell scripts + 30 templates. Same `sh -n` limitation applies: `if [ -z "$x" ; then` passes, because `[` is just a command name — one of my first mutation attempts, and it was a bad test rather than a linter gap.

## Unrelated finding, not touched here

`locale_fpv.cgi` has **no reader anywhere in the tree** — the only references are CLAUDE.md:155 and structure.md:49. `mj-settings.cgi:13` hardcodes `j/locale.cgi` and isn't `fw_variant`-gated, so FPV builds appear to get the standard labels. Either the docs drifted or FPV lost its labels; worth a look independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
