### PR TITLE
login: declare in-page fetches, and stop the sign-in page haunting history

### DIFF
--- a/www/a/main.js
+++ b/www/a/main.js
@@ -35,6 +35,20 @@ function sleep(ms) {
 // transcript away. Anything that wants this behaviour opts in.
 function apiFetch(url, init) {
 	const opts = Object.assign({ credentials: 'same-origin' }, init || {});
+	// Declare ourselves rather than leaving majestic to infer it. The signal it
+	// had to work from — Sec-Fetch-Dest — is attached by the browser, not by us:
+	// Safari only sends it from 16.4, and browsers withhold it from origins they
+	// do not consider trustworthy, which is the plain-HTTP address a camera is
+	// normally reached at. So the dialog this helper exists to prevent was still
+	// firing after a reboot with "stay signed in" unticked (issue #120). A header
+	// we set ourselves does not depend on either.
+	//
+	// Headers, not Object.assign: callers pass plain objects today, but a Headers
+	// instance has no own enumerable properties, so assigning over one would
+	// silently drop everything it carries. new Headers() accepts both.
+	const headers = new Headers(opts.headers || {});
+	headers.set('X-Requested-With', 'XMLHttpRequest');
+	opts.headers = headers;
 	return fetch(url, opts).then(r => {
 		if (r.status !== 401) return r;
 		// replace(), not href: this document is already dead — the promise below

--- a/www/login.html
+++ b/www/login.html
@@ -88,6 +88,12 @@
 				if (raw.charAt(0) !== '/' || raw.charAt(1) === '/' || raw.indexOf('\\') !== -1) {
 					return '/cgi-bin/status.cgi';
 				}
+				// Never point back at this page. The already-signed-in check below
+				// acts on it, so a ?next= aimed here would spin: probe says OK,
+				// replace() lands here again, probe says OK…
+				if (raw.split(/[?#]/)[0] === location.pathname) {
+					return '/cgi-bin/status.cgi';
+				}
 				return raw;
 			}
 
@@ -96,6 +102,31 @@
 				err.classList.add('show');
 				btn.disabled = false;
 			}
+
+			// Nothing to ask for if the session is already good. This page can be
+			// reached holding a valid one from a bookmark, the Back button, or a
+			// restored tab — Safari's History > Recently Closed Tabs reopens the
+			// URL the tab last held, and before the replace() below that was this
+			// page, so signing in landed the user right back on the sign-in form
+			// (issue #120).
+			//
+			// Asks as a NAVIGATION (Accept: text/html) with redirect: 'manual', so a
+			// logged-out camera answers 302 to this very page rather than 401. That
+			// matters for the dialog: an older majestic decides whether to send
+			// WWW-Authenticate from Sec-Fetch-Dest alone, which JS cannot set and
+			// Safari below 16.4 does not send — asking as a plain fetch would raise
+			// the native prompt on the sign-in page itself against such a build. The
+			// redirect branch is taken by every version, so this never can.
+			//
+			// A 3xx arrives as an opaque redirect: status 0, ok false. Only a real
+			// 200 means the session is live.
+			fetch('/cgi-bin/j/pulse.cgi', {
+				credentials: 'same-origin',
+				redirect: 'manual',
+				headers: { 'Accept': 'text/html' }
+			}).then(function (r) {
+				if (r.ok) location.replace(safeNext());
+			}).catch(function () { /* offline: show the form */ });
 
 			form.addEventListener('submit', function (ev) {
 				ev.preventDefault();
@@ -114,7 +145,12 @@
 					body: body
 				}).then(function (r) {
 					if (r.ok) {
-						location.href = safeNext();
+						// replace(), not href: this page has served its purpose, and
+						// leaving it in the tab's history is what let a restored tab
+						// or Back put the sign-in form back in front of a user who is
+						// already signed in (issue #120). apiFetch() takes the same
+						// care for the same reason.
+						location.replace(safeNext());
 					} else if (r.status === 403) {
 						fail('Invalid username or password.');
 					} else {


### PR DESCRIPTION
Two things @usa- found on #120.

## 1. The Basic dialog is back after a reboot

majestic suppresses the native prompt for in-page script, but the only signal it had was `Sec-Fetch-Dest` — attached by the browser, not by us. Safari ships Fetch Metadata only from **16.4**, and browsers withhold `Sec-Fetch-*` from origins they do not consider trustworthy, which is the plain-HTTP address a camera is normally reached at. Without it an `apiFetch()` call is indistinguishable from curl, so the heartbeat raises the dialog the moment a session lapses.

`apiFetch` now sets `X-Requested-With`, so the client says what it is instead of being inferred.

`Headers` rather than `Object.assign`: callers pass plain objects today, but a `Headers` instance has no own enumerable properties, so assigning over one would silently drop every header it carries. `new Headers()` takes both.

## 2. Recently Closed Tabs reopens the sign-in page

Sign in, close the tab, restore it from **History → Recently Closed Tabs**, and the sign-in form is back — while opening `/` in the same browser goes straight through.

Not a Safari quirk. The successful login did `location.href`, so `/login.html?next=…` stayed in that tab's history, and restoring the tab restores that entry. The page had no reason to notice the session was already good, so it rendered the form to a signed-in user.

- `location.replace()` on the post-login hop, so this page never enters history. `apiFetch()` already takes the same care, for the same reason.
- A check on load: if the session is live, go straight to `next`. That heals a stale `/login.html` from history, a bookmark, Back, or a restored tab.

The check asks as a **navigation** (`Accept: text/html`, `redirect: 'manual'`) rather than as a plain fetch, on purpose. A logged-out camera answers it with `302` to this same page instead of `401`, and the redirect branch is taken by every majestic version — so against a build older than the paired change, where `WWW-Authenticate` still turns on `Sec-Fetch-Dest` alone, this cannot raise the native prompt on the sign-in page itself. A 3xx arrives as an opaque redirect (`status 0`, `ok false`); only a real `200` means the session is live.

`safeNext()` now also refuses a `?next=` pointing back here, which with that check in place would otherwise spin: probe says OK, `replace()` lands here, probe says OK…

## Verified

Against a lab hi3516av300: logged out the probe is `302` with no `WWW-Authenticate`, logged in it is `200`.

## Paired with

The majestic change that honours `X-Requested-With`. The header is inert without it, so this is safe to merge either way round.

Reported-by: usa- <https://github.com/usa->
Ref: #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)