### PR TITLE
fw-update: say what the log is doing when the camera goes quiet

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -155,13 +155,30 @@
 	// about 30s later. Starting early costs nothing when the camera is still
 	// working: pollBack only watches, and rebootedAlready() keeps answering false
 	// while the reported uptime is older than this run.
-	function beginPollBack() {
+	function beginPollBack(quiet) {
 		if (polling) return;
 		polling = true;
 		if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
 		// Tidy the half-drawn meter, but do NOT declare the stream over: the
 		// socket can still be open here and more output may yet arrive.
 		commitLine();
+		// Getting here on silence rather than on a reboot announcement means the
+		// transcript stops mid-flash, at whatever byte the camera reached — issue
+		// #120 has it ending on "Verifying kb: 1056/4844 (21%)". That is expected:
+		// majestic streams this log while its own text is paged in from the rootfs
+		// partition sysupgrade is overwriting, and free_resources dropped the page
+		// cache first, so the next fault it takes reads the new image at a stale
+		// offset and kills it. The upgrade is fine — sysupgrade is detached and
+		// carries on from RAM — but a pane that just freezes looks like one that
+		// has hung, so mark the gap rather than leaving it unexplained.
+		//
+		// Worded as a gap, not as an ending: the socket may still be open, and
+		// output that resumes must not land under a note saying it had stopped.
+		if (quiet) {
+			doneNode.appendData('--- no output for ' + (QUIET_MS / 1000) +
+				's; the camera is busy flashing ---\n');
+			out.scrollTop = out.scrollHeight;
+		}
 		// "do not power off" is a warning about an interrupted flash, so do not
 		// say it when sysupgrade has already told us it wrote nothing.
 		status('warning', noop
@@ -257,7 +274,7 @@
 		// naturally quiet download and time-sync phases cannot trip it.
 		quietTimer = setInterval(() => {
 			if (polling) { clearInterval(quietTimer); quietTimer = null; return; }
-			if (sawFlash && performance.now() - lastData > QUIET_MS) beginPollBack();
+			if (sawFlash && performance.now() - lastData > QUIET_MS) beginPollBack(true);
 		}, 3000);
 		status('warning', 'Preparing — freeing memory…');
 		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -360,8 +377,11 @@
 		if (now && installedBefore && now === installedBefore && !forced) {
 			if (noop) {
 				// sysupgrade said so itself: the image offered was the one already
-				// installed, so it wrote nothing. Nothing failed.
-				status('success', 'Already running ' + now + ' — nothing to update.');
+				// installed, so it wrote nothing. Nothing failed — so lead with the
+				// good news. "Already running X — nothing to update" put the negative
+				// first and read as a refusal to somebody who had just asked for an
+				// upgrade (issue #120).
+				status('success', 'Already up to date — running ' + now + '.');
 				setTimeout(() => location.href = 'status.cgi', 1500);
 				return;
 			}


### PR DESCRIPTION
Two things @usa- reported in #120 after testing the cookie-login build.

## The same-version message led with the negative

> When **"Reflash even if the same version"** is disabled, the last message before the redirect to the main page is still **"Already running 2.6.08.16-lite — nothing to update."**

Reworded to **"Already up to date — running X."**, as suggested when #149 was closed. Same meaning, but it no longer reads as a refusal to somebody who has just asked for an upgrade — and it now matches the wording already used while polling back.

## The transcript freezes mid-flash

> When **"Reflash even if the same version"** is enabled, on **both SigmaStar cameras** the output sometimes stops while verifying the written RootFS. However, after some time, it continues normally and redirects to the main page.

His screenshot ends on `Verifying kb: 1056/4844 (21%)` with the status bar already green — so the upgrade worked, and only the log stopped.

That is expected, and it is worth stating plainly. majestic streams this log while its own text is paged in from the rootfs partition sysupgrade is overwriting. `free_resources` drops the page cache first to find room for the download, so the eviction is likely rather than theoretical, and the next fault majestic takes reads the new image at a stale offset — garbage or `EIO`. Where that lands is nondeterministic, which is exactly the "sometimes" in the report. sysupgrade itself escapes this by pivoting into a ramfs and finishes regardless, which is why the camera still comes back updated.

Ruled out on the way to that: `tail -F` keeps following its descriptor across the `mount -o move /tmp` that the pivot performs (checked on a lab camera), so the stream is not lost at the pivot — and indeed his log continues well past it, through the whole kernel write.

Nothing on this page can prevent the stall, but a pane that simply stops looks like one that has hung. So mark the gap:

```
Verifying kb: 1056/4844 (21%)
--- no output for 15s; the camera is busy flashing ---
```

Worded as a gap, not as an ending. The socket may still be open at that point — `beginPollBack` is explicitly documented not to declare the stream over — so output that resumes must not land underneath a note claiming it had stopped. The existing `--- connection to the camera ended here ---` marker stays where it belongs, on `ws.onclose`.

## Related

- OpenIPC/firmware#2280 fixes the third item in the same report: the ramfs pivot leaving `/overlay/root/dev/null` and `/overlay/root/ram` behind.
- The "Stay signed in" checkbox he asked for landed in #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)