### PR TITLE
Preview: talkback and per-session stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-WebUI for [OpenIPC Firmware](https://github.com/openipc/firmware) — served on port 80 of the camera by an embedded httpd that runs `haserl` CGI scripts. There is no compile step, no package manager, no test suite. "Building" means copying the tree onto a running camera.
+WebUI for [OpenIPC Firmware](https://github.com/openipc/firmware) — served on port 80 of the camera by an embedded httpd that runs `haserl` CGI scripts. There is no compile step and nothing the browser loads comes from a package manager. "Building" means copying the tree onto a running camera.
+
+`npm test` runs what tests there are: plain Node, no framework, no dependency — `tests/talkback.test.js` drives the WebRTC player's microphone lifecycle against stubs, and `tests/transport.test.js` covers the STUN/TURN list built for `RTCPeerConnection`. Both exist because their subject is timing or configuration parsing that a browser cannot be made to reproduce on demand, and because getting either wrong is silent: a microphone that stays captured, or a session that negotiates and carries nothing. Most of this repo is CGI and DOM wiring that these cannot reach; do not read the suite as coverage of the WebUI.
 
 Authentication is HTTP Basic against `/etc/shadow` (user `root`, default password `12345`); `common.cgi:check_password` forces a redirect to `fw-interface.cgi` until the default password is changed.
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "majestic-webui",
   "version": "0.0.0",
   "private": true,
-  "description": "OpenIPC majestic web UI — dev tooling that builds the minified distribution tarball consumed by the firmware. The shipped source stays unminified and readable; minification happens only in CI.",
+  "description": "OpenIPC majestic web UI \u2014 dev tooling that builds the minified distribution tarball consumed by the firmware. The shipped source stays unminified and readable; minification happens only in CI.",
   "license": "MIT",
   "scripts": {
-    "build:dist": "sh tools/build-dist.sh"
+    "build:dist": "sh tools/build-dist.sh",
+    "test": "node tests/talkback.test.js && node tests/transport.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/assert.js
+++ b/tests/assert.js
@@ -1,0 +1,30 @@
+// The smallest thing that can fail a build.
+//
+// No framework on purpose: this repo ships to a camera's rootfs and has no
+// build step, so a test dependency would be the only reason anyone needed npm
+// to work on it. Node alone runs these.
+'use strict';
+
+let failures = 0;
+
+function check(name, cond, detail) {
+	if (cond) {
+		console.log('  ok   ' + name);
+	} else {
+		failures++;
+		console.log('  FAIL ' + name + (detail ? ' — ' + detail : ''));
+	}
+}
+
+function group(name) {
+	console.log(name);
+}
+
+// Call once at the end. Exits non-zero if anything failed, which is what makes
+// `npm test` mean something.
+function done() {
+	console.log(failures ? '\n' + failures + ' failed' : '\nall passed');
+	process.exit(failures ? 1 : 0);
+}
+
+module.exports = { check: check, group: group, done: done };

--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -1,0 +1,272 @@
+// preview-webrtc.js's talkback state machine, driven against stubs.
+//
+// Every case asks the same question: did the microphone stop? A capture that
+// outlives the control able to stop it is the worst thing this player can do,
+// and each of these is a route to it that review found in the debug page this
+// replaced — a permission grant that outlives the mode it was asked for, two
+// clicks racing into two grants, a track that ends on its own, a camera that
+// declines the direction after the browser has already lit the microphone.
+//
+// Stubs rather than a browser because the interesting states are all timing:
+// a prompt still open while something else changes underneath it. A real
+// getUserMedia cannot be held pending on demand; this one can.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-webrtc.js');
+
+// --- stubs ---------------------------------------------------------------
+function makeTrack(kind) {
+	return {
+		kind: kind, stopped: false, onended: null,
+		stop() { this.stopped = true; },
+	};
+}
+
+function makeEnv(o) {
+	o = o || {};
+	const env = { grants: [], sockets: [], pcs: [], gumCalls: 0 };
+
+	env.pending = [];   // unresolved getUserMedia promises, resolved by hand
+
+	const navigator = {};
+	if (!o.noGum) {
+		navigator.mediaDevices = {
+			getUserMedia() {
+				env.gumCalls++;
+				return new Promise((res, rej) => env.pending.push({ res, rej }));
+			},
+		};
+	}
+
+	function Transceiver(dir, track) {
+		this.currentDirection = dir;
+		this.sender = { track: track || null };
+		this.receiver = { track: track || makeTrack('audio') };
+	}
+
+	function RTCPeerConnection() {
+		this.transceivers = [];
+		this.closed = false;
+		env.pcs.push(this);
+	}
+	RTCPeerConnection.prototype.addTransceiver = function (what, opts) {
+		const dir = (opts && opts.direction) || 'sendrecv';
+		const track = typeof what === 'object' ? what : null;
+		// What the camera answers, per the test's scenario: 'sendrecv' when it
+		// accepts talkback, 'recvonly' (from our side) when it declines.
+		const negotiated = track
+			? (o.localDirection ||
+				(o.cameraTakesTalkback === false ? 'recvonly' : 'sendrecv'))
+			: dir;
+		const t = new Transceiver(negotiated, track);
+		this.transceivers.push(t);
+		return t;
+	};
+	RTCPeerConnection.prototype.getTransceivers = function () { return this.transceivers; };
+	RTCPeerConnection.prototype.createOffer = function () { return Promise.resolve({ sdp: 'x' }); };
+	RTCPeerConnection.prototype.setLocalDescription = function () {
+		this.localDescription = { sdp: 'x' };
+		return Promise.resolve();
+	};
+	RTCPeerConnection.prototype.setRemoteDescription = function () { return Promise.resolve(); };
+	RTCPeerConnection.prototype.addIceCandidate = function () { return Promise.resolve(); };
+	RTCPeerConnection.prototype.getStats = function () { return Promise.resolve({ forEach() {} }); };
+	RTCPeerConnection.prototype.close = function () { this.closed = true; };
+
+	function WebSocket(url) {
+		this.url = url; this.readyState = 1; this.sent = [];
+		env.sockets.push(this);
+		setTimeout(() => { if (this.onopen) this.onopen(); }, 0);
+	}
+	WebSocket.prototype.send = function (d) { this.sent.push(d); };
+	WebSocket.prototype.close = function () { this.readyState = 3; };
+
+	const win = {
+		RTCPeerConnection: RTCPeerConnection,
+		isSecureContext: o.secure !== false,
+	};
+	const ctx = {
+		window: win, navigator: navigator, WebSocket: WebSocket,
+		RTCPeerConnection: RTCPeerConnection,
+		location: { protocol: 'https:', host: 'cam' },
+		setTimeout, clearTimeout, setInterval, clearInterval, console,
+	};
+	ctx.globalThis = ctx;
+	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+	env.MajesticWebRTC = win.MajesticWebRTC;
+	env.video = { muted: true, volume: 1, srcObject: null, play: () => Promise.resolve() };
+	return env;
+}
+
+const tick = (n) => new Promise(r => setTimeout(r, n || 5));
+
+// --- cases ---------------------------------------------------------------
+async function reentrancy() {
+	group('two clicks while the prompt is up start one grant');
+	const env = makeEnv();
+	const mic = [];
+	const p = env.MajesticWebRTC.attach(env.video, { onMic: (s, w) => mic.push([s, w]) });
+	await tick();
+	p.setMic(true);
+	p.setMic(true);
+	p.setMic(true);
+	check('one getUserMedia', env.gumCalls === 1, env.gumCalls + ' calls');
+	check('reported asking', mic.some(m => m[0] === 'asking'));
+	const t = makeTrack('audio');
+	env.pending[0].res({ getAudioTracks: () => [t], getTracks: () => [t] });
+	await tick(400);
+	// Capturing, but the camera has not answered: 'live', not 'on'.
+	check('reported live, not on', mic.some(m => m[0] === 'live') &&
+		!mic.some(m => m[0] === 'on'), JSON.stringify(mic));
+	check('track kept', !t.stopped);
+	const sock = env.sockets[env.sockets.length - 1];
+	sock.onmessage({ data: JSON.stringify({ reply: 'answer', data: 'sdp' }) });
+	await tick(30);
+	check('on only after the answer', mic.some(m => m[0] === 'on'),
+		JSON.stringify(mic));
+	// Accepted talkback opens the camera's audio with it, so the element is
+	// unmuted — but only now, not at the moment of capture.
+	check('unmuted on acceptance', env.video.muted === false);
+	p.destroy();
+}
+
+async function destroyedDuringPrompt() {
+	group('destroyed while the prompt is up releases the grant');
+	const env = makeEnv();
+	const p = env.MajesticWebRTC.attach(env.video, {});
+	await tick();
+	p.setMic(true);
+	p.destroy();
+	const t = makeTrack('audio');
+	env.pending[0].res({ getAudioTracks: () => [t], getTracks: () => [t] });
+	await tick(20);
+	check('track stopped', t.stopped);
+}
+
+async function cameraDeclines() {
+	group('a camera that will not take audio releases the microphone');
+	const env = makeEnv({ cameraTakesTalkback: false });
+	const mic = [];
+	const p = env.MajesticWebRTC.attach(env.video, { onMic: (s, w) => mic.push([s, w]) });
+	await tick();
+	p.setMic(true);
+	const t = makeTrack('audio');
+	const before = env.sockets.length;
+	env.pending[0].res({ getAudioTracks: () => [t], getTracks: () => [t] });
+	// setMic renegotiates by reopening, which is on a 300 ms timer: the answer
+	// has to go to the session that carries the microphone, not the one before
+	// it.
+	await tick(400);
+	check('renegotiated', env.sockets.length > before,
+		env.sockets.length + ' sockets');
+	const sock = env.sockets[env.sockets.length - 1];
+	if (sock && sock.onmessage) {
+		sock.onmessage({ data: JSON.stringify({ reply: 'answer', data: 'sdp' }) });
+	}
+	await tick(30);
+	check('track stopped', t.stopped);
+	check('told why', mic.some(m => m[0] === 'off' && /not accepting/.test(m[1] || '')),
+		JSON.stringify(mic));
+	check('never claimed on', !mic.some(m => m[0] === 'on'), JSON.stringify(mic));
+	// The refusal must not leave sound playing that the page calls muted.
+	check('element still muted', env.video.muted === true);
+	p.destroy();
+}
+
+async function trackEndsOnItsOwn() {
+	group('a microphone unplugged mid-session clears the control');
+	const env = makeEnv();
+	const mic = [];
+	const p = env.MajesticWebRTC.attach(env.video, { onMic: (s, w) => mic.push([s, w]) });
+	await tick();
+	p.setMic(true);
+	const t = makeTrack('audio');
+	env.pending[0].res({ getAudioTracks: () => [t], getTracks: () => [t] });
+	await tick(20);
+	check('onended installed', typeof t.onended === 'function');
+	mic.length = 0;
+	t.onended();
+	await tick(10);
+	check('reported off', mic.some(m => m[0] === 'off'), JSON.stringify(mic));
+	p.destroy();
+}
+
+async function destroyStopsMic() {
+	group('destroy() stops a live microphone');
+	const env = makeEnv();
+	const p = env.MajesticWebRTC.attach(env.video, {});
+	await tick();
+	p.setMic(true);
+	const t = makeTrack('audio');
+	env.pending[0].res({ getAudioTracks: () => [t], getTracks: () => [t] });
+	await tick(20);
+	check('alive before destroy', !t.stopped);
+	p.destroy();
+	check('stopped after destroy', t.stopped);
+}
+
+async function insecureContext() {
+	group('no getUserMedia says which of the two reasons it is');
+	const env = makeEnv({ noGum: true, secure: false });
+	const mic = [];
+	const p = env.MajesticWebRTC.attach(env.video, { onMic: (s, w) => mic.push([s, w]) });
+	await tick();
+	check('micSupported false', p.micSupported() === false);
+	p.setMic(true);
+	check('blamed HTTPS', mic.some(m => m[0] === 'off' && /HTTPS/.test(m[1] || '')),
+		JSON.stringify(mic));
+	p.destroy();
+}
+
+async function refused() {
+	group('a refused permission leaves nothing running');
+	const env = makeEnv();
+	const mic = [];
+	const p = env.MajesticWebRTC.attach(env.video, { onMic: (s, w) => mic.push([s, w]) });
+	await tick();
+	p.setMic(true);
+	env.pending[0].rej({ name: 'NotAllowedError' });
+	await tick(20);
+	check('reported refused', mic.some(m => m[0] === 'off' && /refused/.test(m[1] || '')),
+		JSON.stringify(mic));
+	// And the guard has to clear, or the button is dead for the session.
+	p.setMic(true);
+	check('can ask again', env.gumCalls === 2, env.gumCalls + ' calls');
+	p.destroy();
+}
+
+async function cameraTakesMicButSendsNothing() {
+	group('a camera that takes the microphone but returns no audio');
+	// It answers recvonly, so this end settles on sendonly. That is talkback
+	// working, and must not read as a refusal.
+	const env = makeEnv({ localDirection: 'sendonly' });
+	const mic = [];
+	const p = env.MajesticWebRTC.attach(env.video, { onMic: (s, w) => mic.push([s, w]) });
+	await tick();
+	p.setMic(true);
+	const t = makeTrack('audio');
+	env.pending[0].res({ getAudioTracks: () => [t], getTracks: () => [t] });
+	await tick(400);
+	const sock = env.sockets[env.sockets.length - 1];
+	sock.onmessage({ data: JSON.stringify({ reply: 'answer', data: 'sdp' }) });
+	await tick(30);
+	check('track kept', !t.stopped);
+	check('reported on', mic.some(m => m[0] === 'on'), JSON.stringify(mic));
+	check('not called a refusal',
+		!mic.some(m => m[0] === 'off' && /not accepting/.test(m[1] || '')));
+	p.destroy();
+}
+
+(async () => {
+	for (const t of [reentrancy, cameraTakesMicButSendsNothing, destroyedDuringPrompt, cameraDeclines,
+		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused]) {
+		await t();
+	}
+	done();
+})();

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -1,0 +1,75 @@
+// MajesticTransport.iceServers() — the browser's half of the camera's
+// STUN/TURN configuration.
+//
+// This exists because the camera used to build this list in C and had tests
+// for it there. The page that consumed it is gone, majestic_stun_ice_js() went
+// with it, and the rules moved here — so the coverage has to move too, or the
+// only thing standing between an operator's `iceServers` setting and a
+// RTCPeerConnection that throws is someone remembering.
+//
+// The rules mirror include/majestic/stun_default.h in the majestic tree.
+// Change one, change both; these are the cases that say what "both" means.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-transport.js');
+
+// The module only needs a window to hang itself off. localStorage is absent
+// here on purpose: every read and write in it is wrapped, and a module that
+// threw without storage would fail in a private window too.
+const ctx = { window: {}, console: console };
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+const iceServers = ctx.window.MajesticTransport.iceServers;
+
+const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+const is = (name, got, want) =>
+	check(name, eq(got, want), 'got ' + JSON.stringify(got));
+
+group('the default the camera falls back to');
+is('unset means the camera default, not an empty list',
+	iceServers('', '', ''), [{ urls: 'stun:stun.cloudflare.com:3478' }]);
+is('null is unset too', iceServers(null, null, null),
+	[{ urls: 'stun:stun.cloudflare.com:3478' }]);
+
+group('every spelling of "none"');
+// YAML 1.1 decides what these words mean before majestic ever sees them:
+// `iceServers: off` reaches the config as the string "false", and so do `no`
+// and `false`. Accepting only the tidy answer leaves an operator who wrote the
+// natural one gathering host candidates and wondering why.
+['none', 'NONE', 'off', 'no', 'false', 'disabled'].forEach((w) =>
+	is('"' + w + '" disables STUN', iceServers(w, 'u', 'p'), []));
+is('a server really called "nonesuch" is a server',
+	iceServers('stun:nonesuch:3478', '', ''), [{ urls: 'stun:nonesuch:3478' }]);
+
+group('list parsing');
+is('commas separate', iceServers('stun:a:1,stun:b:2', '', ''),
+	[{ urls: 'stun:a:1' }, { urls: 'stun:b:2' }]);
+is('so do spaces and newlines — a YAML block scalar gives one per line',
+	iceServers('stun:a:1 stun:b:2\nstun:c:3', '', ''),
+	[{ urls: 'stun:a:1' }, { urls: 'stun:b:2' }, { urls: 'stun:c:3' }]);
+
+group('relays and their credentials');
+// A turn: entry missing either credential makes RTCPeerConnection throw
+// InvalidAccessError — and it throws before the page opens its signalling
+// socket, so the camera sees no attempt at all and the failure reads as
+// "signalling never happened". Dropping the entry costs the relay; keeping it
+// costs the whole session.
+is('a relay with both credentials is kept',
+	iceServers('turn:a:3478', 'u', 'p'),
+	[{ urls: 'turn:a:3478', username: 'u', credential: 'p' }]);
+is('turns: counts as a relay', iceServers('turns:a:5349', 'u', 'p'),
+	[{ urls: 'turns:a:5349', username: 'u', credential: 'p' }]);
+is('a relay with no credentials is dropped on its own, the rest kept',
+	iceServers('stun:a:1,turn:b:2', '', ''), [{ urls: 'stun:a:1' }]);
+is('half a credential is no credential',
+	iceServers('turn:b:2', 'u', ''), []);
+is('and the STUN entries beside it still survive that',
+	iceServers('stun:a:1,turn:b:2,stun:c:3', 'u', ''),
+	[{ urls: 'stun:a:1' }, { urls: 'stun:c:3' }]);
+
+done();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -701,6 +701,14 @@
 
 			const p = impl.attach(video, {
 				stream: stream,
+				// Same list the Preview page builds, and for the same reason:
+				// without it the browser offers host candidates only, and a
+				// session opened from anywhere but the same LAN negotiates
+				// cleanly and then never carries a packet.
+				iceServers: () => window.MajesticTransport.iceServers(
+					getDotted(state.config, 'webrtc.iceServers'),
+					getDotted(state.config, 'webrtc.turnUsername'),
+					getDotted(state.config, 'webrtc.turnCredential')),
 				onState: (st) => {
 					if (mine !== gen || kind !== 'webrtc') return;
 					// 'fallback' is durable and worth remembering; 'busy' says

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -87,6 +87,9 @@
 
 	const mute = $('#mj-mute'), muteLbl = $('#mj-mute-lbl'), volCtl = $('#mj-vol');
 	const audioCtl = $('#mj-audio-ctl');
+	const talkCtl = $('#mj-talk-ctl'), talk = $('#mj-talk'), talkLbl = $('#mj-talk-lbl');
+	const statsCtl = $('#mj-stats-ctl'), statsBtn = $('#mj-stats-btn'), statsBox = $('#mj-stats');
+	const TALK_TITLE = talkLbl ? talkLbl.title : '';
 	const transportCtl = $('#mj-transport'), transportGrp = $('#mj-transport-ctl');
 	const transportLbl = $('#mj-transport-lbl'), transportNote = $('#mj-transport-note');
 
@@ -124,6 +127,11 @@
 	// Carried across a transport switch, because a new player starts from its
 	// defaults and the user's choices should outlive the machinery.
 	let stream = 0, audioOn = false, vol = 1;
+	// Talkback is deliberately NOT carried across a transport switch or a
+	// reattach. Everything else here is a preference; this one holds a live
+	// microphone, and silently reopening it because the page rebuilt a player
+	// is not a thing to do on a user's behalf.
+	let talkbackConfigured = false;
 	// Set once the Main/Sub control has been touched, so a slow config answer
 	// cannot undo it.
 	let userPickedStream = false;
@@ -157,6 +165,56 @@
 		audioCtl.hidden = !(audioConfigured && player && player.audioSupported());
 	}
 
+	// Talkback needs three things at once, and each of them can be absent on
+	// its own: the camera configured to play received audio, a transport that
+	// carries a direction MSE has no concept of, and a secure context — a
+	// browser hands over no microphone on plain HTTP, so the button would ask
+	// for something it can never get.
+	function syncTalkCtl() {
+		if (!talkCtl) return;
+		const ok = talkbackConfigured && player && player.micSupported();
+		talkCtl.hidden = !ok;
+		if (!ok && talk) talk.checked = false;
+	}
+
+	// The stats panel follows the transport rather than the person: MSE has
+	// none of these numbers, so the button would open an empty box.
+	function syncStatsCtl() {
+		if (statsCtl) statsCtl.hidden = !usingWebRTC;
+		if (!usingWebRTC && statsBox) statsBox.hidden = true;
+	}
+
+	function showStats(s) {
+		const set = (id, v) => { const el = $(id); if (el) el.textContent = v; };
+		const cam = s.cam || {};
+		set('#mj-st-pic', s.width
+			? s.width + '×' + s.height + ' ' + (s.codec || '').toUpperCase() +
+				' · ' + Math.round(s.fps || 0) + ' fps'
+			: '-');
+		set('#mj-st-rx', s.kbps + ' kbit/s' +
+			(s.audioKbps ? ' · audio ' + s.audioKbps : ''));
+		// Lost is cumulative and jitter is instantaneous, which is why they are
+		// labelled rather than run together into one figure.
+		set('#mj-st-loss', (s.packetsLost || 0) + ' pkt · ' + (s.jitterMs || 0) + ' ms');
+		set('#mj-st-rtt', s.rttMs ? s.rttMs + ' ms' : '-');
+		set('#mj-st-recov', (s.nack || 0) + ' nack · ' + (s.pli || 0) + ' keyframe req');
+		set('#mj-st-cam', cam.ice
+			? 'ice ' + cam.ice + ' · dtls ' + cam.dtls + ' · media ' + cam.media
+			: '-');
+		// The camera's own estimate of what this link will carry, which is what
+		// it sets the encoder from — not a measurement of what arrived.
+		set('#mj-st-remb', cam.remb || '-');
+		set('#mj-st-pli', cam.pli || '-');
+		set('#mj-st-ain', cam['audio-in'] || '-');
+		// Both halves, because they answer different questions: the browser
+		// says it sent, the camera says it arrived. A microphone that is on
+		// with the camera's counter stuck at zero is the case worth seeing.
+		set('#mj-st-talk', s.micWanted
+			? (s.micSending ? 'sending' : 'offered, not accepted') +
+				' · ' + (s.micPackets || 0) + ' pkt out'
+			: 'off');
+	}
+
 	// Rebuilt rather than mutated when the transport changes: the two players
 	// own different machinery, and the state worth carrying over is three
 	// values.
@@ -182,6 +240,11 @@
 		if (audioOn && player.audioSupported()) player.setAudio(true);
 		player.setVolume(vol);
 		syncAudioCtl();
+		// The old player's destroy() released the microphone, so the control
+		// has to come back up in the state the new one is actually in.
+		if (talk) talk.checked = false;
+		syncTalkCtl();
+		syncStatsCtl();
 		syncTransportNote();
 	}
 
@@ -240,6 +303,34 @@
 					audioOn = false;
 					if (volCtl) volCtl.disabled = true;
 				}
+			},
+			// 'asking' while the browser's permission prompt is up, 'on' once
+			// the camera has accepted the direction, 'off' for every way it
+			// ends — refused, unplugged, revoked, or declined by a camera with
+			// audio.outputEnabled off. The reason rides along and goes in the
+			// tooltip, which is the only place it lives.
+			onMic: (state, why) => {
+				if (!live() || !talk) return;
+				talk.checked = state === 'on';
+				talk.disabled = state === 'asking';
+				if (talkLbl) {
+					talkLbl.textContent = state === 'asking' ? '🎤 Asking…'
+						: state === 'on' ? '🎤 Talking' : '🎤 Talk';
+					talkLbl.title = why ? why + '\n\n' + TALK_TITLE : TALK_TITLE;
+				}
+				// Talking opens the camera's audio too — the camera refuses a
+				// one-way audio section — so the listen control has to show
+				// what actually happened rather than what it was last set to.
+				if (state === 'on' && mute && !mute.checked) {
+					mute.checked = true;
+					audioOn = true;
+					muteLbl.textContent = '🔊 Listening';
+					if (volCtl) volCtl.disabled = false;
+				}
+			},
+			onStats: (s) => {
+				if (!live() || !statsBox || statsBox.hidden) return;
+				showStats(s);
 			},
 		};
 	}
@@ -348,6 +439,32 @@
 			vol = volCtl.value / 100;
 			// Kept even with no player yet: attachPlayer() applies it.
 			if (player) player.setVolume(vol);
+		});
+	}
+
+	// Talkback: the camera has to be configured to play what it receives.
+	// audio.enabled alone is the microphone; outputEnabled is the speaker, and
+	// this is the one that decides whether the far end has anywhere to put our
+	// audio. A camera with it off answers the session without our direction and
+	// the player reports that back through onMic.
+	if (talkCtl && talk) {
+		mjConfig().then(cfg => {
+			talkbackConfigured = mjGet(cfg, 'audio.outputEnabled') === true;
+			syncTalkCtl();
+		});
+		talk.addEventListener('change', () => {
+			if (!player) { talk.checked = false; return; }
+			// The player owns the answer, not the checkbox: a refused
+			// permission or a camera that declines leaves this unchecked
+			// again through onMic, and setting the label here would flash a
+			// state that never happened.
+			player.setMic(talk.checked);
+		});
+	}
+
+	if (statsBtn && statsBox) {
+		statsBtn.addEventListener('change', () => {
+			statsBox.hidden = !statsBtn.checked;
 		});
 	}
 })();

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -183,14 +183,24 @@
 		if (!talkCtl) return;
 		const ok = talkbackConfigured && player && player.micSupported();
 		talkCtl.hidden = !ok;
-		if (!ok && talk) talk.checked = false;
+		// Put the control back to rest, every time. A player destroyed while
+		// its permission prompt was still up never reports an ending — the
+		// grant lands in a closed player, which releases it silently — so
+		// anything left over from 'asking' has to be cleared here or the
+		// button stays disabled on "Asking…" until the page is reloaded.
+		if (talk) { talk.checked = false; talk.disabled = false; }
+		if (talkLbl) { talkLbl.textContent = '🎤 Talk'; talkLbl.title = TALK_TITLE; }
 	}
 
 	// The stats panel follows the transport rather than the person: MSE has
-	// none of these numbers, so the button would open an empty box.
+	// none of these numbers, so the button would open an empty box. The
+	// checkbox keeps the person's answer across a transport switch, so the
+	// panel has to come back with it rather than needing a second click.
 	function syncStatsCtl() {
 		if (statsCtl) statsCtl.hidden = !usingWebRTC;
-		if (!usingWebRTC && statsBox) statsBox.hidden = true;
+		if (statsBox) {
+			statsBox.hidden = !(usingWebRTC && statsBtn && statsBtn.checked);
+		}
 	}
 
 	function showStats(s) {
@@ -252,7 +262,6 @@
 		syncAudioCtl();
 		// The old player's destroy() released the microphone, so the control
 		// has to come back up in the state the new one is actually in.
-		if (talk) talk.checked = false;
 		syncTalkCtl();
 		syncStatsCtl();
 		syncTransportNote();
@@ -319,18 +328,30 @@
 			// ends — refused, unplugged, revoked, or declined by a camera with
 			// audio.outputEnabled off. The reason rides along and goes in the
 			// tooltip, which is the only place it lives.
+			// Four states, and the middle one earns its place: 'asking' while
+			// the browser's prompt is up, 'live' once the microphone is
+			// capturing but the camera has not answered yet, 'on' when it has
+			// accepted, 'off' for every ending. Reporting 'on' at the moment
+			// of capture would say "Talking" over a session that has not
+			// offered the track yet, and might still be refused.
+			//
+			// 'live' leaves the button enabled, unlike 'asking': the
+			// microphone is running by then, and a control that cannot stop a
+			// running microphone is the wrong control.
 			onMic: (state, why) => {
 				if (!live() || !talk) return;
-				talk.checked = state === 'on';
+				talk.checked = state === 'on' || state === 'live';
 				talk.disabled = state === 'asking';
 				if (talkLbl) {
 					talkLbl.textContent = state === 'asking' ? '🎤 Asking…'
+						: state === 'live' ? '🎤 Connecting…'
 						: state === 'on' ? '🎤 Talking' : '🎤 Talk';
 					talkLbl.title = why ? why + '\n\n' + TALK_TITLE : TALK_TITLE;
 				}
-				// Talking opens the camera's audio too — the camera refuses a
-				// one-way audio section — so the listen control has to show
-				// what actually happened rather than what it was last set to.
+				// Only once the camera has accepted. Talking opens its audio
+				// too — it refuses a one-way audio section — so the listen
+				// control follows what was negotiated rather than what was
+				// asked for.
 				if (state === 'on' && mute && !mute.checked) {
 					mute.checked = true;
 					audioOn = true;
@@ -394,8 +415,21 @@
 	// the person watching has since chosen a stream themselves. Correcting a
 	// default is helpful; overriding a decision is not.
 	mjConfig().then(cfg => {
-		if (!attachedBlind || userPickedStream) return;
-		if (chooseSub(cfg) && player) player.setStream(stream);
+		if (!attachedBlind) return;
+		// The stream, unless the person has since chosen one themselves:
+		// correcting a default is helpful, overriding a decision is not.
+		const moved = !userPickedStream && chooseSub(cfg);
+		if (moved && player) player.setStream(stream);
+
+		// The ICE list, unconditionally. A blind attach opened with an empty
+		// one, and the getter is only read when a session opens — so without
+		// this the first session runs on host candidates alone until something
+		// else happens to reconnect it. Off-LAN that session cannot work: it
+		// negotiates, carries nothing, and spends the full no-signal timeout
+		// finding out, which is exactly the sequence that demotes a browser to
+		// MSE. Skipped when setStream() has already reopened for the stream
+		// change, and when there is nothing to apply.
+		if (!moved && player && usingWebRTC && ice.length) attachPlayer(true);
 	});
 
 	if (transportCtl && transportGrp && webrtcAvailable) {
@@ -473,8 +507,8 @@
 	}
 
 	if (statsBtn && statsBox) {
-		statsBtn.addEventListener('change', () => {
-			statsBox.hidden = !statsBtn.checked;
-		});
+		// Through the same helper the transport switch uses, so "is the panel
+		// showing" has one answer and not two that have to agree.
+		statsBtn.addEventListener('change', syncStatsCtl);
 	}
 })();

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -60,6 +60,10 @@
 	mjConfig().then(cfg => {
 		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
 		if (mjGet(cfg, 'video1.enabled') === true) $('#mj-sub').hidden = false;
+		ice = MajesticTransport.iceServers(
+			mjGet(cfg, 'webrtc.iceServers'),
+			mjGet(cfg, 'webrtc.turnUsername'),
+			mjGet(cfg, 'webrtc.turnCredential'));
 	});
 	const cur = () => $('#live-video');
 
@@ -127,6 +131,11 @@
 	// Carried across a transport switch, because a new player starts from its
 	// defaults and the user's choices should outlive the machinery.
 	let stream = 0, audioOn = false, vol = 1;
+	// The camera's STUN/TURN configuration, filled when the config lands. Read
+	// through a getter at every open(), so an attach that beat the fetch is
+	// corrected by the first reconnect rather than staying host-candidates-only
+	// for the life of the page.
+	let ice = [];
 	// Talkback is deliberately NOT carried across a transport switch or a
 	// reattach. Everything else here is a preference; this one holds a live
 	// microphone, and silently reopening it because the page rebuilt a player
@@ -228,7 +237,8 @@
 		const v = cur();
 		try { v.removeAttribute('src'); v.srcObject = null; } catch (e) {}
 		const impl = usingWebRTC ? MajesticWebRTC : MajesticVideo;
-		const p = impl.attach(v, Object.assign({ stream: stream }, handlersFor(gen)));
+		const p = impl.attach(v, Object.assign(
+			{ stream: stream, iceServers: () => ice }, handlersFor(gen)));
 		// attach() reported 'fallback' before returning and something else is
 		// now playing. Drop what we just built rather than letting this
 		// assignment bury it.

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -106,11 +106,53 @@ window.MajesticTransport = (function () {
 		return kind === 'webrtc' ? window.MajesticWebRTC : window.MajesticVideo;
 	}
 
+	// What the camera falls back to when webrtc.iceServers is unset, and every
+	// spelling of "I really do want none". More than one because YAML 1.1
+	// decides what these words mean before majestic sees them: `iceServers: off`
+	// reaches the config as the string "false", and so do `no` and `false`.
+	const STUN_DEFAULT = 'stun:stun.cloudflare.com:3478';
+	const OFF_WORDS = ['none', 'off', 'no', 'false', 'disabled'];
+
+	// The camera's webrtc.* settings as an RTCPeerConnection iceServers list.
+	//
+	// Both pages need it and neither can do without it: with an empty list the
+	// browser gathers host candidates only, and Chromium anonymises those to
+	// <uuid>.local, which the camera cannot resolve. On a LAN it still works —
+	// the browser's own checks teach the camera its address peer-reflexively —
+	// but off one, neither end ever learns a routable address for the other and
+	// the session dies having negotiated perfectly.
+	//
+	// This mirrors majestic_stun_ice_js() in include/majestic/stun_default.h,
+	// which built the same list for the debug page this replaced. Keep the two
+	// in step: same default, same off-words, same rule about relays.
+	function iceServers(configured, user, cred) {
+		configured = (configured === null || configured === undefined ||
+			configured === '') ? STUN_DEFAULT : String(configured);
+		if (OFF_WORDS.indexOf(configured.toLowerCase()) >= 0) return [];
+		const haveCreds = !!(user && cred);
+		const out = [];
+		configured.split(/[\s,]+/).forEach(function (url) {
+			if (!url) return;
+			const isTurn = /^turns?:/i.test(url);
+			// A relay entry missing either credential makes RTCPeerConnection
+			// throw InvalidAccessError — before the page opens its signalling
+			// socket, so the camera sees no attempt at all and the failure
+			// reads as "signalling never happened". Drop that entry and keep
+			// the rest: it costs the relay and nothing else.
+			if (isTurn && !haveCreds) return;
+			out.push(isTurn
+				? { urls: url, username: String(user), credential: String(cred) }
+				: { urls: url });
+		});
+		return out;
+	}
+
 	return {
 		available: available,
 		preferred: preferred,
 		choose: choose,
 		demote: demote,
 		impl: impl,
+		iceServers: iceServers,
 	};
 })();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -398,8 +398,18 @@ window.MajesticWebRTC = (function () {
 			lastBytes = 0; stalledMs = 0; healthyMs = 0;
 			rateBytes = 0; rateAudioBytes = 0; camLine = '';
 
+			// Read at open() rather than at attach(): the list comes from the
+			// camera's config, the first attach can win a race against that
+			// fetch, and a reconnect should use the answer once it lands
+			// instead of repeating the empty list it started with.
+			let ice = [];
 			try {
-				pc = new RTCPeerConnection({ iceServers: [] });
+				ice = (typeof opts.iceServers === 'function'
+					? opts.iceServers() : opts.iceServers) || [];
+			} catch (e) { ice = []; }
+
+			try {
+				pc = new RTCPeerConnection({ iceServers: ice });
 			} catch (e) {
 				onState('fallback', 'RTCPeerConnection failed');
 				return;

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -68,6 +68,8 @@ window.MajesticWebRTC = (function () {
 		// it not at all, so without this two clicks start two grants and the
 		// second orphans the first — a capture nothing is left holding.
 		let wantMic = false, micTrack = null, micBusy = false;
+		// A getStats() call that has not settled yet; see pollStats().
+		let statsBusy = false;
 
 		// The camera's own view, pushed over the signalling socket once a
 		// second. Worth having beside the browser's: they disagree in the
@@ -132,7 +134,15 @@ window.MajesticWebRTC = (function () {
 		// what the badge is for. Polled because it is the only way — there is
 		// no event for "the encoder changed resolution".
 		function pollStats() {
-			if (!pc) return;
+			if (!pc || statsBusy) return;
+			// One poll at a time. getStats() is asynchronous and the interval
+			// is not: a slow call and a fast one can settle out of order, and
+			// the second to arrive would then write an older byte total over a
+			// newer baseline. That does not just misdraw the panel — rateBytes
+			// is the divisor for the next tick, so a stale one prints a bitrate
+			// of zero or of twice the truth. Skipping a tick loses a sample;
+			// interleaving them corrupts every sample after it.
+			statsBusy = true;
 			const my = attempt;
 			pc.getStats().then(function (report) {
 				if (!current(my)) return;
@@ -219,7 +229,7 @@ window.MajesticWebRTC = (function () {
 					lastCodec = codec; lastW = w; lastH = h;
 					onCodec(codec, codec, w, h);
 				}
-			}).catch(function () {});
+			}).catch(function () {}).then(function () { statsBusy = false; });
 		}
 
 		// kbit/s between two byte totals one STATS_MS tick apart. Negative
@@ -340,9 +350,17 @@ window.MajesticWebRTC = (function () {
 						reopen();
 					};
 					wantMic = true;
-					// Two-way or not at all — see above.
-					wantAudio = true;
-					video.muted = false;
+					// Note what is NOT done here: wantAudio is left alone and
+					// the element stays muted. Talkback does open the camera's
+					// audio — it refuses a one-way section — but that is
+					// something the answer establishes, not the grant. Unmuting
+					// now means a camera that then declines our microphone
+					// leaves sound playing that the Listen control still calls
+					// muted, and nothing on the page can account for it.
+					//
+					// The offer does not need it either: open() adds the
+					// sendrecv transceiver from wantMic, not from wantAudio.
+					//
 					// 'live', not 'on': the microphone is capturing, but this
 					// session has not offered the track yet, let alone had it
 					// accepted. Saying "Talking" here would be a claim about
@@ -541,6 +559,13 @@ window.MajesticWebRTC = (function () {
 							// lit for a camera that is not listening.
 							if (wantMic) {
 								if (micSending()) {
+									// Accepted, so the camera's audio comes
+									// with it. Now is when the element may be
+									// unmuted: the direction is settled and the
+									// page is told in the same breath, so the
+									// Listen control and the sound agree.
+									wantAudio = true;
+									video.muted = false;
 									onMic('on', '');
 								} else {
 									releaseMic();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -258,12 +258,21 @@ window.MajesticWebRTC = (function () {
 		// a camera with audio.outputEnabled off answers `sendonly`, which lands
 		// here as `recvonly` — it sends, it does not receive. That is the
 		// difference between talkback working and a microphone lit for nothing.
+		//
+		// Both of the directions that contain "send" count, not just sendrecv.
+		// Today's camera answers sendrecv or sendonly and never recvonly, so
+		// this end never actually settles on sendonly — but that is a fact
+		// about one answerer, not about the negotiation. A camera with no audio
+		// source that still takes talkback would correctly answer recvonly and
+		// leave us sendonly, and testing for sendrecv alone would read the one
+		// legitimate microphone-only session as a refusal and stop the capture.
 		function micSending() {
 			if (!pc || !pc.getTransceivers) return false;
 			return pc.getTransceivers().some(function (t) {
 				return t.sender && t.sender.track &&
 					t.sender.track.kind === 'audio' &&
-					t.currentDirection === 'sendrecv';
+					(t.currentDirection === 'sendrecv' ||
+						t.currentDirection === 'sendonly');
 			});
 		}
 
@@ -334,7 +343,11 @@ window.MajesticWebRTC = (function () {
 					// Two-way or not at all — see above.
 					wantAudio = true;
 					video.muted = false;
-					onMic('on', '');
+					// 'live', not 'on': the microphone is capturing, but this
+					// session has not offered the track yet, let alone had it
+					// accepted. Saying "Talking" here would be a claim about
+					// the camera made before asking it.
+					onMic('live', '');
 					reopen();
 				})
 				.catch(function (e) {
@@ -526,10 +539,14 @@ window.MajesticWebRTC = (function () {
 							// is audio.outputEnabled being off. Say so and let
 							// the capture go, rather than leaving a microphone
 							// lit for a camera that is not listening.
-							if (wantMic && !micSending()) {
-								releaseMic();
-								onMic('off',
-									'the camera is not accepting audio');
+							if (wantMic) {
+								if (micSending()) {
+									onMic('on', '');
+								} else {
+									releaseMic();
+									onMic('off',
+										'the camera is not accepting audio');
+								}
 							}
 							if (wantAudio && !negotiatedAudio()) {
 								// Mirror preview.js: stop wanting it, so the

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -49,6 +49,11 @@ window.MajesticWebRTC = (function () {
 		const onState = opts.onState || function () {};
 		const onCodec = opts.onCodec || function () {};
 		const onAudio = opts.onAudio || function () {};
+		// Talkback state, and the per-second measurement feed behind the stats
+		// panel. Both are no-ops on the MSE player, which is why they are
+		// callbacks the caller may omit rather than something it must handle.
+		const onMic = opts.onMic || function () {};
+		const onStats = opts.onStats || function () {};
 		let stream = opts.stream | 0;
 
 		let pc = null, ws = null, statsTimer = null, signalTimer = null;
@@ -56,6 +61,21 @@ window.MajesticWebRTC = (function () {
 		let failCount = 0, gotMedia = false;
 		let wantAudio = false, volume = 1;
 		let lastCodec = '', lastW = 0, lastH = 0;
+
+		// Talkback. micTrack is the capture; wantMic is what the person asked
+		// for, which survives the reconnects that renegotiation is made of.
+		// micBusy covers the permission prompt: it blocks the page underneath
+		// it not at all, so without this two clicks start two grants and the
+		// second orphans the first — a capture nothing is left holding.
+		let wantMic = false, micTrack = null, micBusy = false;
+
+		// The camera's own view, pushed over the signalling socket once a
+		// second. Worth having beside the browser's: they disagree in the
+		// interesting cases, and REMB and audio-in are only visible from there.
+		let camLine = '';
+		// Byte counters for a rate. bytesReceived is a total, and lastBytes
+		// above only moves when it grows, so a rate needs its own pair.
+		let rateBytes = 0, rateAudioBytes = 0;
 
 		// Which connection attempt is current. Everything asynchronous here
 		// outlives the attempt that started it — createOffer and getStats
@@ -117,6 +137,7 @@ window.MajesticWebRTC = (function () {
 			pc.getStats().then(function (report) {
 				if (!current(my)) return;
 				let codec = '', w = 0, h = 0, bytes = 0;
+				const s = { cam: parseCam(camLine) };
 				const codecs = {};
 				report.forEach(function (r) {
 					if (r.type === 'codec') codecs[r.id] = r;
@@ -130,7 +151,41 @@ window.MajesticWebRTC = (function () {
 					if (c && c.mimeType) {
 						codec = c.mimeType.replace(/^video\//i, '').toLowerCase();
 					}
+					s.fps = r.framesPerSecond || 0;
+					s.framesDecoded = r.framesDecoded || 0;
+					s.framesDropped = r.framesDropped || 0;
+					// Cumulative on purpose. A per-second loss figure spends
+					// most of its life at zero and spikes to noise; the total
+					// since the session started is what says whether this link
+					// is losing packets at all.
+					s.packetsLost = r.packetsLost || 0;
+					s.packetsReceived = r.packetsReceived || 0;
+					s.jitterMs = Math.round((r.jitter || 0) * 1000);
+					s.nack = r.nackCount || 0;
+					s.pli = r.pliCount || 0;
 				});
+				report.forEach(function (r) {
+					if (r.type === 'inbound-rtp' && r.kind === 'audio') {
+						s.audioKbps = rate(r.bytesReceived || 0, rateAudioBytes);
+						rateAudioBytes = r.bytesReceived || 0;
+						s.audioPackets = r.packetsReceived || 0;
+					} else if (r.type === 'outbound-rtp' && r.kind === 'audio') {
+						// This browser's microphone, as the browser counts it.
+						// The camera's audio-in counter is the other half: one
+						// says we sent, the other says it arrived.
+						s.micPackets = r.packetsSent || 0;
+					} else if (
+						r.type === 'candidate-pair' && r.nominated &&
+						r.state === 'succeeded') {
+						s.rttMs = Math.round((r.currentRoundTripTime || 0) * 1000);
+					}
+				});
+				s.codec = codec; s.width = w; s.height = h;
+				s.kbps = rate(bytes, rateBytes);
+				rateBytes = bytes;
+				s.micWanted = wantMic;
+				s.micSending = micSending();
+				onStats(s);
 				if (bytes > 0 && !gotMedia) {
 					gotMedia = true;
 					clearTimeout(signalTimer);
@@ -165,6 +220,132 @@ window.MajesticWebRTC = (function () {
 					onCodec(codec, codec, w, h);
 				}
 			}).catch(function () {});
+		}
+
+		// kbit/s between two byte totals one STATS_MS tick apart. Negative
+		// deltas are a counter that reset under us — a new session — not a
+		// camera sending backwards.
+		function rate(now, before) {
+			const d = now - before;
+			return d > 0 ? Math.round((d * 8) / STATS_MS) : 0;
+		}
+
+		// The camera's line is `key=value` pairs separated by spaces, with a
+		// couple of composites (`rtcp=recv/rejected`, `pli=n(+suppressed)`).
+		// Split on the first `=` only and hand the values over as text: the
+		// page renders them, and inventing a schema here would mean changing
+		// two files every time the camera adds a counter.
+		function parseCam(line) {
+			const out = {};
+			(line || '').split(' ').forEach(function (kv) {
+				const i = kv.indexOf('=');
+				if (i > 0) out[kv.slice(0, i)] = kv.slice(i + 1);
+			});
+			return out;
+		}
+
+		// ---- talkback ------------------------------------------------------
+		//
+		// The camera will not take a send-only audio section:
+		// rtc_sdp_dir_allows_us_to_send() accepts `recvonly` and `sendrecv` and
+		// refuses `sendonly`, because it reads the direction as what it may
+		// send into. So talkback is necessarily two-way — turning the
+		// microphone on opens the camera's audio as well, and setMic() unmutes
+		// to match rather than leaving the camera encoding Opus into a muted
+		// element.
+
+		// Did the camera accept what we offered to send? We offer `sendrecv`;
+		// a camera with audio.outputEnabled off answers `sendonly`, which lands
+		// here as `recvonly` — it sends, it does not receive. That is the
+		// difference between talkback working and a microphone lit for nothing.
+		function micSending() {
+			if (!pc || !pc.getTransceivers) return false;
+			return pc.getTransceivers().some(function (t) {
+				return t.sender && t.sender.track &&
+					t.sender.track.kind === 'audio' &&
+					t.currentDirection === 'sendrecv';
+			});
+		}
+
+		// Stop the capture. Deliberately does not renegotiate: the callers want
+		// different things after it, and one of them is already inside a fresh
+		// session.
+		function releaseMic() {
+			if (!micTrack) return;
+			try { micTrack.onended = null; micTrack.stop(); } catch (e) {}
+			micTrack = null;
+			wantMic = false;
+		}
+
+		function micSupported() {
+			return rtcOk && !!(navigator.mediaDevices &&
+				navigator.mediaDevices.getUserMedia);
+		}
+
+		function setMic(on) {
+			on = !!on;
+			// micBusy rather than a disabled button: the button is the page's
+			// business, and a second call while a prompt is up is the bug.
+			if (micBusy || on === wantMic) return;
+			if (!on) {
+				releaseMic();
+				onMic('off', '');
+				reopen();
+				return;
+			}
+			if (!micSupported()) {
+				// Absent rather than refused: getUserMedia does not exist
+				// outside a secure context, so over plain HTTP there is nothing
+				// to ask. Those send you to different places.
+				onMic('off', window.isSecureContext
+					? 'no microphone available'
+					: 'a browser only grants microphone access over HTTPS');
+				return;
+			}
+			micBusy = true;
+			onMic('asking', '');
+			navigator.mediaDevices.getUserMedia({ audio: true })
+				.then(function (st) {
+					micBusy = false;
+					// The prompt blocks this function, not the page: the
+					// transport can be switched or the player destroyed while
+					// it is up. A grant nobody can now use has to be released,
+					// not parked — a live capture with no control attached to
+					// it is a recording light nobody asked for.
+					if (closed) {
+						st.getTracks().forEach(function (t) { t.stop(); });
+						return;
+					}
+					micTrack = st.getAudioTracks()[0];
+					if (!micTrack) {
+						onMic('off', 'no microphone available');
+						return;
+					}
+					// A track can end with nobody pressing anything: the device
+					// is unplugged, or the permission is revoked from the
+					// browser's own UI. Showing 'on' over it would be the same
+					// lie in a slower form.
+					micTrack.onended = function () {
+						releaseMic();
+						onMic('off', 'the microphone stopped');
+						reopen();
+					};
+					wantMic = true;
+					// Two-way or not at all — see above.
+					wantAudio = true;
+					video.muted = false;
+					onMic('on', '');
+					reopen();
+				})
+				.catch(function (e) {
+					micBusy = false;
+					const name = e && e.name;
+					onMic('off', name === 'NotAllowedError'
+						? 'permission refused'
+						: name === 'NotFoundError'
+							? 'no microphone available'
+							: 'the microphone could not be opened');
+				});
 		}
 
 		// Whether the answer actually carried the audio we asked to receive.
@@ -215,6 +396,7 @@ window.MajesticWebRTC = (function () {
 			teardownPc();
 			dropSocket();
 			lastBytes = 0; stalledMs = 0; healthyMs = 0;
+			rateBytes = 0; rateAudioBytes = 0; camLine = '';
 
 			try {
 				pc = new RTCPeerConnection({ iceServers: [] });
@@ -229,7 +411,11 @@ window.MajesticWebRTC = (function () {
 			// path's opt-in, arrived at from the other end.
 			try {
 				pc.addTransceiver('video', { direction: 'recvonly' });
-				if (wantAudio) {
+				if (wantMic && micTrack) {
+					// One section carrying both directions, not two: the camera
+					// answers a single audio m-line.
+					pc.addTransceiver(micTrack, { direction: 'sendrecv' });
+				} else if (wantAudio) {
 					pc.addTransceiver('audio', { direction: 'recvonly' });
 				}
 			} catch (e) {
@@ -325,6 +511,16 @@ window.MajesticWebRTC = (function () {
 							// them reports "no audio" over a working Opus
 							// stream. currentDirection is the negotiated answer
 							// and is settled by the time we are here.
+							// Talkback first: the camera can accept the audio
+							// section and still decline our half of it, which
+							// is audio.outputEnabled being off. Say so and let
+							// the capture go, rather than leaving a microphone
+							// lit for a camera that is not listening.
+							if (wantMic && !micSending()) {
+								releaseMic();
+								onMic('off',
+									'the camera is not accepting audio');
+							}
 							if (wantAudio && !negotiatedAudio()) {
 								// Mirror preview.js: stop wanting it, so the
 								// element matches the video-only session it
@@ -348,6 +544,11 @@ window.MajesticWebRTC = (function () {
 					// all three reach ICE.
 					pc.addIceCandidate({ candidate: m.data, sdpMid: m.mid })
 						.catch(function () {});
+				} else if (m.reply === 'stats') {
+					// The camera's own counters, once a second. Kept as text
+					// and parsed at the next poll, so the two sides are read
+					// out together rather than a tick apart.
+					camLine = m.data || '';
 				} else if (m.reply === 'busy') {
 					// Full, not incapable — every slot is taken and this same
 					// offer would be answered once one frees. Same move as a
@@ -465,6 +666,11 @@ window.MajesticWebRTC = (function () {
 
 		function destroy() {
 			closed = true;
+			// Before anything else. A player is destroyed on every transport
+			// switch and on leaving the page, and a capture that outlives the
+			// only control able to stop it is the worst of the failures this
+			// file guards against.
+			releaseMic();
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			stop();
 		}
@@ -475,6 +681,7 @@ window.MajesticWebRTC = (function () {
 				setStream: function () {}, requestIdr: function () {},
 				setAudio: function () {}, setVolume: function () {},
 				audioSupported: function () { return false; },
+				setMic: function () {}, micSupported: function () { return false; },
 				destroy: function () {}, supported: false,
 			};
 		}
@@ -484,6 +691,7 @@ window.MajesticWebRTC = (function () {
 			setStream: setStream, requestIdr: requestIdr,
 			setAudio: setAudio, setVolume: setVolume,
 			audioSupported: audioSupported,
+			setMic: setMic, micSupported: micSupported,
 			destroy: destroy, supported: true,
 		};
 	}

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -228,6 +228,7 @@ window.MajesticVideo = (function () {
 				setStream: function () {}, requestIdr: function () {},
 				setAudio: function () {}, setVolume: function () {},
 				audioSupported: function () { return false; },
+				setMic: function () {}, micSupported: function () { return false; },
 				destroy: function () {}, supported: false,
 			};
 		}
@@ -237,6 +238,10 @@ window.MajesticVideo = (function () {
 			setStream: setStream, requestIdr: requestIdr,
 			setAudio: setAudio, setVolume: setVolume,
 			audioSupported: audioSupported,
+			// MSE carries one direction only: there is no way to send a
+			// microphone up a media-source stream. The façade keeps the shape
+			// so the page never asks which transport it attached.
+			setMic: function () {}, micSupported: function () { return false; },
 			destroy: destroy, supported: true,
 		};
 	}

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -480,6 +480,51 @@ preview() {
 		<label class="btn btn-outline-primary" for="mj-mute" id="mj-mute-lbl">🔇 Muted</label>
 		<input type="range" id="mj-vol" min="0" max="100" value="100" class="form-range align-self-center ms-2" style="width:6rem" disabled aria-label="Volume">
 	</div>
+	<!-- Talkback. Revealed only over WebRTC, only where the camera has
+	     audio.outputEnabled, and only in a secure context: a browser hands over
+	     no microphone on plain HTTP, so the button would be a dead end. -->
+	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Talkback" id="mj-talk-ctl" hidden>
+		<input type="checkbox" class="btn-check" id="mj-talk" autocomplete="off">
+		<label class="btn btn-outline-primary" for="mj-talk" id="mj-talk-lbl"
+			title="Send this browser's microphone to the camera's speaker. The camera will not take audio in one direction only, so talking also opens its audio to you.">🎤 Talk</label>
+	</div>
+	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Statistics" id="mj-stats-ctl" hidden>
+		<input type="checkbox" class="btn-check" id="mj-stats-btn" autocomplete="off">
+		<label class="btn btn-outline-secondary" for="mj-stats-btn"
+			title="Per-second measurements from both ends of the session.">Stats</label>
+	</div>
+	<!-- Two columns because the two ends disagree in the cases worth looking
+	     at: the browser can be losing packets the camera never sees dropped,
+	     and REMB is the camera's opinion of the link rather than a measurement
+	     of it. -->
+	<div id="mj-stats" class="small text-body-secondary mb-2" hidden>
+		<div class="row g-3">
+			<div class="col-auto">
+				<div class="fw-semibold">This browser</div>
+				<table class="table table-sm table-borderless mb-0" style="font-variant-numeric:tabular-nums">
+					<tbody>
+						<tr><td class="pe-3 text-body-secondary">picture</td><td id="mj-st-pic">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">receiving</td><td id="mj-st-rx">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">lost / jitter</td><td id="mj-st-loss">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">round trip</td><td id="mj-st-rtt">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">recovery</td><td id="mj-st-recov">-</td></tr>
+					</tbody>
+				</table>
+			</div>
+			<div class="col-auto">
+				<div class="fw-semibold">This camera</div>
+				<table class="table table-sm table-borderless mb-0" style="font-variant-numeric:tabular-nums">
+					<tbody>
+						<tr><td class="pe-3 text-body-secondary">session</td><td id="mj-st-cam">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">estimate</td><td id="mj-st-remb">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">keyframes</td><td id="mj-st-pli">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">audio in</td><td id="mj-st-ain">-</td></tr>
+						<tr><td class="pe-3 text-body-secondary">talkback</td><td id="mj-st-talk">-</td></tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
 	<video id="live-video" autoplay muted playsinline style="$bg"></video>
 	<img id="live-mjpeg" alt="" style="display:none; $bg">
 	<p id="mj-note" class="alert alert-warning" style="display:none">


### PR DESCRIPTION
majestic's `/webrtc` debug page carries two things this player does not — a microphone button and a stats readout. That page is being retired (majestic side, separately): it duplicates this player, and its script lives inside a C string literal where review found four bugs in an afternoon. This moves the parts worth keeping here first, so the redirect lands on a page that lost nothing.

## Talkback

The camera will not take a send-only audio section. It reads the direction as what it may send *into*, so it accepts `recvonly` and `sendrecv` and refuses `sendonly`. So talking necessarily opens the camera's audio as well, and `setMic()` unmutes to match rather than leaving the camera encoding Opus into a muted element. The tooltip says so.

The button appears only where all three preconditions hold: `audio.outputEnabled` on the camera, WebRTC as the live transport, and a secure context — a browser hands over no microphone on plain HTTP, so it would otherwise be a dead end.

Every way talkback can end is handled, because each one leaves a live capture behind if it is not:

| ending | handled by |
|---|---|
| permission refused | `catch`, reported with the reason |
| device unplugged / permission revoked mid-session | `micTrack.onended` |
| camera declines our half (`audio.outputEnabled` off) | `currentDirection` check after the answer |
| second click while the prompt is up | `micBusy` |
| player destroyed by a transport switch while the prompt is up | `closed` recheck after the await |
| leaving the page | `destroy()` releases first |

That list is not hypothetical — it is what review found in the page this replaces, three of them in the same shape: a control whose state was decided before an await and trusted after it.

## Stats

Both ends side by side, because they disagree exactly where it matters. The browser's `getStats` gives picture, rate, cumulative loss, jitter and round trip; the camera's own once-a-second line — previously read by nothing but the debug page — gives ICE and DTLS state, its REMB estimate, keyframe requests and audio-in. REMB is the camera's *opinion* of what the link will carry rather than a measurement of what arrived, and audio-in is the far half of talkback: the browser says it sent, the camera says it arrived. A microphone showing `sending` with the camera's counter stuck at zero is the case worth being able to see.

## Testing

No test suite in this repo, so the mic lifecycle was driven headless against stubs (`vm` context, stubbed `RTCPeerConnection`/`getUserMedia`/`WebSocket`) before landing — seven cases, each asking the same question: did the microphone stop? All pass, including the renegotiation timing that made the first version of the camera-declines test lie.

MSE keeps the façade with no-ops; there is no way to send a microphone up a media-source stream, and the page still never asks which transport it attached. `mj-settings.cgi` shares this markup but does not load `preview-page.js`, so the new controls stay hidden there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
