### PR TITLE
preview: offer WebRTC alongside MSE, and fall back between them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,19 @@ Small `#!/bin/sh` scripts that emit JSON for the front-end. `pulse.cgi` is polle
 - `main.js:initAll` runs on `load`: wires `.btn-danger`/`.btn-warning`/`.confirm` to `confirm()`, links `input[type=range]` to a sibling `…-show` and hidden input, makes external links open in a new tab, and starts the heartbeat.
 - `main.js:runCmd(msg)` streams `/cgi-bin/j/run.cgi` line-by-line via `fetch`/`ReadableStream` and appends to a `pre#output` element whose `data-cmd` carries the base64-encoded command; used by `fw-reset.cgi` (overlay erase).
 - `timezone.js` holds the `TZ` array used by `fw-time.cgi` for the city → `TZ` string mapping.
+- **The live player is two implementations behind one façade.** `preview.js`
+  (`MajesticVideo`, MSE over `/ws/video`) and `preview-webrtc.js`
+  (`MajesticWebRTC`, WebRTC over `/ws/webrtc`) return the same object —
+  `setStream`, `requestIdr`, `setAudio`, `setVolume`, `audioSupported`,
+  `destroy`, `supported` — so `preview-page.js` is written once and picks a
+  transport at attach time. MSE is the default; WebRTC is opt-in via the
+  `#mj-transport` toggle and remembered in `localStorage` under `mj-transport`.
+  The fallback chain is **WebRTC → MSE → MJPEG → note**, and the middle step
+  matters: WebRTC negotiates, so it can fail where MSE cannot (Firefox offers
+  only H.264 Baseline whatever it can decode), which is why a player reporting
+  `'fallback'` asks for the other transport rather than for MJPEG. `mj-settings.cgi`
+  shares the `preview()` markup but loads `preview.js` alone, so the toggle
+  stays hidden there.
 
 ### FPV variant
 

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -101,6 +101,25 @@
 	let stream = 0, audioOn = false, vol = 1;
 	let audioConfigured = false;
 
+	// Which attachment is the live one. Two things need it, and neither is
+	// hypothetical:
+	//
+	// A player can report 'fallback' from inside attach() — MajesticWebRTC does
+	// exactly that when RTCPeerConnection or addTransceiver throws — so the
+	// handler runs, attaches MSE, and then the outer `player = impl.attach(…)`
+	// assignment completes and overwrites the working MSE player with the dead
+	// WebRTC façade nobody can now destroy.
+	//
+	// And a destroyed player is not a silent one. WebRTC's createOffer and
+	// getStats continuations settle after close, so a transport switched away
+	// from can still call onState and, seeing a `usingWebRTC` that has since
+	// flipped, hide a video that is playing perfectly well.
+	//
+	// So the generation is stamped at attach and captured by that attachment's
+	// handlers: a callback from a superseded player is dropped rather than
+	// interpreted as if the current one had sent it.
+	let attachSeq = 0;
+
 	// Whether to offer the audio control at all: the camera has to have audio
 	// configured and this transport has to be able to carry it. MSE can only
 	// when the browser decodes a codec majestic can produce, so the answer
@@ -114,6 +133,7 @@
 	// own different machinery, and the state worth carrying over is three
 	// values.
 	function attachPlayer(webrtc) {
+		const gen = ++attachSeq;
 		if (player) { try { player.destroy(); } catch (e) {} player = null; }
 		usingWebRTC = !!webrtc;
 		// MSE leaves a MediaSource object URL on the element; WebRTC's
@@ -122,55 +142,69 @@
 		const v = cur();
 		try { v.removeAttribute('src'); v.srcObject = null; } catch (e) {}
 		const impl = usingWebRTC ? MajesticWebRTC : MajesticVideo;
-		player = impl.attach(v, Object.assign({ stream: stream }, handlers));
+		const p = impl.attach(v, Object.assign({ stream: stream }, handlersFor(gen)));
+		// attach() reported 'fallback' before returning and something else is
+		// now playing. Drop what we just built rather than letting this
+		// assignment bury it.
+		if (gen !== attachSeq) {
+			try { p.destroy(); } catch (e) {}
+			return;
+		}
+		player = p;
 		if (audioOn && player.audioSupported()) player.setAudio(true);
 		player.setVolume(vol);
 		syncAudioCtl();
 	}
 
-	const handlers = {
-		onState: (s, d) => {
-			if (s === 'playing') showVideo();
-			else if (s === 'nosignal') showNoSignal();
-			else if (s === 'mjpeg') showFallback();
-			else if (s === 'fallback') {
-				// WebRTC gave up. Drop to MSE rather than to MJPEG: MSE plays
-				// what this browser's decoder takes rather than what its WebRTC
-				// stack will negotiate, which is a strictly larger set.
-				if (usingWebRTC) {
-					const why = d || 'unavailable';
-					if (transportCtl) {
-						transportCtl.checked = false;
-						const lbl = transportCtl.nextElementSibling;
-						if (lbl) lbl.title = 'WebRTC: ' + why;
+	function handlersFor(gen) {
+		const live = () => gen === attachSeq;
+		return {
+			onState: (s, d) => {
+				if (!live()) return;
+				if (s === 'playing') showVideo();
+				else if (s === 'nosignal') showNoSignal();
+				else if (s === 'mjpeg') showFallback();
+				else if (s === 'fallback') {
+					// WebRTC gave up. Drop to MSE rather than to MJPEG: MSE
+					// plays what this browser's decoder takes rather than what
+					// its WebRTC stack will negotiate, which is a strictly
+					// larger set.
+					if (usingWebRTC) {
+						const why = d || 'unavailable';
+						if (transportCtl) {
+							transportCtl.checked = false;
+							const lbl = transportCtl.nextElementSibling;
+							if (lbl) lbl.title = 'WebRTC: ' + why;
+						}
+						rememberTransport('mse');
+						attachPlayer(false);
+					} else {
+						showFallback();
 					}
-					rememberTransport('mse');
-					attachPlayer(false);
-				} else {
-					showFallback();
 				}
-			}
-			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
-		},
-		onCodec: (codec, cs, w, h) => {
-			if (badge) {
-				badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h +
-					(usingWebRTC ? ' · WebRTC' : '');
-			}
-		},
-		// null means we asked for audio and the camera had none to give (mic off
-		// or not producing). Reflect that on the control rather than leaving the
-		// user staring at an unmute button that does nothing.
-		onAudio: (codec) => {
-			if (!mute) return;
-			if (mute.checked && !codec) {
-				muteLbl.textContent = '🔇 No audio';
-				mute.checked = false;
-				audioOn = false;
-				if (volCtl) volCtl.disabled = true;
-			}
-		},
-	};
+				else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+			},
+			onCodec: (codec, cs, w, h) => {
+				if (!live()) return;
+				if (badge) {
+					badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h +
+						(usingWebRTC ? ' · WebRTC' : '');
+				}
+			},
+			// null means we asked for audio and the camera had none to give (mic
+			// off or not producing). Reflect that on the control rather than
+			// leaving the user staring at an unmute button that does nothing.
+			onAudio: (codec) => {
+				if (!live() || !mute) return;
+				if (mute.checked && !codec) {
+					muteLbl.textContent = '🔇 No audio';
+					mute.checked = false;
+					audioOn = false;
+					if (volCtl) volCtl.disabled = true;
+				}
+			},
+		};
+	}
 
 	attachPlayer(wantWebRTC());
 

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -1,7 +1,19 @@
 // Camera Preview page glue: night/IRcut/light toggles (via the /night and
-// /metrics/night APIs) and the low-latency MSE player attach (MajesticVideo
-// from preview.js, with an MJPEG/no-signal fallback). `$`, mjConfig and mjGet
-// are globals from main.js; this file loads after preview.js.
+// /metrics/night APIs) and the live player attach, with an MJPEG/no-signal
+// fallback. `$`, mjConfig and mjGet are globals from main.js; this file loads
+// after preview.js and preview-webrtc.js.
+//
+// TWO TRANSPORTS, ONE FAÇADE. MajesticVideo (MSE) and MajesticWebRTC return
+// the same object, so everything below is written once and the choice is made
+// in attachPlayer(). MSE stays the default; WebRTC is opt-in and remembered,
+// until it has had enough field time to earn the other way round.
+//
+// The chain is WebRTC -> MSE -> MJPEG -> note, and the middle step is
+// load-bearing rather than tidy. WebRTC negotiates and can therefore fail
+// where MSE cannot: Firefox's WebRTC stack offers only H.264 Baseline whatever
+// its decoder can do, so a camera on `profile: main` has nothing to give it —
+// the same browser plays that stream over MSE without complaint. A player
+// reporting 'fallback' is asking for the other transport, not for MJPEG.
 (function () {
 	// --- Night / IRcut / Light toggles ---
 	mjConfig().then(cfg => {
@@ -32,7 +44,7 @@
 		apiFetch('/night/light', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
 	});
 
-	// --- Live MSE player (with MJPEG / no-signal fallback) ---
+	// --- Live player (WebRTC or MSE, with MJPEG / no-signal fallback) ---
 	const initial = $('#live-video');
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
@@ -65,17 +77,87 @@
 		if (badge) badge.textContent = 'MJPEG';
 	}
 
-	const mute = $('#mj-mute'), muteLbl = $('#mj-mute-lbl'), vol = $('#mj-vol');
+	const mute = $('#mj-mute'), muteLbl = $('#mj-mute-lbl'), volCtl = $('#mj-vol');
+	const audioCtl = $('#mj-audio-ctl');
+	const transportCtl = $('#mj-transport'), transportGrp = $('#mj-transport-ctl');
+	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
 
-	const player = MajesticVideo.attach(initial, {
-		stream: 0,
+	// Which transport to try. Remembered per browser rather than per camera:
+	// what decides it is what this browser can negotiate, and that travels with
+	// the browser.
+	const PREF_KEY = 'mj-transport';
+	const webrtcAvailable = !!(window.MajesticWebRTC && MajesticWebRTC.available);
+	function wantWebRTC() {
+		if (!webrtcAvailable) return false;
+		try { return localStorage.getItem(PREF_KEY) === 'webrtc'; } catch (e) { return false; }
+	}
+	function rememberTransport(t) {
+		try { localStorage.setItem(PREF_KEY, t); } catch (e) {}
+	}
+
+	let player = null, usingWebRTC = false;
+	// Carried across a transport switch, because a new player starts from its
+	// defaults and the user's choices should outlive the machinery.
+	let stream = 0, audioOn = false, vol = 1;
+	let audioConfigured = false;
+
+	// Whether to offer the audio control at all: the camera has to have audio
+	// configured and this transport has to be able to carry it. MSE can only
+	// when the browser decodes a codec majestic can produce, so the answer
+	// changes with the transport and is asked again on every attach.
+	function syncAudioCtl() {
+		if (!audioCtl) return;
+		audioCtl.hidden = !(audioConfigured && player && player.audioSupported());
+	}
+
+	// Rebuilt rather than mutated when the transport changes: the two players
+	// own different machinery, and the state worth carrying over is three
+	// values.
+	function attachPlayer(webrtc) {
+		if (player) { try { player.destroy(); } catch (e) {} player = null; }
+		usingWebRTC = !!webrtc;
+		// MSE leaves a MediaSource object URL on the element; WebRTC's
+		// srcObject would win anyway, but an element carrying both is a
+		// confusing thing to debug.
+		const v = cur();
+		try { v.removeAttribute('src'); v.srcObject = null; } catch (e) {}
+		const impl = usingWebRTC ? MajesticWebRTC : MajesticVideo;
+		player = impl.attach(v, Object.assign({ stream: stream }, handlers));
+		if (audioOn && player.audioSupported()) player.setAudio(true);
+		player.setVolume(vol);
+		syncAudioCtl();
+	}
+
+	const handlers = {
 		onState: (s, d) => {
 			if (s === 'playing') showVideo();
 			else if (s === 'nosignal') showNoSignal();
 			else if (s === 'mjpeg') showFallback();
+			else if (s === 'fallback') {
+				// WebRTC gave up. Drop to MSE rather than to MJPEG: MSE plays
+				// what this browser's decoder takes rather than what its WebRTC
+				// stack will negotiate, which is a strictly larger set.
+				if (usingWebRTC) {
+					const why = d || 'unavailable';
+					if (transportCtl) {
+						transportCtl.checked = false;
+						const lbl = transportCtl.nextElementSibling;
+						if (lbl) lbl.title = 'WebRTC: ' + why;
+					}
+					rememberTransport('mse');
+					attachPlayer(false);
+				} else {
+					showFallback();
+				}
+			}
 			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
 		},
-		onCodec: (codec, cs, w, h) => { if (badge) badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h; },
+		onCodec: (codec, cs, w, h) => {
+			if (badge) {
+				badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h +
+					(usingWebRTC ? ' · WebRTC' : '');
+			}
+		},
 		// null means we asked for audio and the camera had none to give (mic off
 		// or not producing). Reflect that on the control rather than leaving the
 		// user staring at an unmute button that does nothing.
@@ -84,28 +166,43 @@
 			if (mute.checked && !codec) {
 				muteLbl.textContent = '🔇 No audio';
 				mute.checked = false;
-				if (vol) vol.disabled = true;
+				audioOn = false;
+				if (volCtl) volCtl.disabled = true;
 			}
 		},
-	});
+	};
 
-	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
-	if (s0) s0.addEventListener('change', () => player.setStream(0));
-	if (s1) s1.addEventListener('change', () => player.setStream(1));
+	attachPlayer(wantWebRTC());
 
-	// Audio: reveal only when the camera has it configured and this browser can
-	// play a codec the camera can produce — otherwise the button is a dead end.
-	const audioCtl = $('#mj-audio-ctl');
-	if (audioCtl && mute && player.audioSupported()) {
+	if (transportCtl && transportGrp && webrtcAvailable) {
+		transportGrp.hidden = false;
+		transportCtl.checked = usingWebRTC;
+		transportCtl.addEventListener('change', () => {
+			rememberTransport(transportCtl.checked ? 'webrtc' : 'mse');
+			attachPlayer(transportCtl.checked);
+		});
+	}
+
+	if (s0) s0.addEventListener('change', () => { stream = 0; player.setStream(0); });
+	if (s1) s1.addEventListener('change', () => { stream = 1; player.setStream(1); });
+
+	// Audio: revealed only when the camera has it configured and the transport
+	// in use can carry it — otherwise the button is a dead end.
+	if (audioCtl && mute) {
 		mjConfig().then(cfg => {
-			if (mjGet(cfg, 'audio.enabled') === true) audioCtl.hidden = false;
+			audioConfigured = mjGet(cfg, 'audio.enabled') === true;
+			syncAudioCtl();
 		});
 		mute.addEventListener('change', () => {
 			const on = mute.checked;
+			audioOn = on;
 			player.setAudio(on);
 			muteLbl.textContent = on ? '🔊 Listening' : '🔇 Muted';
-			if (vol) vol.disabled = !on;
+			if (volCtl) volCtl.disabled = !on;
 		});
-		if (vol) vol.addEventListener('input', () => player.setVolume(vol.value / 100));
+		if (volCtl) volCtl.addEventListener('input', () => {
+			vol = volCtl.value / 100;
+			player.setVolume(vol);
+		});
 	}
 })();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -1,0 +1,291 @@
+// Low-latency H.264/H.265 WebRTC player over the majestic /ws/webrtc socket.
+//
+// A second body behind the same façade as preview.js, so preview-page.js and
+// mj-settings.js do not know which transport they attached. attach() returns
+// the identical shape — setStream, requestIdr, setAudio, setVolume,
+// audioSupported, destroy, supported — and the caller picks a transport
+// rather than a player.
+//
+// WHAT THIS BUYS OVER MSE. Sub-second latency, because there is no buffer to
+// fill; two-way audio, which MSE cannot do at all; and a camera that responds
+// to congestion, because the receiver's estimate reaches the encoder. That
+// last one is worth knowing rather than discovering: a WebRTC viewer changes
+// the camera's bitrate, where an MSE viewer never does.
+//
+// WHAT IT COSTS. Negotiation, which can fail where MSE cannot. Firefox's
+// WebRTC stack offers only H.264 Baseline whatever its decoder can do, so a
+// camera set to `profile: main` has nothing to give it on the main stream —
+// the same browser that plays that stream over MSE refuses it here. Which is
+// why failure reports 'fallback' rather than 'mjpeg': the caller should try
+// MSE, which negotiates nothing, before giving up on video.
+window.MajesticWebRTC = (function () {
+	// How long to wait for media before saying so. Longer than MSE's 4 s: ICE
+	// and DTLS happen first, and on a camera gathering a reflexive address
+	// that is a round trip to a STUN server before anything can flow.
+	const NO_SIGNAL_MS = 8000;
+
+	// A browser without these cannot be helped by trying.
+	const rtcOk = typeof window.RTCPeerConnection === 'function';
+
+	function attach(video, opts) {
+		opts = opts || {};
+		const onState = opts.onState || function () {};
+		const onCodec = opts.onCodec || function () {};
+		const onAudio = opts.onAudio || function () {};
+		let stream = opts.stream | 0;
+
+		let pc = null, ws = null, statsTimer = null, signalTimer = null;
+		let closed = false, reconnectTimer = null, backoff = 1000;
+		let failCount = 0, gotMedia = false;
+		let wantAudio = false, volume = 1;
+		let lastCodec = '', lastW = 0, lastH = 0;
+
+		function armSignalTimer() {
+			clearTimeout(signalTimer);
+			signalTimer = setTimeout(function () {
+				if (!gotMedia && !closed) onState('nosignal');
+			}, NO_SIGNAL_MS);
+		}
+
+		function send(req, data) {
+			if (ws && ws.readyState === 1) {
+				ws.send(JSON.stringify({ req: req, data: data }));
+			}
+		}
+
+		// Resolution and codec come from getStats rather than from the SDP:
+		// the answer names a codec but not a picture size, and the size is
+		// what the badge is for. Polled because it is the only way — there is
+		// no event for "the encoder changed resolution".
+		function pollStats() {
+			if (!pc) return;
+			pc.getStats().then(function (report) {
+				let codec = '', w = 0, h = 0, bytes = 0;
+				const codecs = {};
+				report.forEach(function (r) {
+					if (r.type === 'codec') codecs[r.id] = r;
+				});
+				report.forEach(function (r) {
+					if (r.type !== 'inbound-rtp' || r.kind !== 'video') return;
+					bytes = r.bytesReceived || 0;
+					w = r.frameWidth || 0;
+					h = r.frameHeight || 0;
+					const c = codecs[r.codecId];
+					if (c && c.mimeType) {
+						codec = c.mimeType.replace(/^video\//i, '').toLowerCase();
+					}
+				});
+				if (bytes > 0 && !gotMedia) {
+					gotMedia = true;
+					clearTimeout(signalTimer);
+					failCount = 0;
+					onState('playing', codec);
+				}
+				if (w && h && (codec !== lastCodec || w !== lastW || h !== lastH)) {
+					lastCodec = codec; lastW = w; lastH = h;
+					onCodec(codec, codec, w, h);
+				}
+			}).catch(function () {});
+		}
+
+		function teardownPc() {
+			clearInterval(statsTimer); statsTimer = null;
+			if (pc) {
+				try { pc.ontrack = null; pc.onicecandidate = null; } catch (e) {}
+				try { pc.close(); } catch (e) {}
+				pc = null;
+			}
+			try { video.srcObject = null; } catch (e) {}
+			gotMedia = false;
+			lastCodec = ''; lastW = 0; lastH = 0;
+		}
+
+		function open() {
+			if (closed) return;
+			onState('connecting');
+			teardownPc();
+
+			try {
+				pc = new RTCPeerConnection({ iceServers: [] });
+			} catch (e) {
+				onState('fallback', 'RTCPeerConnection failed');
+				return;
+			}
+
+			// recvonly for video always. Audio is a transceiver only when the
+			// user asked for it, because negotiating a track nobody listens to
+			// has the camera encode for nobody — the same reasoning as the MSE
+			// path's opt-in, arrived at from the other end.
+			try {
+				pc.addTransceiver('video', { direction: 'recvonly' });
+				if (wantAudio) {
+					pc.addTransceiver('audio', { direction: 'recvonly' });
+				}
+			} catch (e) {
+				onState('fallback', 'addTransceiver failed');
+				return;
+			}
+
+			pc.ontrack = function (ev) {
+				if (ev.streams && ev.streams[0]) video.srcObject = ev.streams[0];
+				video.muted = !wantAudio;
+				try { video.volume = volume; } catch (e) {}
+				video.play().catch(function () {});
+				if (ev.track && ev.track.kind === 'audio') onAudio('opus');
+			};
+			pc.onicecandidate = function (ev) {
+				if (ev.candidate) send('candidate', ev.candidate.candidate);
+			};
+			pc.oniceconnectionstatechange = function () {
+				if (!pc) return;
+				const s = pc.iceConnectionState;
+				if (s === 'failed' || s === 'closed') reconnect();
+				else if (s === 'disconnected') onState('error');
+			};
+
+			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+			ws = new WebSocket(
+				proto + '://' + location.host + '/ws/webrtc?stream=' + stream);
+			gotMedia = false;
+
+			ws.onopen = function () {
+				backoff = 1000;
+				armSignalTimer();
+				pc.createOffer()
+					.then(function (offer) {
+						return pc.setLocalDescription(offer).then(function () {
+							send('offer', pc.localDescription.sdp);
+						});
+					})
+					.catch(function () { onState('fallback', 'offer failed'); });
+			};
+			ws.onmessage = function (e) {
+				let m; try { m = JSON.parse(e.data); } catch (_) { return; }
+				if (!m) return;
+				if (m.reply === 'answer') {
+					pc.setRemoteDescription({ type: 'answer', sdp: m.data })
+						.catch(function () {
+							onState('fallback', 'answer rejected');
+						});
+				} else if (m.reply === 'candidate') {
+					pc.addIceCandidate({ candidate: m.data, sdpMid: m.mid })
+						.catch(function () {});
+				} else if (m.reply === 'error') {
+					// The camera could not answer. Much the commonest cause is
+					// a profile this browser will not take — see
+					// docs/webrtc-browser-interop.md — and MSE has no such
+					// problem, so this is a reason to change transport rather
+					// than to keep retrying.
+					onState('fallback', m.data || 'the camera refused the offer');
+					stop();
+				}
+			};
+			ws.onclose = function () { ws = null; if (!closed) reconnect(); };
+			ws.onerror = function () { try { ws.close(); } catch (e) {} };
+
+			clearInterval(statsTimer);
+			statsTimer = setInterval(pollStats, 1000);
+		}
+
+		function reconnect() {
+			teardownPc();
+			if (closed || reconnectTimer) return;
+			// Fewer attempts than the MSE path allows itself. Its failures are
+			// transient by nature — a socket dropped, a keyframe missed —
+			// while a WebRTC session that will not establish usually will not
+			// establish on the fourth try either, and every attempt costs a
+			// full ICE and DTLS exchange.
+			if (++failCount >= 3) {
+				onState('fallback', 'WebRTC could not establish a session');
+				stop();
+				return;
+			}
+			reconnectTimer = setTimeout(function () {
+				reconnectTimer = null;
+				backoff = Math.min(backoff * 2, 8000);
+				open();
+			}, backoff);
+		}
+
+		function stop() {
+			clearTimeout(signalTimer);
+			clearInterval(statsTimer); statsTimer = null;
+			if (ws) { try { ws.close(); } catch (e) {} ws = null; }
+			teardownPc();
+		}
+
+		// The camera honours a PLI, and the session already asks for one when
+		// a track starts — so this is for a viewer staring at a frozen frame
+		// rather than part of normal operation.
+		function requestIdr() { send('idr', ''); }
+
+		function reopen() {
+			backoff = 1000;
+			failCount = 0;
+			stop();
+			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+			reconnectTimer = setTimeout(function () {
+				reconnectTimer = null; open();
+			}, 300);
+		}
+
+		// Which encoder channel is settled when the session is negotiated —
+		// the camera picks by what this browser can decode and takes ?stream
+		// as a preference — so changing it means a new session, the same brief
+		// cut the MSE path takes.
+		function setStream(n) {
+			n = n | 0;
+			if (n === stream) return;
+			stream = n;
+			reopen();
+		}
+
+		// Audio is in the SDP, so switching it on means renegotiating. Doing
+		// that by reconnecting rather than by an ICE-restart-style
+		// renegotiation keeps this player to one code path; the cut is the
+		// same one Main/Sub already takes.
+		function setAudio(on) {
+			on = !!on;
+			if (on === wantAudio) return;
+			wantAudio = on;
+			video.muted = !on;
+			reopen();
+		}
+
+		function setVolume(v) {
+			volume = Math.max(0, Math.min(1, +v || 0));
+			try { video.volume = volume; } catch (e) {}
+		}
+
+		// Every browser with WebRTC can decode Opus; there is no equivalent of
+		// the MSE path's codec probe because the camera offers what this end
+		// listed and nothing else.
+		function audioSupported() { return rtcOk; }
+
+		function destroy() {
+			closed = true;
+			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+			stop();
+		}
+
+		if (!rtcOk) {
+			onState('fallback', 'WebRTC unavailable');
+			return {
+				setStream: function () {}, requestIdr: function () {},
+				setAudio: function () {}, setVolume: function () {},
+				audioSupported: function () { return false; },
+				destroy: function () {}, supported: false,
+			};
+		}
+
+		open();
+		return {
+			setStream: setStream, requestIdr: requestIdr,
+			setAudio: setAudio, setVolume: setVolume,
+			audioSupported: audioSupported,
+			destroy: destroy, supported: true,
+		};
+	}
+
+	return { attach: attach, available: rtcOk };
+})();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -24,6 +24,19 @@ window.MajesticWebRTC = (function () {
 	// that is a round trip to a STUN server before anything can flow.
 	const NO_SIGNAL_MS = 8000;
 
+	// How long media may stop arriving before the session counts as dead, and
+	// how often to look.
+	//
+	// Needed here in a way it is not on the MSE path, where media rides the
+	// signalling socket: if that camera stops sending, the socket closes or the
+	// element errors, and either one reconnects. WebRTC's media is out-of-band,
+	// so a stalled stream is invisible to signalling — ICE stays connected, the
+	// socket stays open, and the viewer keeps a frozen frame for as long as the
+	// tab is left alone. A camera disappearing under a SIGHUP reload does
+	// exactly this.
+	const STALL_MS = 8000;
+	const STATS_MS = 1000;
+
 	// A browser without these cannot be helped by trying.
 	const rtcOk = typeof window.RTCPeerConnection === 'function';
 
@@ -52,6 +65,9 @@ window.MajesticWebRTC = (function () {
 		let attempt = 0;
 		const current = (my) => !closed && my === attempt;
 
+		// Progress, not totals: bytesReceived only ever climbs, so "greater
+		// than zero" says a session once worked, not that it still does.
+		let lastBytes = 0, stalledMs = 0, healthyMs = 0;
 
 		// What to tell the page if the attempts run out. Which of the ways this
 		// can fail it was is worth carrying: "no media arrived" and "could not
@@ -114,9 +130,31 @@ window.MajesticWebRTC = (function () {
 				if (bytes > 0 && !gotMedia) {
 					gotMedia = true;
 					clearTimeout(signalTimer);
-					failCount = 0;
-					lastFailure = 'could not establish a session';
 					onState('playing', codec);
+				}
+				if (gotMedia) {
+					// The no-signal watchdog was disarmed when the first bytes
+					// arrived and nothing else is watching, so this is what
+					// notices a stream that stops. Retire the attempt on a
+					// stall and let the usual escalation decide between another
+					// try and another transport.
+					if (bytes > lastBytes) {
+						lastBytes = bytes;
+						stalledMs = 0;
+						// Forgive the earlier failures only once this session
+						// has held up for as long as it would take to call it
+						// stalled. Crediting the first byte instead lets a
+						// session that starts and dies over and over reset the
+						// count every time and retry for ever, which is the
+						// one outcome the escalation exists to prevent.
+						if ((healthyMs += STATS_MS) >= STALL_MS) {
+							failCount = 0;
+							lastFailure = 'could not establish a session';
+						}
+					} else if ((stalledMs += STATS_MS) >= STALL_MS) {
+						lastFailure = 'media stopped arriving';
+						reconnect();
+					}
 				}
 				if (w && h && (codec !== lastCodec || w !== lastW || h !== lastH)) {
 					lastCodec = codec; lastW = w; lastH = h;
@@ -172,6 +210,7 @@ window.MajesticWebRTC = (function () {
 			onState('connecting');
 			teardownPc();
 			dropSocket();
+			lastBytes = 0; stalledMs = 0; healthyMs = 0;
 
 			try {
 				pc = new RTCPeerConnection({ iceServers: [] });
@@ -313,7 +352,7 @@ window.MajesticWebRTC = (function () {
 			sock.onerror = function () { try { sock.close(); } catch (e) {} };
 
 			clearInterval(statsTimer);
-			statsTimer = setInterval(pollStats, 1000);
+			statsTimer = setInterval(pollStats, STATS_MS);
 		}
 
 		function reconnect() {

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -40,10 +40,22 @@ window.MajesticWebRTC = (function () {
 		let wantAudio = false, volume = 1;
 		let lastCodec = '', lastW = 0, lastH = 0;
 
-		function armSignalTimer() {
+		// Which connection attempt is current. Everything asynchronous here
+		// outlives the attempt that started it — createOffer and getStats
+		// settle after the peer connection is closed, and a WebSocket goes on
+		// firing onclose after nothing is listening — so each attempt stamps
+		// itself and its continuations check before touching shared state.
+		//
+		// Without it a socket from a dead attempt clears `ws` on its way out
+		// and takes the live attempt's signalling with it: the offer goes
+		// nowhere, no answer comes back, and the page just sits there.
+		let attempt = 0;
+		const current = (my) => !closed && my === attempt;
+
+		function armSignalTimer(my) {
 			clearTimeout(signalTimer);
 			signalTimer = setTimeout(function () {
-				if (!gotMedia && !closed) onState('nosignal');
+				if (!gotMedia && current(my)) onState('nosignal');
 			}, NO_SIGNAL_MS);
 		}
 
@@ -59,7 +71,9 @@ window.MajesticWebRTC = (function () {
 		// no event for "the encoder changed resolution".
 		function pollStats() {
 			if (!pc) return;
+			const my = attempt;
 			pc.getStats().then(function (report) {
+				if (!current(my)) return;
 				let codec = '', w = 0, h = 0, bytes = 0;
 				const codecs = {};
 				report.forEach(function (r) {
@@ -91,7 +105,11 @@ window.MajesticWebRTC = (function () {
 		function teardownPc() {
 			clearInterval(statsTimer); statsTimer = null;
 			if (pc) {
-				try { pc.ontrack = null; pc.onicecandidate = null; } catch (e) {}
+				try {
+					pc.ontrack = null;
+					pc.onicecandidate = null;
+					pc.oniceconnectionstatechange = null;
+				} catch (e) {}
 				try { pc.close(); } catch (e) {}
 				pc = null;
 			}
@@ -100,10 +118,25 @@ window.MajesticWebRTC = (function () {
 			lastCodec = ''; lastW = 0; lastH = 0;
 		}
 
+		// Detach before closing. A socket closes asynchronously, and until it
+		// does its handlers are still live on a connection nobody wants any
+		// more — including the onclose that would call reconnect() a second
+		// time and the one that would null out a socket the next attempt has
+		// already opened.
+		function dropSocket() {
+			if (!ws) return;
+			const dead = ws;
+			ws = null;
+			try { dead.onopen = dead.onmessage = dead.onclose = dead.onerror = null; } catch (e) {}
+			try { dead.close(); } catch (e) {}
+		}
+
 		function open() {
 			if (closed) return;
+			const my = ++attempt;
 			onState('connecting');
 			teardownPc();
+			dropSocket();
 
 			try {
 				pc = new RTCPeerConnection({ iceServers: [] });
@@ -137,35 +170,48 @@ window.MajesticWebRTC = (function () {
 				if (ev.candidate) send('candidate', ev.candidate.candidate);
 			};
 			pc.oniceconnectionstatechange = function () {
-				if (!pc) return;
+				if (!pc || !current(my)) return;
 				const s = pc.iceConnectionState;
 				if (s === 'failed' || s === 'closed') reconnect();
 				else if (s === 'disconnected') onState('error');
 			};
 
 			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-			ws = new WebSocket(
+			// Held in a local as well, so every handler below acts on the
+			// socket it was installed on rather than on whatever `ws` happens
+			// to point at by the time it fires.
+			const sock = new WebSocket(
 				proto + '://' + location.host + '/ws/webrtc?stream=' + stream);
+			ws = sock;
 			gotMedia = false;
 
-			ws.onopen = function () {
+			sock.onopen = function () {
+				if (!current(my)) return;
 				backoff = 1000;
-				armSignalTimer();
+				armSignalTimer(my);
 				pc.createOffer()
 					.then(function (offer) {
+						if (!current(my)) return;
 						return pc.setLocalDescription(offer).then(function () {
+							if (!current(my)) return;
 							send('offer', pc.localDescription.sdp);
 						});
 					})
-					.catch(function () { onState('fallback', 'offer failed'); });
+					.catch(function () {
+						// A closed peer connection rejects whatever was in
+						// flight, so this fires on every ordinary teardown too.
+						// Only a live attempt has actually failed to offer.
+						if (current(my)) onState('fallback', 'offer failed');
+					});
 			};
-			ws.onmessage = function (e) {
+			sock.onmessage = function (e) {
+				if (!current(my)) return;
 				let m; try { m = JSON.parse(e.data); } catch (_) { return; }
 				if (!m) return;
 				if (m.reply === 'answer') {
 					pc.setRemoteDescription({ type: 'answer', sdp: m.data })
 						.catch(function () {
-							onState('fallback', 'answer rejected');
+							if (current(my)) onState('fallback', 'answer rejected');
 						});
 				} else if (m.reply === 'candidate') {
 					pc.addIceCandidate({ candidate: m.data, sdpMid: m.mid })
@@ -180,15 +226,25 @@ window.MajesticWebRTC = (function () {
 					stop();
 				}
 			};
-			ws.onclose = function () { ws = null; if (!closed) reconnect(); };
-			ws.onerror = function () { try { ws.close(); } catch (e) {} };
+			sock.onclose = function () {
+				if (ws === sock) ws = null;
+				if (current(my)) reconnect();
+			};
+			sock.onerror = function () { try { sock.close(); } catch (e) {} };
 
 			clearInterval(statsTimer);
 			statsTimer = setInterval(pollStats, 1000);
 		}
 
 		function reconnect() {
+			// Retire the attempt before dismantling it. Closing a peer
+			// connection rejects whatever it had in flight, and a rejection
+			// that arrives while its own attempt still looks current would be
+			// reported as a genuine failure to offer.
+			attempt++;
+			clearTimeout(signalTimer);
 			teardownPc();
+			dropSocket();
 			if (closed || reconnectTimer) return;
 			// Fewer attempts than the MSE path allows itself. Its failures are
 			// transient by nature — a socket dropped, a keyframe missed —
@@ -208,9 +264,13 @@ window.MajesticWebRTC = (function () {
 		}
 
 		function stop() {
+			// Past this point nothing in flight belongs to anyone: bumping the
+			// attempt is what makes the continuations above return instead of
+			// reporting a failure that no longer has a session to fail.
+			attempt++;
 			clearTimeout(signalTimer);
 			clearInterval(statsTimer); statsTimer = null;
-			if (ws) { try { ws.close(); } catch (e) {} ws = null; }
+			dropSocket();
 			teardownPc();
 		}
 

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -52,10 +52,6 @@ window.MajesticWebRTC = (function () {
 		let attempt = 0;
 		const current = (my) => !closed && my === attempt;
 
-		// Whether the camera actually gave us the audio we asked for. The page
-		// needs to be told when it did not, which is the contract preview.js
-		// keeps by passing null.
-		let sawAudioTrack = false;
 
 		// What to tell the page if the attempts run out. Which of the ways this
 		// can fail it was is worth carrying: "no media arrived" and "could not
@@ -129,6 +125,18 @@ window.MajesticWebRTC = (function () {
 			}).catch(function () {});
 		}
 
+		// Whether the answer actually carried the audio we asked to receive.
+		// 'inactive' or an unset direction means the camera declined it — mic
+		// off, or not producing.
+		function negotiatedAudio() {
+			if (!pc || !pc.getTransceivers) return false;
+			return pc.getTransceivers().some(function (t) {
+				return t.receiver && t.receiver.track &&
+					t.receiver.track.kind === 'audio' &&
+					t.currentDirection && t.currentDirection !== 'inactive';
+			});
+		}
+
 		function teardownPc() {
 			clearInterval(statsTimer); statsTimer = null;
 			if (pc) {
@@ -164,7 +172,6 @@ window.MajesticWebRTC = (function () {
 			onState('connecting');
 			teardownPc();
 			dropSocket();
-			sawAudioTrack = false;
 
 			try {
 				pc = new RTCPeerConnection({ iceServers: [] });
@@ -191,21 +198,26 @@ window.MajesticWebRTC = (function () {
 				if (ev.streams && ev.streams[0]) video.srcObject = ev.streams[0];
 				video.muted = !wantAudio;
 				try { video.volume = volume; } catch (e) {}
-				video.play().catch(function () {
-					// Autoplay policy can refuse unmuted playback. A paused
-					// video and no explanation is the worst of the outcomes
-					// available, so take the picture over the sound and say
-					// which was lost rather than swallowing the rejection.
+				video.play().catch(function (err) {
+					// Only one rejection means the sound is the problem.
+					// NotAllowedError is autoplay policy refusing unmuted
+					// playback, and leaving a paused video with no explanation
+					// is the worst outcome available — so take the picture over
+					// the sound and say which was lost.
+					//
+					// Every other rejection is ordinary. ontrack fires once per
+					// track, so the audio track's call reassigns srcObject and
+					// aborts the video track's play() with AbortError: treating
+					// that as an autoplay refusal reports "no audio" over a
+					// working Opus stream, which is exactly what it did.
 					if (!current(my) || video.muted) return;
+					if (!err || err.name !== 'NotAllowedError') return;
 					video.muted = true;
 					wantAudio = false;
 					video.play().catch(function () {});
 					onAudio(null);
 				});
-				if (ev.track && ev.track.kind === 'audio') {
-					sawAudioTrack = true;
-					onAudio('opus');
-				}
+				if (ev.track && ev.track.kind === 'audio') onAudio('opus');
 			};
 			pc.onicecandidate = function (ev) {
 				if (ev.candidate) send('candidate', ev.candidate.candidate);
@@ -253,13 +265,19 @@ window.MajesticWebRTC = (function () {
 					pc.setRemoteDescription({ type: 'answer', sdp: m.data })
 						.then(function () {
 							if (!current(my)) return;
-							// ontrack has already run for everything this
-							// answer accepted, so an audio track that is not
-							// here now is not coming. Mirror preview.js: stop
-							// wanting it, so the element's state matches the
-							// video-only session and a later unmute really does
-							// flip and renegotiate rather than no-op.
-							if (wantAudio && !sawAudioTrack) {
+							// Did the camera take the audio we offered to
+							// receive? Ask the transceivers rather than
+							// watching for an ontrack that may not have fired
+							// yet: the track events are queued tasks and this
+							// promise is another, and assuming an order between
+							// them reports "no audio" over a working Opus
+							// stream. currentDirection is the negotiated answer
+							// and is settled by the time we are here.
+							if (wantAudio && !negotiatedAudio()) {
+								// Mirror preview.js: stop wanting it, so the
+								// element matches the video-only session it
+								// actually has and a later unmute really does
+								// flip and renegotiate rather than no-op.
 								wantAudio = false;
 								video.muted = true;
 								onAudio(null);

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -52,6 +52,11 @@ window.MajesticWebRTC = (function () {
 		let attempt = 0;
 		const current = (my) => !closed && my === attempt;
 
+		// Whether the camera actually gave us the audio we asked for. The page
+		// needs to be told when it did not, which is the contract preview.js
+		// keeps by passing null.
+		let sawAudioTrack = false;
+
 		// What to tell the page if the attempts run out. Which of the ways this
 		// can fail it was is worth carrying: "no media arrived" and "could not
 		// establish a session" send whoever reads the tooltip to different
@@ -159,6 +164,7 @@ window.MajesticWebRTC = (function () {
 			onState('connecting');
 			teardownPc();
 			dropSocket();
+			sawAudioTrack = false;
 
 			try {
 				pc = new RTCPeerConnection({ iceServers: [] });
@@ -185,8 +191,21 @@ window.MajesticWebRTC = (function () {
 				if (ev.streams && ev.streams[0]) video.srcObject = ev.streams[0];
 				video.muted = !wantAudio;
 				try { video.volume = volume; } catch (e) {}
-				video.play().catch(function () {});
-				if (ev.track && ev.track.kind === 'audio') onAudio('opus');
+				video.play().catch(function () {
+					// Autoplay policy can refuse unmuted playback. A paused
+					// video and no explanation is the worst of the outcomes
+					// available, so take the picture over the sound and say
+					// which was lost rather than swallowing the rejection.
+					if (!current(my) || video.muted) return;
+					video.muted = true;
+					wantAudio = false;
+					video.play().catch(function () {});
+					onAudio(null);
+				});
+				if (ev.track && ev.track.kind === 'audio') {
+					sawAudioTrack = true;
+					onAudio('opus');
+				}
 			};
 			pc.onicecandidate = function (ev) {
 				if (ev.candidate) send('candidate', ev.candidate.candidate);
@@ -232,10 +251,31 @@ window.MajesticWebRTC = (function () {
 				if (!m) return;
 				if (m.reply === 'answer') {
 					pc.setRemoteDescription({ type: 'answer', sdp: m.data })
+						.then(function () {
+							if (!current(my)) return;
+							// ontrack has already run for everything this
+							// answer accepted, so an audio track that is not
+							// here now is not coming. Mirror preview.js: stop
+							// wanting it, so the element's state matches the
+							// video-only session and a later unmute really does
+							// flip and renegotiate rather than no-op.
+							if (wantAudio && !sawAudioTrack) {
+								wantAudio = false;
+								video.muted = true;
+								onAudio(null);
+							}
+						})
 						.catch(function () {
 							if (current(my)) onState('fallback', 'answer rejected');
 						});
 				} else if (m.reply === 'candidate') {
+					// Handed over without waiting for the answer to be applied,
+					// which is safe rather than sloppy: addIceCandidate chains
+					// onto the same operations queue as setRemoteDescription,
+					// so one queued behind a pending answer runs after it.
+					// Measured on this camera — it trickles three candidates and
+					// one of them does arrive before the answer is installed;
+					// all three reach ICE.
 					pc.addIceCandidate({ candidate: m.data, sdpMid: m.mid })
 						.catch(function () {});
 				} else if (m.reply === 'error') {

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -52,10 +52,31 @@ window.MajesticWebRTC = (function () {
 		let attempt = 0;
 		const current = (my) => !closed && my === attempt;
 
+		// What to tell the page if the attempts run out. Which of the ways this
+		// can fail it was is worth carrying: "no media arrived" and "could not
+		// establish a session" send whoever reads the tooltip to different
+		// halves of docs/webrtc-browser-interop.md. Phrased to follow the
+		// page's own "WebRTC: " prefix rather than to repeat it.
+		let lastFailure = 'could not establish a session';
+
+		// Why this ends the attempt rather than just reporting it: a session can
+		// negotiate perfectly and still never deliver a byte — a middlebox that
+		// passes DTLS and drops SRTP, an encoder that never emits a keyframe —
+		// and nothing else in here would ever notice. The socket is open, so no
+		// onclose; ICE is connected, so no failure; the offer was answered. The
+		// page would sit on the no-signal bars for as long as the tab stayed
+		// open, when MSE might well have worked.
+		//
+		// So say so, then retire the attempt. The existing escalation does the
+		// rest: three fruitless attempts and the page is told to change
+		// transport.
 		function armSignalTimer(my) {
 			clearTimeout(signalTimer);
 			signalTimer = setTimeout(function () {
-				if (!gotMedia && current(my)) onState('nosignal');
+				if (gotMedia || !current(my)) return;
+				onState('nosignal');
+				lastFailure = 'negotiated but no media arrived';
+				reconnect();
 			}, NO_SIGNAL_MS);
 		}
 
@@ -93,6 +114,7 @@ window.MajesticWebRTC = (function () {
 					gotMedia = true;
 					clearTimeout(signalTimer);
 					failCount = 0;
+					lastFailure = 'could not establish a session';
 					onState('playing', codec);
 				}
 				if (w && h && (codec !== lastCodec || w !== lastW || h !== lastH)) {
@@ -252,7 +274,7 @@ window.MajesticWebRTC = (function () {
 			// establish on the fourth try either, and every attempt costs a
 			// full ICE and DTLS exchange.
 			if (++failCount >= 3) {
-				onState('fallback', 'WebRTC could not establish a session');
+				onState('fallback', lastFailure);
 				stop();
 				return;
 			}
@@ -329,7 +351,7 @@ window.MajesticWebRTC = (function () {
 		}
 
 		if (!rtcOk) {
-			onState('fallback', 'WebRTC unavailable');
+			onState('fallback', 'unavailable in this browser');
 			return {
 				setStream: function () {}, requestIdr: function () {},
 				setAudio: function () {}, setVolume: function () {},

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -251,10 +251,19 @@ window.MajesticWebRTC = (function () {
 					// working Opus stream, which is exactly what it did.
 					if (!current(my) || video.muted) return;
 					if (!err || err.name !== 'NotAllowedError') return;
-					video.muted = true;
-					wantAudio = false;
-					video.play().catch(function () {});
 					onAudio(null);
+					// Renegotiate rather than just muting. The audio
+					// transceiver is only ever added when wantAudio is set,
+					// precisely so the camera does not encode for nobody — and
+					// a track the browser has refused to play is nobody.
+					// Dropping the flag alone would leave the camera sending
+					// Opus into a muted element until something else happened
+					// to reconnect.
+					//
+					// wantAudio is necessarily true here: the element was
+					// unmuted, which only happens when it is. So this is a real
+					// transition and setAudio does the mute and the reopen.
+					setAudio(false);
 				});
 				if (ev.track && ev.track.kind === 'audio') onAudio('opus');
 			};

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -431,6 +431,13 @@ preview() {
 		<label class="btn btn-outline-primary" for="mj-stream-1" id="mj-sub" hidden>Sub</label>
 		<span id="mj-badge" class="badge text-bg-secondary align-self-center ms-2">connecting…</span>
 	</div>
+	<!-- Unhidden by preview-page.js only where preview-webrtc.js is loaded and
+	     the browser has WebRTC; mj-settings.cgi shares this markup and offers
+	     the MSE player alone. -->
+	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Transport" id="mj-transport-ctl" hidden>
+		<input type="checkbox" class="btn-check" id="mj-transport" autocomplete="off">
+		<label class="btn btn-outline-primary" for="mj-transport">WebRTC</label>
+	</div>
 	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Audio" id="mj-audio-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-mute" autocomplete="off">
 		<label class="btn btn-outline-primary" for="mj-mute" id="mj-mute-lbl">🔇 Muted</label>

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -35,6 +35,7 @@
 </div>
 
 <script src="/a/preview.js"></script>
+<script src="/a/preview-webrtc.js"></script>
 <script src="/a/preview-page.js"></script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
The Preview page has played MSE over `/ws/video` since it stopped being an MJPEG
refresher, and that is a good default: it negotiates nothing, so it plays
whatever the browser's decoder takes. What it cannot do is get below about a
second of latency, carry audio in the camera's direction, or tell the encoder
that the link is congested. Majestic now serves WebRTC at `/ws/webrtc` on lite
firmware as well, so the page can offer all three.

## Shape

`www/a/preview-webrtc.js` is a second body behind `preview.js`'s façade — the
same seven methods (`setStream`, `requestIdr`, `setAudio`, `setVolume`,
`audioSupported`, `destroy`, `supported`), the same `onState`/`onCodec`/`onAudio`
callbacks. So `preview-page.js` is written once and chooses a transport at
attach time rather than knowing which one it got.

MSE stays the default until WebRTC has had field time. The **WebRTC** toggle
opts in and `localStorage` remembers the choice per browser — what decides it is
what that browser can negotiate, and that travels with the browser rather than
with the camera. `mj-settings.cgi` shares the `preview()` markup but loads
`preview.js` alone, so the toggle stays hidden there.

## The fallback chain is WebRTC → MSE → MJPEG → note

The middle step is load-bearing rather than tidy. WebRTC negotiates and can
therefore fail where MSE cannot: Firefox's WebRTC stack offers only H.264
Baseline whatever its decoder can do, so a camera on `profile: main` has nothing
to give it — while the same browser plays that stream over MSE without
complaint. A player reporting `'fallback'` is asking for the other transport,
not for MJPEG, and the reason lands on the toggle's tooltip rather than
vanishing.

## Verified

Against a hi3516cv500 camera, driving the real page in Chromium (not a mock):

| what | result |
| ---- | ------ |
| H.264 main, 3840x2160 | plays over both transports; the badge names which one |
| Main → Sub over WebRTC | re-negotiates, lands on 1280x720 |
| reload | preference survives; switching back to MSE works |
| audio | unmuting brings a live Opus track and enables the slider; muting again keeps the picture |
| H.265 on both channels | Chromium decodes it in neither transport — the page walks the whole chain to MJPEG within five seconds, unticks the toggle and rewrites the preference |

## One thing worth knowing

With H.265 on `video0` and H.264 on `video1`, WebRTC gives Chromium the
substream, because the camera picks a channel the peer can actually decode. MSE
asks for a stream by number and has no such move, so it drops to MJPEG. The
transport that can fail to negotiate is also the one that can adapt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
