### PR TITLE
settings: fix three review findings from #173 and #174

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -172,14 +172,19 @@
 	const RENDERABLE = new Set(['boolean', 'integer', 'string', 'array']);
 
 	// A field hidden by visibleWhen is not on the page, so a search must not
-	// count it. Same rule the rendered page applies (visMatches), evaluated
-	// against the saved config rather than the DOM because the controlling
-	// section may not be mounted.
+	// count it. Same rule the rendered page applies (visMatches) — and against
+	// the same value: the mounted control when the controlling field is on
+	// screen, including an edit that has not been saved yet, falling back to the
+	// saved config and then the schema default for sections that are not
+	// rendered. Reading only the config made the count disagree with the page
+	// as soon as someone touched a controller.
 	function fieldVisible(f) {
 		const vw = f.sub && f.sub.visibleWhen;
 		if (!vw || !vw.field) return true;
 		const parent = f.dot.slice(0, f.dot.lastIndexOf('.'));
 		const sibDot = parent + '.' + vw.field;
+		const mounted = (state.fields || []).find(x => x.dot === sibDot);
+		if (mounted) return visMatches(vw, mounted.getValue());
 		let v = getDotted(state.config, sibDot);
 		if (v === undefined) {
 			const sib = sectionFields(f.dot.split('.')[0]).find(x => x.dot === sibDot);
@@ -555,6 +560,11 @@
 
 		applyVisibility();
 
+		// renderField writes labels as plain text; with a query already active,
+		// the section just mounted has to pick up the marks too, or navigating
+		// to a hit highlights its hints and not its field names.
+		highlightPanel();
+
 		updateDirty();
 	}
 
@@ -729,6 +739,7 @@
 
 	function applyVisibility() {
 		state.visUpdaters = [];
+		const controllers = new Set();
 		const byDot = {};
 		for (const f of state.fields) byDot[f.dot] = f;
 		for (const f of state.fields) {
@@ -742,6 +753,14 @@
 			ctrl.control.addEventListener('input', update);
 			state.visUpdaters.push(update);
 			update();
+			// flipping a controller changes which rows exist, so a live search
+			// has to recount. Once per controller, not once per dependent field.
+			if (!controllers.has(ctrl)) {
+				controllers.add(ctrl);
+				const recount = () => { if (state.q.trim()) buildNav(); };
+				ctrl.control.addEventListener('change', recount);
+				ctrl.control.addEventListener('input', recount);
+			}
 		}
 	}
 
@@ -1119,15 +1138,19 @@
 			// nothing pending: leave the hidden bar empty rather than parked on a
 			// stale message
 			lbl.textContent = n
-				? (n + ' change' + (n === 1 ? '' : 's') + ' pending.')
+				? (n + ' change' + (n === 1 ? '' : 's') + ' pending.' +
+					(apply ? ' A pipeline reload is still due.' : ''))
 				: (apply
 					? 'Saved. Resolution, codec and frame-rate changes take effect after a pipeline reload (the video streams will blink briefly).'
 					: '');
 		}
 		const save = document.getElementById('mj-save');
 		if (save) save.classList.toggle('d-none', n === 0);
+		// Apply reloads the pipeline and the page with it, which would throw
+		// away unsaved edits — and two buttons at once is a fourth state the
+		// three-state model does not have. Save first; Apply comes back after.
 		const applyBtn = document.getElementById('mj-apply-btn');
-		if (applyBtn) applyBtn.classList.toggle('d-none', !apply);
+		if (applyBtn) applyBtn.classList.toggle('d-none', !(apply && n === 0));
 	}
 
 	// A message that outranks the computed status until it is cleared (the

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -565,6 +565,11 @@
 		// to a hit highlights its hints and not its field names.
 		highlightPanel();
 
+		// Counts are read off the mounted controls, so swapping sections changes
+		// what they are read from — including when the swap discarded unsaved
+		// edits, which is exactly when the old numbers are wrong.
+		if (state.q.trim()) buildNav();
+
 		updateDirty();
 	}
 


### PR DESCRIPTION
Follow-up to #173 and #174. The automated review on both landed **seconds after each merge**, so none of it was addressed before landing. All three findings are real; this fixes them.

### 1. Highlights vanished on navigation (#173)

`renderField()` writes labels as plain text, and `highlightPanel()` only ran from the search box — so clicking a hit while a query was active marked that section's *hints* but not its *field names*. That is half of "matches highlighted in the tree and again in the open section".

`load()` now re-marks after rendering. It still cannot re-render the form per keystroke, which is the whole reason highlighting is in-place — that would reset every control and lose unsaved edits.

### 2. Visibility counts went stale (#173)

`fieldVisible()` evaluated `visibleWhen` against the **saved config**, while the mounted form evaluates the same rule against the control's **current** value. An unsaved change to a controller made the tree disagree with the page.

Concretely: search `offset` with `osd.anchor=proportional` and OSD is correctly absent (`offsetX`/`offsetY` are hidden). Flip the anchor to `topLeft` without saving and the two offset rows appear on the page — but OSD stayed out of the results.

It now prefers the mounted control, falling back to the saved config and then the schema default for sections that are not rendered. A controller change also recounts the tree while a search is live.

### 3. Apply was offered with unsaved edits (#174)

`Save Changes` showed on `dirtyN > 0` and `Apply now` on `applyPending`, independently — so both could appear at once. That is a fourth state the agreed three-state model does not have, and worse, `Apply` triggers `location.reload()`, which would have discarded the unsaved edits.

Apply is now gated on there being nothing unsaved. The pending reload is still a fact while editing, so the status carries it instead of losing it: *"1 change pending. A pipeline reload is still due."*

## Verified

On a hi3516av300 with the API proxied through so the save path is real:

- searching `codec` then clicking **Main stream** marks `Codec` in the label, not just the hints
- flipping `osd.anchor` **unsaved** moves OSD into the `offset` results with a count of `2`, matching the two rows that became visible
- save → edit → revert walks Apply-only, Save-only, Apply-only — never both

`tools/lint-templates.sh`, `node --check` and `tools/build-dist.sh` pass. The camera was left in the state it started in.
