### PR TITLE
status: explain the load average figure on the CPU card

### DIFF
--- a/www/cgi-bin/status.cgi
+++ b/www/cgi-bin/status.cgi
@@ -27,7 +27,12 @@
 			<div class="x-small text-uppercase text-secondary">CPU</div>
 			<div class="lh-1 my-1"><span class="fs-3 fw-semibold" id="st-cpu">–</span><span class="x-small text-secondary"> %</span></div>
 			<div class="progress" style="height:4px"><div id="bar-cpu" class="progress-bar" style="width:0"></div></div>
-			<div class="x-small text-secondary mt-1">load <span id="st-load">–</span></div>
+			<div class="x-small text-secondary mt-1">load <span id="st-load">–</span>
+				<a href="https://github.com/OpenIPC/wiki/blob/master/en/trouble-load-average.md"
+				   class="text-secondary text-decoration-none"
+				   aria-label="Why is the load average high?"
+				   title="1-minute load average — not a CPU-usage figure. Linux counts tasks in uninterruptible sleep as well as runnable ones, and vendor SDK driver threads stay in that state permanently, so on SigmaStar SoCs this reads 12-13 even on an idle camera. Judge the CPU by the percentage above. Click for details.">ⓘ</a>
+			</div>
 			<div id="spark-cpu" class="spark mt-1"></div>
 		</div></div>
 	</div>


### PR DESCRIPTION
## Why

A user wired their cameras into Zabbix and immediately got permanent overload alerts from one of them. The Device Status card is where they went looking, and it shows this:

```
CPU
33 %
load 13.35
```

A load average of 13 next to 33% CPU reads as a camera in serious trouble. It isn't — on SigmaStar SoCs that is the **idle** value.

Linux counts tasks in uninterruptible sleep towards the load average, and the SigmaStar MI kernel modules park one thread per pipeline port in that state between frames. Measured on an SSC30KQ: twelve such threads, load 12.4, **72% idle**. Stopping the streamer drops the count to two and the load decays 12.39 → 2.47 over 185 s along the 60 s EMA curve; restarting brings both back. Enabling audio adds one thread and the load settles at 13.36 — reproducing the reporter's screenshot value of 13.35 exactly.

## What this changes

Nothing here was actually wrong, which is worth stating since it shaped the fix:

- **CPU %** is computed from `node_cpu_seconds_total` deltas and is correct.
- The **All systems OK** badge keys off temperature, memory and CPU only (`www/a/status.js:172-176`) — the load average never fed it, so a green badge beside "load 13.35" was never a contradiction.

Only the bare number misleads. So it is kept — it is meaningful on other vendors' SoCs, and movement above the floor is meaningful everywhere — and given a tooltip plus a link to the new wiki article covering the mechanism and what to monitor instead:

> 1-minute load average — not a CPU-usage figure. Linux counts tasks in uninterruptible sleep as well as runnable ones, and vendor SDK driver threads stay in that state permanently, so on SigmaStar SoCs this reads 12-13 even on an idle camera. Judge the CPU by the percentage above. Click for details.

Companion article, merged in OpenIPC/wiki#490: [en/trouble-load-average.md](https://github.com/OpenIPC/wiki/blob/master/en/trouble-load-average.md)

## Implementation notes

Three details came from the repo's existing conventions rather than preference:

- A plain `title=` attribute, matching `title="HLS clients"` on the same page. Bootstrap's `Tooltip` is only initialised in `www/a/fpv-wfb.js`, so `data-bs-toggle="tooltip"` would silently do nothing here.
- No `target="_blank"` — `www/a/main.js:333` already sets it on every `a[href^=http]`.
- `text-secondary` and `text-decoration-none` are both already in the purged `www/a/bootstrap.min.css`, so `tools/regen-bootstrap-css.sh` does not need to run.

## Verification

Deployed to a lab SSC30KQ and rendered in headless Chromium — the ⓘ sits inline after the number without disturbing the card or the sparkline below it. The camera was restored afterwards.

## Unrelated, but found while doing this

`www/cgi-bin/mj-settings.cgi:42` tells users "Go to https://wiki.openipc.org for more information" in the alert shown **when majestic is not running**. That domain no longer belongs to OpenIPC — it resolves, but serves an unrelated commercial site, and every article path 404s. Happy to fix in this PR or a separate one, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQXuiLPei8LC4r9S3j9KU2