### PR TITLE
settings: give Live adjustments the low-latency transport, on the substream

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -677,25 +677,48 @@
 	function attachLivePreview(video) {
 		const stream = getDotted(state.config, 'video1.enabled') === true ? 1 : 0;
 
+		// Which attachment is the live one. MajesticWebRTC can report 'fallback'
+		// from inside attach() — it does exactly that when RTCPeerConnection or
+		// addTransceiver throws — so the handler below runs, installs MSE, and
+		// then the outer assignment completes and buries it under the façade
+		// that just failed. The picture would look right and the handle would be
+		// wrong, which is worse: state.previewPlayer is what the tab teardown
+		// destroys, so every visit would leave a live socket behind.
+		let gen = 0;
+
 		function attach(kind) {
+			const mine = ++gen;
+
+			// Whatever is running loses its handle here, so it has to be closed
+			// here. In the synchronous case there is nothing yet to close.
+			if (state.previewPlayer) {
+				try { state.previewPlayer.destroy(); } catch (e) {}
+				state.previewPlayer = null;
+			}
+
 			const impl = window.MajesticTransport.impl(kind);
 			if (!impl) return;
-			state.previewPlayer = impl.attach(video, {
+
+			const p = impl.attach(video, {
 				stream: stream,
-				onState: (st, detail) => {
-					if (kind !== 'webrtc') return;
+				onState: (st) => {
+					if (mine !== gen || kind !== 'webrtc') return;
 					// 'fallback' is durable and worth remembering; 'busy' says
 					// the camera is full, which it will not be for long.
 					if (st === 'fallback' || st === 'busy') {
 						if (st === 'fallback') window.MajesticTransport.demote();
-						if (state.previewPlayer) {
-							try { state.previewPlayer.destroy(); } catch (e) {}
-							state.previewPlayer = null;
-						}
 						attach('mse');
 					}
 				},
 			});
+
+			// Superseded while attach() was still running: something else is
+			// playing now, so drop what we just built rather than bury it.
+			if (mine !== gen) {
+				try { p.destroy(); } catch (e) {}
+				return;
+			}
+			state.previewPlayer = p;
 		}
 
 		attach(window.MajesticTransport.preferred());

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -648,6 +648,59 @@
 
 	function titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
 
+	// The preview beside the live knobs, on the transport with the least lag.
+	//
+	// WebRTC, because this is the one page where latency is the feature: someone
+	// is dragging a saturation slider and watching for the effect, and MSE is
+	// about a second behind where WebRTC is not. The earlier reasoning for
+	// keeping this page on MSE — that a WebRTC viewer joins the encoder's
+	// bitrate loop and would disturb a judgement about image quality — does not
+	// survive looking at what the page actually offers. Brightness, contrast,
+	// saturation, hue, mirror and flip are ISP knobs; nothing here judges an
+	// encoder setting, and whoever is tuning videoN.bitrate is on another tab
+	// with no preview at all.
+	//
+	// The substream, by the same convention the Preview page follows: the main
+	// channel is what an NVR or the SD card records, and this preview only has
+	// to show what the ISP is doing — which looks the same on either channel,
+	// because both are the same picture scaled. Main where no substream is
+	// configured, because /ws/video subscribes to whatever number it is handed
+	// and then quietly delivers nothing, which reads as "no signal" rather than
+	// as a misconfiguration. state.config is loaded by the time this runs; the
+	// knobs beside the preview are rendered from it.
+	//
+	// The fallback is a dozen lines rather than a call into shared code, because
+	// what the Preview page does on a fallback — badge, MJPEG, keeping a toggle
+	// in step — has nothing to do with this panel. The part that must not
+	// diverge is which transport to prefer and what to remember, and that is
+	// preview-transport.js.
+	function attachLivePreview(video) {
+		const stream = getDotted(state.config, 'video1.enabled') === true ? 1 : 0;
+
+		function attach(kind) {
+			const impl = window.MajesticTransport.impl(kind);
+			if (!impl) return;
+			state.previewPlayer = impl.attach(video, {
+				stream: stream,
+				onState: (st, detail) => {
+					if (kind !== 'webrtc') return;
+					// 'fallback' is durable and worth remembering; 'busy' says
+					// the camera is full, which it will not be for long.
+					if (st === 'fallback' || st === 'busy') {
+						if (st === 'fallback') window.MajesticTransport.demote();
+						if (state.previewPlayer) {
+							try { state.previewPlayer.destroy(); } catch (e) {}
+							state.previewPlayer = null;
+						}
+						attach('mse');
+					}
+				},
+			});
+		}
+
+		attach(window.MajesticTransport.preferred());
+	}
+
 	// The Live adjustments leaf: the preview and the x-live knobs side by side, so
 	// dragging one shows its effect without scrolling. One "Reset all" rather than
 	// a per-knob reset. The knobs register in state.fields, so the page Save and
@@ -666,8 +719,7 @@
 				'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
 				'</div></div>';
 			row.appendChild(pv);
-			state.previewPlayer =
-				window.MajesticVideo.attach(pv.querySelector('#mj-live-video'), { stream: 0 });
+			attachLivePreview(pv.querySelector('#mj-live-video'));
 		}
 
 		const col = el('div', withVideo ? 'col-12 col-lg-5' : 'col-12 col-lg-6');

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -112,102 +112,13 @@
 	}
 	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
 
-	// Which transport to try. WebRTC unless something says otherwise: it is
-	// sub-second where MSE is about a second behind, it carries audio, and its
-	// receiver reports let the camera match the encoder to the link. MSE stays
-	// one tick away for the browsers and cameras where negotiation cannot be
-	// made to work.
-	//
-	// Remembered per browser rather than per camera, because what decides it is
-	// what this browser can negotiate, and that travels with the browser.
-	//
-	// Two kinds of "not WebRTC", kept apart on purpose:
-	//
-	//   mj-transport-pick — what the person chose. Permanent until they choose
-	//                       again, in either direction.
-	//   mj-transport-auto — what a failure decided for them, with the time it
-	//                       was decided. Expires, because the reasons expire:
-	//                       a camera switched to H.265, a stream that stalled,
-	//                       a network that was having a bad afternoon. Without
-	//                       the expiry, one bad session would demote a browser
-	//                       for good and nobody would ever know why their
-	//                       preview was a second behind.
-	//
-	// mj-transport is the previous release's single key, and it is read once
-	// and thrown away. It could not hold this distinction: a fallback wrote
-	// 'mse' into it and so did unticking the box, so every browser that had
-	// ever fallen back looks, to the code above, exactly like someone who
-	// chose MSE on purpose. Carrying those forward would pin them off the new
-	// default permanently — the precise outcome the split exists to prevent.
-	const OLD_KEY = 'mj-transport';
-	const PICK_KEY = 'mj-transport-pick';
-	const AUTO_KEY = 'mj-transport-auto';
-	// Long enough not to re-annoy someone whose camera genuinely cannot serve
-	// their browser, short enough that fixing the camera shows up the same day.
-	const AUTO_FOR_MS = 6 * 60 * 60 * 1000;
-
-	const webrtcAvailable = !!(window.MajesticWebRTC && MajesticWebRTC.available);
-
-	function readPref(k) {
-		try { return localStorage.getItem(k); } catch (e) { return null; }
-	}
-	function writePref(k, v) {
-		try {
-			if (v === null) localStorage.removeItem(k); else localStorage.setItem(k, v);
-		} catch (e) {}
-	}
-
-	// 'webrtc' under the old key was unambiguous — only the toggle wrote it —
-	// so it survives as a choice. 'mse' was not, so it becomes a demotion:
-	// nothing changes for that browser today, and in six hours it tries WebRTC
-	// again instead of never.
-	function migrateOldPref() {
-		const old = readPref(OLD_KEY);
-		if (old === null) return;
-		writePref(OLD_KEY, null);
-		if (readPref(PICK_KEY) !== null || readPref(AUTO_KEY) !== null) return;
-		if (old === 'webrtc') writePref(PICK_KEY, 'webrtc');
-		else if (old === 'mse') writePref(AUTO_KEY, String(Date.now()));
-	}
-
-	// A demotion that has not expired. The window is bounded at both ends:
-	// a timestamp in the future is not "very fresh", it is a clock that moved
-	// or a value this code did not write, and either way honouring it would
-	// suppress WebRTC for far longer than the six hours advertised.
-	function autoDemoted() {
-		const raw = readPref(AUTO_KEY);
-		const at = /^\d+$/.test(raw || '') ? parseInt(raw, 10) : 0;
-		const age = Date.now() - at;
-		if (!at || age < 0 || age > AUTO_FOR_MS) {
-			if (raw !== null) writePref(AUTO_KEY, null);
-			return false;
-		}
-		return true;
-	}
-
-	function wantWebRTC() {
-		if (!webrtcAvailable) return false;
-		migrateOldPref();
-		const chosen = readPref(PICK_KEY);
-		if (chosen === 'webrtc') return true;
-		if (chosen === 'mse') return false;
-		return !autoDemoted();
-	}
-
-	// The person picked a transport: that outranks anything a failure decided.
-	function rememberTransport(t) {
-		writePref(PICK_KEY, t);
-		writePref(AUTO_KEY, null);
-		writePref(OLD_KEY, null);
-	}
-
-	// A failure picked one. Recorded separately and with an expiry, and never
-	// against an explicit choice to use WebRTC — someone who ticked the box
-	// gets it back on the next load rather than being quietly overruled.
-	function rememberDemotion() {
-		if (readPref(PICK_KEY) === 'webrtc') return;
-		writePref(AUTO_KEY, String(Date.now()));
-	}
+	// Which transport to try, and the memory behind it, both live in
+	// preview-transport.js — the settings page needs the same rules and two
+	// copies would drift. See that file for why each of them is what it is.
+	const webrtcAvailable = MajesticTransport.available();
+	const wantWebRTC = () => MajesticTransport.preferred() === 'webrtc';
+	const rememberTransport = t => MajesticTransport.choose(t);
+	const rememberDemotion = () => MajesticTransport.demote();
 
 	let player = null, usingWebRTC = false;
 	// Carried across a transport switch, because a new player starts from its

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -1,0 +1,116 @@
+// Which transport a preview should use, and the memory behind that choice.
+//
+// Two pages need this now — the Preview page and the Live adjustments panel in
+// settings — and the rules are subtle enough that two copies would drift within
+// a release: a legacy key that has to be migrated exactly once, a demotion that
+// expires, a bounded window that rejects clocks running backwards, and the
+// difference between a camera that cannot serve this browser and one that is
+// merely busy. Divergence there would show up as "the preview behaves
+// differently on the settings page", which is the kind of bug nobody files.
+//
+// What is deliberately NOT here is the attach-and-fall-back dance. The two
+// pages want different things from it — one has a badge, an MJPEG fallback and
+// a transport toggle to keep in step, the other has a bare video element — and
+// a shared version would be an abstraction over two callers with one of them
+// bent to fit. The dance is a dozen lines; the rules below are not.
+window.MajesticTransport = (function () {
+	// What the person chose. Permanent until they choose again.
+	const PICK_KEY = 'mj-transport-pick';
+	// What a failure decided for them, and when. Expires, because the reasons
+	// expire: a camera switched to H.265, a stream that stalled, a network
+	// having a bad afternoon.
+	const AUTO_KEY = 'mj-transport-auto';
+	// The single key an earlier release used for both. It cannot tell a choice
+	// from a fallback — both wrote 'mse' — so it is read once and thrown away.
+	const OLD_KEY = 'mj-transport';
+
+	// Long enough not to re-annoy someone whose camera genuinely cannot serve
+	// their browser, short enough that fixing the camera shows up the same day.
+	const AUTO_FOR_MS = 6 * 60 * 60 * 1000;
+
+	function read(k) {
+		try { return localStorage.getItem(k); } catch (e) { return null; }
+	}
+	function write(k, v) {
+		try {
+			if (v === null) localStorage.removeItem(k); else localStorage.setItem(k, v);
+		} catch (e) {}
+	}
+
+	// 'webrtc' under the old key was unambiguous — only the toggle ever wrote
+	// it — so it survives as a choice. 'mse' was not, so it becomes a demotion:
+	// nothing changes for that browser today, and in six hours it tries WebRTC
+	// again rather than never.
+	function migrate() {
+		const old = read(OLD_KEY);
+		if (old === null) return;
+		write(OLD_KEY, null);
+		if (read(PICK_KEY) !== null || read(AUTO_KEY) !== null) return;
+		if (old === 'webrtc') write(PICK_KEY, 'webrtc');
+		else if (old === 'mse') write(AUTO_KEY, String(Date.now()));
+	}
+
+	// A demotion that has not expired. The window is bounded at both ends: a
+	// timestamp in the future is not a very fresh demotion, it is a clock that
+	// moved or a value this code did not write, and honouring it would suppress
+	// WebRTC for far longer than the six hours advertised.
+	function demoted() {
+		const raw = read(AUTO_KEY);
+		const at = /^\d+$/.test(raw || '') ? parseInt(raw, 10) : 0;
+		const age = Date.now() - at;
+		if (!at || age < 0 || age > AUTO_FOR_MS) {
+			if (raw !== null) write(AUTO_KEY, null);
+			return false;
+		}
+		return true;
+	}
+
+	function available() {
+		return !!(window.MajesticWebRTC && window.MajesticWebRTC.available);
+	}
+
+	// 'webrtc' unless something says otherwise. WebRTC is sub-second where MSE
+	// is about a second behind, carries audio, and lets the camera match the
+	// encoder to the link; MSE is what serves the browsers and cameras where
+	// negotiation cannot be made to work.
+	function preferred() {
+		if (!available()) return 'mse';
+		migrate();
+		const chosen = read(PICK_KEY);
+		if (chosen === 'webrtc') return 'webrtc';
+		if (chosen === 'mse') return 'mse';
+		return demoted() ? 'mse' : 'webrtc';
+	}
+
+	// The person picked a transport: that outranks anything a failure decided.
+	function choose(kind) {
+		write(PICK_KEY, kind === 'webrtc' ? 'webrtc' : 'mse');
+		write(AUTO_KEY, null);
+		write(OLD_KEY, null);
+	}
+
+	// A failure picked one. Recorded apart from a choice and with an expiry, and
+	// never against an explicit choice of WebRTC — someone who ticked the box
+	// gets it back on the next load rather than being quietly overruled.
+	//
+	// Not for a camera that is merely full: it will not be full for long, and
+	// remembering that would park a browser on the slower transport because
+	// somebody else happened to be watching.
+	function demote() {
+		if (read(PICK_KEY) === 'webrtc') return;
+		write(AUTO_KEY, String(Date.now()));
+	}
+
+	// The implementation behind a name, for a caller doing its own attaching.
+	function impl(kind) {
+		return kind === 'webrtc' ? window.MajesticWebRTC : window.MajesticVideo;
+	}
+
+	return {
+		available: available,
+		preferred: preferred,
+		choose: choose,
+		demote: demote,
+		impl: impl,
+	};
+})();

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -82,6 +82,8 @@ fi
 </div>
 
 <script src="/a/preview.js"></script>
+<script src="/a/preview-webrtc.js"></script>
+<script src="/a/preview-transport.js"></script>
 <script src="/a/mj-settings.js" defer></script>
 
 <% fi %>

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -36,6 +36,7 @@
 
 <script src="/a/preview.js"></script>
 <script src="/a/preview-webrtc.js"></script>
+<script src="/a/preview-transport.js"></script>
 <script src="/a/preview-page.js"></script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
This page is where latency is the feature. Someone is dragging a saturation slider and watching for the effect, and MSE is about a second behind where WebRTC is not.

**The reasoning that kept it on MSE was mine and it was wrong.** I argued that a WebRTC viewer joins the encoder's bitrate loop and would disturb a judgement about image quality. That does not survive looking at what the page actually offers: Brightness, Contrast, Saturation, Hue, Mirror and Flip are all ISP knobs. Nothing here judges an encoder setting, and whoever is tuning `videoN.bitrate` is on another tab with no preview at all. The objection applied to nobody, while the cost — a second of lag on a control being dragged — landed on everybody.

It takes **the substream** too, by the convention #192 established: the main channel is what an NVR or the SD card records, and this preview only has to show what the ISP is doing, which looks the same on either channel because both are the same picture scaled. Main where no substream is configured, because `/ws/video` subscribes to whatever number it is handed and then quietly delivers nothing.

## One extraction, deliberately narrow

`preview-transport.js` now owns **which transport to prefer and what to remember about it**. Two pages need those rules and they are subtle enough that two copies would drift within a release:

- a legacy key migrated exactly once, distinguishing a choice from a fallback;
- a demotion that expires after six hours;
- a window bounded at *both* ends, so a clock running backwards cannot suppress WebRTC for a week;
- the difference between a camera that cannot serve this browser and one that is merely busy.

Divergence there would present as *"the preview behaves differently on the settings page"*, which is the kind of bug nobody files.

**The attach-and-fall-back dance stays in both callers, on purpose.** What the Preview page does on a fallback — badge, MJPEG, keeping a toggle and a note in step — has nothing to do with this panel, and a shared version would be an abstraction over two callers with one of them bent to fit. It is a dozen lines either side; the rules above are not.

## Verified

On a hi3516cv500:

| | |
| --- | --- |
| Live adjustments | plays 1280x720 over WebRTC (`srcObject` set) |
| `RTCPeerConnection` made to throw | same panel, same substream, over MSE |

Sixteen cases across the preview suite still pass — which is what the extraction had to earn, since it touched the Preview page's preference handling as well.

Refs #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)