### PR TITLE
settings: teach visibleWhen notEquals and in, fail open on unknown

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -487,6 +487,19 @@
 		}
 	}
 
+	// Evaluate a visibleWhen condition against the controlling field's value.
+	// Supports equals (v === value), notEquals (v !== value) and in (v is one
+	// of a list). An unrecognised operator returns true — a field is shown
+	// rather than stranded invisible when a newer schema uses a condition this
+	// build does not know yet.
+	function visMatches(vw, v) {
+		v = String(v);
+		if ('equals' in vw) return v === String(vw.equals);
+		if ('notEquals' in vw) return v !== String(vw.notEquals);
+		if (Array.isArray(vw.in)) return vw.in.map(String).includes(v);
+		return true;
+	}
+
 	function applyVisibility() {
 		state.visUpdaters = [];
 		const byDot = {};
@@ -497,7 +510,7 @@
 			const parent = f.dot.slice(0, f.dot.lastIndexOf('.'));
 			const ctrl = byDot[parent + '.' + vw.field];
 			if (!ctrl) continue;
-			const update = () => { f.p.style.display = String(ctrl.getValue()) === String(vw.equals) ? '' : 'none'; };
+			const update = () => { f.p.style.display = visMatches(vw, ctrl.getValue()) ? '' : 'none'; };
 			ctrl.control.addEventListener('change', update);
 			ctrl.control.addEventListener('input', update);
 			state.visUpdaters.push(update);


### PR DESCRIPTION
`visibleWhen` has only ever matched equality, so a field could be shown when a sibling holds a value but not when it holds *anything but* that value. The OSD placement settings in majestic want the second kind — the offset inputs belong on screen for every anchor except `proportional`, where the legacy `posX`/`posY` apply instead.

## Change

`visMatches()` now understands three operators:

| schema | shown when |
| --- | --- |
| `{field, equals: "v"}` | control === v (unchanged) |
| `{field, notEquals: "v"}` | control !== v (new) |
| `{field, in: ["a","b"]}` | control is one of the list (new) |

An **unrecognised** operator returns `true` — a field a newer schema gates with a condition this build does not know is shown rather than stranded invisible. `equals` is untouched, so every existing schema behaves exactly as before.

## Why fail-open matters

It makes the pairing safe across version skew. When majestic emits `notEquals` on the OSD offsets and `equals` on `posX`/`posY`, a camera running an **older** WebUI (which only knows `equals`) sees the offsets' `notEquals` as unknown → shows them, and shows `posX`/`posY` on the `equals` match — i.e. it degrades to "all four fields shown", today's behaviour, rather than hiding a field permanently.

## Tested

`node --check` clean. The evaluator by table:

```
equals proportional   vs proportional   -> show
equals proportional   vs top-left       -> hide
notEquals proportional vs proportional  -> hide
notEquals proportional vs bottom-right  -> show
in [top,bottom]       vs top            -> show
in [top,bottom]       vs left           -> hide
unknown operator                        -> show (fail open)
boolean true          vs "true"         -> show   (usbcam/uvcgadget enabled gates)
```

Pairs with OpenIPC/majestic#379 (the schema-emitting half). Land this first, or in the same firmware, so the majestic side has a frontend that understands `notEquals`.
