### PR TITLE
preview: add an unmute button to the live MSE player

### DIFF
--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -65,6 +65,8 @@
 		if (badge) badge.textContent = 'MJPEG';
 	}
 
+	const mute = $('#mj-mute'), muteLbl = $('#mj-mute-lbl'), vol = $('#mj-vol');
+
 	const player = MajesticVideo.attach(initial, {
 		stream: 0,
 		onState: (s, d) => {
@@ -74,9 +76,36 @@
 			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
 		},
 		onCodec: (codec, cs, w, h) => { if (badge) badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h; },
+		// null means we asked for audio and the camera had none to give (mic off
+		// or not producing). Reflect that on the control rather than leaving the
+		// user staring at an unmute button that does nothing.
+		onAudio: (codec) => {
+			if (!mute) return;
+			if (mute.checked && !codec) {
+				muteLbl.textContent = '🔇 No audio';
+				mute.checked = false;
+				if (vol) vol.disabled = true;
+			}
+		},
 	});
 
 	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
 	if (s0) s0.addEventListener('change', () => player.setStream(0));
 	if (s1) s1.addEventListener('change', () => player.setStream(1));
+
+	// Audio: reveal only when the camera has it configured and this browser can
+	// play a codec the camera can produce — otherwise the button is a dead end.
+	const audioCtl = $('#mj-audio-ctl');
+	if (audioCtl && mute && player.audioSupported()) {
+		mjConfig().then(cfg => {
+			if (mjGet(cfg, 'audio.enabled') === true) audioCtl.hidden = false;
+		});
+		mute.addEventListener('change', () => {
+			const on = mute.checked;
+			player.setAudio(on);
+			muteLbl.textContent = on ? '🔊 Listening' : '🔇 Muted';
+			if (vol) vol.disabled = !on;
+		});
+		if (vol) vol.addEventListener('input', () => player.setVolume(vol.value / 100));
+	}
 })();

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -91,6 +91,12 @@ window.MajesticVideo = (function () {
 			// a mic that is off or not producing. Report it either way so the
 			// page can say so rather than leave a dead unmute button.
 			onAudio(wantAudio ? (info.audioCodec || null) : null);
+			// We asked for audio and got a video-only stream: stop wanting it, so
+			// state stays consistent with the (now video-only) connection and a
+			// later unmute actually flips wantAudio and reconnects rather than
+			// no-opping. No reconnect here — this stream is already what a mute
+			// would have produced.
+			if (wantAudio && !info.audioCodec) { wantAudio = false; video.muted = true; }
 			mime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
 			if (!mseOk || !MediaSource.isTypeSupported(mime)) {
 				onState('mjpeg', 'codec ' + info.codec + ' not playable here');

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -3,15 +3,31 @@ window.MajesticVideo = (function () {
 	const MAX_QUEUE = 240;
 	const LIVE_EDGE = 1.0;
 
+	// Audio is opt-in per connection: the camera only encodes it while someone
+	// is listening, so unmuting reconnects with &audio=<what this browser can
+	// decode>. The list is probed rather than sniffed from the user agent,
+	// because the answer is a browser-version detail: Opus in MP4 plays in
+	// Chrome and Firefox, Safari needs AAC. Order is only a hint — the camera
+	// prefers whichever of these it is already encoding.
+	const AUDIO_CODECS = ['opus', 'mp4a.40.2'];
+	const audioPrefs = (function () {
+		if (!('MediaSource' in window)) return '';
+		return AUDIO_CODECS.filter(function (c) {
+			return MediaSource.isTypeSupported('audio/mp4; codecs="' + c + '"');
+		}).join(',');
+	})();
+
 	function attach(video, opts) {
 		opts = opts || {};
 		const onState = opts.onState || function () {};
 		const onCodec = opts.onCodec || function () {};
+		const onAudio = opts.onAudio || function () {};
 		let stream = opts.stream | 0;
 		let ws = null, ms = null, sb = null, objUrl = null;
 		let queue = [], started = false, mime = null;
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let gotSignal = false, signalTimer = null, failCount = 0;
+		let wantAudio = false, volume = 1;
 
 		const mseOk = ('MediaSource' in window);
 		const NO_SIGNAL_MS = 4000;
@@ -51,11 +67,15 @@ window.MajesticVideo = (function () {
 		function onVideoError(e) {
 			if (!closed && e.target === video) reconnect();
 		}
+		// The element is replaced on every (re)connect, so mute and volume have
+		// to be re-applied — cloneNode does not carry them, and defaulting to
+		// muted would silence the stream the user just asked to hear.
 		function freshVideo() {
 			const old = video;
 			const nv = old.cloneNode(false);
 			nv.removeAttribute('src');
-			nv.muted = true;
+			nv.muted = !wantAudio;
+			nv.volume = volume;
 			if (old.parentNode) old.parentNode.replaceChild(nv, old);
 			old.removeEventListener('error', onVideoError);
 			try { old.removeAttribute('src'); old.load(); } catch (e) {}
@@ -67,6 +87,10 @@ window.MajesticVideo = (function () {
 			markSignal();
 			failCount = 0;
 			onCodec(info.codec, info.codecString, info.width, info.height);
+			// Null when we asked for audio and the camera has none to give —
+			// a mic that is off or not producing. Report it either way so the
+			// page can say so rather than leave a dead unmute button.
+			onAudio(wantAudio ? (info.audioCodec || null) : null);
 			mime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
 			if (!mseOk || !MediaSource.isTypeSupported(mime)) {
 				onState('mjpeg', 'codec ' + info.codec + ' not playable here');
@@ -112,7 +136,9 @@ window.MajesticVideo = (function () {
 			freshVideo();
 			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 			onState('connecting');
-			ws = new WebSocket(proto + '://' + location.host + '/ws/video?stream=' + stream);
+			let url = proto + '://' + location.host + '/ws/video?stream=' + stream;
+			if (wantAudio && audioPrefs) url += '&audio=' + audioPrefs;
+			ws = new WebSocket(url);
 			ws.binaryType = 'arraybuffer';
 			gotSignal = false;
 			ws.onopen = function () { backoff = 1000; armSignalTimer(); };
@@ -149,16 +175,40 @@ window.MajesticVideo = (function () {
 			if (ws && ws.readyState === 1) ws.send(JSON.stringify({ request: 'idr' }));
 		}
 
-		function setStream(n) {
-			n = n | 0;
-			if (n === stream) return;
-			stream = n;
+		function reopen() {
 			backoff = 1000;
 			failCount = 0;
 			stop();
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			reconnectTimer = setTimeout(function () { reconnectTimer = null; open(); }, 300);
 		}
+
+		function setStream(n) {
+			n = n | 0;
+			if (n === stream) return;
+			stream = n;
+			reopen();
+		}
+
+		// Whether the stream carries an audio track is fixed when the socket
+		// opens, so toggling it reconnects — the same brief cut as switching
+		// Main/Sub. Muting is not just an element flag: it drops the
+		// subscription so the camera stops encoding audio for nobody. Must be
+		// called from a click, or autoplay policy blocks unmuted playback.
+		function setAudio(on) {
+			on = !!on && !!audioPrefs;
+			if (on === wantAudio) return;
+			wantAudio = on;
+			video.muted = !on;
+			reopen();
+		}
+
+		function setVolume(v) {
+			volume = Math.max(0, Math.min(1, +v || 0));
+			try { video.volume = volume; } catch (e) {}
+		}
+
+		function audioSupported() { return !!audioPrefs; }
 
 		function destroy() {
 			closed = true;
@@ -168,11 +218,21 @@ window.MajesticVideo = (function () {
 
 		if (!mseOk) {
 			onState('mjpeg', 'MSE unavailable');
-			return { setStream: function () {}, requestIdr: function () {}, destroy: function () {}, supported: false };
+			return {
+				setStream: function () {}, requestIdr: function () {},
+				setAudio: function () {}, setVolume: function () {},
+				audioSupported: function () { return false; },
+				destroy: function () {}, supported: false,
+			};
 		}
 
 		open();
-		return { setStream: setStream, requestIdr: requestIdr, destroy: destroy, supported: true };
+		return {
+			setStream: setStream, requestIdr: requestIdr,
+			setAudio: setAudio, setVolume: setVolume,
+			audioSupported: audioSupported,
+			destroy: destroy, supported: true,
+		};
 	}
 
 	return { attach: attach };

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -27,7 +27,7 @@ mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilt
 			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=2</dt>
 			<dd>RTSP JPEG stream.</dd>
 			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=0</dt>
-			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview).</dd>
+			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview). Append <code>&amp;audio=opus,mp4a.40.2</code> to mux in an audio track for the codecs your player accepts.</dd>
 			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=1</dt>
 			<dd>Low-latency H.264/H.265 sub stream (fMP4/MSE).</dd>
 			<dt class="cp2cb">http://<%= $network_address %>/mjpeg</dt>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -394,6 +394,11 @@ preview() {
 		<label class="btn btn-outline-primary" for="mj-stream-1" id="mj-sub" hidden>Sub</label>
 		<span id="mj-badge" class="badge text-bg-secondary align-self-center ms-2">connecting…</span>
 	</div>
+	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Audio" id="mj-audio-ctl" hidden>
+		<input type="checkbox" class="btn-check" id="mj-mute" autocomplete="off">
+		<label class="btn btn-outline-primary" for="mj-mute" id="mj-mute-lbl">🔇 Muted</label>
+		<input type="range" id="mj-vol" min="0" max="100" value="100" class="form-range align-self-center ms-2" style="width:6rem" disabled aria-label="Volume">
+	</div>
 	<video id="live-video" autoplay muted playsinline style="$bg"></video>
 	<img id="live-mjpeg" alt="" style="display:none; $bg">
 	<p id="mj-note" class="alert alert-warning" style="display:none">


### PR DESCRIPTION
Closes OpenIPC/majestic#289.

The preview player was hardcoded muted with no way to hear the camera — you had to open an RTSP player or a separate `/audio.opus` tab. This adds a mute toggle and volume slider that unmute the live stream in place.

## How it works

Audio rides the same `/ws/video` stream, negotiated per connection. The player probes which codecs this browser can decode in MP4 (Opus for Chrome/Firefox, AAC for Safari) and, on unmute, reconnects with `&audio=<list>` — the same brief cut as switching Main/Sub. Muting reconnects without it, so the camera stops encoding audio when nobody is listening.

The control only appears when `audio.enabled` is true in the config **and** the browser can actually play one of the codecs the camera produces. If the camera reports no audio track (mic off or not producing), the button says so rather than sitting silent.

Also fixes `freshVideo()`, which forced `muted = true` on every reconnect and would re-silence the element the instant the user unmuted — the cloned `<video>` does not carry the mute state or volume, so both are now re-applied.

## Requires

A majestic build that muxes audio into `/ws/video?...&audio=` (companion daemon change). Against an older daemon the `&audio=` parameter is ignored and the stream stays video-only, so the button simply produces no audio — no breakage.

Verified end to end in headless Chromium against a live camera: unmute reveals the control, negotiates Opus, and the `<video>` element decodes audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)