### PR TITLE
webui: stop the volume slider stretching its button group, and name the blank enum choice

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -338,6 +338,16 @@ pre#output[data-cmd] {
 	}
 }
 
+/* The 2.5rem `.form-range` above is sized for the settings form, where a slider
+   is a row of its own. On the live player the volume slider shares a
+   `.btn-group` with the mute button, and a 40px-tall item stretched the group:
+   the button grew to match while its text stayed on the first line, which read
+   as a label stuck to the top of an over-tall button (OpenIPC/majestic#291).
+   Back to Bootstrap's own height, so the group matches the Stream one. */
+#mj-audio-ctl .form-range {
+	height: 1.5rem;
+}
+
 .mj-live-video {
 	display: block; /* avoid the inline baseline gap below the <video> */
 	width: 100%;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -681,7 +681,7 @@
 			control = p.querySelector('select');
 		} else if (type === 'string' && isSensorPath) {
 			p = el('p', 'select mj-row mj-wide');
-			const opts = '<option value=""></option>' + SENSORS.map(s => option(s, String(eff) === s)).join('');
+			const opts = option('', !eff) + SENSORS.map(s => option(s, String(eff) === s)).join('');
 			p.innerHTML =
 				'<label for="' + id + '" class="form-label">' + esc(desc) + '</label>' +
 				'<select class="form-select" id="' + id + '">' + opts + '</select>';
@@ -1021,8 +1021,14 @@
 		return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 	}
 
+	// An empty enum member is a real choice — majestic uses it for "inherit"
+	// (outgoing/records audioCodec follow audio.codec) and for "auto-detect"
+	// (isp.sensorConfig). Rendered verbatim it is an invisible blank row that
+	// reads as a separator, so give it the same word the resolution pickers
+	// use for the same idea (OpenIPC/majestic#291).
 	function option(v, selected) {
-		return '<option value="' + esc(v) + '"' + (selected ? ' selected' : '') + '>' + esc(v) + '</option>';
+		return '<option value="' + esc(v) + '"' + (selected ? ' selected' : '') + '>' +
+			(String(v) === '' ? 'Auto' : esc(v)) + '</option>';
 	}
 
 	function showError(msg) {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -674,7 +674,18 @@
 			p = el('p', 'select mj-row');
 			// short enums get a moderate width cap; long-option enums stay full-width
 			if (enumVals.some(o => String(o).length > 14)) p.classList.add('mj-wide');
-			const opts = enumVals.map(o => option(o, String(eff) === String(o))).join('');
+			// A select can only show a value it has an option for. majestic narrows
+			// some enums to what that consumer can actually carry (outgoing.audioCodec
+			// drops opus, which FLV cannot frame), but a hand-written majestic.yaml
+			// can still pin one — and the daemon honours it deliberately. Without a
+			// place to hold it the browser falls back to the first option and the page
+			// reports a codec that is not the one in effect, so carry the live value
+			// as an explicitly-unsupported entry instead.
+			const cur = eff === undefined || eff === null ? '' : String(eff);
+			const unlisted = cur !== '' && !enumVals.some(o => String(o) === cur);
+			const opts =
+				(unlisted ? option(cur, true, cur + ' (unsupported)') : '') +
+				enumVals.map(o => option(o, !unlisted && cur === String(o))).join('');
 			p.innerHTML =
 				'<label for="' + id + '" class="form-label">' + esc(desc) + '</label>' +
 				'<select class="form-select" id="' + id + '">' + opts + '</select>';
@@ -1025,10 +1036,12 @@
 	// (outgoing/records audioCodec follow audio.codec) and for "auto-detect"
 	// (isp.sensorConfig). Rendered verbatim it is an invisible blank row that
 	// reads as a separator, so give it the same word the resolution pickers
-	// use for the same idea (OpenIPC/majestic#291).
-	function option(v, selected) {
+	// use for the same idea (OpenIPC/majestic#291). `label` overrides the text
+	// for callers that need to say more about the value than its own name.
+	function option(v, selected, label) {
+		const text = label !== undefined ? label : (String(v) === '' ? 'Auto' : v);
 		return '<option value="' + esc(v) + '"' + (selected ? ' selected' : '') + '>' +
-			(String(v) === '' ? 'Auto' : esc(v)) + '</option>';
+			esc(text) + '</option>';
 	}
 
 	function showError(msg) {


### PR DESCRIPTION
Two cosmetic reports from the post-release feedback on OpenIPC/majestic#291.

## The mute button

> The contents of the `[🔇 Muted]` / `[🔊 Listening]` button are not vertically centered.

The cause is one rule above the fix in this same file: `.form-range { height: 2.5rem }`, set for the settings form where a slider owns its row. On the live player the volume slider shares a `.btn-group` with the mute button, and a flex container is as tall as its tallest item — so the group became 40px, the button stretched to match, and its 21px line box stayed at the top.

Measured against master, with the page's real markup and stylesheets:

| | height | text offset from centre |
|---|---|---|
| Stream button (`Main`) | 31px | 0.00 |
| Mute button — **before** | 40px | **−4.50** |
| Mute button — **after** | 31px | 0.00 |

`Muted`, `Listening` and `No audio` all measure the same. Scoping the slider back to Bootstrap's own `1.5rem` fixes the centring *and* lines the two toolbars up, which is the other half of what the screenshot shows.

## The blank enum option

> There does not appear to be a way to select the documented "empty" value.

An empty string is a real enum member — majestic uses it for "inherit" (`outgoing`/`records` `audioCodec` follow `audio.codec`) and `isp.sensorConfig` uses it for auto-detect — but rendered verbatim it is a blank row that reads as a separator, so the documented value looked unavailable.

Label it **Auto**, the same word `RES_AUTO_LABEL` already uses for the same idea in the resolution pickers. Only the label changes; the value posted is still `""`. This also folds the `isp.sensorConfig` branch's hand-written blank `<option>` into the shared helper, which now marks it selected when nothing is set rather than relying on the browser's default.

Needs the majestic side to actually emit `""` in those enums — the daemon currently strips it. Verified together by rendering this `mj-settings.js` against a schema from a camera running that change: the codec select shows **Auto** first and selected, hints render as sub-text, and the AAC-file row appears only once Audio source is `file`.

`npm run build:dist` (the `check.yml` gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
