### PR TITLE
settings: let a long switch label wrap instead of leaving the card

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -130,10 +130,15 @@
 	max-width: 20rem;
 }
 
-/* a switch is as wide as its own label, so the glyph hugs the text instead of
-   sitting a card-width away from it */
+/* A switch is as wide as its own label, so the glyph hugs the text instead of
+   sitting a card-width away from it. Shrink stays enabled (0 *1* auto): a
+   switch carries its label inline, unlike every other row where the <label> is
+   a block above the control and wraps on its own, so a no-shrink wrapper would
+   size to the unwrapped text and spill out of the column — which the 63-char
+   rtsp.fecAdaptive title did. min-width comes from .mj-ctl-in above, without
+   which flex-shrink alone still cannot go under the content width. */
 .boolean .mj-ctl-in {
-	flex: 0 0 auto;
+	flex: 0 1 auto;
 }
 
 .x-small {


### PR DESCRIPTION
On `mj-settings.cgi?tab=rtsp`, **Adapt FEC strength to RTCP-reported loss; PLI forces a keyframe** runs past the right edge of the card and takes its `↺` off-screen with it.

### Why that row and not the others

Every other long label on the page is a block `<label class="form-label">` *above* its control, so it wraps on its own. A switch is the exception: its label lives inline next to the toggle, inside `.mj-ctl-in`. #173 pinned that wrapper with

```css
.boolean .mj-ctl-in { flex: 0 0 auto; }
```

so the reset glyph would hug the switch text rather than strand a card-width away from it. But `flex-shrink: 0` also forbids wrapping — the wrapper sizes to the *unwrapped* label, and anything wider than the column simply leaves the card.

`rtsp.fecAdaptive` is the only title in the whole schema long enough to reach that width (63 chars). Measured on the lab hi3516av300: column 446px, wrapper 555px — **119px** of overhang at 1440px, 138px at 390px.

### Fix

`flex: 0 1 auto` — shrinking back on. Short switch labels are untouched (basis `auto`, no grow, so they still size to their own text and the glyph still hugs); a label that needs the whole column now gets it and wraps. `min-width: 0` was already inherited from `.mj-ctl-in`, which `flex-shrink` needs in order to go under the content width at all.

One line of CSS, no JS change.

### Verification

On `root@openipc-hi3516av300` (`rtc/busy-vs-cannot+7bec0908`), driving the camera's own `config.schema.json`, `config.json` and the deployed CSS:

- swept **all 19 sections** at 1440px and 390px, measuring every `.mj-ctl-in` against its row — `fecAdaptive` was the *only* overflowing row before, and there are **none** after
- short switch rows (`Enable`, `Enable back-channel`, `Enable FlexFEC repair flow for RTSP video`) keep their hugging `↺` at both widths
- `tools/lint-templates.sh` — ok: 29 haserl templates, 16 shell scripts
- `tools/build-dist.sh` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
