### PR TITLE
fw-reset: stop the factory reset killing its own progress log

### DIFF
--- a/www/a/main.js
+++ b/www/a/main.js
@@ -111,8 +111,8 @@ function setProgressBar(id, value, name) {
 }
 
 // Plain fetch, not apiFetch, and it has to stay that way. Its only caller is
-// runCmd() on fw-reset.cgi, which streams `sysupgrade -s -n -x` — the factory
-// reset that erases the overlay, /etc/majestic.token with it, and then reboots.
+// runCmd() on fw-reset.cgi, which streams `sysupgrade -s -n -x --web` — the
+// factory reset that erases the overlay, /etc/majestic.token with it, and reboots.
 // Losing the session is the EXPECTED end of this request, not an error, and the
 // whole point of the page is to show the log until the camera goes. Redirecting
 // on a 401 here would blank the transcript at the moment it matters most, and

--- a/www/cgi-bin/fw-reset.cgi
+++ b/www/cgi-bin/fw-reset.cgi
@@ -2,7 +2,23 @@
 <%in p/common.cgi %>
 <%
 	page_title="Erasing Overlay"
-	c="/usr/sbin/sysupgrade -s -n -x"
+	# --web is not optional here, despite there being no WebSocket in sight.
+	#
+	# free_resources() opens with `killall -q -3 majestic` unless web_update is
+	# set — and majestic is the server running this very CGI, whose stdout is the
+	# stream feeding the box below. Without the flag the reset kills its own
+	# progress log: the transcript stops dead on "Stop services, sync files, free
+	# up memory", the line printed immediately before the signal, and the page
+	# then sits there while the camera wipes and reboots underneath it (#154).
+	#
+	# The flag reads as upgrade-specific because /ws/upgrade needed it first, but
+	# what it means to sysupgrade is "majestic is streaming this, leave it
+	# alone", which is just as true of the run.cgi flow. Besides skipping the
+	# sysupgrade self-update it gates nothing else, and nothing later in the run
+	# touches majestic: that killall is the only one in the script, and -n
+	# rewrites rootfs_data, not the rootfs majestic runs from. So the log now
+	# survives all the way to the reboot.
+	c="/usr/sbin/sysupgrade -s -n -x --web"
 	r="true"
 %>
 

--- a/www/cgi-bin/fw-reset.cgi
+++ b/www/cgi-bin/fw-reset.cgi
@@ -31,6 +31,13 @@
 
 <script>
 	const el = $('pre#output');
+	// Stop the header heartbeat for the same reason fw-update.js does: every tick
+	// forks a dozen processes and makes a loopback request into the majestic that
+	// is streaming this log. Fine on an idle camera, ruinous on one erasing its
+	// own flash — and only now worth saying, because until --web above kept
+	// majestic alive these ticks died against a stopped server anyway. Keeping it
+	// running would trade one bug for a quieter one.
+	if (typeof stopHeartbeat === 'function') stopHeartbeat();
 	runCmd("cmd")
 </script>
 <%in p/footer.cgi %>


### PR DESCRIPTION
Fixes the remaining half of #154 — the reset transcript stopping dead on `Stop services, sync files, free up memory`.

## Cause

`fw-reset.cgi` streams `sysupgrade` through `j/run.cgi`, which **majestic serves**, and runs it without `--web`. So `free_resources()` opens with:

```sh
echo_c 37 "\nStop services, sync files, free up memory"   # <- the last line anyone sees
if [ "1" != "$web_update" ]; then
        killall -q -3 majestic                            # <- kills the server feeding the page
```

The reset kills its own progress log. The page then sits there while the camera wipes and reboots underneath it.

`--web` reads as upgrade-specific because `/ws/upgrade` needed it first, but what it means to sysupgrade is *"majestic is streaming this, leave it alone"* — just as true of the `run.cgi` flow. Besides skipping the sysupgrade self-update it gates nothing else, and nothing later in the run touches majestic: that `killall` is the only one in the script, and `-n` rewrites `rootfs_data`, not the rootfs majestic runs from.

Fixing it here rather than in sysupgrade means **existing cameras get it from a WebUI update alone** — 1.0.57 already understands the flag.

## Verified on an hi3516av300

Streaming the real thing through `run.cgi`, the transcript now runs past where it used to die:

```
Stop services, sync files, free up memory      <- previously ended here
  … Uptime / Memory / Processes …
Unmounting SD card
Protected: flashing continues even if this terminal disconnects.
Moving the flash phase into RAM
Flashing from RAM (pid 2572)
OverlayFS / Erase overlay partition
Unconditional reboot
```

`ps` mid-run confirms majestic stays up for the whole thing:

```
 2489 root  11:28 majestic -s
 2563 root   0:00 {run.cgi} /bin/sh /var/www/cgi-bin/j/run.cgi
 2572 root   0:00 {sysupgrade} /bin/sh /usr/sbin/sysupgrade -s -n -x --web
```

Camera came back factory-default as expected.

## Correction

I got this wrong the first time and told the reporter it didn't reproduce. `run.cgi` prints a shell prompt of its own (`root@cam:/tmp# <cmd>`), so his transcript looked like an SSH session — I reproduced the CLI path, which has no majestic in the middle of it and therefore never showed the bug. Not goke-specific; it reproduces anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)