### PR TITLE
endpoints: show the address the browser actually used

### DIFF
--- a/www/a/main.js
+++ b/www/a/main.js
@@ -335,6 +335,20 @@ function initAll() {
 		});
 	});
 
+	// Endpoint URLs are rendered server-side against the camera's default-route
+	// address, which is wrong the moment the WebUI is reached over a VPN, a
+	// reverse proxy or a hostname (issue #164). Rewrite them to the address the
+	// browser actually used. This has to happen here rather than in the haserl:
+	// majestic's CGI bridge passes neither the port nor the scheme, and libevent
+	// strips the port off HTTP_HOST. Runs before the .cp2cb wiring below so a
+	// copy picks up the rewritten text.
+	const epTls = location.protocol === 'https:';
+	$$('.ep-http').forEach(el => el.textContent = epTls ? 'https' : 'http');
+	$$('.ep-ws').forEach(el => el.textContent = epTls ? 'wss' : 'ws');
+	// host and hostname both keep the brackets an IPv6 literal needs in a URL
+	$$('.ep-host').forEach(el => el.textContent = location.host);      // host[:port]
+	$$('.ep-addr').forEach(el => el.textContent = location.hostname);  // RTSP has its own port
+
 	// click-to-copy for .cp2cb snippets (HTTPS uses the clipboard API, plain
 	// http falls back to a hidden textarea + execCommand)
 	$$('.cp2cb').forEach(el => {

--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -76,7 +76,7 @@ fi
 			<h3>Remote send</h3>
 			<dl class="small list mb-0">
 				<dt>Webhook</dt>
-				<dd class="text-break cp2cb">http://root:PASSWORD@<%= $network_address %>/cgi-bin/ext-telegram.cgi?send=image</dd>
+				<dd class="text-break cp2cb"><span class="ep-http">http</span>://root:PASSWORD@<span class="ep-host"><%= $network_address %></span>/cgi-bin/ext-telegram.cgi?send=image</dd>
 			</dl>
 			<p class="small text-secondary mt-2">Call this URL to trigger an image send. Click to copy, then replace <code>PASSWORD</code> with your WebUI password.</p>
 		</div></div>

--- a/www/cgi-bin/fw-settings.cgi
+++ b/www/cgi-bin/fw-settings.cgi
@@ -50,7 +50,7 @@ fi
 
 			<hr class="my-3">
 			<p class="small text-secondary mb-1">Or create one remotely (click to copy, then replace <code>PASSWORD</code> with your WebUI password):</p>
-			<pre class="cp2cb small mb-0">wget --content-disposition http://root:PASSWORD@<%= $network_address %>/cgi-bin/ext-backuper.cgi?backup=create</pre>
+			<pre class="cp2cb small mb-0">wget --content-disposition <span class="ep-http">http</span>://root:PASSWORD@<span class="ep-host"><%= $network_address %></span>/cgi-bin/ext-backuper.cgi?backup=create</pre>
 
 			<details class="mt-3">
 				<summary class="small">Restore from a backup (manual)</summary>

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -2,10 +2,23 @@
 <%in p/common.cgi %>
 <% page_title="Majestic Endpoints"
 
+# Ask the live config rather than majestic.yaml, which omits keys left at their
+# default.
+mj_config=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null)
+
 # system.unsafe switches authentication off for every HTTP and RTSP endpoint, so
-# the credentials note below would be wrong. Ask the live config rather than
-# majestic.yaml, which omits keys left at their default.
-mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilter -e '@.system.unsafe' 2>/dev/null)
+# the credentials note below would be wrong.
+mj_unsafe=$(echo "$mj_config" | jsonfilter -e '@.system.unsafe' 2>/dev/null)
+
+# Hosts below are placeholders: every HTTP and WebSocket endpoint here is served
+# on the WebUI's own origin, so main.js overwrites the .ep-* spans with the
+# address the browser actually used. RTSP is the exception — its port is its
+# own, and only the default 554 may be left out of the URL.
+rtsp_port=$(echo "$mj_config" | jsonfilter -e '@.rtsp.port' 2>/dev/null)
+case "$rtsp_port" in
+	''|*[!0-9]*) rtsp_port=554 ;;
+esac
+[ "$rtsp_port" = "554" ] && rtsp_suffix= || rtsp_suffix=":$rtsp_port"
 %>
 
 <%in p/header.cgi %>
@@ -20,23 +33,23 @@ mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilt
 	<div class="col">
 		<h3>Video</h3>
 		<dl>
-			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=0</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><%= $rtsp_suffix %>/stream=0</dt>
 			<dd>RTSP main stream.</dd>
-			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=1</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><%= $rtsp_suffix %>/stream=1</dt>
 			<dd>RTSP sub stream.</dd>
-			<dt class="cp2cb">rtsp://<%= $network_address %>/stream=2</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><%= $rtsp_suffix %>/stream=2</dt>
 			<dd>RTSP JPEG stream.</dd>
-			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=0</dt>
+			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><%= $network_address %></span>/ws/video?stream=0</dt>
 			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview). Append <code>&amp;audio=opus,mp4a.40.2</code> to mux in an audio track for the codecs your player accepts.</dd>
-			<dt class="cp2cb">ws://<%= $network_address %>/ws/video?stream=1</dt>
+			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><%= $network_address %></span>/ws/video?stream=1</dt>
 			<dd>Low-latency H.264/H.265 sub stream (fMP4/MSE).</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/mjpeg</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/mjpeg</dt>
 			<dd>MJPEG video stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/video.mp4</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/video.mp4</dt>
 			<dd>MP4 video stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/hls</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/hls</dt>
 			<dd>HLS live-streaming in web browser.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/mjpeg.html</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/mjpeg.html</dt>
 			<dd>MJPEG live-streaming in web browser.</dd>
 		</dl>
 	</div>
@@ -44,19 +57,19 @@ mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilt
 	<div class="col">
 		<h3>Audio</h3>
 		<dl>
-			<dt class="cp2cb">http://<%= $network_address %>/audio.opus</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.opus</dt>
 			<dd>Opus audio stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/audio.m4a</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.m4a</dt>
 			<dd>AAC audio stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/audio.pcm</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.pcm</dt>
 			<dd>Raw PCM audio stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/audio.alaw</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.alaw</dt>
 			<dd>A-law compressed audio stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/audio.ulaw</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.ulaw</dt>
 			<dd>μ-law compressed audio stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/audio.g711a</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.g711a</dt>
 			<dd>G.711 A-law audio stream.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/play_audio</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/play_audio</dt>
 			<dd>Play audio file on camera speaker.</dd>
 		</dl>
 	</div>
@@ -64,11 +77,11 @@ mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilt
 	<div class="col">
 		<h3>Images</h3>
 		<dl>
-			<dt class="cp2cb">http://<%= $network_address %>/image.jpg</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/image.jpg</dt>
 			<dd>Snapshot in JPEG format.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/image.heif</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/image.heif</dt>
 			<dd>Snapshot in HEIF format.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/image.yuv420</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/image.yuv420</dt>
 			<dd>Snapshot in YUV420 format.</dd>
 		</dl>
 	</div>
@@ -76,15 +89,15 @@ mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilt
 	<div class="col">
 		<h3>Night</h3>
 		<dl>
-			<dt class="cp2cb">http://<%= $network_address %>/night/on</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/on</dt>
 			<dd>Turn on night mode.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/night/off</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/off</dt>
 			<dd>Turn off night mode.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/night/toggle</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/toggle</dt>
 			<dd>Toggle night mode.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/night/ircut</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/ircut</dt>
 			<dd>Toggle camera ircut.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/night/light</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/light</dt>
 			<dd>Toggle camera light.</dd>
 		</dl>
 	</div>
@@ -92,13 +105,13 @@ mj_unsafe=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null | jsonfilt
 	<div class="col">
 		<h3>Monitoring</h3>
 		<dl>
-			<dt class="cp2cb">http://<%= $network_address %>/api/v1/config.json</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/api/v1/config.json</dt>
 			<dd>Default Majestic config in JSON format.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/api/v1/config.schema.json</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/api/v1/config.schema.json</dt>
 			<dd>Available Majestic settings in JSON format.</dd>
 			<dt><a href="https://github.com/openipc/wiki/blob/master/en/majestic-config.md">https://github.com/openipc/wiki</a></dt>
 			<dd>Available Majestic settings in YAML format.</dd>
-			<dt class="cp2cb">http://<%= $network_address %>/metrics</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/metrics</dt>
 			<dd>Node exporter for <a href="https://prometheus.io">Prometheus</a>.</dd>
 		</dl>
 	</div>

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -14,10 +14,17 @@ mj_unsafe=$(echo "$mj_config" | jsonfilter -e '@.system.unsafe' 2>/dev/null)
 # on the WebUI's own origin, so main.js overwrites the .ep-* spans with the
 # address the browser actually used. RTSP is the exception — its port is its
 # own, and only the default 554 may be left out of the URL.
+#
+# Majestic only range-checks rtsp.port on the write path, so a hand-edited
+# majestic.yaml can leave a port no URL can use. Anything outside 1-65535 falls
+# back to the default a bare rtsp:// implies. The ?????? arm drops 6-digit and
+# longer values before the numeric test, which has no defined behaviour once
+# the operand no longer fits a long.
 rtsp_port=$(echo "$mj_config" | jsonfilter -e '@.rtsp.port' 2>/dev/null)
 case "$rtsp_port" in
-	''|*[!0-9]*) rtsp_port=554 ;;
+	''|*[!0-9]*|??????*) rtsp_port=554 ;;
 esac
+[ "$rtsp_port" -ge 1 ] && [ "$rtsp_port" -le 65535 ] || rtsp_port=554
 [ "$rtsp_port" = "554" ] && rtsp_suffix= || rtsp_suffix=":$rtsp_port"
 %>
 


### PR DESCRIPTION
Fixes #164.

### The bug

`mj-endpoints.cgi` built all 27 URLs from `$network_address` — the source address of the camera's default route (`p/common.cgi:540`). Reach the WebUI over a VPN, a reverse proxy or a hostname and every link points at a LAN address the client can't resolve.

### Why it isn't a `HTTP_HOST` fix

The issue suggests reading the `Host` header server-side. That can't work here. Majestic's CGI bridge (`on_cgi_bin`, `src/websrv/api.c`) sets exactly `QUERY_STRING`, `SCRIPT_NAME`, `HTTP_HOST`, `HTTP_REFERER`, `HTTP_COOKIE`, `REQUEST_METHOD`, `CONTENT_TYPE`, `CONTENT_LENGTH` — no `SERVER_PORT`, no scheme. And `HTTP_HOST` comes from libevent's `evhttp_request_get_host()`, which deliberately **strips the port** off the header. So the haserl would:

- **lose the port** — `http://proxy:8080/` renders as `http://proxy/image.jpg`, which is the reverse-proxy case the issue is about (`system.webPort` is configurable 1–65535);
- **guess the scheme wrong** — majestic serves real TLS on `system.httpsPort`, so the links would stay `http://`/`ws://` and get blocked as mixed content;
- **render an unvalidated attacker-supplied header** into the page.

### What this does instead

Host and scheme become spans that `main.js` fills from `location` — the same source `logs.js`, `preview.js` and `fw-update.js` already use to build their WS handshake URLs:

| span | filled with |
|---|---|
| `.ep-http` | `http` / `https` per `location.protocol` |
| `.ep-ws` | `ws` / `wss` |
| `.ep-host` | `location.host` — host and port |
| `.ep-addr` | `location.hostname` — no port, for RTSP |

The server still renders `$network_address` into those spans, so with JS off the page is byte-for-byte what it is today. `.cp2cb` reads `textContent` at click time, so click-to-copy picks up the rewritten text with no change.

RTSP is the one endpoint not on the WebUI's origin: it gets the host without a port, plus `rtsp.port` from the live config when that isn't the default 554 — which the page ignored entirely before. The same `config.json` fetch that already backed the `system.unsafe` notice is reused, so there's no extra request.

The remote-webhook snippets on **Settings** and **Telegram** carried the same hardcoded address and get the same two spans.

### Caveat

An `rtsp://` link aimed at a VPN or proxy host only resolves if 554/TCP is forwarded too — the WebUI can't know that. It's still strictly better than today's LAN address, which is unreachable by definition in that scenario.

### Testing

Headless chromium against the rendered page, three ways:

| accessed as | RTSP | WS | HTTP |
|---|---|---|---|
| `http://127.0.0.1:8731/` | `rtsp://127.0.0.1:8554/stream=0` | `ws://127.0.0.1:8731/ws/video?stream=0` | `http://127.0.0.1:8731/mjpeg` |
| `https://127.0.0.1:8732/` | `rtsp://127.0.0.1:8554/stream=0` | `wss://127.0.0.1:8732/ws/video?stream=0` | `https://127.0.0.1:8732/mjpeg` |
| `http://[::1]:8733/` | `rtsp://[::1]:8554/stream=0` | `ws://[::1]:8733/ws/video?stream=0` | `http://[::1]:8733/mjpeg` |

The IPv6 row caught a bug in the first draft: `location.hostname` already brackets an IPv6 literal, so bracketing it again gave `[[::1]]`. Both `host` and `hostname` keep the brackets; no special case needed.

`tools/lint-templates.sh` passes (29 templates, 16 shell scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
