### PR TITLE
endpoints: read majestic's config in the browser instead of via jsonfilter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This is a majestic-side feature; the WebUI just provides the login page and the 
 
 - `sbin/updatewebui [branch]` — fetches a branch zip from GitHub, wipes `/var/www`, then copies `sbin/*` → `/usr/sbin` and `www/*` → `/var/www`. This is the canonical "deploy from source" path. Default branch is `master`.
 - Edits to a running camera can also be made directly under `/var/www/cgi-bin/` and `/usr/sbin/`.
-- There is no local way to run the UI off-camera — every script assumes camera-side binaries (`majestic`, `yaml-cli`, `ipcinfo`, `fw_printenv`, `haserl`, `jsonfilter`, `jshn.sh`, `chpasswd`, `sysupgrade`).
+- There is no local way to run the UI off-camera — every script assumes camera-side binaries (`majestic`, `yaml-cli`, `ipcinfo`, `fw_printenv`, `haserl`, `chpasswd`, `sysupgrade`).
 
 ## Architecture
 

--- a/sbin/telegram
+++ b/sbin/telegram
@@ -22,12 +22,21 @@ else
 	telegram_message="$(echo "$telegram_caption" | sed "s/%hostname/$(hostname -s)/;s/%datetime/$(date +"%F %T")/;s/%soctemp/$(ipcinfo --temp)/")"
 fi
 
+# Both files below live in a private directory rather than straight in /tmp.
+# This script runs as root, from cron and from a webhook anyone who can reach the
+# camera can fire, and the old paths were fully predictable -- hostname and
+# timestamp for the snapshot, the pid for the response -- so a symlink planted at
+# either path would have been followed and clobbered. mktemp -d keeps the
+# snapshot's basename, which is what Telegram shows as the document name.
+workdir=$(mktemp -d /tmp/telegram.XXXXXX) || exit 1
+trap 'rm -rf "$workdir"' EXIT INT TERM
+
 filename="$(hostname -s | tr ' ' '-')"-"$(date +'%Y%m%d-%H%M%S')"
 if [ "$telegram_heif" = "true" ]; then
-	snapshot=/tmp/${filename}.heif
+	snapshot=$workdir/${filename}.heif
 	wget -q -T1 localhost/image.heif -O "$snapshot"
 else
-	snapshot=/tmp/${filename}.jpg
+	snapshot=$workdir/${filename}.jpg
 	wget -q -T1 localhost/image.jpg -O "$snapshot"
 fi
 
@@ -77,12 +86,11 @@ fi
 #
 # The command line is no longer echoed. It carries the bot token, and printing it
 # was the only reason the webhook had to filter its own output before parsing it.
-body=/tmp/telegram-response.$$
-command="${command} --output ${body} --write-out '%{http_code}'"
+body=$workdir/response.json
+command="${command} --output '${body}' --write-out '%{http_code}'"
 
 http=$(eval "$command")
 [ -s "$body" ] && cat "$body"
-rm -f "$body" "$snapshot"
 
 case "$http" in
 200) exit 0 ;;

--- a/sbin/telegram
+++ b/sbin/telegram
@@ -64,8 +64,27 @@ else
 	command="${command} -F 'caption=${telegram_message}'"
 fi
 
-echo "$command"
-eval "$command"
-rm -f "$snapshot"
+# The response body still goes to stdout for anyone running this by hand or out
+# of cron. What is new is the exit status: this used to `exit 0` unconditionally,
+# so a rejected send reported success and ext-telegram.cgi's ?send=image webhook
+# had to dig `ok` out of the JSON body with jsonfilter to find out otherwise.
+# Telegram answers a rejected send with 4xx, so the HTTP code alone settles it
+# and the camera no longer needs a JSON parser on flash for this.
+#
+# --write-out rather than --fail-with-body: curl is pinned at 7.76.0 in the
+# firmware, the very release that added --fail-with-body, so going through the
+# status code leaves no version floor to trip over later.
+#
+# The command line is no longer echoed. It carries the bot token, and printing it
+# was the only reason the webhook had to filter its own output before parsing it.
+body=/tmp/telegram-response.$$
+command="${command} --output ${body} --write-out '%{http_code}'"
 
-exit 0
+http=$(eval "$command")
+[ -s "$body" ] && cat "$body"
+rm -f "$body" "$snapshot"
+
+case "$http" in
+200) exit 0 ;;
+*) exit 1 ;;
+esac

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -364,6 +364,41 @@ function initAll() {
 	$$('.ep-host').forEach(el => el.textContent = location.host);      // host[:port]
 	$$('.ep-addr').forEach(el => el.textContent = location.hostname);  // RTSP has its own port
 
+	// ...and RTSP's own port is the one value on that page location cannot
+	// supply, along with whether majestic is serving everything unauthenticated.
+	// Both used to be read server-side out of /api/v1/config.json with
+	// jsonfilter, which cost the camera a shell-out to a JSON parser -- and the
+	// firmware a 63KB libubox -- to do what JSON.parse does here for nothing.
+	// Guarded on the spans so only mj-endpoints.cgi pays for the config fetch;
+	// mjConfig() caches, so a page that already asked does not ask twice.
+	//
+	// Majestic only range-checks rtsp.port on the write path, so a hand-edited
+	// majestic.yaml can leave a port no URL can use. Anything outside 1-65535 is
+	// ignored in favour of the default a bare rtsp:// implies, and 554 is left
+	// off the URL entirely.
+	if ($('.ep-rtsp') || $('#ep-unsafe')) mjConfig().then(cfg => {
+		// The old server-side read saw every value as a string, so a port that
+		// arrived quoted still worked. Coercing number|string (and nothing else,
+		// so a stray `true` cannot become port 1) keeps that latitude.
+		const raw = mjGet(cfg, 'rtsp.port');
+		const port = (typeof raw === 'number' || typeof raw === 'string') ? Number(raw) : NaN;
+		if (Number.isInteger(port) && port >= 1 && port <= 65535 && port !== 554)
+			$$('.ep-rtsp').forEach(el => el.textContent = ':' + port);
+
+		// The string form is accepted alongside the boolean on purpose. majestic
+		// reports unsafe as a JSON boolean, but jsonfilter printed `true` for
+		// either, and the two notes are not symmetric: failing to warn that
+		// authentication is off is the harmful direction, so anything that used to
+		// warn still warns. A key majestic is too old to report stays undefined
+		// and keeps the authenticated note, as before.
+		const unsafe = mjGet(cfg, 'system.unsafe');
+		if (unsafe === true || unsafe === 'true') {
+			const authNote = $('#ep-auth'), unsafeNote = $('#ep-unsafe');
+			if (authNote) authNote.hidden = true;
+			if (unsafeNote) unsafeNote.hidden = false;
+		}
+	});
+
 	// click-to-copy for .cp2cb snippets (HTTPS uses the clipboard API, plain
 	// http falls back to a hidden textarea + execCommand)
 	$$('.cp2cb').forEach(el => {

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -385,17 +385,23 @@ function initAll() {
 		if (Number.isInteger(port) && port >= 1 && port <= 65535 && port !== 554)
 			$$('.ep-rtsp').forEach(el => el.textContent = ':' + port);
 
-		// The string form is accepted alongside the boolean on purpose. majestic
-		// reports unsafe as a JSON boolean, but jsonfilter printed `true` for
-		// either, and the two notes are not symmetric: failing to warn that
-		// authentication is off is the harmful direction, so anything that used to
-		// warn still warns. A key majestic is too old to report stays undefined
-		// and keeps the authenticated note, as before.
-		const unsafe = mjGet(cfg, 'system.unsafe');
-		if (unsafe === true || unsafe === 'true') {
-			const authNote = $('#ep-auth'), unsafeNote = $('#ep-unsafe');
-			if (authNote) authNote.hidden = true;
-			if (unsafeNote) unsafeNote.hidden = false;
+		// Both notes start hidden, so this reveals exactly one -- and only once the
+		// config is real. mjConfig() turns a failed or non-OK fetch into {}, which
+		// is indistinguishable from "unsafe is off" if you only test the leaf, and
+		// answering that with the authenticated note would be a security warning
+		// failing open. The old server-side read did fail open that way (an empty
+		// jsonfilter result rendered the authenticated note), but the read lived on
+		// the camera, where the only way to come back empty was localhost failing.
+		// From the browser the ways to come back empty are far broader, so the
+		// section has to be present before either note is trusted.
+		//
+		// The string form is accepted alongside the boolean because jsonfilter
+		// printed `true` for either. A majestic too old to report the key at all
+		// still has a system section, so it keeps the authenticated note, as before.
+		if (mjGet(cfg, 'system')) {
+			const unsafe = mjGet(cfg, 'system.unsafe');
+			const note = $(unsafe === true || unsafe === 'true' ? '#ep-unsafe' : '#ep-auth');
+			if (note) note.hidden = false;
 		}
 	});
 

--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -6,10 +6,16 @@ config_file=/etc/webui/telegram.conf
 params="enabled token channel thread_id interval caption crontab document heif proxy"
 
 # webhook for remote send, returns [t|f]
+#
+# sbin/telegram now reports the send through its exit status, so the answer no
+# longer means parsing Telegram's JSON reply with jsonfilter. It also means the
+# failure path finally answers: the old pipeline emitted an EMPTY body whenever
+# telegram bailed out before curl ran (unconfigured, no token, no channel),
+# because there was no JSON for jsonfilter to find an `ok` in.
 if [ "$GET_send" = "image" ]; then
 	echo "Content-type: text/html; charset=UTF-8"
 	echo
-	telegram | grep -v curl | jsonfilter -e '@.ok'
+	if telegram >/dev/null 2>&1; then echo true; else echo false; fi
 	exit 0
 fi
 

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -4,11 +4,13 @@
 
 <%in p/header.cgi %>
 
-<!-- Both notes ship and main.js unhides the right one from majestic's config.
-     system.unsafe defaults to false, so the authenticated note is what renders
-     before — and if — that config arrives, which is exactly where the old
-     server-side read landed when it came back empty. -->
-<p id="ep-auth" class="small text-secondary">These endpoints authenticate as user <code>root</code> with the same password you use for this WebUI. Players such as VLC ask for it when you open a bare URL.</p>
+<!-- Both notes ship hidden and main.js unhides whichever majestic's config says
+     is true. Neither is the default on purpose: claiming these endpoints are
+     authenticated when the config never arrived would be a security warning
+     failing open, and defaulting the other way would flash a red banner at every
+     visitor whose camera is fine. Saying nothing until it knows is the only
+     honest default. -->
+<p id="ep-auth" class="small text-secondary" hidden>These endpoints authenticate as user <code>root</code> with the same password you use for this WebUI. Players such as VLC ask for it when you open a bare URL.</p>
 <p id="ep-unsafe" class="small text-danger" hidden>Authentication is switched off for every endpoint (<code>system.unsafe</code>) — anyone who can reach the camera can open these URLs.</p>
 
 <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -1,50 +1,25 @@
 #!/usr/bin/haserl
 <%in p/common.cgi %>
-<% page_title="Majestic Endpoints"
-
-# Ask the live config rather than majestic.yaml, which omits keys left at their
-# default.
-mj_config=$(wget -q -T1 -O - localhost/api/v1/config.json 2>/dev/null)
-
-# system.unsafe switches authentication off for every HTTP and RTSP endpoint, so
-# the credentials note below would be wrong.
-mj_unsafe=$(echo "$mj_config" | jsonfilter -e '@.system.unsafe' 2>/dev/null)
-
-# Hosts below are placeholders: every HTTP and WebSocket endpoint here is served
-# on the WebUI's own origin, so main.js overwrites the .ep-* spans with the
-# address the browser actually used. RTSP is the exception — its port is its
-# own, and only the default 554 may be left out of the URL.
-#
-# Majestic only range-checks rtsp.port on the write path, so a hand-edited
-# majestic.yaml can leave a port no URL can use. Anything outside 1-65535 falls
-# back to the default a bare rtsp:// implies. The ?????? arm drops 6-digit and
-# longer values before the numeric test, which has no defined behaviour once
-# the operand no longer fits a long.
-rtsp_port=$(echo "$mj_config" | jsonfilter -e '@.rtsp.port' 2>/dev/null)
-case "$rtsp_port" in
-	''|*[!0-9]*|??????*) rtsp_port=554 ;;
-esac
-[ "$rtsp_port" -ge 1 ] && [ "$rtsp_port" -le 65535 ] || rtsp_port=554
-[ "$rtsp_port" = "554" ] && rtsp_suffix= || rtsp_suffix=":$rtsp_port"
-%>
+<% page_title="Majestic Endpoints" %>
 
 <%in p/header.cgi %>
 
-<% if [ "$mj_unsafe" = "true" ]; then %>
-<p class="small text-danger">Authentication is switched off for every endpoint (<code>system.unsafe</code>) — anyone who can reach the camera can open these URLs.</p>
-<% else %>
-<p class="small text-secondary">These endpoints authenticate as user <code>root</code> with the same password you use for this WebUI. Players such as VLC ask for it when you open a bare URL.</p>
-<% fi %>
+<!-- Both notes ship and main.js unhides the right one from majestic's config.
+     system.unsafe defaults to false, so the authenticated note is what renders
+     before — and if — that config arrives, which is exactly where the old
+     server-side read landed when it came back empty. -->
+<p id="ep-auth" class="small text-secondary">These endpoints authenticate as user <code>root</code> with the same password you use for this WebUI. Players such as VLC ask for it when you open a bare URL.</p>
+<p id="ep-unsafe" class="small text-danger" hidden>Authentication is switched off for every endpoint (<code>system.unsafe</code>) — anyone who can reach the camera can open these URLs.</p>
 
 <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">
 	<div class="col">
 		<h3>Video</h3>
 		<dl>
-			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><%= $rtsp_suffix %>/stream=0</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><span class="ep-rtsp"></span>/stream=0</dt>
 			<dd>RTSP main stream.</dd>
-			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><%= $rtsp_suffix %>/stream=1</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><span class="ep-rtsp"></span>/stream=1</dt>
 			<dd>RTSP sub stream.</dd>
-			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><%= $rtsp_suffix %>/stream=2</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><span class="ep-rtsp"></span>/stream=2</dt>
 			<dd>RTSP JPEG stream.</dd>
 			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><%= $network_address %></span>/ws/video?stream=0</dt>
 			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview). Append <code>&amp;audio=opus,mp4a.40.2</code> to mux in an audio track for the codecs your player accepts.</dd>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -581,7 +581,6 @@ pagename=$(basename "$SCRIPT_NAME")
 pagename="${pagename%%.*}"
 
 include /etc/webui/webui.conf
-include /usr/share/libubox/jshn.sh
 
 check_password
 %>


### PR DESCRIPTION
## Summary

`mj-endpoints.cgi` shelled out to `jsonfilter` twice per page load to read `system.unsafe` and `rtsp.port` out of `/api/v1/config.json`, and `ext-telegram.cgi` used it a third time to find `ok` in Telegram's reply. Those three calls are the only thing on a standard camera that needs `jsonfilter` — and `jsonfilter` pulls in `libubox`.

On a camera image that is 48KB of flash for the two that are used, plus 35KB more of `libubox` that nothing calls at all:

| file | bytes | who needs it |
|---|---|---|
| `/usr/bin/jsonfilter` | 18,068 | these 3 call sites, nothing else |
| `/usr/lib/libubox.so` | 30,404 | `jsonfilter` |
| `/usr/bin/jshn` | 9,692 | nothing |
| `/usr/lib/libblobmsg_json.so` | 9,508 | only `jshn` |
| `/usr/lib/libjson_script.so` | 9,480 | nothing |
| `/usr/share/libubox/jshn.sh` | 6,018 | sourced by `common.cgi`, never called |

`gk7205v300-lite` currently builds at 5120KB against a 5120KB cap, so this is not a rounding error — dropping the lot is a measured **32KiB** off that image.

## What changed

**The endpoints page no longer parses JSON on the camera.** `main.js` already has `mjConfig()` (a cached `/api/v1/config.json`) and `mjGet(cfg, 'dot.path')` — the same dot-path lookup `jsonfilter -e '@.a.b'` was doing — and `status.js`, `preview-page.js` and `sdcard.js` already use them. `mj-endpoints.cgi` is itself already JS-hydrated, because the haserl cannot know the address the browser actually used (#169). So the RTSP port and the unsafe warning move to the same place as the rest of the page's dynamic values. The server-side `wget -T1` to localhost on every page load goes with them.

Both notes now ship, with the danger one `hidden`; JS unhides it when `system.unsafe` is set. Before JS runs — and if it never does — the authenticated note is what shows, which is exactly where the old server-side read landed when it came back empty.

**The webhook uses an exit status instead of a JSON field.** `sbin/telegram` used to `exit 0` unconditionally, so a failed send reported success and `?send=image` had to read the JSON body to learn otherwise. Two bugs fall out of fixing that:

- a rejected send reported success to cron;
- when `telegram` bailed out before curl ran (unconfigured, no token, no channel) there was no JSON at all, so `?send=image` answered with an **empty body** rather than `false`.

`--write-out '%{http_code}'` rather than `--fail-with-body`, because the firmware pins curl at 7.76.0 — the exact release that added `--fail-with-body` — so going through the status code leaves no version floor to trip over later.

The command line is no longer echoed. It carries the bot token, and printing it was the only reason the webhook had to `grep -v curl` its own output before parsing it. (`--verbose` still writes the request line to stderr, so this is not a complete fix for token exposure — just the part this PR is already touching.)

**`common.cgi` no longer sources `jshn.sh`.** Every page load sourced it; no page has ever called a jshn function.

## Verification

Hardware: **ssc30kq** (`nightly-20260814-a0b9687`, `ssc30kq_lite`, full WebUI, majestic running).

- With `jsonfilter`, `libubox.so`, `libblobmsg_json.so`, `libjson_script.so`, `jshn` and `jshn.sh` **all deleted from the camera**, both pages render with no shell errors, all three `.ep-rtsp` spans present, both notes present with the danger one `hidden`.
- Rendered-page diff against `master` on the same camera is *only* the intended delta: one `<p>` becomes two, and `<span class="ep-rtsp"></span>` appears in the three RTSP lines. Nothing else moves.
- `?send=image` unconfigured: `master` returns an empty body, this branch returns `false`. `telegram` exits 1.
- `%{http_code}` capture verified through `eval` on the camera's own curl: 200 on a served URL, `000` on an unreachable one, body still written to the file.
- Camera restored afterwards — every touched file md5-matches the read-only image again.

Logic: the new JS was differential-tested in node against the shell it replaces, over the real camera config plus 14 synthetic cases (custom port, quoted port, min/max, out-of-range, 6-digit, negative, missing section, empty config, unsafe on/off). **All 15 agree with the old behaviour.** One case originally diverged — `system.unsafe` arriving as the string `"true"` would have shown "authenticated" while auth was actually off — so the check accepts the string form alongside the boolean, since failing to warn is the harmful direction.

Gates, both run in a container matching CI (`ubuntu:24.04` + `haserl` from universe, `node:20`):

- `tools/lint-templates.sh` → `ok: 29 haserl templates, 16 shell scripts`
- `npm run build:dist` → `built majestic-webui-dist.tar.gz`

## Not in this PR

Turning `BR2_PACKAGE_JSONFILTER` off in the firmware defconfigs has to land **after** this, since the WebUI reaches buildroot as a rolling `dist` release asset — the reverse order would ship a WebUI calling a missing binary. FPV boards keep `jsonfilter` regardless: `wifibroadcast-ng`'s `wifibroadcast` script still uses it for `@.video0.size`.

## Test plan

- [x] Both pages render on real hardware with `jsonfilter` and all of `libubox` removed
- [x] Rendered diff vs `master` contains only the intended change
- [x] `?send=image` returns `false` instead of an empty body when unconfigured
- [x] `%{http_code}` capture verified through `eval` on the camera's curl
- [x] New JS matches the old shell on 15/15 cases
- [x] `lint-templates.sh` and `build:dist` pass
- [ ] A real Telegram send against a live bot token — needs a token I do not have; the 200-vs-non-200 contract is verified, but not against api.telegram.org
