### PR TITLE
webui: start the reboot watch on time, and finish the log honestly

### DIFF
--- a/www/a/ext-ntfy.js
+++ b/www/a/ext-ntfy.js
@@ -10,7 +10,7 @@
 		btn.disabled = true;
 		out.className = 'small ms-2 text-secondary';
 		out.textContent = 'Sending…';
-		fetch('?send=test')
+		fetch('?send=test', { credentials: 'same-origin' })
 			.then(r => r.text())
 			.then(d => {
 				const ok = d.trim() === 'OK';

--- a/www/a/files.js
+++ b/www/a/files.js
@@ -81,7 +81,7 @@
 		return attr(devZone + ' — ' + new Date(ms).toLocaleString() + ' your time');
 	}
 
-	fetch('/cgi-bin/j/pulse.cgi').then(r => r.json()).then(j => {
+	fetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' }).then(r => r.json()).then(j => {
 		devZone = j.timezone || '';
 		devIana = ianaOrNull(devZone);
 		devOffsetMs = parseTzOffsetMs(j.utc_offset); // main.js; null if unusable

--- a/www/a/fw-time.js
+++ b/www/a/fw-time.js
@@ -20,7 +20,7 @@
 		btn.disabled = true;
 		s.className = 'small text-secondary';
 		s.textContent = 'working…';
-		fetch(url)
+		fetch(url, { credentials: 'same-origin' })
 			.then(r => r.json())
 			.then(j => {
 				s.className = 'small alert alert-' + j.result + ' py-1 px-2 mb-0';
@@ -80,7 +80,7 @@
 		const set = $('#set-time');
 		if (set) set.addEventListener('click', e => call('/cgi-bin/j/time.cgi?set=' + Math.floor(Date.now() / 1000), e.currentTarget));
 
-		fetch('/cgi-bin/j/pulse.cgi')
+		fetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' })
 			.then(r => r.json())
 			// skew = device epoch minus browser epoch, so `Date.now() + skew` is
 			// the camera's clock. Same quantity and sign the header bar reports

--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -39,6 +39,12 @@
 	const noopMarker = /Same version, nothing to update/i;
 	let noop = false;
 
+	// sysupgrade announces the reboot before taking it. That announcement is the
+	// earliest honest moment to start watching for the camera to come back, and
+	// waiting for anything later is what made this page sit doing nothing while
+	// the camera was already serving again in another tab.
+	const rebootMarker = /Unconditional reboot|Rebooting now/i;
+
 	// Whether --force_ver was requested. It reflashes the same version on purpose,
 	// so an unchanged version afterwards is a success, not a failure.
 	let forced = false;
@@ -52,6 +58,17 @@
 	// NTP at any moment — either would move this baseline under us and turn the
 	// comparison into a false "it rebooted" or a missed one.
 	let startedAt = 0;
+
+	// When the last byte of log arrived, and whether the watch for the camera's
+	// return has already been started. See beginPollBack().
+	let lastData = 0;
+	let polling = false;
+	let quietTimer = null;
+	// How long the log may go silent, once the flash is under way, before the
+	// camera is assumed to have gone. Generous, because a quiet stretch is normal
+	// during the download and the time sync — but those happen before any write,
+	// so this only ever arms itself after sawFlash.
+	const QUIET_MS = 15000;
 
 	// The version this page was rendered with, compared against the rebooted
 	// camera's. A failed sysupgrade reboots too, so "it answered again" is not
@@ -102,7 +119,59 @@
 	// Markers can straddle two frames, so match against a rolling window of the
 	// recent stream rather than each chunk in isolation.
 	let recent = '';
+	// The stream stops wherever the camera happened to die, which is almost never
+	// on a line boundary: flashcp redraws its meter with \r and no trailing
+	// newline, so the last thing written stays half-drawn ("Verifying kb:
+	// 4648/4836 (96%)") and the pane reads as hung rather than finished.
+	function commitLine() {
+		if (!lineArr.length) return;
+		doneNode.appendData(lineArr.join('') + '\n');
+		lineArr = [];
+		col = 0;
+		lineNode.data = '';
+		out.scrollTop = out.scrollHeight;
+	}
+
+	// Only ws.onclose knows the stream is really over. The reboot announcement
+	// and the silence heuristic both start the watch while the socket may still
+	// deliver more, so writing this there would let genuine output land
+	// underneath a note claiming the connection had already ended.
+	let logClosed = false;
+	function endLog() {
+		if (logClosed) return;
+		logClosed = true;
+		commitLine();
+		doneNode.appendData('--- connection to the camera ended here; it is rebooting ---\n');
+		out.scrollTop = out.scrollHeight;
+	}
+
+	// Start watching for the camera to come back. Three things can get us here
+	// and whichever happens first wins: sysupgrade announced the reboot, the log
+	// went quiet after the flash had started, or the socket closed.
+	//
+	// Waiting on the socket alone was the mistake. A reboot that never disturbs
+	// majestic — a same-version run writes nothing — closes no sockets, so the
+	// browser is not told until the rebooted camera resets the stale connection,
+	// about 30s later. Starting early costs nothing when the camera is still
+	// working: pollBack only watches, and rebootedAlready() keeps answering false
+	// while the reported uptime is older than this run.
+	function beginPollBack() {
+		if (polling) return;
+		polling = true;
+		if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+		// Tidy the half-drawn meter, but do NOT declare the stream over: the
+		// socket can still be open here and more output may yet arrive.
+		commitLine();
+		// "do not power off" is a warning about an interrupted flash, so do not
+		// say it when sysupgrade has already told us it wrote nothing.
+		status('warning', noop
+			? 'Already up to date — waiting for the camera to come back…'
+			: 'Waiting for the camera to reboot — do not power off…');
+		pollBack();
+	}
+
 	function append(t) {
+		lastData = performance.now();
 		const s = t.replace(ansi, '');
 		let commit = '';
 		for (let i = 0; i < s.length; i++) {
@@ -128,6 +197,9 @@
 		recent = (recent + s).slice(-512);
 		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
 		if (!noop && noopMarker.test(recent)) noop = true;
+		// Said out loud by sysupgrade immediately before it reboots, so there is
+		// nothing left to wait for.
+		if (rebootMarker.test(recent)) beginPollBack();
 		if (!aborted && abortMarker.test(recent)) {
 			aborted = true;
 			if (sawFlash) {
@@ -168,6 +240,18 @@
 		forced = p.force;
 		noop = false;
 		startedAt = performance.now();
+		lastData = startedAt;
+		polling = false;
+		logClosed = false;
+		if (quietTimer) clearInterval(quietTimer);
+		// The log dying mid-flash is the other way the camera leaves without
+		// saying so — majestic is simply overwritten, and "Unconditional reboot"
+		// never reaches us. Only armed once a write has actually started, so the
+		// naturally quiet download and time-sync phases cannot trip it.
+		quietTimer = setInterval(() => {
+			if (polling) { clearInterval(quietTimer); quietTimer = null; return; }
+			if (sawFlash && performance.now() - lastData > QUIET_MS) beginPollBack();
+		}, 3000);
 		status('warning', 'Preparing — freeing memory…');
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 		const ws = new WebSocket(proto + '://' + location.host + '/ws/upgrade');
@@ -183,13 +267,21 @@
 		// server-side concern: majestic pings /ws/upgrade while the child is idle.)
 		ws.onclose = () => {
 			if (!opened) return;   // handshake failed → onerror reports it
-			if (aborted && !sawFlash) return;   // gave up before touching flash; no reboot is coming
-			// "do not power off" is a warning about an interrupted flash, so do not
-			// say it when sysupgrade has already told us it wrote nothing.
-			status('warning', noop
-				? 'Already up to date — waiting for the camera to come back…'
-				: 'Waiting for the camera to reboot — do not power off…');
-			pollBack();
+			if (aborted && !sawFlash) {
+				// Gave up before touching flash; no reboot is coming, and the log
+				// above is the whole story.
+				if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+				commitLine();
+				return;
+			}
+			// Usually last of the three triggers rather than first — by the time a
+			// hard reboot resets this socket, beginPollBack() has normally already
+			// run. Kept because it is the only one that fires when the camera goes
+			// without a word.
+			// The socket is genuinely closed now, so the transcript can be
+			// closed off too — whichever trigger already started the watch.
+			endLog();
+			beginPollBack();
 		};
 		ws.onerror = () => { if (!opened) { status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); resumeHeartbeat(); } };
 	}
@@ -204,7 +296,7 @@
 		const ctl = new AbortController();
 		const to = setTimeout(() => ctl.abort(), 5000);
 		try {
-			const r = await fetch('fw-update.cgi?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal });
+			const r = await fetch('fw-update.cgi?_=' + Date.now(), { credentials: 'same-origin', cache: 'no-store', signal: ctl.signal });
 			if (!r.ok) return null;
 			const doc = new DOMParser().parseFromString(await r.text(), 'text/html');
 			const el = doc.getElementById('fw-installed');
@@ -265,7 +357,7 @@
 		const ctl = new AbortController();
 		const to = setTimeout(() => ctl.abort(), 2500);
 		try {
-			const r = await fetch('/cgi-bin/j/pulse.cgi?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal });
+			const r = await fetch('/cgi-bin/j/pulse.cgi?_=' + Date.now(), { credentials: 'same-origin', cache: 'no-store', signal: ctl.signal });
 			if (!r.ok) return false;
 			const up = Number((await r.json()).uptime_s);
 			if (!isFinite(up)) return false;
@@ -286,7 +378,7 @@
 		function ping() {
 			const ctl = new AbortController();
 			const to = setTimeout(() => ctl.abort(), 2500);
-			return fetch('/?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal })
+			return fetch('/?_=' + Date.now(), { credentials: 'same-origin', cache: 'no-store', signal: ctl.signal })
 				.then(() => { clearTimeout(to); return true; })
 				.catch(() => { clearTimeout(to); return false; });
 		}
@@ -335,7 +427,7 @@
 		showProgress();
 		status('warning', 'Uploading firmware…');
 		try {
-			const r = await fetch('/upload', { method: 'POST', headers: { 'File-Location': '/tmp/firmware.tgz' }, body: f });
+			const r = await fetch('/upload', { method: 'POST', credentials: 'same-origin', headers: { 'File-Location': '/tmp/firmware.tgz' }, body: f });
 			if (!r.ok) { status('danger', 'Upload failed (' + r.status + ').'); resumeHeartbeat(); return; }
 			append('Uploaded ' + f.name + ' (' + f.size + ' bytes)\n');
 			startUpgrade('/tmp/firmware.tgz');

--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -210,6 +210,13 @@
 			} else {
 				// Nothing reached flash, so no reboot is coming and the log above is
 				// the whole story. Say so now instead of waiting out pollBack.
+				//
+				// This is the one exit that leaves the socket open: sysupgrade gave up
+				// without rebooting, so the `tail -F` behind it never emits again and
+				// ws.onclose may never fire. Nothing else will stop the quiet timer,
+				// and it would otherwise tick for the life of the tab.
+				if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+				commitLine();
 				status('danger', 'The upgrade was aborted — see the log below. Nothing was written to flash, so the camera is unchanged.');
 				resumeHeartbeat();
 			}
@@ -283,7 +290,14 @@
 			endLog();
 			beginPollBack();
 		};
-		ws.onerror = () => { if (!opened) { status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.'); resumeHeartbeat(); } };
+		// Same cleanup as the pre-flash abort above: the timer is armed before the
+		// socket is, so a handshake that never completes would leave it ticking.
+		ws.onerror = () => {
+			if (opened) return;
+			if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+			status('danger', 'Could not start the upgrade. Another session may be in progress, or the camera is unreachable.');
+			resumeHeartbeat();
+		};
 	}
 
 	// Read the version the camera is running NOW. Re-fetches this page instead of

--- a/www/a/logs.js
+++ b/www/a/logs.js
@@ -77,7 +77,7 @@
 		return new Date(ms).toLocaleString() + ' ' + raw.slice(m[0].length);
 	}
 
-	fetch('/cgi-bin/j/logmeta.cgi').then(r => r.json()).then(meta => {
+	fetch('/cgi-bin/j/logmeta.cgi', { credentials: 'same-origin' }).then(r => r.json()).then(meta => {
 		const off = parseTzOffsetMs(meta.tz_offset); // main.js; null if unusable
 		if (off === null) return; // leave tzOffsetMs null: raw beats wrongly shifted
 		tzOffsetMs = off;

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -62,7 +62,7 @@ function setProgressBar(id, value, name) {
 
 async function* makeTextFileLineIterator(url) {
 	const td = new TextDecoder('utf-8');
-	const response = await fetch(url);
+	const response = await fetch(url, { credentials: 'same-origin' });
 	const rd = response.body.getReader();
 	let { value: chunk, done: readerDone } = await rd.read();
 	chunk = chunk ? td.decode(chunk) : '';
@@ -134,7 +134,7 @@ function heartbeat() {
 	// otherwise stop the heartbeat for the rest of the page's life.
 	const ctl = new AbortController();
 	const to = setTimeout(() => ctl.abort(), 5000);
-	fetch('/cgi-bin/j/pulse.cgi', { signal: ctl.signal })
+	fetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin', signal: ctl.signal })
 		.then((response) => response.json())
 		.then((json) => {
 			if (json.soc_temp !== '') {

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -19,17 +19,17 @@
 			.catch(() => {}));
 
 	$('#toggle-night').addEventListener('click', () => {
-		fetch('/night/toggle').then(api => api.json()).then(data => {
+		fetch('/night/toggle', { credentials: 'same-origin' }).then(api => api.json()).then(data => {
 			$('#toggle-night').checked = data;
 			if (!$('#toggle-ircut').disabled) $('#toggle-ircut').checked = data;
 			if (!$('#toggle-light').disabled) $('#toggle-light').checked = data;
 		});
 	});
 	$('#toggle-ircut').addEventListener('click', () => {
-		fetch('/night/ircut').then(api => api.json()).then(data => { $('#toggle-ircut').checked = data; });
+		fetch('/night/ircut', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-ircut').checked = data; });
 	});
 	$('#toggle-light').addEventListener('click', () => {
-		fetch('/night/light').then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
+		fetch('/night/light', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
 	});
 
 	// --- Live MSE player (with MJPEG / no-signal fallback) ---


### PR DESCRIPTION
Three findings from @usa- testing the previous fix on four cameras (#120). None of them were that fix failing.

## 1. The reboot watch started ~30s too late

`pollBack()` had exactly one call site: `ws.onclose`. On a same-version run nothing is flashed, so majestic is never disturbed and the hard reboot closes no sockets — the browser is not told until the rebooted camera resets the stale connection. Measured: **30.2s**.

@usa- observed exactly this and asked what it was for:

> After “Unconditional reboot”, I can already open the camera’s main page in another tab, but the upgrade tab does not redirect to it until roughly another 30 seconds have passed.

It was not deliberate. Now any of three signals starts the watch, whichever is first:

| trigger | covers |
|---|---|
| `Unconditional reboot` in the log | sysupgrade says so before it goes |
| log silent 15s **after** a write started | camera dies mid-flash without a word |
| socket close | the camera goes without either |

Starting early is free — `pollBack()` only watches, and `rebootedAlready()` keeps answering false while the reported uptime is older than this run. The silence trigger arms only after `sawFlash`, so the naturally quiet download and time-sync phases cannot trip it.

## 2. The log froze mid-line

Also their point:

> The browser can display an incomplete log for about a minute, so I think it would be better to show a completed output.

`flashcp` redraws its meter with `\r` and no trailing newline, so whatever it was drawing when the camera went stayed half-finished (`Verifying kb: 4648/4836 (96%)`). That line is now committed as soon as the watch starts.

The "connection ended here" note is deliberately **not** written at that moment — the socket may still be open and delivering, and a note claiming the stream had ended would let genuine output land underneath it. Only `ws.onclose` knows the stream is over, so only `ws.onclose` writes it. (Caught by automated review on the first revision of this PR, which was right.)

## 3. Credentials on every fetch — consistency, *not* the Safari fix

14 `fetch()` call sites omitted `credentials: same-origin` while 12 already passed it. That is what the spec has mandated as the default since 2017, so it changes nothing at runtime; it just removes a split that will eventually bite someone.

**I want to be explicit that this does not fix Safari.** My first theory was that missing credentials explained @usa-’s Safari failure. Their own follow-up refutes it: the error also fires for `/metrics`, and the *shipped* `status.js` already passes `credentials: "same-origin"` there. I then tested the next theory — that the wildcard `Access-Control-Allow-Origin: *` on those endpoints was being rejected on a credentialed request — against WebKit2GTK, which shares WebCore with Safari:

```
/metrics             [ACAO: *]  -> HTTP 200
/cgi-bin/j/pulse.cgi [ACAO: *]  -> HTTP 200
/api/v1/config.json  [no ACAO]  -> HTTP 200
/                    [no ACAO]  -> HTTP 200
```

All fine, so that theory is dead too. Safari remains unexplained and is being tracked in #120.

## Verification

Lab SigmaStar on 2.6.08.14, real page driven in headless Chromium: the transcript ends on a complete line and the page returns to the status page on its own, without the dead-socket wait.

## Note on the first revision

The branch was originally cut from a local `master` that still carried the preview-audio commits, so the first push included `preview.js` changes that are not mine and are already merged as #147. It has been rebased onto `origin/master`; the diff is now only the files this PR is about.