### PR TITLE
files: download everything direct, the server pins the disposition now

### DIFF
--- a/www/a/files.js
+++ b/www/a/files.js
@@ -18,26 +18,19 @@
 	// connection buffer and take the camera's RAM with it.
 	function fileUrl(p) { return p.split('/').map(encodeURIComponent).join('/'); }
 	function isMedia(n) { return VID.test(n) || IMG.test(n) || AUD.test(n); }
-	// Types the browser would execute in the camera's own origin if it ever
-	// rendered them inline instead of saving them.
-	const ACTIVE = /\.(x?html?|xht|svg|xml)$/i;
-	// Above this, an active file goes direct like everything else. Firmware
-	// carrying the CGI flow-control fix caps the buffer at 1 MiB, but this UI
-	// still has to be safe on the builds that predate it — which is the whole
-	// reason downloads went direct in the first place — and there the CGI
-	// holds the entire file in RAM.
-	const CGI_ATTACH_MAX = 1048576;
+	// Everything goes direct now, including the types a browser would execute
+	// in the camera's own origin. Those used to detour through download.cgi
+	// for its Content-Disposition: attachment, which the static handler could
+	// not send — but that only covered files up to a size cap, and only a
+	// click, never a pasted URL or a new tab. majestic pins the disposition
+	// itself now, for anything outside the web root that is not media, so the
+	// cases this could not reach are covered and the detour is not needed.
+	// The download attribute stays: the server sends no filename with the
+	// disposition, leaving the name to the client that knows it.
 	function download(path, name) {
-		const f = entry(name);
-		if (ACTIVE.test(name) && f && f.size <= CGI_ATTACH_MAX) {
-			// download.cgi pins Content-Disposition: attachment, which the
-			// static handler cannot.
-			location = '/cgi-bin/j/download.cgi?path=' + encodeURIComponent(path);
-			return;
-		}
 		const a = document.createElement('a');
 		a.href = fileUrl(path);
-		a.download = name; // same-origin, so this wins over an inline media type
+		a.download = name;
 		document.body.appendChild(a);
 		a.click();
 		a.remove();


### PR DESCRIPTION
Pairs with a majestic change, and should land after it.

## What

Active types — `.html`, `.xhtml`, `.xht`, `.svg`, `.xml` — detoured through `download.cgi` for its `Content-Disposition: attachment`, *"which the static handler cannot"*. It can now. majestic sends the disposition itself for anything served from outside the web root that is not media, so the detour buys nothing, and the CGI is left with the folder and multi-select tarballs — the two call sites that genuinely need packing server-side.

```diff
-	const ACTIVE = /\.(x?html?|xht|svg|xml)$/i;
-	const CGI_ATTACH_MAX = 1048576;
 	function download(path, name) {
-		const f = entry(name);
-		if (ACTIVE.test(name) && f && f.size <= CGI_ATTACH_MAX) {
-			location = '/cgi-bin/j/download.cgi?path=' + encodeURIComponent(path);
-			return;
-		}
 		const a = document.createElement('a');
 		a.href = fileUrl(path);
 		a.download = name;
```

## Why it could not have been finished here

Two gaps this side could not close, both of which the server sees:

- It was gated on `CGI_ATTACH_MAX`, so an **active file over 1 MiB went direct anyway**. A size cap on an XSS guard only decides how big the payload has to be.
- The direct path leaned on the `download` attribute, which decides what a **click** does — not a pasted URL, not a new tab.

majestic now answers all three the same way: outside the web root, only `video/*`, `audio/*` and non-SVG `image/*` render; everything else is `application/octet-stream` with `attachment`, and the response carries `X-Content-Type-Options: nosniff` so the extension allowlist cannot be sniffed around.

The `download` attribute stays regardless — majestic deliberately sends no `filename` parameter with the disposition, leaving the name to the client that already knows it.

## Ordering

Needs that majestic change. Until a camera carries it, active files from storage render inline, as they did before this UI ever routed around it — so merge this after that ships, not before.

`npm run build:dist` (the `check` workflow's gate — terser plus `node --check`) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kg8iwEv8W661epKBBiTv6F
