### PR TITLE
Add an in-UI camera switcher to the navbar

### DIFF
--- a/www/a/cameras-switch.js
+++ b/www/a/cameras-switch.js
@@ -100,10 +100,13 @@
 			var a = document.createElement('a');
 			a.className = 'dropdown-item d-flex align-items-center gap-2';
 			a.href = entry.href;
-			// main.js forces every http(s) link to target=_blank, so these
-			// cross-origin peer links open in a new tab. Sever the opener so the
-			// peer page cannot reach back through window.opener and navigate this
-			// admin tab (tabnabbing).
+			// Open peers in a new tab, matching how the rest of the UI treats
+			// external http links. main.js sets target=_blank on the anchors
+			// present at load, but the switcher builds these later (async, and
+			// again on every refresh), so set it here rather than rely on that
+			// one-time pass. rel=noopener severs window.opener so the peer page
+			// cannot reach back and navigate this admin tab (tabnabbing).
+			a.target = '_blank';
 			a.rel = 'noopener noreferrer';
 
 			var label = document.createElement('span');

--- a/www/a/cameras-switch.js
+++ b/www/a/cameras-switch.js
@@ -134,13 +134,29 @@
 		var box = document.getElementById('cam-switch');
 		if (!box) return;
 
-		// apiFetch (main.js) carries the session and never 401s this endpoint —
-		// 200 on-link, 404 off-link or on a majestic without it. Anything but a
-		// good JSON body leaves the switcher hidden.
-		apiFetch('/api/v1/peers', { headers: { 'Accept': 'application/json' } })
+		// Plain fetch, not apiFetch, and without credentials — matching
+		// www/cameras.html. The roster needs no session (the camera answers on
+		// the caller's address, and the endpoint is subnet-gated, not
+		// auth-gated), and on the shared openipc.local origin a cookie could
+		// otherwise be handed to whichever camera replies next. apiFetch's only
+		// extra — a redirect to login on 401 — is wrong here anyway: this runs
+		// unprompted in the background, not on a user action.
+		//
+		// Bounded so a stalled reply self-terminates well before the next tick
+		// rather than piling up behind the timer. 200 on-link, 404 off it or on
+		// a majestic without the endpoint; anything else hides the switcher.
+		var ctl = new AbortController();
+		var giveUp = setTimeout(function () { ctl.abort(); }, 5000);
+
+		fetch('/api/v1/peers', {
+			credentials: 'omit',
+			signal: ctl.signal,
+			headers: { 'Accept': 'application/json' }
+		})
 			.then(function (r) { return r.ok ? r.json() : null; })
 			.then(function (data) { build(box, data && data.cameras); })
-			.catch(function () { hide(box); });
+			.catch(function () { hide(box); })
+			.finally(function () { clearTimeout(giveUp); });
 	}
 
 	function start() {

--- a/www/a/cameras-switch.js
+++ b/www/a/cameras-switch.js
@@ -100,6 +100,11 @@
 			var a = document.createElement('a');
 			a.className = 'dropdown-item d-flex align-items-center gap-2';
 			a.href = entry.href;
+			// main.js forces every http(s) link to target=_blank, so these
+			// cross-origin peer links open in a new tab. Sever the opener so the
+			// peer page cannot reach back through window.opener and navigate this
+			// admin tab (tabnabbing).
+			a.rel = 'noopener noreferrer';
 
 			var label = document.createElement('span');
 			label.textContent = entry.cam.name || entry.cam.address;
@@ -130,6 +135,13 @@
 		box.classList.remove('d-none');
 	}
 
+	// The interval, so a definitive 404 can stop it (see refresh()).
+	var timer = null;
+
+	function stop() {
+		if (timer) { clearInterval(timer); timer = null; }
+	}
+
 	function refresh() {
 		var box = document.getElementById('cam-switch');
 		if (!box) return;
@@ -153,7 +165,14 @@
 			signal: ctl.signal,
 			headers: { 'Accept': 'application/json' }
 		})
-			.then(function (r) { return r.ok ? r.json() : null; })
+			.then(function (r) {
+				// A 404 is definitive: either this majestic has no peers
+				// endpoint (older build) or we are off its subnet. Neither
+				// changes while the page is open, so stop the timer rather than
+				// 404 every minute for the life of the tab.
+				if (r.status === 404) { stop(); return null; }
+				return r.ok ? r.json() : null;
+			})
 			.then(function (data) { build(box, data && data.cameras); })
 			.catch(function () { hide(box); })
 			.finally(function () { clearTimeout(giveUp); });
@@ -161,7 +180,7 @@
 
 	function start() {
 		refresh();
-		setInterval(refresh, REFRESH_MS);
+		timer = setInterval(refresh, REFRESH_MS);
 	}
 
 	if (document.readyState === 'loading') {

--- a/www/a/cameras-switch.js
+++ b/www/a/cameras-switch.js
@@ -1,0 +1,156 @@
+// Camera switcher: a navbar dropdown, present on every authenticated page, that
+// lists the other OpenIPC cameras on this link and jumps to any of them in one
+// click. The feature it surfaces already exists — browsing openipc.local shows
+// the same list — but nobody administering a camera by its IP would ever know
+// that, so this makes the fleet reachable from wherever they already are.
+//
+// Fed by GET /api/v1/peers, the same roster the openipc.local selector uses. It
+// is subnet-gated (404 off-link) and absent on older majestic (404), and either
+// way the switcher simply stays hidden: no new disclosure, no hard dependency.
+//
+// The href helpers below are copied verbatim from www/cameras.html. That page is
+// served before authentication and so cannot pull /a/*.js, which is why the two
+// cannot share a file. The peer roster is untrusted network input in both, so
+// the validation MUST stay identical — change one, change the other.
+(function () {
+	'use strict';
+
+	// How often to re-read the roster. Discovery sweeps server-side every 30s and
+	// the list changes slowly, so this is deliberately lazy — nothing hangs off
+	// main.js's 2s heartbeat.
+	var REFRESH_MS = 60000;
+
+	// --- validated hrefs (keep in step with www/cameras.html) -----------------
+
+	function isIPv4(s) {
+		var p = s.split('.');
+		return p.length === 4 && p.every(function (o) {
+			// No leading zeros: "010" is octal to some URL parsers, so a value
+			// that looks like the shown address could resolve to a different host.
+			return /^(0|[1-9]\d{0,2})$/.test(o) && +o <= 255;
+		});
+	}
+
+	function ipv6Host(s) {
+		if (s.indexOf(':') === -1) return null;
+		try {
+			var h = new URL('http://[' + s + ']/').hostname;
+			return h.charAt(0) === '[' ? h : null;
+		} catch (e) { return null; }
+	}
+
+	function addressHref(address) {
+		if (typeof address !== 'string' || !address) return null;
+		if (isIPv4(address)) return 'http://' + address + '/';
+		var v6 = ipv6Host(address);
+		return v6 ? 'http://' + v6 + '/' : null;
+	}
+
+	// A published url is honoured only when its host is a literal address equal to
+	// the one the entry shows and it carries no userinfo, so a hostile
+	// announcement cannot display one camera and send the click to another.
+	function cameraHref(cam) {
+		var shown = addressHref(cam.address);
+		if (cam.url && /^https?:\/\//i.test(cam.url)) {
+			try {
+				var u = new URL(cam.url);
+				var host = u.hostname.replace(/^\[|\]$/g, '');
+				var canon = isIPv4(host) ? host : ipv6Host(host);
+				if (!u.username && !u.password && canon
+						&& addressHref(host) === shown) {
+					return cam.url;
+				}
+			} catch (e) { /* unparseable: fall through to the address */ }
+		}
+		return shown;
+	}
+
+	// --- the switcher ---------------------------------------------------------
+
+	function hide(box) {
+		if (box) box.classList.add('d-none');
+	}
+
+	function build(box, cameras) {
+		if (!Array.isArray(cameras)) { hide(box); return; }
+
+		var self = null;
+		var others = [];
+		cameras.forEach(function (cam) {
+			if (!cam || typeof cam !== 'object') return;
+			if (cam.self) { if (!self) self = cam; return; }
+			var href = cameraHref(cam);
+			if (href) others.push({ cam: cam, href: href });
+		});
+
+		// Nothing to switch to: leave the control hidden, so a lone camera or an
+		// off-link admin sees nothing new, and its presence means "others exist".
+		if (!others.length) { hide(box); return; }
+
+		var name = box.querySelector('#cam-switch-name');
+		if (name) name.textContent = (self && self.name) || 'This camera';
+
+		var count = box.querySelector('#cam-switch-count');
+		if (count) count.textContent = '+' + others.length;
+
+		var menu = box.querySelector('#cam-switch-menu');
+		menu.replaceChildren();
+
+		others.forEach(function (entry) {
+			var a = document.createElement('a');
+			a.className = 'dropdown-item d-flex align-items-center gap-2';
+			a.href = entry.href;
+
+			var label = document.createElement('span');
+			label.textContent = entry.cam.name || entry.cam.address;
+			a.appendChild(label);
+
+			var addr = document.createElement('span');
+			addr.className = 'ms-auto small text-secondary';
+			addr.textContent = entry.cam.address;
+			a.appendChild(addr);
+
+			var li = document.createElement('li');
+			li.appendChild(a);
+			menu.appendChild(li);
+		});
+
+		var sep = document.createElement('li');
+		sep.innerHTML = '<hr class="dropdown-divider">';
+		menu.appendChild(sep);
+
+		var allLi = document.createElement('li');
+		var all = document.createElement('a');
+		all.className = 'dropdown-item';
+		all.href = '/cameras.html';
+		all.textContent = 'See all cameras…';
+		allLi.appendChild(all);
+		menu.appendChild(allLi);
+
+		box.classList.remove('d-none');
+	}
+
+	function refresh() {
+		var box = document.getElementById('cam-switch');
+		if (!box) return;
+
+		// apiFetch (main.js) carries the session and never 401s this endpoint —
+		// 200 on-link, 404 off-link or on a majestic without it. Anything but a
+		// good JSON body leaves the switcher hidden.
+		apiFetch('/api/v1/peers', { headers: { 'Accept': 'application/json' } })
+			.then(function (r) { return r.ok ? r.json() : null; })
+			.then(function (data) { build(box, data && data.cameras); })
+			.catch(function () { hide(box); });
+	}
+
+	function start() {
+		refresh();
+		setInterval(refresh, REFRESH_MS);
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', start);
+	} else {
+		start();
+	}
+}());

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -19,6 +19,7 @@ Pragma: no-cache
 	<link rel="stylesheet" href="/a/bootstrap.override.css">
 	<script src="/a/bootstrap.bundle.min.js"></script>
 	<script src="/a/main.js"></script>
+	<script src="/a/cameras-switch.js" defer></script>
 </head>
 
 <body id="page-<%= $pagename %>" class="<%= $fw_variant %>">
@@ -83,6 +84,27 @@ Pragma: no-cache
 						</ul>
 					</li>	
 					<li class="nav-item"><a class="nav-link" href="preview.cgi">Preview</a></li>
+					<!-- Other OpenIPC cameras on this link. Hidden until
+					     /a/cameras-switch.js confirms there are peers; inert
+					     markup, filled by JS with textContent (peer names are
+					     untrusted), so nothing is interpolated server-side. -->
+					<li class="nav-item dropdown d-none" id="cam-switch">
+						<!-- The label is this camera's own hostname, which the user
+						     can set to anything, so it is coloured with the brand
+						     accent and given a camera glyph to read as "the device
+						     you are on" rather than another menu word. -->
+						<a aria-expanded="false" class="nav-link dropdown-toggle d-inline-flex align-items-center gap-1 text-primary" data-bs-toggle="dropdown" href="#" id="cam-switch-toggle" role="button">
+							<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+								<path d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2z"/>
+							</svg>
+							<span class="fw-semibold" id="cam-switch-name">This camera</span>
+							<!-- "+N" for the other cameras: reads as "N more" rather
+							     than a bare count, and stays muted so it does not
+							     compete with the accented hostname. -->
+							<span class="small fw-normal text-body-secondary" id="cam-switch-count"></span>
+						</a>
+						<ul aria-labelledby="cam-switch-toggle" class="dropdown-menu dropdown-menu-end" id="cam-switch-menu"></ul>
+					</li>
 					<li class="nav-item"><a class="nav-link" href="#" id="nav-logout" title="Sign out">Sign out</a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
The `openipc.local` camera selector (#165) only helps someone who already knows to type that name. Anyone administering a camera by its IP or its own hostname never learns the others on the LAN exist. This surfaces them from **inside the authenticated UI** — a switcher in the top navbar, on every page, listing the other OpenIPC cameras on the link with one-click jump to each.


```
Information  Majestic  Firmware  Tools  Extensions  Preview  📷 openipc-hi3516av300 +4 ▾  Sign out
                                                                    │
                                              openipc-gk7205v200   10.216.128.49
                                              openipc-hi3516ev300  10.216.128.68
                                              openipc-hi3516cv300  10.216.128.52
                                              openipc-t31          10.216.128.35
                                              ─────────────────────────────────
                                              See all cameras…
```

## How it works

Fed by `GET /api/v1/peers` — the same roster the `openipc.local` page uses. That endpoint is **subnet-gated** and **absent on older majestic** (a 404 either way), and the switcher treats both as "nothing to show" and stays hidden. So there is **no new disclosure and no hard version dependency**: on a camera without the backend, or reached from off the discovery link, the control simply does not appear. Its presence means there are others here.

The label is **this camera's own hostname**, coloured with the brand accent and given a camera glyph so a user-set name reads as *the device you are on* rather than another menu word; a muted **+N** says how many others exist. The dropdown lists them by hostname and address, with **See all cameras…** through to `/cameras.html`.

## Shape

- Lives in `header.cgi` (the nav, included on every page) + a new `/a/cameras-switch.js` loaded after `main.js`, whose `apiFetch` it reuses. No new page, no backend change.
- Re-reads the roster on a lazy **60 s** timer, not off `main.js`'s 2 s heartbeat — peers change slowly (30 s discovery sweep).
- The href validation is **copied from `www/cameras.html`**, not shared: that page is served pre-auth and cannot pull `/a/*.js`. The roster is untrusted network input in both, so the copies must stay identical. A link is built only when its target is a literal IP **matching the address shown**; a published `url` is honoured only when its host equals that address and carries no userinfo; malformed entries are dropped; names are written with `textContent`.

## Verified

Against a link of six OpenIPC cameras (headless Chromium, live authenticated session):

- switcher shows this camera + the five others, each a validated link, `See all` → `/cameras.html`
- a roster of **only this camera**, an **empty/non-array** body, or a **404** endpoint all leave it **hidden**
- **malformed** (`null`, non-string address, `evil.tld`, `10.0.0.1@evil.tld`, leading-zero octets) and **misdirecting** (`url` host ≠ shown address) entries are dropped
- IPv6 addresses (incl. uppercase/uncompressed) bracket correctly

Valid HTML5, no new dependency, no `/a/*` requirement (self-populates via JS); ships in the dist tarball with no `build-dist.sh` change.

Needs a majestic that serves `GET /api/v1/peers`; against a build without it the switcher stays hidden.
