### PR TITLE
fw-update: confirm a reboot by uptime, not by catching the camera offline

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -43,6 +43,10 @@
 	// so an unchanged version afterwards is a success, not a failure.
 	let forced = false;
 
+	// When this run began, so a camera's own uptime can be read as "it booted
+	// during this upgrade". See rebootedAlready().
+	let startedAt = 0;
+
 	// The version this page was rendered with, compared against the rebooted
 	// camera's. A failed sysupgrade reboots too, so "it answered again" is not
 	// evidence that anything was flashed (issue #120, t31x).
@@ -157,6 +161,7 @@
 		recent = '';
 		forced = p.force;
 		noop = false;
+		startedAt = Date.now();
 		status('warning', 'Preparing — freeing memory…');
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
@@ -173,7 +178,11 @@
 		ws.onclose = () => {
 			if (!opened) return;   // handshake failed → onerror reports it
 			if (aborted && !sawFlash) return;   // gave up before touching flash; no reboot is coming
-			status('warning', 'Waiting for the camera to reboot — do not power off…');
+			// "do not power off" is a warning about an interrupted flash, so do not
+			// say it when sysupgrade has already told us it wrote nothing.
+			status('warning', noop
+				? 'Already up to date — waiting for the camera to come back…'
+				: 'Waiting for the camera to reboot — do not power off…');
 			pollBack();
 		};
 		ws.onerror = () => { if (!opened) { status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); resumeHeartbeat(); } };
@@ -231,9 +240,42 @@
 		setTimeout(() => location.href = 'status.cgi', 1500);
 	}
 
-	// Confirm a real reboot before reporting done: the camera must first go
-	// UNREACHABLE, then come back — and then confirmUpgrade checks what it came
-	// back as.
+	// Positive evidence that the camera restarted, instead of inferring it from a
+	// gap in our own polling. The camera's uptime is compared against how long
+	// this run has been going: anything smaller means it booted during the
+	// upgrade, and anything larger means the boot predates it.
+	//
+	// The down-then-up watch below cannot see a reboot it was not awake for. When
+	// nothing is flashed (a same-version run) majestic is never disturbed, so the
+	// hard `reboot -f` closes no sockets: the browser only learns the connection
+	// died when the REBOOTED camera resets it — measured at 30s after
+	// "Unconditional reboot" on an av300, by which point the camera is already
+	// back. downSeen then never flips, and a perfectly good upgrade was reported
+	// as "the camera never rebooted".
+	//
+	// Returns false, never throws: on an older camera whose pulse.cgi predates
+	// uptime_s this is simply unavailable, and the watch below still applies.
+	async function rebootedAlready() {
+		const ctl = new AbortController();
+		const to = setTimeout(() => ctl.abort(), 2500);
+		try {
+			const r = await fetch('/cgi-bin/j/pulse.cgi?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal });
+			if (!r.ok) return false;
+			const up = Number((await r.json()).uptime_s);
+			if (!isFinite(up)) return false;
+			// 5s of slack so a camera that booted moments before this page loaded
+			// is not mistaken for one that rebooted just now.
+			return up < (Date.now() - startedAt) / 1000 - 5;
+		} catch (err) {
+			return false;
+		} finally {
+			clearTimeout(to);
+		}
+	}
+
+	// Confirm a real reboot before reporting done: the camera must either go
+	// UNREACHABLE and come back, or tell us its uptime is younger than this run —
+	// and then confirmUpgrade checks what it came back as.
 	function pollBack() {
 		function ping() {
 			const ctl = new AbortController();
@@ -245,12 +287,25 @@
 		let downSeen = false, tries = 0;
 		const DOWN_TRIES = 160;   // ~8 min: silent download (≤2 min) + verify + flash + reboot
 		const UP_TRIES = 200;     // ~10 min: a stale-clock first boot can fsck and take minutes
+		// A same-version run writes nothing, so there is no download or flash to
+		// wait out — only the reboot itself. Giving that the full 8 minutes would
+		// leave the page sitting on a camera that finished in seconds.
+		const downTries = noop ? 20 : DOWN_TRIES;   // ~60s when nothing is being written
 		async function tick() {
 			const up = await ping();
 			if (!downSeen) {
 				if (!up) { downSeen = true; tries = 0; status('warning', 'Camera is rebooting — waiting for it to come back…'); }
-				else if (++tries > DOWN_TRIES) {
+				// It is answering, which is either "has not rebooted yet" or "already
+				// finished and came back while we were not looking". Ask it directly,
+				// but not on every tick — pulse.cgi forks a dozen processes, and the
+				// whole point of stopHeartbeat() was to stop hammering it.
+				else if (tries % 4 === 0 && await rebootedAlready()) { confirmUpgrade(); return; }
+				else if (++tries > downTries) {
 					if (sawFlash) status('warning', 'Still flashing — the camera has not rebooted yet. Give it a few minutes, then reload.');
+					// Nothing was written, so "we never saw it go down" is not evidence
+					// of a failure — there was nothing that could have failed. Take
+					// sysupgrade at its word rather than crying wolf.
+					else if (noop) { confirmUpgrade(); }
 					else { status('danger', 'The camera never rebooted — the update may have failed. Check the log above and try again.'); resumeHeartbeat(); }
 					return;
 				}

--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -45,6 +45,12 @@
 
 	// When this run began, so a camera's own uptime can be read as "it booted
 	// during this upgrade". See rebootedAlready().
+	//
+	// performance.now(), not Date.now(): this is a duration, and the wall clock
+	// is the one thing that cannot be trusted to hold still here. sysupgrade
+	// synchronises time mid-run, and the browser's own clock can be stepped by
+	// NTP at any moment — either would move this baseline under us and turn the
+	// comparison into a false "it rebooted" or a missed one.
 	let startedAt = 0;
 
 	// The version this page was rendered with, compared against the rebooted
@@ -161,7 +167,7 @@
 		recent = '';
 		forced = p.force;
 		noop = false;
-		startedAt = Date.now();
+		startedAt = performance.now();
 		status('warning', 'Preparing — freeing memory…');
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
@@ -265,7 +271,7 @@
 			if (!isFinite(up)) return false;
 			// 5s of slack so a camera that booted moments before this page loaded
 			// is not mistaken for one that rebooted just now.
-			return up < (Date.now() - startedAt) / 1000 - 5;
+			return up < (performance.now() - startedAt) / 1000 - 5;
 		} catch (err) {
 			return false;
 		} finally {

--- a/www/cgi-bin/j/pulse.cgi
+++ b/www/cgi-bin/j/pulse.cgi
@@ -38,6 +38,14 @@ mem_used=$(awk '
 overlay_used=$(df | grep /overlay | xargs | cut -d' ' -f5)
 uptime=$(awk '{m=$1/60; h=m/60; printf "%sd %sh %sm %ss\n", int(h/24), int(h%24), int(m%60), int($1%60) }' /proc/uptime)
 
+# The same value in raw seconds. fw-update.js compares it against how long the
+# upgrade has been running to establish that the camera really did reboot;
+# recovering that from the "0d 0h 1m 2s" label above would mean parsing a string
+# written for humans. `read` is a builtin, so this costs the 2s heartbeat no
+# extra fork.
+read -r uptime_s _ </proc/uptime
+uptime_s=${uptime_s%.*}
+
 # Majestic's own uptime: system uptime minus the process start time (field 22 of
 # /proc/<pid>/stat is starttime in clock ticks since boot). Computed live each
 # poll, so it stays correct even if majestic restarts on its own. Formatted
@@ -59,8 +67,8 @@ fi
 # renders the camera's wall clock.
 now=$(date '+%s %z')
 
-payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","utc_offset":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s","mj_uptime":"%s"}' \
-	"${soc_temp}" "${now% *}" "$(cat /etc/timezone)" "${now#* }" "${mem_used}" "${overlay_used//%/}" "${daynight_value:=-1}" "$uptime" "$mj_uptime")
+payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","utc_offset":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s","uptime_s":%d,"mj_uptime":"%s"}' \
+	"${soc_temp}" "${now% *}" "$(cat /etc/timezone)" "${now#* }" "${mem_used}" "${overlay_used//%/}" "${daynight_value:=-1}" "$uptime" "${uptime_s:-0}" "$mj_uptime")
 
 echo "HTTP/1.1 200 OK
 Content-type: application/json


### PR DESCRIPTION
Reported by @usa- in #120: after the fix for the original failure, *"when upgrading to the same version, after the “Unconditional reboot” and camera restart, the browser does not redirect to the main page."*

Reproduced and fixed on a lab hi3516av300.

## Why it happens

`pollBack()` confirms a restart by watching the camera go unreachable and then answer again. That only works while the flash is disturbing majestic.

When `compare_versions()` finds the installed build already on offer, sysupgrade writes nothing — so majestic is never touched, and the hard `reboot -f` closes no sockets. The browser only learns the connection died when the **rebooted** camera resets it:

```
[   8.6s] Same version, nothing to update
[   8.6s] Unconditional reboot
[  38.7s] CLOSE: ECONNRESET          <- 30.2s later, camera already back up
```

By then there is no "down" left to observe. `downSeen` never flips, the 8-minute `DOWN_TRIES` budget expires, and the page accuses a perfectly good upgrade of having failed.

## Fix

**Ask the camera instead of inferring it.** `pulse.cgi` now reports `uptime_s` alongside the display string it already computes — via `read`, a builtin, so the 2s heartbeat gains no extra fork. `pollBack()` treats *"answering, and up for less time than this run has been going"* as positive evidence of a restart. That covers every reboot the poller can miss, not just this one: a fast camera, a throttled background tab, a laptop that slept through the window. It is throttled to every 4th tick, since `pulse.cgi` forks a dozen processes and not hammering it is the whole point of `stopHeartbeat()`.

**The same-version case also gets a floor of its own.** Nothing is written, so there is no download or flash to wait out, and "we never saw it go down" is not evidence of failure when there was nothing that could fail. The wait drops to ~60s and ends in `confirmUpgrade()` rather than an accusation. This keeps the page working on a camera whose `pulse.cgi` predates `uptime_s`, where the check simply returns `false`. The "do not power off" warning is dropped from that path too — it warns about an interrupted flash, and there is no flash.

## Verification

Real page driven in headless Chromium against the camera, same-version upgrade, identical run both times:

| | before (master) | after |
|---|---|---|
| 13s | Upgrading… | Upgrading… |
| 65s | Waiting for the camera to reboot… | Camera is back — checking the installed version… |
| 68s | *(stuck)* | Already running 2.6.08.13-lite — nothing to update. |
| 71s | *(stuck; false failure at 8 min)* | **redirected to status.cgi** |

## Noted, not changed

`flashMarker` still lists `Stopping web server before flashing`, which no longer appears anywhere in sysupgrade. It is left in deliberately: cameras run whatever sysupgrade their installed firmware shipped with, so dropping an alternative that older scripts still print would regress flash detection on them. It costs nothing to keep.