### PR TITLE
fw-update: stop calling a same-version reflash a failure, and drop the per-character rebuild

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -30,6 +30,15 @@
 	const abortMarker = /Aborting\./;
 	let aborted = false;
 
+	// compare_versions() prints this when the image on offer is the one already
+	// installed, and then nothing is written. Reflashing the same build is a
+	// reasonable thing to do, but the version check below cannot tell that apart
+	// from a flash that silently did nothing — both end on the version they
+	// started on. Without this, "nothing needed doing" is reported as "the update
+	// did not apply", which reads as a failure (issue #120).
+	const noopMarker = /Same version, nothing to update/i;
+	let noop = false;
+
 	// Whether --force_ver was requested. It reflashes the same version on purpose,
 	// so an unchanged version afterwards is a success, not a failure.
 	let forced = false;
@@ -72,8 +81,13 @@
 	const lineNode = document.createTextNode('');
 	out.appendChild(doneNode);
 	out.appendChild(lineNode);
-	let line = '';   // the line currently being drawn, after the last \n
-	let col = 0;     // cursor position within it
+	// The line being drawn is an array of characters, not a string: the cursor can
+	// land anywhere in it, and rebuilding a string per character (slice + concat +
+	// slice) is quadratic in the line length. curl's meter is short enough not to
+	// care, but a tool emitting a long line with no newline would have made this
+	// the slowest thing on the page.
+	let lineArr = [];   // the line currently being drawn, after the last \n
+	let col = 0;        // cursor position within it
 
 	// Markers can straddle two frames, so match against a rolling window of the
 	// recent stream rather than each chunk in isolation.
@@ -84,24 +98,26 @@
 		for (let i = 0; i < s.length; i++) {
 			const ch = s[i];
 			if (ch === '\n') {
-				commit += line + '\n';
-				line = '';
+				commit += lineArr.join('') + '\n';
+				lineArr = [];
 				col = 0;
 			} else if (ch === '\r') {
 				col = 0;
 			} else {
-				line = line.slice(0, col) + ch + line.slice(col + 1);
-				col++;
+				lineArr[col++] = ch;
 			}
 		}
+		// One join per frame rather than a string rebuild per character; finished
+		// lines leave through appendData and are never re-copied.
 		if (commit) doneNode.appendData(commit);
-		lineNode.data = line;
+		lineNode.data = lineArr.join('');
 		out.scrollTop = out.scrollHeight;
 		// Deliberately still the raw stream: the markers below are whole-line
 		// messages, and matching them on what was received rather than on what
 		// survived the redraws keeps this decoupled from the rendering.
 		recent = (recent + s).slice(-512);
 		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
+		if (!noop && noopMarker.test(recent)) noop = true;
 		if (!aborted && abortMarker.test(recent)) {
 			aborted = true;
 			if (sawFlash) {
@@ -140,6 +156,7 @@
 		aborted = false;
 		recent = '';
 		forced = p.force;
+		noop = false;
 		status('warning', 'Preparing — freeing memory…');
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
@@ -198,6 +215,13 @@
 			now = await installedNow();
 		}
 		if (now && installedBefore && now === installedBefore && !forced) {
+			if (noop) {
+				// sysupgrade said so itself: the image offered was the one already
+				// installed, so it wrote nothing. Nothing failed.
+				status('success', 'Already running ' + now + ' — nothing to update.');
+				setTimeout(() => location.href = 'status.cgi', 1500);
+				return;
+			}
 			status('danger', 'The camera rebooted but is still running ' + now +
 				' — the update did not apply. Check the log above and try again.');
 			resumeHeartbeat();


### PR DESCRIPTION
Two things: the Goke symptom from #120, and a review finding on #135 that was not addressed before it merged.

### 1. "Already on this version" is not a failure

Reflashing the build you are already on is reasonable, and sysupgrade handles it — `compare_versions` prints `Same version, nothing to update` and writes nothing.

But `confirmUpgrade()` only sees that the camera came back on the version it started on, which is *also* what a flash that silently did nothing looks like. So it reported "the update did not apply" and did not redirect.

That is exactly the **Goke** report in #120:

> The upgrade finishes with "Unconditional reboot", but after the camera reboots, the browser does not redirect to the status page.
> …I cannot tell whether the firmware was actually upgraded, because I was reinstalling the same firmware version.

The version check was doing its job; the message was wrong. Now it watches for sysupgrade's own marker and says the honest thing — *already running X, nothing to update* — then redirects as usual. A genuinely unchanged version **without** that marker still reports failure, which is the case the check exists for.

### 2. append() was quadratic in line length

Raised in review on #135, not acted on. It rebuilt the in-progress line with `slice + concat + slice` per character. The cursor can land anywhere in the line, so the line is now an array of characters, joined once per frame.

curl's meter is far too short to notice, but a tool emitting a long line without a newline would have made this the slowest thing on the page. Measured: **60 000 characters on one line renders in 5 ms**.

### Verification

Real `curl -#` bytes captured off an ssc30kq plus a 120-redraw synthetic meter, fed at 1, 7, 180 and 4096-byte frame boundaries:

```
  ok   real curl bytes (3 CR, 2 NL) chunk=1/7/180/4096: NL preserved, CR gone
  ok   synthetic 120 redraws (120 CR, 1 NL) chunk=1/7/180/4096: NL preserved, CR gone
  ok   shorter redraw keeps the tail
  ok   CRLF still a newline
  ok   same-version marker detected
  ok   marker NOT set on a real update
  ok   60k-char line stays fast (5ms)

13 passed, 0 failed
```

The invariant is "carriage returns collapse, newlines are preserved exactly" — my first version of this test asserted "renders as one line", which is wrong for any input containing real newlines and produced a false failure.

Refs #120, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)