### PR TITLE
webui: send a lapsed session to the login page instead of nowhere

### DIFF
--- a/www/a/ext-ntfy.js
+++ b/www/a/ext-ntfy.js
@@ -10,7 +10,7 @@
 		btn.disabled = true;
 		out.className = 'small ms-2 text-secondary';
 		out.textContent = 'Sending…';
-		fetch('?send=test', { credentials: 'same-origin' })
+		apiFetch('?send=test', { credentials: 'same-origin' })
 			.then(r => r.text())
 			.then(d => {
 				const ok = d.trim() === 'OK';

--- a/www/a/files.js
+++ b/www/a/files.js
@@ -81,7 +81,7 @@
 		return attr(devZone + ' — ' + new Date(ms).toLocaleString() + ' your time');
 	}
 
-	fetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' }).then(r => r.json()).then(j => {
+	apiFetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' }).then(r => r.json()).then(j => {
 		devZone = j.timezone || '';
 		devIana = ianaOrNull(devZone);
 		devOffsetMs = parseTzOffsetMs(j.utc_offset); // main.js; null if unusable
@@ -91,9 +91,9 @@
 		// the "loading…" placeholder with "empty" before the first load lands.
 		if (entries.length) render();
 	}).catch(() => {});
-	function api(qs) { return fetch('/cgi-bin/j/files.cgi?' + qs, { credentials: 'same-origin' }).then(r => r.json()); }
+	function api(qs) { return apiFetch('/cgi-bin/j/files.cgi?' + qs, { credentials: 'same-origin' }).then(r => r.json()); }
 	function op(p) {
-		return fetch('/cgi-bin/j/files.cgi', {
+		return apiFetch('/cgi-bin/j/files.cgi', {
 			method: 'POST', credentials: 'same-origin',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			body: new URLSearchParams(p).toString(),
@@ -272,7 +272,7 @@
 	function probeCodec(path, signal) {
 		// no-store: this 16 KiB slice is not a copy of the file worth keeping
 		// around under the URL the <video> is about to request.
-		return fetch(fileUrl(path), {
+		return apiFetch(fileUrl(path), {
 			credentials: 'same-origin', cache: 'no-store', signal,
 			headers: { Range: 'bytes=0-16383' },
 		}).then(res => {
@@ -402,7 +402,7 @@
 		st.textContent = 'loading…'; ta.value = '';
 		if (cm) { cm.toTextArea(); cm = null; }
 		bootstrap.Modal.getOrCreateInstance('#fm-editor').show();
-		fetch('/cgi-bin/j/files.cgi?cat=' + encodeURIComponent(path), { credentials: 'same-origin' })
+		apiFetch('/cgi-bin/j/files.cgi?cat=' + encodeURIComponent(path), { credentials: 'same-origin' })
 			.then(r => r.ok ? r.text() : Promise.reject()).then(text => {
 				ta.value = text; st.textContent = '';
 				loadCM().then(ok => {
@@ -415,7 +415,7 @@
 		$('#fm-editor-save').onclick = () => {
 			const content = cm ? cm.getValue() : ta.value;
 			st.textContent = 'saving…';
-			fetch('/cgi-bin/j/save.cgi?path=' + encodeURIComponent(path), { method: 'POST', credentials: 'same-origin', body: content })
+			apiFetch('/cgi-bin/j/save.cgi?path=' + encodeURIComponent(path), { method: 'POST', credentials: 'same-origin', body: content })
 				.then(r => r.json()).then(d => { st.textContent = d.ok ? 'saved' : ('error: ' + (d.error || '')); if (d.ok) reload(); })
 				.catch(() => { st.textContent = 'save failed'; });
 		};

--- a/www/a/fw-network.js
+++ b/www/a/fw-network.js
@@ -21,7 +21,7 @@
 	function scan() {
 		const btn = $('#wifi-scan'), st = $('#wifi-scan-status'), sel = $('#wifi-results');
 		btn.disabled = true; st.textContent = 'scanning…'; sel.classList.add('d-none'); sel.innerHTML = '';
-		fetch('/cgi-bin/j/network.cgi?scan=1', { credentials: 'same-origin' })
+		apiFetch('/cgi-bin/j/network.cgi?scan=1', { credentials: 'same-origin' })
 			.then(r => r.json()).then(d => {
 				btn.disabled = false;
 				const nets = (d.networks || []).sort((a, b) => b.signal - a.signal);

--- a/www/a/fw-time.js
+++ b/www/a/fw-time.js
@@ -20,7 +20,7 @@
 		btn.disabled = true;
 		s.className = 'small text-secondary';
 		s.textContent = 'working…';
-		fetch(url, { credentials: 'same-origin' })
+		apiFetch(url, { credentials: 'same-origin' })
 			.then(r => r.json())
 			.then(j => {
 				s.className = 'small alert alert-' + j.result + ' py-1 px-2 mb-0';
@@ -80,7 +80,7 @@
 		const set = $('#set-time');
 		if (set) set.addEventListener('click', e => call('/cgi-bin/j/time.cgi?set=' + Math.floor(Date.now() / 1000), e.currentTarget));
 
-		fetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' })
+		apiFetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' })
 			.then(r => r.json())
 			// skew = device epoch minus browser epoch, so `Date.now() + skew` is
 			// the camera's clock. Same quantity and sign the header bar reports

--- a/www/a/logs.js
+++ b/www/a/logs.js
@@ -77,7 +77,7 @@
 		return new Date(ms).toLocaleString() + ' ' + raw.slice(m[0].length);
 	}
 
-	fetch('/cgi-bin/j/logmeta.cgi', { credentials: 'same-origin' }).then(r => r.json()).then(meta => {
+	apiFetch('/cgi-bin/j/logmeta.cgi', { credentials: 'same-origin' }).then(r => r.json()).then(meta => {
 		const off = parseTzOffsetMs(meta.tz_offset); // main.js; null if unusable
 		if (off === null) return; // leave tzOffsetMs null: raw beats wrongly shifted
 		tzOffsetMs = off;

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -14,10 +14,39 @@ function sleep(ms) {
 	return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+// Every same-origin request the UI makes should go through here.
+//
+// majestic answers an unauthenticated in-page fetch with a BARE 401 — no
+// WWW-Authenticate — so the browser has nothing to raise a native Basic dialog
+// from. That is the right thing for the server to do: the dialog cannot say
+// where you were going, and Safari used to pop it every couple of seconds off
+// the heartbeat alone once a session lapsed (issue #154).
+//
+// The cost is that the failure is now silent — a stale header bar, a save that
+// quietly does nothing — so catch it in one place and go to the login page with
+// somewhere to come back to.
+//
+// Deliberately NOT a patch over window.fetch. fw-update.js expects a 401 while
+// the camera reboots mid-upgrade and handles it itself, with wording that
+// depends on knowing an upgrade was in flight; a blanket redirect would race it
+// and throw the transcript away. Anything that wants that behaviour opts in.
+function apiFetch(url, init) {
+	const opts = Object.assign({ credentials: 'same-origin' }, init || {});
+	return fetch(url, opts).then(r => {
+		if (r.status !== 401) return r;
+		location.href = '/login.html?next=' +
+			encodeURIComponent(location.pathname + location.search);
+		// Never settles. The navigation is already under way, and letting a
+		// caller run its .then() on a 401 body would paint an error onto a page
+		// that is in the middle of leaving.
+		return new Promise(() => {});
+	});
+}
+
 let _mjCfg;
 function mjConfig() {
 	if (!_mjCfg)
-		_mjCfg = fetch('/api/v1/config.json', { credentials: 'same-origin' })
+		_mjCfg = apiFetch('/api/v1/config.json', { credentials: 'same-origin' })
 			.then(r => r.ok ? r.json() : {}).catch(() => ({}));
 	return _mjCfg;
 }
@@ -62,7 +91,7 @@ function setProgressBar(id, value, name) {
 
 async function* makeTextFileLineIterator(url) {
 	const td = new TextDecoder('utf-8');
-	const response = await fetch(url, { credentials: 'same-origin' });
+	const response = await apiFetch(url, { credentials: 'same-origin' });
 	const rd = response.body.getReader();
 	let { value: chunk, done: readerDone } = await rd.read();
 	chunk = chunk ? td.decode(chunk) : '';
@@ -134,7 +163,7 @@ function heartbeat() {
 	// otherwise stop the heartbeat for the rest of the page's life.
 	const ctl = new AbortController();
 	const to = setTimeout(() => ctl.abort(), 5000);
-	fetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin', signal: ctl.signal })
+	apiFetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin', signal: ctl.signal })
 		.then((response) => response.json())
 		.then((json) => {
 			if (json.soc_temp !== '') {
@@ -227,7 +256,7 @@ function initAll() {
 		logout.addEventListener('click', async ev => {
 			ev.preventDefault();
 			try {
-				const r = await fetch('/logout', { method: 'POST', credentials: 'same-origin' });
+				const r = await apiFetch('/logout', { method: 'POST', credentials: 'same-origin' });
 				// 200 cleared the session, 204 means there was none to clear — either
 				// way the session is gone, so it is safe to leave. Only a network error
 				// or a 5xx leaves it possibly alive: keep the user here to retry rather

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -26,16 +26,23 @@ function sleep(ms) {
 // quietly does nothing — so catch it in one place and go to the login page with
 // somewhere to come back to.
 //
-// Deliberately NOT a patch over window.fetch. fw-update.js expects a 401 while
-// the camera reboots mid-upgrade and handles it itself, with wording that
-// depends on knowing an upgrade was in flight; a blanket redirect would race it
-// and throw the transcript away. Anything that wants that behaviour opts in.
+// Deliberately NOT a patch over window.fetch. The pages that deliberately
+// outlive their own session must not be redirected out from under: fw-update.js
+// expects a 401 while the camera reboots mid-upgrade and handles it itself, with
+// wording that depends on knowing an upgrade was in flight, and
+// makeTextFileLineIterator below streams the factory reset that destroys the
+// session in the first place. A blanket redirect would race both and throw the
+// transcript away. Anything that wants this behaviour opts in.
 function apiFetch(url, init) {
 	const opts = Object.assign({ credentials: 'same-origin' }, init || {});
 	return fetch(url, opts).then(r => {
 		if (r.status !== 401) return r;
-		location.href = '/login.html?next=' +
-			encodeURIComponent(location.pathname + location.search);
+		// replace(), not href: this document is already dead — the promise below
+		// never settles, so anything awaiting it stays awaiting forever. Leaving a
+		// history entry lets Back restore exactly that from the bfcache after the
+		// user signs in, giving them a page that looks alive and is not.
+		location.replace('/login.html?next=' +
+			encodeURIComponent(location.pathname + location.search));
 		// Never settles. The navigation is already under way, and letting a
 		// caller run its .then() on a 401 body would paint an error onto a page
 		// that is in the middle of leaving.
@@ -89,9 +96,17 @@ function setProgressBar(id, value, name) {
 	}
 }
 
+// Plain fetch, not apiFetch, and it has to stay that way. Its only caller is
+// runCmd() on fw-reset.cgi, which streams `sysupgrade -s -n -x` — the factory
+// reset that erases the overlay, /etc/majestic.token with it, and then reboots.
+// Losing the session is the EXPECTED end of this request, not an error, and the
+// whole point of the page is to show the log until the camera goes. Redirecting
+// on a 401 here would blank the transcript at the moment it matters most, and
+// the never-settling promise apiFetch hands back would strand the loop below
+// before it could run the fw-restart.cgi hop at the end.
 async function* makeTextFileLineIterator(url) {
 	const td = new TextDecoder('utf-8');
-	const response = await apiFetch(url, { credentials: 'same-origin' });
+	const response = await fetch(url, { credentials: 'same-origin' });
 	const rd = response.body.getReader();
 	let { value: chunk, done: readerDone } = await rd.read();
 	chunk = chunk ? td.decode(chunk) : '';

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -196,7 +196,7 @@
 				parts.push(encodeURIComponent(name) + '=' + encodeURIComponent(val));
 			}
 			if (parts.length)
-				fetch('/api/v1/image?' + parts.join('&'),
+				apiFetch('/api/v1/image?' + parts.join('&'),
 					{ method: 'POST', credentials: 'same-origin' }).catch(() => {});
 		}, 120);
 	}
@@ -450,7 +450,7 @@
 		clearError();
 		try {
 			const q = dots.map(d => 'key=' + encodeURIComponent(d)).join('&');
-			const res = await fetch('/api/v1/reset?' + q, { credentials: 'same-origin' });
+			const res = await apiFetch('/api/v1/reset?' + q, { credentials: 'same-origin' });
 			if (!res.ok) {
 				const txt = await safeText(res);
 				showError('Reset failed (HTTP ' + res.status + '). ' + txt);
@@ -866,7 +866,7 @@
 		btn.textContent = 'Saving…';
 		clearError();
 		try {
-			const res = await fetch('/api/v1/config', {
+			const res = await apiFetch('/api/v1/config', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'same-origin',
@@ -917,7 +917,7 @@
 			try {
 				const ctl = new AbortController();
 				const t = setTimeout(() => ctl.abort(), 3000);
-				const r = await fetch('/api/v1/config.json',
+				const r = await apiFetch('/api/v1/config.json',
 					{ cache: 'no-store', credentials: 'same-origin', signal: ctl.signal });
 				clearTimeout(t);
 				if (r.ok) return true;
@@ -933,7 +933,7 @@
 		if (btn) { btn.disabled = true; btn.textContent = 'Applying…'; }
 		stopLivePreview();   // the stream drops while the pipeline rebuilds
 		try {
-			await fetch('j/mj-apply.cgi', { credentials: 'same-origin' });
+			await apiFetch('j/mj-apply.cgi', { credentials: 'same-origin' });
 		} catch (e) { /* the reload may sever this request — expected */ }
 		const up = await pollUp(30000);
 		if (up) {
@@ -955,7 +955,7 @@
 		btn.textContent = '…';
 		clearError();
 		try {
-			const res = await fetch('/api/v1/reset?key=' + encodeURIComponent(dot), { credentials: 'same-origin' });
+			const res = await apiFetch('/api/v1/reset?key=' + encodeURIComponent(dot), { credentials: 'same-origin' });
 			if (!res.ok) {
 				if (res.status === 404) {
 					btn.title = 'Server has no recorded default for this key.';
@@ -989,7 +989,7 @@
 	/* helpers */
 
 	async function fetchJson(url) {
-		const r = await fetch(url, { credentials: 'same-origin' });
+		const r = await apiFetch(url, { credentials: 'same-origin' });
 		if (!r.ok) throw new Error('HTTP ' + r.status + ' for ' + url);
 		return r.json();
 	}

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -14,22 +14,22 @@
 	});
 
 	['night', 'ircut', 'light'].forEach(n =>
-		fetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
+		apiFetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
 			.then(r => r.text()).then(v => { $('#toggle-' + n).checked = +v > 0; })
 			.catch(() => {}));
 
 	$('#toggle-night').addEventListener('click', () => {
-		fetch('/night/toggle', { credentials: 'same-origin' }).then(api => api.json()).then(data => {
+		apiFetch('/night/toggle', { credentials: 'same-origin' }).then(api => api.json()).then(data => {
 			$('#toggle-night').checked = data;
 			if (!$('#toggle-ircut').disabled) $('#toggle-ircut').checked = data;
 			if (!$('#toggle-light').disabled) $('#toggle-light').checked = data;
 		});
 	});
 	$('#toggle-ircut').addEventListener('click', () => {
-		fetch('/night/ircut', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-ircut').checked = data; });
+		apiFetch('/night/ircut', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-ircut').checked = data; });
 	});
 	$('#toggle-light').addEventListener('click', () => {
-		fetch('/night/light', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
+		apiFetch('/night/light', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
 	});
 
 	// --- Live MSE player (with MJPEG / no-signal fallback) ---

--- a/www/a/sdcard.js
+++ b/www/a/sdcard.js
@@ -13,16 +13,16 @@
 	}
 	function recPrefix() { return (mjGet(cfg, 'records.path') || '').split('%')[0].replace(/\/+$/, ''); }
 
-	function api(qs) { return fetch('/cgi-bin/j/sdcard.cgi' + (qs ? '?' + qs : ''), { credentials: 'same-origin' }).then(r => r.json()); }
+	function api(qs) { return apiFetch('/cgi-bin/j/sdcard.cgi' + (qs ? '?' + qs : ''), { credentials: 'same-origin' }).then(r => r.json()); }
 	function op(p) {
-		return fetch('/cgi-bin/j/sdcard.cgi', {
+		return apiFetch('/cgi-bin/j/sdcard.cgi', {
 			method: 'POST', credentials: 'same-origin',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			body: new URLSearchParams(p).toString(),
 		}).then(r => r.json());
 	}
 	function setConfig(obj) {
-		return fetch('/api/v1/config', {
+		return apiFetch('/api/v1/config', {
 			method: 'POST', credentials: 'same-origin',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(obj),
@@ -31,7 +31,7 @@
 
 	function load() {
 		// fetch config fresh each time (so record-toggle changes show immediately)
-		return fetch('/api/v1/config.json', { credentials: 'same-origin' })
+		return apiFetch('/api/v1/config.json', { credentials: 'same-origin' })
 			.then(r => r.ok ? r.json() : {}).catch(() => ({}))
 			.then(c => { cfg = c; const rp = recPrefix(); return api(rp ? 'rec=' + encodeURIComponent(rp) : ''); })
 			.then(d => { state = d; render(); })

--- a/www/a/status.js
+++ b/www/a/status.js
@@ -135,7 +135,7 @@
 	}
 
 	function tick() {
-		fetch('/metrics', { credentials: 'same-origin' })
+		apiFetch('/metrics', { credentials: 'same-origin' })
 			.then(r => r.ok ? r.text() : Promise.reject(r.status))
 			.then(text => {
 				fails = 0;


### PR DESCRIPTION
Client half of #154. Pairs with the majestic change that stops answering a browser's own `fetch()` with `WWW-Authenticate` — that removes the Safari Basic dialog, but on its own it trades a confusing prompt for a confusing no-op: the header bar goes stale, a save quietly does nothing, and nothing says why.

## What changed

`apiFetch()` in `main.js` defaults `credentials` to `same-origin` and, on a 401, sends the browser to `/login.html?next=<current page>` — something the native dialog could never do, since it has no idea where you were going.

The returned promise deliberately **never settles**. The navigation is already under way, and letting callers run their `.then()` on a 401 body paints an error onto a page that is in the middle of leaving.

31 call sites across ten files move over.

## Why opt-in and not a `window.fetch` patch

A global wrapper is a smaller diff and catches pages we haven't written yet, but it fights `fw-update.js`, where a 401 is **expected**: `installedNow()` reads it as "the reboot cleared the session" and redirects with wording that depends on knowing an upgrade was in flight (#120, #146). A blanket redirect would race that and throw the transcript away mid-flash.

So `fw-update.js`'s four call sites stay on plain `fetch`, and the helper is something a page asks for.

## Why #154 surfaces it

`fw-reset.cgi` runs `sysupgrade -s -n -x`. `-n` wipes the overlay, which takes `/etc` — and with it `/etc/majestic.token`, the stay-signed-in key. The reboot clears the in-RAM sessions too, so nothing is left to authenticate with, and every background fetch on the still-open page gets a 401. The heartbeat alone fires every two seconds.

## Checks

`npm run build:dist` and `tools/lint-templates.sh` both pass (29 templates, 16 shell scripts). Deployed to a lab hi3516av300 alongside the majestic build; unauthenticated in-page fetches now come back as a bare 401 with no challenge header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
