### PR TITLE
escape the attribute contexts, and four text sites #178 missed

### DIFF
--- a/www/cgi-bin/fpv-wfb.cgi
+++ b/www/cgi-bin/fpv-wfb.cgi
@@ -392,9 +392,9 @@ update_wfbinfo
                     <p class="range" id="txpower_wrap">
                         <% tooltip_label "txpower" "TX Power" "Transmit power in dBm. Higher values increase range but consume more power and may cause interference. Check local regulations for maximum allowed values." %>
                         <span class="input-group">
-                            <input type="hidden" id="txpower" name="txpower" value="<%= $wfb_txpower %>">
-                            <input type="range" class="form-control form-range" id="txpower-range" value="<%= $wfb_txpower %>" min="0" max="55" step="1">
-                            <span class="input-group-text show-value" id="txpower-show"><%= $wfb_txpower %></span>
+                            <input type="hidden" id="txpower" name="txpower" value="<% attr_escape "$wfb_txpower" %>">
+                            <input type="range" class="form-control form-range" id="txpower-range" value="<% attr_escape "$wfb_txpower" %>" min="0" max="55" step="1">
+                            <span class="input-group-text show-value" id="txpower-show"><% esc "$wfb_txpower" %></span>
                         </span>
                     </p>
 

--- a/www/cgi-bin/fw-interface.cgi
+++ b/www/cgi-bin/fw-interface.cgi
@@ -52,7 +52,7 @@ tcur=${webui_theme:-dark}
 				<% field_hidden "action" "access" %>
 				<p class="string">
 					<label for="ui_username" class="form-label">Username</label>
-					<input type="text" id="ui_username" name="ui_username" value="<%= $ui_username %>" class="form-control" autocomplete="username" disabled>
+					<input type="text" id="ui_username" name="ui_username" value="<% attr_escape "$ui_username" %>" class="form-control" autocomplete="username" disabled>
 				</p>
 				<% field_password "password_default" "Password" %>
 				<% field_password "password_confirm" "Confirm password" %>

--- a/www/cgi-bin/fw-restart.cgi
+++ b/www/cgi-bin/fw-restart.cgi
@@ -4,7 +4,7 @@ Cache-Control: no-store
 Pragma: no-cache
 
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="<%= ${webui_theme:=dark} %>">
+<html lang="en" data-bs-theme="<% attr_escape "${webui_theme:=dark}" %>">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/www/cgi-bin/fw-restart.cgi
+++ b/www/cgi-bin/fw-restart.cgi
@@ -4,7 +4,14 @@ Cache-Control: no-store
 Pragma: no-cache
 
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="<% attr_escape "${webui_theme:=dark}" %>">
+<!-- Not escaped, and the include that would make escaping possible is not
+     wanted here. This page carries no includes at all: it runs reboot below and
+     has to render while the system is going down, so it pulls in no auth gate
+     and sources nothing. That also means webui_theme is never set on this page
+     and the := always supplies the literal "dark" - there is no device-derived
+     value here to escape. Note haserl expands an include tag even inside an
+     HTML comment, so this note cannot name the tag it is talking about. -->
+<html lang="en" data-bs-theme="<%= ${webui_theme:=dark} %>">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/www/cgi-bin/fw-time.cgi
+++ b/www/cgi-bin/fw-time.cgi
@@ -44,9 +44,9 @@ ntp_summary=$(echo $server_0 $server_1 $server_2 $server_3 | sed 's/ /, /g')
 			<h3>Current</h3>
 			<dl class="small list mb-0">
 				<dt>Device time</dt><dd id="tz-now">—</dd>
-				<dt>Zone name</dt><dd><%= $tz_name %></dd>
-				<dt>POSIX string</dt><dd class="text-break"><%= $tz_data %></dd>
-				<dt>NTP servers</dt><dd><%= "${ntp_summary:-—}" %></dd>
+				<dt>Zone name</dt><dd><% esc "$tz_name" %></dd>
+				<dt>POSIX string</dt><dd class="text-break"><% esc "$tz_data" %></dd>
+				<dt>NTP servers</dt><dd><% esc "${ntp_summary:-—}" %></dd>
 			</dl>
 		</div></div>
 	</div>
@@ -61,12 +61,12 @@ ntp_summary=$(echo $server_0 $server_1 $server_2 $server_3 | sed 's/ /, /g')
 				<datalist id="tz_list"></datalist>
 				<p class="string" id="tz_name_wrap">
 					<label for="tz_name" class="form-label">Zone name</label>
-					<input type="text" id="tz_name" name="tz_name" value="<%= $tz_name %>" class="form-control" list="tz_list">
+					<input type="text" id="tz_name" name="tz_name" value="<% attr_escape "$tz_name" %>" class="form-control" list="tz_list">
 					<span class="hint text-secondary">Type the name of the nearest large city.</span>
 				</p>
 				<p class="string" id="tz_data_wrap">
 					<label for="tz_data" class="form-label">Zone string</label>
-					<input type="text" id="tz_data" name="tz_data" value="<%= $tz_data %>" class="form-control" readonly>
+					<input type="text" id="tz_data" name="tz_data" value="<% attr_escape "$tz_data" %>" class="form-control" readonly>
 					<span class="hint text-secondary">Control string of the timezone selected above.</span>
 				</p>
 				<button type="button" class="btn btn-sm btn-outline-secondary" id="frombrowser">Use browser timezone</button>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -4,7 +4,7 @@ Cache-Control: no-store
 Pragma: no-cache
 
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="<%= ${webui_theme:=dark} %>">
+<html lang="en" data-bs-theme="<% attr_escape "${webui_theme:=dark}" %>">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
@@ -22,7 +22,7 @@ Pragma: no-cache
 	<script src="/a/cameras-switch.js" defer></script>
 </head>
 
-<body id="page-<%= $pagename %>" class="<%= $fw_variant %>">
+<body id="page-<% attr_escape "$pagename" %>" class="<% attr_escape "$fw_variant" %>">
 	<nav class="navbar navbar-expand-lg bg-body-tertiary">
 		<div class="container">
 			<a class="navbar-brand" href="status.cgi"><img alt="Image: OpenIPC logo" height="32" src="/a/logo.svg"><span class="x-small ms-1"><% esc "$fw_variant" %></span></a>


### PR DESCRIPTION
Finishing the pass #178 started. Two things came out of it, and the first changes the severity.

## This one is a real stored XSS, not hardening

`fw-time.cgi` writes `POST_tz_name` and `POST_tz_data` **straight to `/etc/timezone` and `/etc/TZ`** with nothing but an emptiness check:

```sh
[ -z "$POST_tz_name" ] && redirect_to ... "Empty timezone name. Skipping."
...
echo "${POST_tz_name}" > /etc/timezone
```

and renders them back in both a `<dd>` and an `<input value=>`. Posting `"><script>alert(1)</script>` through the ordinary form on an ssc30kq:

```
payload written to /etc/timezone: "><script>alert(1)</script>
raw <script>alert(1) occurrences: 2
text context:
  <dt>Zone name</dt><dd>"><script>alert(1)</script></dd>
attribute context:
  <input type="text" id="tz_name" name="tz_name" value="">
```

The quote closed the attribute and truncated the tag. It **persists** — it is a file on the overlay, so it survives reboot. Authenticated, but the WebUI login is the only thing in front of it.

After this PR, same POST, same camera:

```
raw <script>alert(1) occurrences: 0   (was 2)
text context:
  <dt>Zone name</dt><dd>&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;</dd>
attribute context:
  <input type="text" id="tz_name" name="tz_name" value="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" class="form-control" list="tz_list">
```

The input keeps its `class` and `list` instead of being cut off mid-tag.

## Why #178 missed it

#178 drove its conversion from a **list of variable names**, and `tz_name`, `tz_data`, `ntp_summary` and `wfb_txpower` were not in it. Four text-context sites went unconverted while that PR reported the sweep as complete. My fault, and they are fixed here. The recheck this time enumerated *every* `<%=` and classified each by context rather than matching against a list I had written by hand.

## What changed

| context | sites | helper |
|---|---|---|
| text | 4 — `tz_name`, `tz_data`, `ntp_summary`, `wfb_txpower` | `esc` |
| attribute | 8 — `tz_name`, `tz_data`, `ui_username`, `wfb_txpower` ×2, `webui_theme` ×2, `pagename`/`fw_variant` | `attr_escape` |

`attr_escape` already existed for exactly this. Its numeric-reference restoration is harmless in an attribute value — a decoded `&#34;` is a character *in* the value, not a delimiter.

## Deliberately not touched, having checked rather than assumed

- **`$SCRIPT_NAME`, 16 sites.** Not attacker-controllable here. majestic only invokes a CGI when the path resolves to a file that exists:

  ```
  /cgi-bin/zprobe.cgi        -> 200
  /cgi-bin/zprobe.cgi/foo    -> 404   (CGI never runs)
  /cgi-bin/zprobe.cgi%22%3E  -> 404
  ```

  and it sets neither `PATH_INFO` nor `REQUEST_URI`. `$pagename` derives from it and is escaped here only because it shares a tag with `$fw_variant`.
- **`$(get_config)`** in `mj-configuration.cgi` — returns a fixed path.
- **`$c` / `$r`** in `fw-reset.cgi` — the script sets them itself.

## Test plan

- [x] Stored XSS reproduced through the real form on real hardware, then confirmed neutralised by this PR (2 raw → 0)
- [x] Attribute no longer truncates — tag keeps `class` and `list`
- [x] `$SCRIPT_NAME` non-controllability verified by probe CGI (404 on crafted paths, no `PATH_INFO`)
- [x] `lint-templates.sh` and `build:dist` pass
- [x] Camera restored — `/etc/TZ`, `/etc/timezone`, all three touched files md5-match the image, reboot sentinel cleared
