### PR TITLE
logs: render timestamps in the viewer's timezone, and stop the header lying

### DIFF
--- a/www/a/fw-time.js
+++ b/www/a/fw-time.js
@@ -88,7 +88,7 @@
 			.then(j => {
 				skew = (Number(j.time_now) * 1000) - Date.now();
 				zone = j.timezone || '';
-				offsetMs = parseTzOffsetMs(j.utc_offset);
+				offsetMs = parseTzOffsetMs(j.utc_offset) || 0;
 			})
 			.catch(() => {})
 			.finally(() => { tick(); setInterval(tick, 1000); });

--- a/www/a/fw-time.js
+++ b/www/a/fw-time.js
@@ -35,10 +35,13 @@
 
 	// Live device clock: grab the device epoch once, keep the offset to the
 	// browser clock, then tick locally (no second 2s poller vs the header).
-	let skew = 0, zone = '';
+	let skew = 0, zone = '', offsetMs = 0;
 	function tick() {
 		const el = $('#tz-now');
-		if (el) el.textContent = new Date(Date.now() + skew).toLocaleString() + (zone ? ' ' + zone : '');
+		// Device wall clock, so it has to go through the camera's UTC offset:
+		// toLocaleString() alone renders the *browser's* zone under the
+		// camera's label. fmtDeviceTime/parseTzOffsetMs come from main.js.
+		if (el) el.textContent = fmtDeviceTime(Date.now() + skew, offsetMs) + (zone ? ' ' + zone : '');
 	}
 
 	function init() {
@@ -79,7 +82,14 @@
 
 		fetch('/cgi-bin/j/pulse.cgi')
 			.then(r => r.json())
-			.then(j => { skew = (Number(j.time_now) * 1000) - Date.now(); zone = j.timezone || ''; })
+			// skew = device epoch minus browser epoch, so `Date.now() + skew` is
+			// the camera's clock. Same quantity and sign the header bar reports
+			// as drift; here it is used to tick, not to warn.
+			.then(j => {
+				skew = (Number(j.time_now) * 1000) - Date.now();
+				zone = j.timezone || '';
+				offsetMs = parseTzOffsetMs(j.utc_offset);
+			})
 			.catch(() => {})
 			.finally(() => { tick(); setInterval(tick, 1000); });
 	}

--- a/www/a/logs.js
+++ b/www/a/logs.js
@@ -2,6 +2,10 @@
 // Streams majestic's /ws/logs WebSocket (a single `logread -f` over which klogd
 // has already merged kernel + application logs) and renders it with a source
 // selector, free-text filter, pause, clear and download. Vanilla JS, no deps.
+//
+// The buffer holds raw syslog lines; timestamps are converted to the viewer's
+// timezone only at render time (see fmtLine), so filtering and severity classing
+// keep working on the untouched wire format.
 (function () {
 	const MAX_LINES = 2000;
 	const el = $('#log');
@@ -41,13 +45,54 @@
 		}
 	}
 
+	// syslogd formats every line with ctime() in its own timezone and stores only
+	// the resulting string (busybox sysklogd/syslogd.c), discarding the time_t --
+	// so the stamp arrives device-local with no year and no zone, and nothing
+	// downstream can re-zone it unaided. j/logmeta.cgi supplies both missing
+	// halves: the offset syslogd is actually running under, and the camera clock
+	// the year is inferred from. Until it answers, lines render as they arrive.
+	const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+	const TS_RE = /^(\w{3})\s+(\d{1,2})\s+(\d{2}):(\d{2}):(\d{2})\s+/;
+	let tzOffsetMs = null; // null until logmeta.cgi answers
+	let deviceSkewMs = 0;  // device epoch - browser epoch
+
+	function fmtLine(raw) {
+		if (tzOffsetMs === null) return raw;
+		const m = TS_RE.exec(raw);
+		if (!m) return raw;
+		const mon = MONTHS.indexOf(m[1]);
+		if (mon < 0) return raw;
+		// The fields are device-local wall clock; Date.UTC reads them as UTC, so
+		// subtracting the offset lands on the true instant.
+		const deviceNow = Date.now() + deviceSkewMs;
+		const year = new Date(deviceNow + tzOffsetMs).getUTCFullYear();
+		let ms = Date.UTC(year, mon, +m[2], +m[3], +m[4], +m[5]) - tzOffsetMs;
+		// No year in the wire format, so every January a December line looks like
+		// the future. More than a day ahead of the camera's own clock means it
+		// belongs to last year.
+		if (ms > deviceNow + 86400000)
+			ms = Date.UTC(year - 1, mon, +m[2], +m[3], +m[4], +m[5]) - tzOffsetMs;
+		// Only the stamp is replaced; host, facility.severity and the message stay
+		// exactly as syslogd wrote them.
+		return new Date(ms).toLocaleString() + ' ' + raw.slice(m[0].length);
+	}
+
+	fetch('/cgi-bin/j/logmeta.cgi').then(r => r.json()).then(meta => {
+		tzOffsetMs = parseTzOffsetMs(meta.tz_offset); // main.js
+		deviceSkewMs = (Number(meta.time_now) * 1000) - Date.now();
+		render(); // redraw whatever arrived while this was in flight
+	}).catch(() => {});
+
 	function atBottom() {
 		return el.scrollHeight - el.clientHeight - el.scrollTop < 4;
 	}
 	function makeRow(l) {
 		const d = document.createElement('div');
+		// Severity is read off the *raw* line: sevClass counts whitespace-separated
+		// tokens, and a localised stamp ("8/12/2026, 6:52:37 PM") has a different
+		// shape, so classing the formatted string would silently match nothing.
 		d.className = 'log-line ' + sevClass(l);
-		d.textContent = l;
+		d.textContent = fmtLine(l);
 		return d;
 	}
 	function render() {
@@ -90,7 +135,9 @@
 	});
 	elClear.addEventListener('click', () => { lines.length = 0; render(); });
 	elDownload.addEventListener('click', () => {
-		const blob = new Blob([lines.join('\n') + '\n'], { type: 'text/plain' });
+		// What is on screen, not the raw buffer -- the raw form is what `logread`
+		// over SSH already gives you.
+		const blob = new Blob([lines.map(l => fmtLine(l)).join('\n') + '\n'], { type: 'text/plain' });
 		const a = document.createElement('a');
 		a.href = URL.createObjectURL(blob);
 		a.download = 'majestic-logs.txt';

--- a/www/a/logs.js
+++ b/www/a/logs.js
@@ -78,7 +78,9 @@
 	}
 
 	fetch('/cgi-bin/j/logmeta.cgi').then(r => r.json()).then(meta => {
-		tzOffsetMs = parseTzOffsetMs(meta.tz_offset); // main.js
+		const off = parseTzOffsetMs(meta.tz_offset); // main.js; null if unusable
+		if (off === null) return; // leave tzOffsetMs null: raw beats wrongly shifted
+		tzOffsetMs = off;
 		deviceSkewMs = (Number(meta.time_now) * 1000) - Date.now();
 		render(); // redraw whatever arrived while this was in flight
 	}).catch(() => {});
@@ -135,9 +137,11 @@
 	});
 	elClear.addEventListener('click', () => { lines.length = 0; render(); });
 	elDownload.addEventListener('click', () => {
-		// What is on screen, not the raw buffer -- the raw form is what `logread`
-		// over SSH already gives you.
-		const blob = new Blob([lines.map(l => fmtLine(l)).join('\n') + '\n'], { type: 'text/plain' });
+		// Exactly what is on screen: same filter as render(), same localised
+		// stamps. Dumping the whole buffer would hand back lines the user had
+		// deliberately filtered out, which is a surprising thing to then share.
+		// The raw, unfiltered form is what `logread` over SSH already gives you.
+		const blob = new Blob([lines.filter(matches).map(l => fmtLine(l)).join('\n') + '\n'], { type: 'text/plain' });
 		const a = document.createElement('a');
 		a.href = URL.createObjectURL(blob);
 		a.download = 'majestic-logs.txt';

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -26,6 +26,21 @@ function mjGet(cfg, dot) {
 	return dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg);
 }
 
+// Camera wall clock. /etc/timezone is a display label, not an IANA name --
+// fw-time.js writes it de-underscored ("America/New York"), which
+// Intl.DateTimeFormat rejects with a RangeError. So the camera's zone is applied
+// as the numeric offset pulse.cgi reports, and the result is formatted as if it
+// were UTC. Loaded on every page (p/header.cgi), so fw-time.js reuses both.
+function parseTzOffsetMs(s) {
+	const m = /^([+-])(\d{2})(\d{2})$/.exec(s || '');
+	if (!m) return 0;
+	return (m[1] === '-' ? -1 : 1) * (+m[2] * 3600000 + +m[3] * 60000);
+}
+
+function fmtDeviceTime(epochMs, offsetMs) {
+	return new Date(epochMs + offsetMs).toLocaleString(undefined, { timeZone: 'UTC' });
+}
+
 function setProgressBar(id, value, name) {
 	$(id).setAttribute('aria-valuenow', value);
 	$(id).title = name + ': ' + value + '%'
@@ -125,9 +140,26 @@ function heartbeat() {
 				st.title = 'SoC temperature ' + json.soc_temp;
 			}
 
+			// Device time, deliberately -- log rows render in the viewer's zone
+			// (logs.js), so these two disagree by design. This bar is the one
+			// place a camera whose clock is actually wrong must look wrong, so
+			// flag real drift rather than hiding it behind the browser's clock.
+			// (Skew is zone-independent: a correct camera reads 0 whatever the
+			// timezones are, so anything here is a genuine clock problem.)
 			if (json.time_now !== '') {
-				const d = new Date(json.time_now * 1000);
-				$('#time-now').textContent = d.toLocaleString() + ' ' + json.timezone;
+				const epochMs = json.time_now * 1000;
+				const text = fmtDeviceTime(epochMs, parseTzOffsetMs(json.utc_offset)) + ' ' + json.timezone;
+				const skew = epochMs - Date.now();
+				const el = $('#time-now');
+				if (Math.abs(skew) > 60000) {
+					const mins = Math.round(skew / 60000);
+					el.textContent = text + ' ⚠ ' + (mins > 0 ? '+' : '') + mins + 'm';
+					el.title = 'Camera clock is ' + Math.abs(mins) + ' minutes ' +
+						(mins > 0 ? 'ahead of' : 'behind') + ' this browser. Check Time Settings.';
+				} else {
+					el.textContent = text;
+					el.title = '';
+				}
 			}
 
 			if (json.mem_used !== '') {

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -31,9 +31,13 @@ function mjGet(cfg, dot) {
 // Intl.DateTimeFormat rejects with a RangeError. So the camera's zone is applied
 // as the numeric offset pulse.cgi reports, and the result is formatted as if it
 // were UTC. Loaded on every page (p/header.cgi), so fw-time.js reuses both.
+// null, not 0, when the offset is missing or malformed: callers that can hold
+// off (logs.js keeps lines raw until it knows the zone) must be able to tell
+// "unknown" from a genuine +0000, or a camera on +0300 would silently render
+// every log line three hours out.
 function parseTzOffsetMs(s) {
 	const m = /^([+-])(\d{2})(\d{2})$/.exec(s || '');
-	if (!m) return 0;
+	if (!m || +m[3] > 59) return null;
 	return (m[1] === '-' ? -1 : 1) * (+m[2] * 3600000 + +m[3] * 60000);
 }
 
@@ -148,7 +152,9 @@ function heartbeat() {
 			// timezones are, so anything here is a genuine clock problem.)
 			if (json.time_now !== '') {
 				const epochMs = json.time_now * 1000;
-				const text = fmtDeviceTime(epochMs, parseTzOffsetMs(json.utc_offset)) + ' ' + json.timezone;
+				// Unlike the log rows there is no raw form to fall back to here, so
+				// an unknown offset renders as UTC rather than blanking the bar.
+				const text = fmtDeviceTime(epochMs, parseTzOffsetMs(json.utc_offset) || 0) + ' ' + json.timezone;
 				const skew = epochMs - Date.now();
 				const el = $('#time-now');
 				if (Math.abs(skew) > 60000) {

--- a/www/cgi-bin/info-logs.cgi
+++ b/www/cgi-bin/info-logs.cgi
@@ -40,6 +40,7 @@ SYSLOG_SIZE=64
 		</div>
 	</div>
 	<div id="log" class="border rounded bg-body-tertiary"></div>
+	<p class="text-secondary small mt-1 mb-0">Times are shown in your browser's timezone. The clock in the top bar is the camera's.</p>
 	<details class="mt-3">
 		<summary class="text-secondary small">Log buffer size — currently <%= $SYSLOG_SIZE %> KiB</summary>
 		<form action="<%= $SCRIPT_NAME %>" method="post" class="row g-2 align-items-end mt-1" style="max-width:30rem">

--- a/www/cgi-bin/j/logmeta.cgi
+++ b/www/cgi-bin/j/logmeta.cgi
@@ -1,0 +1,36 @@
+#!/bin/sh
+# The UTC offset syslogd is *actually* running under, so logs.js can turn the
+# "Mmm dd hh:mm:ss" stamps coming out of /ws/logs into real instants.
+#
+# busybox syslogd formats every line with ctime() and stores only the string
+# (sysklogd/syslogd.c), discarding the time_t -- so the wall clock in a log line
+# is device-local with no year and no zone, and this offset is the missing half.
+#
+# Deliberately not `date +%z` and not /etc/TZ: /etc/init.d/rcS exports TZ once at
+# boot, so syslogd keeps whatever zone was current then, and info-logs.cgi
+# restarts it with the CGI's inherited environment rather than the file. Only the
+# daemon's own /proc entry is right in every state, including after a timezone
+# change but before the reboot that makes it stick.
+spid=$(pidof syslogd | cut -d' ' -f1)
+stz=$(tr '\0' '\n' < "/proc/$spid/environ" 2>/dev/null | sed -n 's/^TZ=//p')
+
+# time_now rides along so logs.js can infer the year the wire format omits
+# without a second request; the epoch is the same under any TZ, so this is still
+# one date(1).
+if [ -n "$stz" ]; then
+	now=$(TZ="$stz" date '+%z %s')
+else
+	# syslogd has no TZ in its environment -- which happens when it is restarted
+	# from a non-login shell, since only /etc/profile and rcS export one. libc
+	# then falls back to /etc/localtime, or UTC if that is missing. Reproduce
+	# that by unsetting TZ; inheriting httpd's would report the zone /etc/TZ held
+	# at boot and shift every line on any camera that is not on UTC.
+	now=$(unset TZ; date '+%z %s')
+fi
+
+echo "HTTP/1.1 200 OK
+Content-type: application/json
+Pragma: no-cache
+
+$(printf '{"tz_offset":"%s","time_now":"%s"}' "${now% *}" "${now#* }")
+"

--- a/www/cgi-bin/j/pulse.cgi
+++ b/www/cgi-bin/j/pulse.cgi
@@ -52,8 +52,15 @@ if [ -n "$mjpid" ] && [ -r "/proc/$mjpid/stat" ]; then
 		   printf "%s%s%sm", (d? d"d ":""), (h||d? h"h ":""), m }' "/proc/$mjpid/stat")
 fi
 
-payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s","mj_uptime":"%s"}' \
-	"${soc_temp}" "$(date +%s)" "$(cat /etc/timezone)" "${mem_used}" "${overlay_used//%/}" "${daynight_value:=-1}" "$uptime" "$mj_uptime")
+# Epoch and UTC offset in one date(1), split with parameter expansion, so the
+# 2s heartbeat gains no extra fork. The header needs both: /etc/timezone is only
+# a display label (fw-time.js writes it de-underscored, e.g. "America/New York",
+# which Intl.DateTimeFormat rejects), so the numeric offset is what actually
+# renders the camera's wall clock.
+now=$(date '+%s %z')
+
+payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","utc_offset":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s","mj_uptime":"%s"}' \
+	"${soc_temp}" "${now% *}" "$(cat /etc/timezone)" "${now#* }" "${mem_used}" "${overlay_used//%/}" "${daynight_value:=-1}" "$uptime" "$mj_uptime")
 
 echo "HTTP/1.1 200 OK
 Content-type: application/json


### PR DESCRIPTION
`info-logs.cgi` shows log lines in GMT while the header reads `8/12/2026, 6:52:37 PM Etc/GMT`. Users read that as the logs being in the wrong timezone.

## The logs were right; the header was lying

`www/a/main.js:129-130` rendered the device epoch with `toLocaleString()` and no `timeZone` option — so the **browser's** zone — then appended `json.timezone`, the **camera's** zone name from `/etc/timezone`. Two different clocks concatenated into one string. `www/a/fw-time.js:41` had the identical bug, on the card explicitly labelled the device clock.

## Why nothing downstream could just re-zone the log lines

busybox syslogd destroys the epoch at ingest — `sysklogd/syslogd.c:837`:

```c
timestamp = ctime(&now) + 4;
timestamp[15] = '\0';
```

That string is `sprintf`'d into `printbuf` and `log_to_shmem()` is handed only the string; the `time_t` reaches `log_locally()` alone, for rotation. So every reader — `logread`, `/ws/logs`, SSH — gets `Mmm dd hh:mm:ss` with no year and no zone.

Alternatives considered and rejected:

- **Read the shm ring directly** (`logread.c:118-129`) — drops the fork, but not the string, and takes on busybox's private IPC ABI (the `"GENA"` key, `shbuf_ds` layout, semaphore protocol) as a permanent compatibility surface.
- **`/dev/kmsg`** — the readable/seekable form landed in Linux 3.5; 17 of 125 defconfigs are older (3.0.8 hi3516cv100/hi3520dv200/fh8852v100, 3.0.101 xm510, 3.3.0 gm813x, 3.4.43 gk710x).
- **`syslogd -R` forwarding into majestic** — inverts the roles; the system's log collector would depend on the camera app being alive.

So the conversion happens in the browser, and no daemon is touched. This also means it reaches every camera already in the field via `sbin/updatewebui`, with no firmware flash and no majestic rebuild.

## Changes

| File | |
|---|---|
| `www/cgi-bin/j/logmeta.cgi` | **new** — the UTC offset syslogd is actually running under, plus the camera epoch |
| `www/a/logs.js` | rows convert to the viewer's zone at render time |
| `www/cgi-bin/j/pulse.cgi` | `utc_offset` from the same `date '+%s %z'` as the epoch — no extra fork on the 2 s heartbeat |
| `www/a/main.js` | `parseTzOffsetMs`/`fmtDeviceTime` globals; header on device time + drift badge |
| `www/a/fw-time.js` | device clock card via the same helper |
| `www/cgi-bin/info-logs.cgi` | one line noting the two clocks now differ on purpose |

Two details worth review attention:

`logmeta.cgi` reads syslogd's **own** `/proc/<pid>/environ`, not `/etc/TZ` and not plain `date +%z`. `rcS:4` exports `TZ` once at boot so syslogd keeps the boot zone; `info-logs.cgi:12` restarts it with the CGI's inherited environment; and a restart from a non-login shell leaves it with no `TZ` at all. That last case is why the fallback *unsets* `TZ` — with `TZ=MSK-3` inherited, `date +%z` reports `+0300` while a `TZ`-less syslogd actually stamps `+0000`.

`logs.js` keeps **raw** lines in its buffer and converts only at render time, so the source selector, filter and `sevClass()` all keep working on the untouched wire format. Severity especially must come off the raw line: `sevClass` counts whitespace-separated tokens, and `8/12/2026, 6:52:37 PM` has a different shape, so classing the formatted string would silently match nothing.

The header stays on device time deliberately — it is the one place a camera whose clock is genuinely wrong must look wrong — so real drift past a minute is flagged inline. Skew is timezone-independent, so a correct camera reads zero whatever the two zones are. `/etc/timezone` is never passed to `Intl`: `fw-time.js:13` writes it de-underscored (`America/New York`) and `Intl.DateTimeFormat` throws `RangeError` on that, which is exactly why the numeric offset is shipped separately.

## Verification

On the lab T31 (busybox 1.36.1, musl, no `/etc/localtime`):

- syslogd under `TZ=MSK-3` stamped `Aug 12 20:00:22` for epoch `1786554022` = `17:00:22 UTC` — exactly the `+0300` `logmeta.cgi` reported, while `pulse.cgi` still read `+0000` from httpd's environment. That divergence is the case the endpoint exists for.
- restarted `TZ`-less, it stamped `17:04:16` for `17:04:17 UTC` and `logmeta.cgi` correctly fell back to `+0000`.
- the conversion functions are exercised against those measured instants under four browser zones, including a half-hour one (`Australia/Adelaide`) and a DST one (`America/New_York`), plus the December-in-January rollover.

`tools/lint-templates.sh` passes (29 templates, 16 shell scripts — the new CGI is in scope) and `npm run build:dist` passes.

## Known limit

Lines already in the ring across a DST transition were stamped at the previous offset and read an hour out. The 64 KiB default buffer is typically minutes of logs, and today none of it is convertible at all.

Out of scope: `www/a/files.js:47` still renders file mtimes in browser time, unlabelled — mtimes are used for ordering, and fixing it would need the files API to carry an offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
