### PR TITLE
preview: say that WebRTC lets the camera change the stream for everyone

### DIFF
--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -88,6 +88,28 @@
 	const mute = $('#mj-mute'), muteLbl = $('#mj-mute-lbl'), volCtl = $('#mj-vol');
 	const audioCtl = $('#mj-audio-ctl');
 	const transportCtl = $('#mj-transport'), transportGrp = $('#mj-transport-ctl');
+	const transportLbl = $('#mj-transport-lbl'), transportNote = $('#mj-transport-note');
+
+	// What the toggle says when nothing has gone wrong. Kept because a failure
+	// replaces it with the reason, and switching back has to put the explanation
+	// there again rather than leave the tooltip stuck on a complaint about a
+	// session that is long over.
+	const TRANSPORT_TITLE = transportLbl ? transportLbl.title : '';
+
+	// The bitrate adaptation is the thing worth disclosing. It is what makes
+	// WebRTC work on a thin link, and it reaches past the person who switched it
+	// on: the encoder is shared with everyone else watching that stream, and
+	// with whatever is recording it. So say it where it cannot be missed, and
+	// only while it is actually happening — a tooltip needs a pointer to find,
+	// and this is not a detail for people who happen to own a mouse.
+	function syncTransportNote() {
+		if (transportNote) {
+			transportNote.hidden = !usingWebRTC;
+		}
+		if (transportLbl && usingWebRTC) {
+			transportLbl.title = TRANSPORT_TITLE;
+		}
+	}
 	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
 
 	// Which transport to try. WebRTC unless something says otherwise: it is
@@ -246,6 +268,7 @@
 		if (audioOn && player.audioSupported()) player.setAudio(true);
 		player.setVolume(vol);
 		syncAudioCtl();
+		syncTransportNote();
 	}
 
 	function handlersFor(gen) {
@@ -265,8 +288,13 @@
 						const why = d || 'unavailable';
 						if (transportCtl) {
 							transportCtl.checked = false;
-							const lbl = transportCtl.nextElementSibling;
-							if (lbl) lbl.title = 'WebRTC: ' + why;
+						}
+						// The reason first, because it is the news, then the
+						// standing explanation — the tooltip is the only place
+						// either of them lives.
+						if (transportLbl) {
+							transportLbl.title =
+								'WebRTC: ' + why + '\n\n' + TRANSPORT_TITLE;
 						}
 						// 'busy' says the camera is full, which will not be
 						// true for long — take MSE now and try WebRTC again on

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -465,8 +465,16 @@ preview() {
 	     the MSE player alone. -->
 	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Transport" id="mj-transport-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-transport" autocomplete="off">
-		<label class="btn btn-outline-primary" for="mj-transport">WebRTC</label>
+		<label class="btn btn-outline-primary" for="mj-transport" id="mj-transport-lbl"
+			title="Sub-second video and two-way audio, and the camera fits the stream to your connection — which changes it for everyone else watching that stream too.">WebRTC</label>
 	</div>
+	<!-- Shown only while WebRTC is the live transport. The tooltip above cannot
+	     be the whole disclosure: it needs a pointer to find, and the thing being
+	     disclosed reaches past the person reading it. -->
+	<p id="mj-transport-note" class="small text-body-secondary mb-2" hidden>
+		The camera is adapting this stream's bitrate to your connection. Anyone
+		else watching the same stream sees that too.
+	</p>
 	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Audio" id="mj-audio-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-mute" autocomplete="off">
 		<label class="btn btn-outline-primary" for="mj-mute" id="mj-mute-lbl">🔇 Muted</label>


### PR DESCRIPTION
Raised by @usa- in #184, and it is a fair hit.

The toggle said `WebRTC` and nothing else. Switching it on puts the viewer in the camera's bitrate loop: the receiver's estimate reconfigures the encoder for whichever channel it is watching. On a thin link that *is* the feature — it is why the preview holds up where MSE tears — but the encoder is shared, so the change reaches every other viewer of that stream and whatever is recording it.

It is bounded and temporary. The configured `videoN.bitrate` is a ceiling, so a viewer can only ever lower it, and the encoder is handed back when the last peer disconnects. But temporary is not the same as disclosed, and deciding it on someone else's behalf from a button labelled with a protocol name is not a fair trade.

## What changes

- A **tooltip** on the toggle: what the transport buys, and what it costs.
- A **line under the control**, shown only while WebRTC is the live transport:
  > The camera is adapting this stream's bitrate to your connection. Anyone else watching the same stream sees that too.

The tooltip alone would not do — it needs a pointer to find, and this is not a detail reserved for people who own a mouse.

The failure path already borrowed that tooltip to explain why WebRTC gave up, so the two now share it: the reason first, because it is the news, then the standing explanation. Otherwise the next person to hover learns only that something once broke.

```
normal:        "Sub-second video and two-way audio, and the camera fits the
                stream to your connection — which changes it for everyone else
                watching that stream too."

after failure: "WebRTC: negotiated but no media arrived
                <blank>
                Sub-second video and two-way audio, and the camera fits …"
```

## Verified

On a hi3516cv500, driving the real page:

| | |
| --- | --- |
| default (WebRTC) | note shown, tooltip carries the explanation |
| switched to MSE | note hidden |
| back to WebRTC | note returns, tooltip unchanged |
| forced failure (`RTCPeerConnection` throws) | note hidden, tooltip has reason **and** explanation |

Existing preview suite re-run and still passing: happy path, both player-lifetime regressions, no-media fallback, and the transport-preference cases.

## Not in this PR

@usa- also asked for an explicit **"allow adjusting bitrate: yes/no"**, which is the right answer for a camera whose streams are already committed to other uses. That needs camera-side work and a decision about where the knob lives, so it is separate. This change only stops the side effect being a surprise.

Refs #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)