### PR TITLE
auth: declare the in-page fetches that opt out of apiFetch (#120)

### DIFF
--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -331,7 +331,7 @@
 		const ctl = new AbortController();
 		const to = setTimeout(() => ctl.abort(), 5000);
 		try {
-			const r = await fetch('fw-update.cgi?_=' + Date.now(), { credentials: 'same-origin', cache: 'no-store', signal: ctl.signal });
+			const r = await rawFetch('fw-update.cgi?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal });
 			// Reachable, but our session no longer authenticates: the reboot cleared
 			// it and a form login left no Basic to fall back on. That is itself proof
 			// the camera came back — report it so the caller sends us to sign in,
@@ -413,7 +413,7 @@
 		const ctl = new AbortController();
 		const to = setTimeout(() => ctl.abort(), 2500);
 		try {
-			const r = await fetch('/cgi-bin/j/pulse.cgi?_=' + Date.now(), { credentials: 'same-origin', cache: 'no-store', signal: ctl.signal });
+			const r = await rawFetch('/cgi-bin/j/pulse.cgi?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal });
 			// A 401 here is ambiguous — the session can be dropped without a reboot
 			// (it expires, or another tab signs out) — so it is not proof of one.
 			// Treat it as "can't tell" and let the unauthenticated / ping below be
@@ -439,7 +439,12 @@
 		function ping() {
 			const ctl = new AbortController();
 			const to = setTimeout(() => ctl.abort(), 2500);
-			return fetch('/?_=' + Date.now(), { credentials: 'same-origin', cache: 'no-store', signal: ctl.signal })
+			// Only reachability is asked here, and "/" is one of the few paths
+			// majestic serves without auth, so any answer at all — including a 401
+			// a future build might start sending — means the camera is back.
+			// rawFetch all the same: it costs nothing, and it leaves no bare
+			// same-origin fetch in this file for the next reader to copy.
+			return rawFetch('/?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal })
 				.then(() => { clearTimeout(to); return true; })
 				.catch(() => { clearTimeout(to); return false; });
 		}
@@ -488,7 +493,7 @@
 		showProgress();
 		status('warning', 'Uploading firmware…');
 		try {
-			const r = await fetch('/upload', { method: 'POST', credentials: 'same-origin', headers: { 'File-Location': '/tmp/firmware.tgz' }, body: f });
+			const r = await rawFetch('/upload', { method: 'POST', headers: { 'File-Location': '/tmp/firmware.tgz' }, body: f });
 			if (!r.ok) { status('danger', 'Upload failed (' + r.status + ').'); resumeHeartbeat(); return; }
 			append('Uploaded ' + f.name + ' (' + f.size + ' bytes)\n');
 			startUpgrade('/tmp/firmware.tgz');

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -33,7 +33,13 @@ function sleep(ms) {
 // makeTextFileLineIterator below streams the factory reset that destroys the
 // session in the first place. A blanket redirect would race both and throw the
 // transcript away. Anything that wants this behaviour opts in.
-function apiFetch(url, init) {
+//
+// Those pages still need the HEADER, though, and that is the half that was
+// missed: suppressing the dialog and redirecting on 401 are separate concerns,
+// and only the second is what they opt out of. rawFetch is the first half on its
+// own — every same-origin request that can be answered 401 goes through one of
+// the two, or Safari raises the native prompt this pair exists to prevent.
+function rawFetch(url, init) {
 	const opts = Object.assign({ credentials: 'same-origin' }, init || {});
 	// Declare ourselves rather than leaving majestic to infer it. The signal it
 	// had to work from — Sec-Fetch-Dest — is attached by the browser, not by us:
@@ -49,7 +55,11 @@ function apiFetch(url, init) {
 	const headers = new Headers(opts.headers || {});
 	headers.set('X-Requested-With', 'XMLHttpRequest');
 	opts.headers = headers;
-	return fetch(url, opts).then(r => {
+	return fetch(url, opts);
+}
+
+function apiFetch(url, init) {
+	return rawFetch(url, init).then(r => {
 		if (r.status !== 401) return r;
 		// replace(), not href: this document is already dead — the promise below
 		// never settles, so anything awaiting it stays awaiting forever. Leaving a
@@ -110,7 +120,7 @@ function setProgressBar(id, value, name) {
 	}
 }
 
-// Plain fetch, not apiFetch, and it has to stay that way. Its only caller is
+// rawFetch, not apiFetch, and it has to stay that way. Its only caller is
 // runCmd() on fw-reset.cgi, which streams `sysupgrade -s -n -x --web` — the
 // factory reset that erases the overlay, /etc/majestic.token with it, and reboots.
 // Losing the session is the EXPECTED end of this request, not an error, and the
@@ -118,9 +128,14 @@ function setProgressBar(id, value, name) {
 // on a 401 here would blank the transcript at the moment it matters most, and
 // the never-settling promise apiFetch hands back would strand the loop below
 // before it could run the fw-restart.cgi hop at the end.
+//
+// rawFetch rather than a bare fetch, though: the wipe destroys the session this
+// stream is running on, so the reconnect after it is exactly the request that
+// gets a 401 — and without the header majestic attaches WWW-Authenticate to it
+// and Safari prompts on top of the transcript.
 async function* makeTextFileLineIterator(url) {
 	const td = new TextDecoder('utf-8');
-	const response = await fetch(url, { credentials: 'same-origin' });
+	const response = await rawFetch(url);
 	const rd = response.body.getReader();
 	let { value: chunk, done: readerDone } = await rd.read();
 	chunk = chunk ? td.decode(chunk) : '';

--- a/www/login.html
+++ b/www/login.html
@@ -57,10 +57,21 @@
 			border: 1px solid #842029; border-radius: .375rem; font-size: .875rem;
 		}
 		.alert.show { display: block; }
+		/* Held back until the already-signed-in probe below has had its say, so a
+		   browser that arrives here holding a good session never paints a sign-in
+		   form it is about to be redirected away from. Current majestic decides
+		   this before the page is sent and this never matters; it is what stops
+		   the flash on a camera whose majestic predates that. */
+		#login[hidden] { display: none; }
 	</style>
+	<noscript>
+		<!-- No script means no probe to wait for, and no redirect either. The
+		     form is all there is, so show it. -->
+		<style>#login[hidden] { display: block; }</style>
+	</noscript>
 </head>
 <body>
-	<form class="card" id="login" autocomplete="on">
+	<form class="card" id="login" autocomplete="on" hidden>
 		<h1>Open<span>IPC</span></h1>
 		<div class="alert" id="err" role="alert"></div>
 		<label for="username">Username</label>
@@ -120,13 +131,35 @@
 			//
 			// A 3xx arrives as an opaque redirect: status 0, ok false. Only a real
 			// 200 means the session is live.
+			// Reveal the form only once the probe has ruled out "already signed
+			// in". Anything but a live session shows it — including a camera that
+			// cannot be reached at all, where the form is the only useful thing
+			// this page has. The timer is the backstop: a probe that neither
+			// resolves nor rejects (a half-open socket to a rebooting camera) must
+			// not leave a blank card on screen for ever.
+			var shown = false;
+			function showForm() {
+				if (shown) return;
+				shown = true;
+				form.hidden = false;
+				// autofocus is evaluated at parse time, when the form was hidden.
+				document.getElementById('password').focus();
+			}
+			var revealTimer = setTimeout(showForm, 1500);
+
 			fetch('/cgi-bin/j/pulse.cgi', {
 				credentials: 'same-origin',
 				redirect: 'manual',
 				headers: { 'Accept': 'text/html' }
 			}).then(function (r) {
-				if (r.ok) location.replace(safeNext());
-			}).catch(function () { /* offline: show the form */ });
+				if (r.ok) {
+					// Signed in already — leave the form hidden, we are navigating.
+					clearTimeout(revealTimer);
+					location.replace(safeNext());
+					return;
+				}
+				showForm();
+			}).catch(function () { /* offline: show the form */ showForm(); });
 
 			form.addEventListener('submit', function (ev) {
 				ev.preventDefault();


### PR DESCRIPTION
`usa-` reports the Basic Auth dialog **still** appears after an unconditional reboot when *Stay signed in on this device* was left unticked — the case #154 was meant to have closed — and that a restored tab flashes the sign-in form for a second or two before redirecting.

## Why the dialog survived

majestic omits `WWW-Authenticate` from a 401 when the request declares itself in-page. `Sec-Fetch-Dest` can't carry that alone: Safari ships Fetch Metadata only from 16.4, and browsers withhold it from origins they don't consider trustworthy — the plain-HTTP address a camera is normally reached at. So `apiFetch()` sets `X-Requested-With`, which depends on neither.

But `apiFetch()` **also** redirects to the login page on 401, and some pages must outlive their own session: `fw-update.js` watches the camera through a reboot it *expects* a 401 from, and `makeTextFileLineIterator` streams the factory reset that destroys the session it's running on. Both opted out by calling bare `fetch()` — and silently lost the header too, which was never the intent.

Suppressing the dialog and redirecting on 401 are separate concerns; only the second is what those callers meant to decline. `rawFetch()` is now the first half on its own, `apiFetch()` layers on top, and the four deliberate opt-outs take `rawFetch`.

`rebootedAlready()` (pulse.cgi) and `installedNow()` (fw-update.cgi) are the two that matter — they poll in exactly the window where the session is gone, which is why the prompt survived the previous fix.

## Measured against a camera, unauthenticated

| request shape | response |
|---|---|
| `Accept: */*` | 401 **+ WWW-Authenticate** → dialog |
| `Accept: */*` + `X-Requested-With` | 401, no challenge |
| `curl`, no headers (CLI shape) | 401 + WWW-Authenticate (unchanged) |

CLI clients are untouched — only a browser gets the dialog, and only a browser sends the header.

## The flash on a restored tab

The page can't know it's signed in until its probe returns, by which time it has painted. Majestic decides this before the page is sent (companion change on the daemon side), so here the form is simply held back until the probe has had its say — with a `noscript` override, since no script means no probe to wait for, and a 1.5 s backstop so a half-open socket to a rebooting camera can't leave a blank card on screen.

Verified in headless Chromium: form reveals when signed out; no flash when signed in.

Reported-by: `usa-`
Ref: #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)