### PR TITLE
webui: make wiping the camera look different from rebooting it

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -472,3 +472,26 @@ pre#output[data-cmd] {
 .form-select {
 	transition: border-color var(--mj-ease), box-shadow var(--mj-ease);
 }
+
+/* Destructive switches (issue #160).
+ *
+ * "Reset config (wipe overlay)" sat in Advanced options rendered exactly like
+ * "Upgrade kernel" directly above it — same weight, same colour, one click, no
+ * question asked. Nothing about it looked like the thing that throws away every
+ * setting on the camera. field_switch marks such a row .destructive when it is
+ * given a confirm message; this is what makes it read as one.
+ */
+.boolean.destructive .form-check-label {
+	color: var(--bs-danger);
+	font-weight: 500;
+}
+
+.boolean.destructive .form-check-input:checked {
+	background-color: var(--bs-danger);
+	border-color: var(--bs-danger);
+}
+
+.boolean.destructive .form-check-input:focus {
+	border-color: var(--bs-danger);
+	box-shadow: 0 0 0 .25rem rgba(var(--bs-danger-rgb), .25);
+}

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -263,14 +263,32 @@ function initAll() {
 	$$('form').forEach(el => el.autocomplete = 'off');
 
 	// For .warning and .danger buttons, ask confirmation on action.
+	//
+	// data-confirm overrides the wording. One shared "Are you sure?" meant that
+	// rebooting the camera and wiping it back to factory asked the identical
+	// question, on two buttons sitting next to each other — so the prompt carried
+	// no information and became something to click through (issue #160). The
+	// generic text stays for everything that has not said otherwise.
 	$$('.btn-danger, .btn-warning, .confirm').forEach(el => {
+		const ask = el.dataset.confirm || "Are you sure?";
 		// for input, find its parent form and attach listener to it submit event
 		if (el.nodeName === "INPUT") {
 			while (el.nodeName !== "FORM") el = el.parentNode
-			el.addEventListener('submit', ev => (!confirm("Are you sure?")) ? ev.preventDefault() : null)
+			el.addEventListener('submit', ev => (!confirm(ask)) ? ev.preventDefault() : null)
 		} else {
-			el.addEventListener('click', ev => (!confirm("Are you sure?")) ? ev.preventDefault() : null)
+			el.addEventListener('click', ev => (!confirm(ask)) ? ev.preventDefault() : null)
 		}
+	});
+
+	// A destructive switch has nothing to intercept at click time: it arms
+	// something that happens later, when the form is submitted, so by the time
+	// the real action runs the user is looking at a different button. Ask as it
+	// is turned ON, and put it back if the answer is no. Turning one OFF is
+	// always safe and never asks.
+	$$('input[type=checkbox][data-confirm]').forEach(el => {
+		el.addEventListener('change', () => {
+			if (el.checked && !confirm(el.dataset.confirm)) el.checked = false;
+		});
 	});
 
 	$$('.refresh').forEach(el => el.addEventListener('click', refresh));

--- a/www/cgi-bin/fw-settings.cgi
+++ b/www/cgi-bin/fw-settings.cgi
@@ -64,15 +64,24 @@ fi
 
 		<div class="card"><div class="card-body">
 			<h3>Maintenance</h3>
-			<div class="d-flex flex-wrap gap-4">
-				<div>
-					<a class="btn btn-outline-secondary confirm" href="fw-restart.cgi">Restart camera</a>
-					<p class="x-small text-secondary mt-1 mb-0">Reboot to apply settings and clear temporary files.</p>
-				</div>
-				<div>
-					<a class="btn btn-danger" href="fw-reset.cgi">Reset firmware</a>
-					<p class="x-small text-secondary mt-1 mb-0">Revert to factory state by wiping the overlay. <span class="text-danger">Destroys all changes.</span></p>
-				</div>
+			<div>
+				<a class="btn btn-outline-secondary confirm" href="fw-restart.cgi"
+					data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>
+				<p class="x-small text-secondary mt-1 mb-0">Reboot to apply settings and clear temporary files.</p>
+			</div>
+			<%
+				# Deliberately not beside "Restart camera" any more. The two sat in one
+				# flex row, a gap apart, and asked the identical "Are you sure?" — so the
+				# only thing separating a reboot from a factory wipe was reading the
+				# button (issue #160). A rule and a heading break the run of controls, so
+				# the destructive one has to be arrived at rather than landed on.
+			%>
+			<hr class="my-4">
+			<h4 class="h6 text-danger mb-1">Danger zone</h4>
+			<div>
+				<a class="btn btn-danger" href="fw-reset.cgi"
+					data-confirm="Reset this camera to factory state?&#10;&#10;Every configuration change is erased: network and Wi-Fi, video and image settings, timezone, passwords, and every extension you have configured.&#10;&#10;You will need to set the camera up again from scratch, and reach it on whatever address DHCP gives it. This cannot be undone.">Reset firmware</a>
+				<p class="x-small text-secondary mt-1 mb-0">Revert to factory state by wiping the overlay. <span class="text-danger">Destroys all changes, and cannot be undone.</span></p>
 			</div>
 		</div></div>
 	</div>

--- a/www/cgi-bin/fw-update.cgi
+++ b/www/cgi-bin/fw-update.cgi
@@ -57,7 +57,7 @@
 		<details class="mt-2">
 			<summary class="text-secondary small">Advanced options</summary>
 			<div class="mt-2">
-				<% field_switch "fw_reset" "Reset config (wipe overlay)" "false" "Erases all your settings — equivalent to a fresh flash." %>
+				<% field_switch "fw_reset" "Reset config (wipe overlay)" "false" "Erases every setting on this camera; it comes back as a fresh flash. <span class='text-danger'>Destroys all changes, and cannot be undone.</span>" "Wipe ALL settings during this upgrade?&#10;&#10;Every configuration change on this camera is erased: network and Wi-Fi, video and image settings, timezone, passwords, and every extension you have configured.&#10;&#10;It comes back as if freshly flashed. This cannot be undone.&#10;&#10;Leave this off unless you specifically want a factory reset." %>
 				<% field_switch "fw_force" "Reflash even if the same version" "false" "Re-writes flash even when installed and target versions match." %>
 			</div>
 		</details>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -239,14 +239,33 @@ field_range() {
 	echo "</p>"
 }
 
+# Escape a string for use inside a double-quoted HTML attribute.
+#
+# Numeric character references are restored on the way out, deliberately: the
+# confirm prompts use &#10; for their line breaks, and escaping the ampersand
+# would put the entity on screen instead of breaking the line. Everything else
+# that could close the attribute or open a tag is neutralised, so a prompt is
+# free to contain a quote without silently truncating the element it lives in.
+attr_escape() {
+	printf '%s' "$1" | sed \
+		-e 's/&/\&amp;/g' \
+		-e 's/</\&lt;/g' \
+		-e 's/>/\&gt;/g' \
+		-e 's/"/\&quot;/g' \
+		-e 's/&amp;#\([0-9][0-9]*\);/\&#\1;/g'
+}
+
 # field_switch "name" "label" "value" "hint" "confirm"
 #
 # A non-empty "confirm" marks the switch destructive: the row is styled in red
 # (see .boolean.destructive in bootstrap.override.css) and main.js asks the given
 # question as it is switched ON. Use it for anything that throws away data —
 # a toggle that wipes the camera must not read like the one above it that
-# upgrades the kernel (issue #160). Use &#10; for a line break in the prompt;
-# the attribute is HTML, so the entity is what reaches confirm() as a newline.
+# upgrades the kernel (issue #160). Use &#10; for a line break in the prompt.
+#
+# Unlike "hint", which is interpolated raw so it can carry a link, this goes
+# through attr_escape: it is an attribute value rather than markup, so a stray
+# quote would end the tag early rather than merely look wrong.
 field_switch() {
 	local n="$1"
 	local l="$2"
@@ -264,7 +283,7 @@ field_switch() {
 		true) v="checked" ;;
 		*)    v="" ;;
 	esac
-	[ -n "$c" ] && extra=" data-confirm=\"${c}\""
+	[ -n "$c" ] && extra=" data-confirm=\"$(attr_escape "$c")\""
 	echo "<p class=\"boolean$([ -n "$c" ] && echo ' destructive')\"><span class=\"form-check form-switch\">" \
 		"<input type=\"hidden\" id=\"${n}-false\" name=\"${n}\" value=\"false\">" \
 		"<input type=\"checkbox\" id=\"${n}\" name=\"${n}\" value=\"true\" class=\"form-check-input\" ${v}${extra}>" \

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -239,17 +239,35 @@ field_range() {
 	echo "</p>"
 }
 
-# field_switch "name" "label" "value" "hint"
+# field_switch "name" "label" "value" "hint" "confirm"
+#
+# A non-empty "confirm" marks the switch destructive: the row is styled in red
+# (see .boolean.destructive in bootstrap.override.css) and main.js asks the given
+# question as it is switched ON. Use it for anything that throws away data —
+# a toggle that wipes the camera must not read like the one above it that
+# upgrades the kernel (issue #160). Use &#10; for a line break in the prompt;
+# the attribute is HTML, so the entity is what reaches confirm() as a newline.
 field_switch() {
 	local n="$1"
 	local l="$2"
 	local v="$3"
 	local h="$4"
+	local c="$5"
+	local extra=""
 	[ "$v" = "eval" ] && v=$(t_value "$n")
-	[ "$v" = "true" ] && v="checked"
-	echo "<p class=\"boolean\"><span class=\"form-check form-switch\">" \
+	# Anything that is not "true" contributes no attribute at all. Testing only
+	# for true left the value itself in the tag, so every switch in the off state
+	# rendered as <input ... class="form-check-input" false> — a stray boolean
+	# attribute literally named "false". Harmless, since nothing reads it, but it
+	# is invalid and it is the sort of thing that makes a later selector lie.
+	case "$v" in
+		true) v="checked" ;;
+		*)    v="" ;;
+	esac
+	[ -n "$c" ] && extra=" data-confirm=\"${c}\""
+	echo "<p class=\"boolean$([ -n "$c" ] && echo ' destructive')\"><span class=\"form-check form-switch\">" \
 		"<input type=\"hidden\" id=\"${n}-false\" name=\"${n}\" value=\"false\">" \
-		"<input type=\"checkbox\" id=\"${n}\" name=\"${n}\" value=\"true\" class=\"form-check-input\" ${v}>" \
+		"<input type=\"checkbox\" id=\"${n}\" name=\"${n}\" value=\"true\" class=\"form-check-input\" ${v}${extra}>" \
 		"<label for=\"${n}\" class=\"form-check-label\">${l}</label></span>"
 	[ -n "$h" ] && echo "<span class=\"hint text-secondary\">${h}</span>"
 	echo "</p>"

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -131,7 +131,8 @@ Pragma: no-cache
 	<h3>Warning.</h3>
 	<p>System settings have been updated, restart to apply pending changes.</p>
 	<span class="d-flex gap-3">
-		<a class="btn btn-danger" href="fw-restart.cgi">Restart camera</a>
+		<a class="btn btn-danger" href="fw-restart.cgi"
+			data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>
 	</span>
 </div>
 <% fi %>


### PR DESCRIPTION
Closes #160.

Three actions can throw away every setting on a camera, and none of them looked or behaved differently from the harmless controls beside them.

## Firmware → Settings → Maintenance

`Restart camera` and `Reset firmware` sat in one flex row a gap apart and asked the identical `Are you sure?`. The only thing separating a reboot from a factory wipe was reading the button.

The reset now lives below a rule under a **Danger zone** heading — arrived at rather than landed on — and each prompt says what it is actually about to do:

> **Restart camera** — Restart the camera now?
> Settings are kept. Video and recording stop for about half a minute while it comes back.

> **Reset firmware** — Reset this camera to factory state?
> Every configuration change is erased: network and Wi-Fi, video and image settings, timezone, passwords, and every extension you have configured.
> You will need to set the camera up again from scratch, and reach it on whatever address DHCP gives it. This cannot be undone.

I kept a prompt on the restart rather than dropping it as @usa- suggested. It is non-destructive but not free — it drops video and recording — and differentiating by *wording* fixes the "same confirmation flow" complaint without making an accidental click on a nav button reboot the camera outright. Easy to change if you disagree.

Varying the text needed a mechanism, so `.btn-danger`/`.btn-warning`/`.confirm` now honour `data-confirm`, falling back to the generic question. The restart-required banner's button gets the same text as the one in Settings, since it is the same action.

## Firmware → Update → Reset config (wipe overlay)

The worst of the three: rendered exactly like `Upgrade kernel` directly above it, one click, no question asked.

`field_switch` now takes an optional confirm message, which marks the row `.destructive` — red label, red switch when on — and `main.js` asks **as it is switched ON**, putting it back if the answer is no.

Confirming on the change rather than at submit matters: by the time the form is submitted the user is looking at a different button entirely, and a prompt there would be about the upgrade, not about the wipe.

Turning a destructive switch **off** never asks. Nothing that has not opted in changes — the other 16 `field_switch` call sites render exactly as before.

## Drive-by

`field_switch` only tested for `"true"`, so an off switch emitted its value straight into the tag:

```html
<input type="checkbox" id="fw_reset" ... class="form-check-input" false>
```

A boolean attribute literally named `false`. Harmless, since nothing reads it, but invalid and the sort of thing a later attribute selector trips over. Fixed on the line I was already editing.

## Verified

Rendered on an hi3516av300 rather than read off the template:

```
fw_kernel  ... class="form-check-input" checked
fw_reset   ... class="form-check-input"  data-confirm="Wipe ALL settings…"
fw_force   ... class="form-check-input"
```

plus `Danger zone` and both distinct `data-confirm` strings on the Settings page. `build:dist` and `lint-templates.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)