### PR TITLE
settings: size the mobile nav tree like the navbar above it

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -428,6 +428,51 @@ pre#output[data-cmd] {
 	}
 }
 
+/* Below md the rail stops being a rail. It is full width, it is the page's
+   primary navigation, and it sits directly under the navbar's own accordion —
+   so it should read like that one rather than like a column label (#183).
+   The 11px uppercase category is an affordance for a 25%-width sidebar; at
+   full width it is just small. Matching the navbar's own scale: a category
+   reads like .navbar-nav .nav-link (1rem), a section like .dropdown-item
+   (0.9rem), and both get a 44px row so they are honest touch targets. */
+@media (max-width: 767.98px) {
+	#mj-settings-nav {
+		font-size: 1rem;
+	}
+
+	.mj-tree-cat {
+		min-height: 2.75rem;
+		padding: 0.5rem 0.25rem;
+		font-size: 1rem;
+		font-weight: 400;
+		letter-spacing: normal;
+		text-transform: none;
+		color: var(--bs-body-color);
+	}
+
+	.mj-tree-sub .nav-link {
+		min-height: 2.75rem;
+		padding: 0.5rem 0.75rem 0.5rem 1.75rem;
+		font-size: 0.9rem;
+	}
+
+	.mj-tree-n {
+		font-size: 0.8125rem;
+	}
+
+	.mj-tree-caret {
+		border-left-width: 0.35rem;
+		border-top-width: 0.3rem;
+		border-bottom-width: 0.3rem;
+	}
+
+	/* 16px keeps iOS from zooming the page when the box takes focus, and the
+	   search sits in the same list it filters — it should not be smaller. */
+	.mj-search .form-control {
+		font-size: 1rem;
+	}
+}
+
 /* search hits, in the tree and in the field labels/hints of the open section */
 mark {
 	padding: 0 0.1em;


### PR DESCRIPTION
Closes #183.

Below `md` the settings rail stops being a rail: it is full width, it is the page's primary navigation, and it sits directly under the navbar's own accordion. It did not read like one.

Measured at 390px, before:

| | navbar | settings tree |
|---|---|---|
| top level | 16px / 400, 40px row | **11px uppercase / 600, 25px row** |
| second level | 14.4px (`.dropdown-item`) | 14px |

The small uppercase category is an affordance for a 25%-wide sidebar, where it separates groups without competing with the sections under it. At full width it is not a label *beside* something — it is the thing you tap, and it was the smallest text on the screen.

## What changes

Below `md` only, the tree takes the navbar's own scale: a category reads like `.navbar-nav .nav-link` (1rem, normal case), a section like `.dropdown-item` (0.9rem), and both sit in a 44px row instead of 25px. After:

| | navbar | settings tree |
|---|---|---|
| top level | 16px / 400, 40px row | 16px / 400, 44px row |
| second level | 14.4px | 14.4px |

The search box goes to 1rem there too — it sits in the list it filters, so it should not be smaller than the list, and 16px is also what stops iOS zooming the page when the field takes focus.

**The desktop rail is untouched**: still 11px uppercase with 14px sections beside the form, where that is the right call.

## On "probably the same underlying code"

Worth saying plainly: they can share the visual language but not the implementation. The navbar accordion is Bootstrap's `collapse` plus `dropdown` over a static list. The settings tree filters as you type, counts the matches per section and marks them, and collapses to one-open-at-a-time — none of which those components do. Same scale and rhythm, different mechanism.

## Verified

On a hi3516ev300, measuring computed styles rather than eyeballing:

- at 390px: category `16px / 400`, 44px row; section `14.4px` — against the navbar's `16px / 400` and `14.4px`
- at 1440px: unchanged, `11px` uppercase with `14px` sections

`tools/lint-templates.sh`, `node --check` and `tools/build-dist.sh` pass. CSS only — no change to `mj-settings.js`.
