### PR TITLE
Add a camera selector for openipc.local

### DIFF
--- a/www/cameras.html
+++ b/www/cameras.html
@@ -84,8 +84,12 @@
 					// the camera published is preferred, but only if it is plain
 					// http/https — it arrives over the network like everything else
 					// here, and javascript: in an href would run on this page.
+					//
+					// Used as sent, not with a slash appended: an authority on its
+					// own is already a valid URL, and appending to one that turned
+					// out to carry a path, a query or a fragment would corrupt it.
 					var href = 'http://' + cam.address + '/';
-					if (cam.url && /^https?:\/\//i.test(cam.url)) href = cam.url + '/';
+					if (cam.url && /^https?:\/\//i.test(cam.url)) href = cam.url;
 
 					var a = document.createElement('a');
 					a.className = 'cam';
@@ -132,7 +136,13 @@
 			// login page, which is the wrong move here: this page is reached before
 			// signing in to anything, so an empty list belongs on screen rather
 			// than a redirect to a camera the user has not chosen.
-			fetch('/api/v1/peers', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+			//
+			// And deliberately without credentials. The roster needs none — the
+			// camera decides on the caller's address, not a session — while the
+			// origin here is the shared name, which every camera answers. Sending
+			// the cookie would hand a session minted by one camera to whichever
+			// one happens to reply next.
+			fetch('/api/v1/peers', { credentials: 'omit', headers: { 'Accept': 'application/json' } })
 				.then(function (r) {
 					if (r.status === 404) throw new Error('This camera does not publish a camera list.');
 					if (!r.ok) throw new Error('The camera list is not available here.');

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -98,7 +98,9 @@
 			}
 
 			function addressHref(address) {
-				if (!address) return null;
+				// A non-string reaches split() and colon tests below and throws,
+				// so anything that is not a string is simply not an address.
+				if (typeof address !== 'string' || !address) return null;
 				if (isIPv4(address)) return 'http://' + address + '/';
 				var v6 = ipv6Host(address);
 				return v6 ? 'http://' + v6 + '/' : null;
@@ -145,6 +147,12 @@
 				var ul = document.createElement('ul');
 
 				cameras.forEach(function (cam) {
+					// The array was checked, but its entries were not: a null or a
+					// non-object among them would throw on cam.address and put an
+					// internal error on screen, the very thing the array check
+					// above was there to avoid.
+					if (!cam || typeof cam !== 'object') return;
+
 					// Addressed numerically rather than by name: a camera's own
 					// .local name only resolves in a browser that speaks mDNS, while
 					// the address came out of the packet it announced itself in.

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -79,7 +79,10 @@
 			function isIPv4(s) {
 				var p = s.split('.');
 				return p.length === 4 && p.every(function (o) {
-					return /^\d{1,3}$/.test(o) && +o <= 255;
+					// No leading zeros: "010" is octal to some URL parsers, so a
+					// value that looks like the shown address could resolve to a
+					// different host in the click. Canonical dotted-decimal only.
+					return /^(0|[1-9]\d{0,2})$/.test(o) && +o <= 255;
 				});
 			}
 
@@ -182,10 +185,14 @@
 						a.appendChild(here);
 					}
 
-					if (cam.quietFor > QUIET_AFTER) {
+					// A finite number only: the comparison alone would let a
+					// string or a missing value through and print "no reply for
+					// undefineds".
+					if (typeof cam.quietFor === 'number' && isFinite(cam.quietFor)
+							&& cam.quietFor > QUIET_AFTER) {
 						var q = document.createElement('span');
 						q.className = 'quiet';
-						q.textContent = 'no reply for ' + cam.quietFor + 's';
+						q.textContent = 'no reply for ' + Math.round(cam.quietFor) + 's';
 						a.appendChild(q);
 					}
 

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -83,19 +83,25 @@
 				});
 			}
 
-			// A bracketed literal only — the address field is a host on its own,
-			// never host:port, so any bare colon here is part of an IPv6 address.
-			function isIPv6(s) {
-				if (s.indexOf(':') === -1) return false;
-				try { return new URL('http://[' + s + ']/').hostname === '[' + s + ']'; }
-				catch (e) { return false; }
+			// The address field is a host on its own, never host:port, so any bare
+			// colon makes it an IPv6 address. Returns the parser's own bracketed
+			// form when it is one, so uppercase or uncompressed spellings are
+			// accepted rather than dropped for not matching character-for-character
+			// — and null otherwise. The parser only reads brackets as an IPv6 host,
+			// so nothing else can slip a different authority through here.
+			function ipv6Host(s) {
+				if (s.indexOf(':') === -1) return null;
+				try {
+					var h = new URL('http://[' + s + ']/').hostname;
+					return h.charAt(0) === '[' ? h : null;
+				} catch (e) { return null; }
 			}
 
 			function addressHref(address) {
 				if (!address) return null;
 				if (isIPv4(address)) return 'http://' + address + '/';
-				if (isIPv6(address)) return 'http://[' + address + ']/';
-				return null;
+				var v6 = ipv6Host(address);
+				return v6 ? 'http://' + v6 + '/' : null;
 			}
 
 			// The camera's own URL is preferred when it is plainly http or https,
@@ -109,7 +115,7 @@
 						var u = new URL(cam.url);
 						var host = u.hostname.replace(/^\[|\]$/g, '');
 						if (!u.username && !u.password
-								&& (isIPv4(host) || isIPv6(host))) {
+								&& (isIPv4(host) || ipv6Host(host))) {
 							return cam.url;
 						}
 					} catch (e) { /* unparseable: fall through to the address */ }

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -69,6 +69,37 @@
 			// so rather than offer it as though it were up.
 			var QUIET_AFTER = 60;
 
+			// Where a link is allowed to point. Everything in the roster reached
+			// this camera over the network, so an entry is only turned into an href
+			// once it is known to name a host and nothing else: "10.0.0.1@evil.tld"
+			// or "10.0.0.1/../.." in an address would send the click somewhere the
+			// list never mentioned. Digits, dots and colons are the whole of an
+			// IPv4 or IPv6 literal, and none of them can start userinfo, a path, a
+			// query or a fragment.
+			function addressHref(address) {
+				if (!address || !/^[0-9a-fA-F.:]+$/.test(address)) return null;
+				var literal6 = address.indexOf(':') !== -1;
+				return 'http://' + (literal6 ? '[' + address + ']' : address) + '/';
+			}
+
+			// The camera's own URL is preferred when it is plainly http or https,
+			// and is used exactly as sent: an authority on its own is already a
+			// valid URL, and appending to one that carried a path or a query would
+			// corrupt it. Its host is checked the same way as an address, so a
+			// published URL cannot point the link at another origin either.
+			function cameraHref(cam) {
+				if (cam.url && /^https?:\/\//i.test(cam.url)) {
+					try {
+						var u = new URL(cam.url);
+						if (/^[0-9a-fA-F.:\[\]]+$/.test(u.hostname) && !u.username
+								&& !u.password) {
+							return cam.url;
+						}
+					} catch (e) { /* unparseable: fall through to the address */ }
+				}
+				return addressHref(cam.address);
+			}
+
 			function render(cameras) {
 				if (!cameras.length) {
 					msg('No cameras answered.');
@@ -78,18 +109,13 @@
 				var ul = document.createElement('ul');
 
 				cameras.forEach(function (cam) {
-					// Built from the address rather than the name: a camera's own
-					// .local name only resolves if this browser does mDNS, while the
-					// address came from the packet it announced itself in. The URL
-					// the camera published is preferred, but only if it is plain
-					// http/https — it arrives over the network like everything else
-					// here, and javascript: in an href would run on this page.
-					//
-					// Used as sent, not with a slash appended: an authority on its
-					// own is already a valid URL, and appending to one that turned
-					// out to carry a path, a query or a fragment would corrupt it.
-					var href = 'http://' + cam.address + '/';
-					if (cam.url && /^https?:\/\//i.test(cam.url)) href = cam.url;
+					// Addressed numerically rather than by name: a camera's own
+					// .local name only resolves in a browser that speaks mDNS, while
+					// the address came out of the packet it announced itself in.
+					// An entry with nothing safe to point at is left out — a link
+					// that goes somewhere else is worse than one that is missing.
+					var href = cameraHref(cam);
+					if (!href) return;
 
 					var a = document.createElement('a');
 					a.className = 'cam';
@@ -142,14 +168,31 @@
 			// origin here is the shared name, which every camera answers. Sending
 			// the cookie would hand a session minted by one camera to whichever
 			// one happens to reply next.
-			fetch('/api/v1/peers', { credentials: 'omit', headers: { 'Accept': 'application/json' } })
+			//
+			// Bounded, like every other request in this UI: a camera that accepts
+			// the connection and then says nothing would otherwise leave the page
+			// on "Looking…" for as long as the tab is open.
+			var ctl = new AbortController();
+			var giveUp = setTimeout(function () { ctl.abort(); }, 5000);
+
+			fetch('/api/v1/peers', {
+				credentials: 'omit',
+				signal: ctl.signal,
+				headers: { 'Accept': 'application/json' }
+			})
 				.then(function (r) {
+					clearTimeout(giveUp);
 					if (r.status === 404) throw new Error('This camera does not publish a camera list.');
 					if (!r.ok) throw new Error('The camera list is not available here.');
 					return r.json();
 				})
 				.then(function (data) { render((data && data.cameras) || []); })
-				.catch(function (e) { msg(e.message || 'Could not reach this camera.', true); });
+				.catch(function (e) {
+					clearTimeout(giveUp);
+					msg(e.name === 'AbortError'
+						? 'This camera did not answer in time.'
+						: (e.message || 'Could not reach this camera.'), true);
+				});
 		}());
 	</script>
 </body>

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="darkreader-lock">
+	<meta name="robots" content="noindex">
+	<title>Cameras · OpenIPC</title>
+	<!-- Self-contained on purpose, like login.html: majestic serves this page
+	     without authentication (you have not chosen a camera to sign in to yet),
+	     so it cannot pull /a/*.css or /a/*.js, which require a valid session. -->
+	<style>
+		:root { color-scheme: dark; }
+		* { box-sizing: border-box; }
+		body {
+			margin: 0; min-height: 100vh; padding: 2rem 1rem;
+			display: flex; align-items: flex-start; justify-content: center;
+			background: #1a1d20; color: #dee2e6;
+			font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+		}
+		.card {
+			width: 100%; max-width: 32rem;
+			background: #212529; border: 1px solid #343a40; border-radius: .5rem;
+			padding: 2rem 1.75rem;
+		}
+		h1 { font-size: 1.25rem; font-weight: 600; margin: 0 0 .35rem; text-align: center; }
+		h1 span { color: #6ea8fe; }
+		.sub { margin: 0 0 1.5rem; text-align: center; font-size: .875rem; color: #adb5bd; }
+		ul { list-style: none; margin: 0; padding: 0; }
+		li { margin-bottom: .5rem; }
+		a.cam {
+			display: flex; align-items: baseline; gap: .75rem;
+			padding: .7rem .85rem; text-decoration: none;
+			background: #2b3035; color: #dee2e6;
+			border: 1px solid #495057; border-radius: .375rem;
+		}
+		a.cam:hover { border-color: #6ea8fe; background: #31373d; }
+		.name { font-weight: 500; }
+		.addr { margin-left: auto; font-size: .875rem; color: #adb5bd; font-variant-numeric: tabular-nums; }
+		.quiet { font-size: .75rem; color: #ffda6a; }
+		.here {
+			font-size: .6875rem; text-transform: uppercase; letter-spacing: .04em;
+			color: #75b798; border: 1px solid #2f6f52; border-radius: .25rem;
+			padding: .1rem .35rem;
+		}
+		.msg { text-align: center; color: #adb5bd; font-size: .875rem; padding: 1rem 0; }
+		.msg.bad { color: #ea868f; }
+	</style>
+</head>
+<body>
+	<main class="card">
+		<h1>Open<span>IPC</span></h1>
+		<p class="sub">Cameras on this network</p>
+		<div id="out"><p class="msg">Looking…</p></div>
+	</main>
+	<script>
+		(function () {
+			var out = document.getElementById('out');
+
+			function msg(text, bad) {
+				var p = document.createElement('p');
+				p.className = bad ? 'msg bad' : 'msg';
+				p.textContent = text;
+				out.replaceChildren(p);
+			}
+
+			// A camera stays listed until it has been silent long enough to expire,
+			// so one that was unplugged is still here for a couple of minutes. Say
+			// so rather than offer it as though it were up.
+			var QUIET_AFTER = 60;
+
+			function render(cameras) {
+				if (!cameras.length) {
+					msg('No cameras answered.');
+					return;
+				}
+
+				var ul = document.createElement('ul');
+
+				cameras.forEach(function (cam) {
+					// Built from the address rather than the name: a camera's own
+					// .local name only resolves if this browser does mDNS, while the
+					// address came from the packet it announced itself in. The URL
+					// the camera published is preferred, but only if it is plain
+					// http/https — it arrives over the network like everything else
+					// here, and javascript: in an href would run on this page.
+					var href = 'http://' + cam.address + '/';
+					if (cam.url && /^https?:\/\//i.test(cam.url)) href = cam.url + '/';
+
+					var a = document.createElement('a');
+					a.className = 'cam';
+					a.href = href;
+
+					var name = document.createElement('span');
+					name.className = 'name';
+					name.textContent = cam.name || cam.address;
+					a.appendChild(name);
+
+					// The camera serving this page is in the list like any other,
+					// and is worth pointing out only so the reader knows which one
+					// they are already talking to. It still takes one click, and it
+					// is addressed here by its own address rather than the shared
+					// name, so the session it issues stays with it.
+					if (cam.self) {
+						var here = document.createElement('span');
+						here.className = 'here';
+						here.textContent = 'you are here';
+						a.appendChild(here);
+					}
+
+					if (cam.quietFor > QUIET_AFTER) {
+						var q = document.createElement('span');
+						q.className = 'quiet';
+						q.textContent = 'no reply for ' + cam.quietFor + 's';
+						a.appendChild(q);
+					}
+
+					var addr = document.createElement('span');
+					addr.className = 'addr';
+					addr.textContent = cam.address;
+					a.appendChild(addr);
+
+					var li = document.createElement('li');
+					li.appendChild(a);
+					ul.appendChild(li);
+				});
+
+				out.replaceChildren(ul);
+			}
+
+			// Deliberately a plain fetch. main.js's apiFetch sends a 401 to the
+			// login page, which is the wrong move here: this page is reached before
+			// signing in to anything, so an empty list belongs on screen rather
+			// than a redirect to a camera the user has not chosen.
+			fetch('/api/v1/peers', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+				.then(function (r) {
+					if (r.status === 404) throw new Error('This camera does not publish a camera list.');
+					if (!r.ok) throw new Error('The camera list is not available here.');
+					return r.json();
+				})
+				.then(function (data) { render((data && data.cameras) || []); })
+				.catch(function (e) { msg(e.message || 'Could not reach this camera.', true); });
+		}());
+	</script>
+</body>
+</html>

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -69,30 +69,47 @@
 			// so rather than offer it as though it were up.
 			var QUIET_AFTER = 60;
 
-			// Where a link is allowed to point. Everything in the roster reached
-			// this camera over the network, so an entry is only turned into an href
-			// once it is known to name a host and nothing else: "10.0.0.1@evil.tld"
-			// or "10.0.0.1/../.." in an address would send the click somewhere the
-			// list never mentioned. Digits, dots and colons are the whole of an
-			// IPv4 or IPv6 literal, and none of them can start userinfo, a path, a
-			// query or a fragment.
+			// Everything in the roster reached this camera over the network, so a
+			// link is only built once its target is confirmed to be a literal IP
+			// address — not merely a string of address-shaped characters. "evil"
+			// or "deadbeef" would pass a loose test and resolve as a DNS name;
+			// "10.0.0.1@host" or "10.0.0.1/.." would send the click off the list
+			// entirely. These check structure, not just the alphabet.
+
+			function isIPv4(s) {
+				var p = s.split('.');
+				return p.length === 4 && p.every(function (o) {
+					return /^\d{1,3}$/.test(o) && +o <= 255;
+				});
+			}
+
+			// A bracketed literal only — the address field is a host on its own,
+			// never host:port, so any bare colon here is part of an IPv6 address.
+			function isIPv6(s) {
+				if (s.indexOf(':') === -1) return false;
+				try { return new URL('http://[' + s + ']/').hostname === '[' + s + ']'; }
+				catch (e) { return false; }
+			}
+
 			function addressHref(address) {
-				if (!address || !/^[0-9a-fA-F.:]+$/.test(address)) return null;
-				var literal6 = address.indexOf(':') !== -1;
-				return 'http://' + (literal6 ? '[' + address + ']' : address) + '/';
+				if (!address) return null;
+				if (isIPv4(address)) return 'http://' + address + '/';
+				if (isIPv6(address)) return 'http://[' + address + ']/';
+				return null;
 			}
 
 			// The camera's own URL is preferred when it is plainly http or https,
-			// and is used exactly as sent: an authority on its own is already a
-			// valid URL, and appending to one that carried a path or a query would
-			// corrupt it. Its host is checked the same way as an address, so a
-			// published URL cannot point the link at another origin either.
+			// and used exactly as sent: an authority on its own is already a valid
+			// URL, and appending to one that carried a path or a query would
+			// corrupt it. Its host must still be a literal address and carry no
+			// userinfo, so a published URL cannot point the link at another origin.
 			function cameraHref(cam) {
 				if (cam.url && /^https?:\/\//i.test(cam.url)) {
 					try {
 						var u = new URL(cam.url);
-						if (/^[0-9a-fA-F.:\[\]]+$/.test(u.hostname) && !u.username
-								&& !u.password) {
+						var host = u.hostname.replace(/^\[|\]$/g, '');
+						if (!u.username && !u.password
+								&& (isIPv4(host) || isIPv6(host))) {
 							return cam.url;
 						}
 					} catch (e) { /* unparseable: fall through to the address */ }

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -118,7 +118,11 @@
 			}
 
 			function render(cameras) {
-				if (!cameras.length) {
+				// The API is trusted to be majestic, but a malformed or truncated
+				// response should show the empty state, not throw an internal error
+				// at the reader — so anything that is not an array is treated as no
+				// cameras rather than assumed to have .forEach.
+				if (!Array.isArray(cameras) || !cameras.length) {
 					msg('No cameras answered.');
 					return;
 				}
@@ -171,6 +175,14 @@
 					li.appendChild(a);
 					ul.appendChild(li);
 				});
+
+				// Every entry may have been dropped for having nothing safe to
+				// link to, which leaves an empty list — say so rather than replace
+				// the page with a blank box.
+				if (!ul.childNodes.length) {
+					msg('No cameras with a usable address.');
+					return;
+				}
 
 				out.replaceChildren(ul);
 			}

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -107,20 +107,29 @@
 			// The camera's own URL is preferred when it is plainly http or https,
 			// and used exactly as sent: an authority on its own is already a valid
 			// URL, and appending to one that carried a path or a query would
-			// corrupt it. Its host must still be a literal address and carry no
-			// userinfo, so a published URL cannot point the link at another origin.
+			// corrupt it.
+			//
+			// Its host must be a literal address, carry no userinfo, and be the
+			// same address the entry displays. Without that last check a hostile
+			// announcement could show one camera's IP and send the click to
+			// another: the roster is untrusted network input, and the whole point
+			// of this page is that the address you see is the camera you reach.
 			function cameraHref(cam) {
+				var shown = addressHref(cam.address);
 				if (cam.url && /^https?:\/\//i.test(cam.url)) {
 					try {
 						var u = new URL(cam.url);
 						var host = u.hostname.replace(/^\[|\]$/g, '');
-						if (!u.username && !u.password
-								&& (isIPv4(host) || ipv6Host(host))) {
+						var canon = isIPv4(host) ? host : ipv6Host(host);
+						// Compare on the address's own canonical href, so an
+						// equivalent v6 spelling still counts as the same host.
+						if (!u.username && !u.password && canon
+								&& addressHref(host) === shown) {
 							return cam.url;
 						}
 					} catch (e) { /* unparseable: fall through to the address */ }
 				}
-				return addressHref(cam.address);
+				return shown;
 			}
 
 			function render(cameras) {

--- a/www/cameras.html
+++ b/www/cameras.html
@@ -225,12 +225,17 @@
 				headers: { 'Accept': 'application/json' }
 			})
 				.then(function (r) {
-					clearTimeout(giveUp);
 					if (r.status === 404) throw new Error('This camera does not publish a camera list.');
 					if (!r.ok) throw new Error('The camera list is not available here.');
+					// Not cleared yet: the deadline has to cover reading the body
+					// too, or a response that stalls after the headers would leave
+					// the page waiting forever.
 					return r.json();
 				})
-				.then(function (data) { render((data && data.cameras) || []); })
+				.then(function (data) {
+					clearTimeout(giveUp);
+					render((data && data.cameras) || []);
+				})
 				.catch(function (e) {
 					clearTimeout(giveUp);
 					msg(e.name === 'AbortError'


### PR DESCRIPTION
Every camera on a link answers `openipc.local`, so a browser that goes there has not said *which* one it wants. With a majestic that serves `GET /api/v1/peers`, that request now lands here instead of on one camera's UI, and this page lists what the camera found: itself, and every other camera it has heard announce itself.

**One click each.**

```
OpenIPC
Cameras on this network

  openipc-hi3516av300   YOU ARE HERE          10.216.128.39
  openipc-hi3516ev300                         10.216.128.68
  openipc-ssc30kq                             10.216.128.33
  openipc-hi3516cv300                         10.216.128.52
  openipc-t31                                 10.216.128.35
```

## Notes on the choices

**The serving camera is in the list.** Leaving it out would mean the one camera you are certainly connected to is the one you cannot open — and finding it again would mean looking up its address. It is marked only so you know which one you are already talking to.

**Links are built from addresses, not names.** A camera's own `.local` name resolves only in a browser that speaks mDNS; the address came out of the packet the camera announced itself in. A published URL is preferred when it is `http`/`https` and ignored otherwise — it arrives over the network like everything else here, and `javascript:` in an `href` would run in this page. Everything else is written with `textContent` for the same reason: a name is whatever a device on the link chose to call itself.

**Each entry points at a specific camera**, never back at the shared name. A session belongs to the camera that issued it, and the next request under `openipc.local` may well reach a different one.

**Self-contained**, like `login.html` and for the same reason — served without authentication, since arriving at `openipc.local` you have not yet picked a camera to sign in to, so it cannot pull `/a/*.css` or `/a/*.js`.

**A camera on its way out of the roster is marked**, not offered as though it were up.

**Plain `fetch`, not `apiFetch`** — the latter redirects a 401 to the login page, which is the wrong answer on a page reached before signing in to anything.

## Verified

Rendered in Chromium against a real link of five OpenIPC cameras: five entries, correct hostnames, every link resolvable. Against a build without the endpoint the fetch 404s and the page says so rather than hanging.

Valid HTML5, no deprecated tags, no `/a/` dependencies, and it lands in `majestic-webui-dist.tar.gz` alongside `login.html` with no change to `tools/build-dist.sh`.
