### PR TITLE
common: add an inline escaper and route device-derived text through it

### DIFF
--- a/www/cgi-bin/ext-telegram.cgi
+++ b/www/cgi-bin/ext-telegram.cgi
@@ -82,7 +82,7 @@ fi
 			<h3>Remote send</h3>
 			<dl class="small list mb-0">
 				<dt>Webhook</dt>
-				<dd class="text-break cp2cb"><span class="ep-http">http</span>://root:PASSWORD@<span class="ep-host"><%= $network_address %></span>/cgi-bin/ext-telegram.cgi?send=image</dd>
+				<dd class="text-break cp2cb"><span class="ep-http">http</span>://root:PASSWORD@<span class="ep-host"><% esc "$network_address" %></span>/cgi-bin/ext-telegram.cgi?send=image</dd>
 			</dl>
 			<p class="small text-secondary mt-2">Call this URL to trigger an image send. Click to copy, then replace <code>PASSWORD</code> with your WebUI password.</p>
 		</div></div>

--- a/www/cgi-bin/ext-vtun.cgi
+++ b/www/cgi-bin/ext-vtun.cgi
@@ -34,7 +34,7 @@ fi
 			<% if [ -e "$conf_file" ]; then %>
 				<dl class="small list">
 					<dt>Status</dt><dd><span class="text-success">Up</span></dd>
-					<dt>VTun ID</dt><dd class="text-break"><%= ${network_macaddr//:/} | tr a-z A-Z %></dd>
+					<dt>VTun ID</dt><dd class="text-break"><% esc "$(echo "${network_macaddr//:/}" | tr a-z A-Z)" %></dd>
 					<dt>Password</dt><dd class="text-break"><% grep password $conf_file | xargs | cut -d' ' -f2 | sed 's/;$//' %></dd>
 				</dl>
 				<p class="small text-secondary">Use these credentials to set up remote access.</p>

--- a/www/cgi-bin/fw-network.cgi
+++ b/www/cgi-bin/fw-network.cgi
@@ -122,14 +122,14 @@ fi
 		<div class="card h-100"><div class="card-body">
 			<h3>Current connection</h3>
 			<dl class="small list mb-0">
-				<dt>Hostname</dt><dd><%= $network_hostname %></dd>
-				<dt>Interface</dt><dd><%= $network_interface %></dd>
+				<dt>Hostname</dt><dd><% esc "$network_hostname" %></dd>
+				<dt>Interface</dt><dd><% esc "$network_interface" %></dd>
 				<dt>Mode</dt><dd><%= $([ "$network_dhcp" = "true" ] && echo DHCP || echo Static) %></dd>
-				<dt>IP</dt><dd><%= $network_address %></dd>
-				<dt>Netmask</dt><dd><%= ${network_netmask:-—} %></dd>
-				<dt>Gateway</dt><dd><%= ${network_gateway:-—} %></dd>
-				<dt>DNS</dt><dd><%= ${network_nameserver:-—} %></dd>
-				<dt>MAC</dt><dd class="text-break"><%= $network_macaddr %></dd>
+				<dt>IP</dt><dd><% esc "$network_address" %></dd>
+				<dt>Netmask</dt><dd><% esc "${network_netmask:-—}" %></dd>
+				<dt>Gateway</dt><dd><% esc "${network_gateway:-—}" %></dd>
+				<dt>DNS</dt><dd><% esc "${network_nameserver:-—}" %></dd>
+				<dt>MAC</dt><dd class="text-break"><% esc "$network_macaddr" %></dd>
 			</dl>
 		</div></div>
 	</div>

--- a/www/cgi-bin/fw-settings.cgi
+++ b/www/cgi-bin/fw-settings.cgi
@@ -50,7 +50,7 @@ fi
 
 			<hr class="my-3">
 			<p class="small text-secondary mb-1">Or create one remotely (click to copy, then replace <code>PASSWORD</code> with your WebUI password):</p>
-			<pre class="cp2cb small mb-0">wget --content-disposition <span class="ep-http">http</span>://root:PASSWORD@<span class="ep-host"><%= $network_address %></span>/cgi-bin/ext-backuper.cgi?backup=create</pre>
+			<pre class="cp2cb small mb-0">wget --content-disposition <span class="ep-http">http</span>://root:PASSWORD@<span class="ep-host"><% esc "$network_address" %></span>/cgi-bin/ext-backuper.cgi?backup=create</pre>
 
 			<details class="mt-3">
 				<summary class="small">Restore from a backup (manual)</summary>

--- a/www/cgi-bin/fw-update.cgi
+++ b/www/cgi-bin/fw-update.cgi
@@ -37,11 +37,11 @@
 				<%# id is a contract with fw-update.js: after the camera reboots it
 				    re-fetches this page and compares the value to decide whether the
 				    upgrade actually applied (issue #120). %>
-				<dt>Installed</dt><dd id="fw-installed"><%= "${fw_version}-${fw_variant}" %></dd>
+				<dt>Installed</dt><dd id="fw-installed"><% esc "${fw_version}-${fw_variant}" %></dd>
 				<dt>Latest on GitHub</dt>
-				<dd><span id="firmware-master-ver"><% if [ -n "$fw_date" ]; then %><%= $fw_date %><% else %><span class="text-secondary">— no access to GitHub —</span><% fi %></span></dd>
-				<dt>SoC</dt><dd><%= $soc %> <span class="text-secondary">(<%= $soc_family %>)</span></dd>
-				<dt>Flash</dt><dd><%= $flash_type %></dd>
+				<dd><span id="firmware-master-ver"><% if [ -n "$fw_date" ]; then %><% esc "$fw_date" %><% else %><span class="text-secondary">— no access to GitHub —</span><% fi %></span></dd>
+				<dt>SoC</dt><dd><% esc "$soc" %> <span class="text-secondary">(<% esc "$soc_family" %>)</span></dd>
+				<dt>Flash</dt><dd><% esc "$flash_type" %></dd>
 			</dl>
 			<div id="fw-status" class="small text-secondary mt-2"></div>
 		</div></div>

--- a/www/cgi-bin/mj-endpoints.cgi
+++ b/www/cgi-bin/mj-endpoints.cgi
@@ -17,23 +17,23 @@
 	<div class="col">
 		<h3>Video</h3>
 		<dl>
-			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><span class="ep-rtsp"></span>/stream=0</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><% esc "$network_address" %></span><span class="ep-rtsp"></span>/stream=0</dt>
 			<dd>RTSP main stream.</dd>
-			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><span class="ep-rtsp"></span>/stream=1</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><% esc "$network_address" %></span><span class="ep-rtsp"></span>/stream=1</dt>
 			<dd>RTSP sub stream.</dd>
-			<dt class="cp2cb">rtsp://<span class="ep-addr"><%= $network_address %></span><span class="ep-rtsp"></span>/stream=2</dt>
+			<dt class="cp2cb">rtsp://<span class="ep-addr"><% esc "$network_address" %></span><span class="ep-rtsp"></span>/stream=2</dt>
 			<dd>RTSP JPEG stream.</dd>
-			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><%= $network_address %></span>/ws/video?stream=0</dt>
+			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><% esc "$network_address" %></span>/ws/video?stream=0</dt>
 			<dd>Low-latency H.264/H.265 main stream (fMP4/MSE, used by Preview). Append <code>&amp;audio=opus,mp4a.40.2</code> to mux in an audio track for the codecs your player accepts.</dd>
-			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><%= $network_address %></span>/ws/video?stream=1</dt>
+			<dt class="cp2cb"><span class="ep-ws">ws</span>://<span class="ep-host"><% esc "$network_address" %></span>/ws/video?stream=1</dt>
 			<dd>Low-latency H.264/H.265 sub stream (fMP4/MSE).</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/mjpeg</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/mjpeg</dt>
 			<dd>MJPEG video stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/video.mp4</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/video.mp4</dt>
 			<dd>MP4 video stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/hls</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/hls</dt>
 			<dd>HLS live-streaming in web browser.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/mjpeg.html</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/mjpeg.html</dt>
 			<dd>MJPEG live-streaming in web browser.</dd>
 		</dl>
 	</div>
@@ -41,19 +41,19 @@
 	<div class="col">
 		<h3>Audio</h3>
 		<dl>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.opus</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/audio.opus</dt>
 			<dd>Opus audio stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.m4a</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/audio.m4a</dt>
 			<dd>AAC audio stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.pcm</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/audio.pcm</dt>
 			<dd>Raw PCM audio stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.alaw</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/audio.alaw</dt>
 			<dd>A-law compressed audio stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.ulaw</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/audio.ulaw</dt>
 			<dd>μ-law compressed audio stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/audio.g711a</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/audio.g711a</dt>
 			<dd>G.711 A-law audio stream.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/play_audio</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/play_audio</dt>
 			<dd>Play audio file on camera speaker.</dd>
 		</dl>
 	</div>
@@ -61,11 +61,11 @@
 	<div class="col">
 		<h3>Images</h3>
 		<dl>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/image.jpg</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/image.jpg</dt>
 			<dd>Snapshot in JPEG format.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/image.heif</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/image.heif</dt>
 			<dd>Snapshot in HEIF format.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/image.yuv420</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/image.yuv420</dt>
 			<dd>Snapshot in YUV420 format.</dd>
 		</dl>
 	</div>
@@ -73,15 +73,15 @@
 	<div class="col">
 		<h3>Night</h3>
 		<dl>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/on</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/night/on</dt>
 			<dd>Turn on night mode.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/off</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/night/off</dt>
 			<dd>Turn off night mode.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/toggle</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/night/toggle</dt>
 			<dd>Toggle night mode.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/ircut</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/night/ircut</dt>
 			<dd>Toggle camera ircut.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/night/light</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/night/light</dt>
 			<dd>Toggle camera light.</dd>
 		</dl>
 	</div>
@@ -89,13 +89,13 @@
 	<div class="col">
 		<h3>Monitoring</h3>
 		<dl>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/api/v1/config.json</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/api/v1/config.json</dt>
 			<dd>Default Majestic config in JSON format.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/api/v1/config.schema.json</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/api/v1/config.schema.json</dt>
 			<dd>Available Majestic settings in JSON format.</dd>
 			<dt><a href="https://github.com/openipc/wiki/blob/master/en/majestic-config.md">https://github.com/openipc/wiki</a></dt>
 			<dd>Available Majestic settings in YAML format.</dd>
-			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><%= $network_address %></span>/metrics</dt>
+			<dt class="cp2cb"><span class="ep-http">http</span>://<span class="ep-host"><% esc "$network_address" %></span>/metrics</dt>
 			<dd>Node exporter for <a href="https://prometheus.io">Prometheus</a>.</dd>
 		</dl>
 	</div>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -268,14 +268,20 @@ attr_escape() {
 # break; for text read off the device that is exactly backwards, because it hands
 # the value a way to emit an entity of its own choosing.
 #
-# printf rather than echo, so nothing re-interprets a backslash on the way out
-# and no trailing newline lands in the middle of an inline element.
+# Substitution rather than a sed pipeline, unlike attr_escape and pre next door.
+# Those run once or twice per page; this one runs 56 times, and a fork and exec of
+# sed per endpoint URL is a poor trade on a camera. Ampersand goes first so the
+# entities the later rounds insert are not themselves re-escaped.
+#
+# printf rather than echo for the result, so nothing re-interprets a backslash and
+# no trailing newline lands in the middle of an inline element.
 esc() {
-	printf '%s' "$1" | sed \
-		-e 's/&/\&amp;/g' \
-		-e 's/</\&lt;/g' \
-		-e 's/>/\&gt;/g' \
-		-e 's/"/\&quot;/g'
+	local s="$1"
+	s=${s//&/&amp;}
+	s=${s//</&lt;}
+	s=${s//>/&gt;}
+	s=${s//\"/&quot;}
+	printf '%s' "$s"
 }
 
 # field_switch "name" "label" "value" "hint" "confirm"

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -255,6 +255,29 @@ attr_escape() {
 		-e 's/&amp;#\([0-9][0-9]*\);/\&#\1;/g'
 }
 
+# Escape a string for use as HTML text content.
+#
+# Not `pre` or `ex`: both wrap what they are given in a block element -- a <pre>,
+# and a <div> carrying a visible "# command" heading -- which is no use for a
+# value sitting inside a <dt> or mid-sentence. Escaping the endpoint addresses
+# with either would have put a <pre> inside every <dt> on mj-endpoints.cgi and
+# taken the click-to-copy wiring with it.
+#
+# Not `attr_escape` either. That one deliberately puts numeric character
+# references back after escaping, so the confirm prompts can carry a &#10; line
+# break; for text read off the device that is exactly backwards, because it hands
+# the value a way to emit an entity of its own choosing.
+#
+# printf rather than echo, so nothing re-interprets a backslash on the way out
+# and no trailing newline lands in the middle of an inline element.
+esc() {
+	printf '%s' "$1" | sed \
+		-e 's/&/\&amp;/g' \
+		-e 's/</\&lt;/g' \
+		-e 's/>/\&gt;/g' \
+		-e 's/"/\&quot;/g'
+}
+
 # field_switch "name" "label" "value" "hint" "confirm"
 #
 # A non-empty "confirm" marks the switch destructive: the row is styled in red

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -25,7 +25,7 @@ Pragma: no-cache
 <body id="page-<%= $pagename %>" class="<%= $fw_variant %>">
 	<nav class="navbar navbar-expand-lg bg-body-tertiary">
 		<div class="container">
-			<a class="navbar-brand" href="status.cgi"><img alt="Image: OpenIPC logo" height="32" src="/a/logo.svg"><span class="x-small ms-1"><%= $fw_variant %></span></a>
+			<a class="navbar-brand" href="status.cgi"><img alt="Image: OpenIPC logo" height="32" src="/a/logo.svg"><span class="x-small ms-1"><% esc "$fw_variant" %></span></a>
 			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
 			</button>

--- a/www/cgi-bin/status.cgi
+++ b/www/cgi-bin/status.cgi
@@ -78,13 +78,13 @@
 		<div class="card h-100"><div class="card-body">
 			<h3>Device</h3>
 			<dl class="small list mb-0">
-				<dt>SoC</dt><dd><%= $soc %> <span class="text-secondary">(<%= $soc_family %>)</span></dd>
-				<dt>Sensor</dt><dd><%= $sensor %></dd>
-				<dt>Firmware</dt><dd><%= "${fw_version}-${fw_variant}" %></dd>
-				<dt>Build</dt><dd class="text-break"><%= $fw_build %></dd>
-				<dt>Majestic</dt><dd><%= $mj_version %></dd>
+				<dt>SoC</dt><dd><% esc "$soc" %> <span class="text-secondary">(<% esc "$soc_family" %>)</span></dd>
+				<dt>Sensor</dt><dd><% esc "$sensor" %></dd>
+				<dt>Firmware</dt><dd><% esc "${fw_version}-${fw_variant}" %></dd>
+				<dt>Build</dt><dd class="text-break"><% esc "$fw_build" %></dd>
+				<dt>Majestic</dt><dd><% esc "$mj_version" %></dd>
 				<% if [ -n "$uboot_version" ]; then %>
-					<dt>U-Boot</dt><dd><%= $uboot_version %></dd>
+					<dt>U-Boot</dt><dd><% esc "$uboot_version" %></dd>
 				<% fi %>
 			</dl>
 		</div></div>
@@ -95,11 +95,11 @@
 		<div class="card h-100"><div class="card-body">
 			<h3>Network</h3>
 			<dl class="small list mb-0">
-				<dt>Host</dt><dd><%= $network_hostname %></dd>
-				<dt>Address</dt><dd><%= $network_address %></dd>
-				<dt>MAC</dt><dd class="text-break"><%= $network_macaddr %></dd>
-				<dt>Link</dt><dd><%= $network_interface %></dd>
-				<dt>Gateway</dt><dd><%= $network_gateway %></dd>
+				<dt>Host</dt><dd><% esc "$network_hostname" %></dd>
+				<dt>Address</dt><dd><% esc "$network_address" %></dd>
+				<dt>MAC</dt><dd class="text-break"><% esc "$network_macaddr" %></dd>
+				<dt>Link</dt><dd><% esc "$network_interface" %></dd>
+				<dt>Gateway</dt><dd><% esc "$network_gateway" %></dd>
 			</dl>
 		</div></div>
 	</div>
@@ -109,10 +109,10 @@
 		<div class="card h-100"><div class="card-body">
 			<h3>Storage</h3>
 			<dl class="small list mb-2">
-				<dt>Flash</dt><dd><%= $flash_size %> MB <span class="text-secondary"><%= $flash_type %></span></dd>
+				<dt>Flash</dt><dd><% esc "$flash_size" %> MB <span class="text-secondary"><% esc "$flash_type" %></span></dd>
 			</dl>
 			<div class="d-flex justify-content-between x-small mb-1">
-				<span class="fw-semibold">Overlay</span><span class="text-secondary"><%= ${overlay_use:-n/a} %></span>
+				<span class="fw-semibold">Overlay</span><span class="text-secondary"><% esc "${overlay_use:-n/a}" %></span>
 			</div>
 			<div id="overlay-bar" class="storage-bar mb-2"></div>
 			<div id="overlay-legend" class="storage-legend x-small mb-3"></div>
@@ -121,7 +121,7 @@
 				<% echo "$sd_rows" | while IFS='|' read mnt use pct; do %>
 					<div class="d-flex align-items-center gap-2 x-small">
 						<span class="badge text-bg-success flex-shrink-0">SD</span>
-						<span class="text-secondary"><%= "$mnt — $use ($pct)" %></span>
+						<span class="text-secondary"><% esc "$mnt — $use ($pct)" %></span>
 					</div>
 				<% done %>
 			<% else %>


### PR DESCRIPTION
## Summary

Qodo raised this on #177 and it was right, just not about that PR — the endpoint addresses were already rendered raw on `master`, and so is every other value `update_caminfo` reads off the device. **56 sites across eight templates** put `<%= $x %>` — sugar for `echo` — straight into the page.

## Why it was never fixed: neither escaper works here

This is the interesting part, and why the review's suggested fix ("use `ex` or `pre`") would have broken the page:

- `ex` wraps its output in `<div class="ex"><h6># command</h6><pre>…</pre></div>` — a block element with a visible heading.
- `pre` wraps in `<pre>` — also block.

`mj-endpoints.cgi` needs the address **inline**, inside a `<dt>` that click-to-copy reads. Either helper would have put a `<pre>` inside all 27 of those `<dt>`s and taken the copy wiring with it.

`attr_escape` is closer, but it deliberately restores numeric character references so the confirm prompts can carry `&#10;` — exactly backwards for text coming off the device, since it hands the value a way to emit an entity of its own choosing.

So this adds **`esc`**: escapes `& < > "`, emits nothing else, `printf` rather than `echo` so no trailing newline lands mid-element.

## Scope: text content only

Three things are deliberately left alone, because escaping them would be wrong rather than merely unnecessary:

- **JSON blob interpolations** — `$labels`, `$boot_exclude`, `$boot_sensors`, `$ov_cats` and the numeric `${ov_*}`. These build the `<script type="application/json">` bootstrap blobs; escaping them breaks the JSON.
- **Attribute contexts** — `$SCRIPT_NAME`, `$tz_name`, `$tz_data`, `$ui_username`, `$wfb_txpower`, `$webui_theme`. Those want `attr_escape`, which already exists. `$SCRIPT_NAME` is also **request**-derived rather than device-derived, which is a different and sharper question than this one — worth its own change.
- `page_title`, `label`, `labels`, `pagename`, loop variables — ours, not the device's.

## One site worth a second look

`fw-update.cgi`: `fw_date` falls back to the raw string from a **GitHub fetch** when the date regex misses. It is **not exploitable today** — `latest_build` filters through `grep -Eo '[A-Za-z0-9._]+-[0-9]{8}-[0-9a-f]+'`, so the value cannot carry markup — but that constraint lives twenty lines from the render site and nothing keeps it there.

## Verification

On an **ssc30kq** (`nightly-20260814`, lite, majestic running), `master` and this branch deployed in turn:

**No rendering change.** All seven affected pages byte-identical, once two sources of live variation are accounted for — `fw-network.cgi` embeds `ifconfig` RX/TX counters (two fetches of the *same* build already differ), and `status.cgi` reports overlay usage, which my own deploy moved from 2.2M to 2.1M. Confirmed by diffing the same build against itself.

**Escaping actually engages.** With `network_address='<script>alert(1)</script>'` planted in the cached sysinfo the pages source on every request:

| | raw `<script>alert(1)` | escaped `&lt;script&gt;` |
|---|---|---|
| `master` | **27** | 0 |
| this branch | **0** | **27** |

27 being exactly the number of `network_address` sites in `mj-endpoints.cgi`. Camera restored afterwards — all nine touched files md5-match the read-only image again.

Gates, in a container matching CI:

```
ok: 29 haserl templates, 16 shell scripts
built majestic-webui-dist.tar.gz
```

## Test plan

- [x] `lint-templates.sh` and `build:dist` pass
- [x] Rendered output byte-identical to master on all seven affected pages
- [x] Injected `<script>` neutralised: 27 raw → 0 raw / 27 escaped
- [x] JSON bootstrap blobs left unescaped and still parse
- [x] Camera restored, all nine files md5-match the image
- [ ] Attribute-context values (`attr_escape`) — deliberately not in this PR
