### PR TITLE
login: a Stay signed in checkbox

### DIFF
--- a/www/login.html
+++ b/www/login.html
@@ -35,7 +35,15 @@
 			display: flex; align-items: center; gap: .5rem;
 			margin-bottom: 1rem; font-size: .875rem; color: #adb5bd; cursor: pointer;
 		}
-		.check input { width: auto; margin: 0; accent-color: #0d6efd; }
+		/* The global input rule above styles text fields (full width, padding,
+		   dark background, border). A checkbox inheriting it renders as a padded
+		   dark box on engines that honour those properties on checkboxes, so
+		   every inherited property is reset here, not just width/margin. */
+		.check input {
+			width: 1rem; height: 1rem; flex: none; margin: 0; padding: 0;
+			background: none; border: 0; border-radius: 0; box-shadow: none;
+			accent-color: #0d6efd;
+		}
 		button {
 			width: 100%; padding: .5rem .75rem;
 			background: #0d6efd; color: #fff; border: 0; border-radius: .375rem;

--- a/www/login.html
+++ b/www/login.html
@@ -31,6 +31,11 @@
 			border: 1px solid #495057; border-radius: .375rem; font-size: 1rem;
 		}
 		input:focus { outline: none; border-color: #6ea8fe; box-shadow: 0 0 0 .2rem rgba(110,168,254,.25); }
+		.check {
+			display: flex; align-items: center; gap: .5rem;
+			margin-bottom: 1rem; font-size: .875rem; color: #adb5bd; cursor: pointer;
+		}
+		.check input { width: auto; margin: 0; accent-color: #0d6efd; }
 		button {
 			width: 100%; padding: .5rem .75rem;
 			background: #0d6efd; color: #fff; border: 0; border-radius: .375rem;
@@ -54,6 +59,10 @@
 		<input id="username" name="username" value="root" autocapitalize="none" autocomplete="username" spellcheck="false">
 		<label for="password">Password</label>
 		<input id="password" name="password" type="password" autocomplete="current-password" autofocus>
+		<!-- Sets a persistent token so a majestic restart (firmware upgrade,
+		     reboot) recovers the session silently instead of landing back here.
+		     Server-side feature: older majestic ignores the extra field. -->
+		<label class="check"><input id="remember" name="remember" type="checkbox"> Stay signed in on this device</label>
 		<button id="submit" type="submit">Sign in</button>
 	</form>
 	<script>
@@ -88,6 +97,7 @@
 				var u = document.getElementById('username').value;
 				var p = document.getElementById('password').value;
 				var body = 'username=' + encodeURIComponent(u) + '&password=' + encodeURIComponent(p);
+				if (document.getElementById('remember').checked) body += '&remember=1';
 
 				fetch('/login', {
 					method: 'POST',


### PR DESCRIPTION
WebUI half of the "Stay logged in" proposal from #120 — a checkbox on the login page that asks majestic for a persistent token, so a majestic restart (a firmware upgrade above all) recovers the session silently instead of presenting the login page again.

All mechanism is majestic-side: token format, 90-day sliding expiry, revocation on password change, and the `/etc/majestic.token` kill switch. The page only adds `remember=1` to the login POST when the box is ticked. An **older majestic ignores the extra field**, so the page works unchanged against both.

Verified on a lab hi3516av300 against the majestic counterpart, through this actual page in a browser: tick, sign in, restart majestic, navigate — lands on the status page with no prompt. Unticked preserves today's behaviour exactly (one session cookie, login page after restart).

Design discussion and the full hardware test matrix: see the majestic-side PR.