### PR TITLE
Preview: remember which stream the person chose

### DIFF
--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -18,13 +18,26 @@ const { check, group, done } = require('./assert');
 
 const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-transport.js');
 
-// The module only needs a window to hang itself off. localStorage is absent
-// here on purpose: every read and write in it is wrapped, and a module that
-// threw without storage would fail in a private window too.
-const ctx = { window: {}, console: console };
-vm.createContext(ctx);
-vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
-const iceServers = ctx.window.MajesticTransport.iceServers;
+// A browser's worth of storage, and no more. Two contexts: one with it, one
+// without — every read and write in the module is wrapped, and a module that
+// threw without storage would fail in a private window too, which is a real
+// browser state and not a hypothetical one.
+function load(withStorage) {
+	const store = {};
+	const ctx = { window: {}, console: console };
+	if (withStorage) {
+		ctx.localStorage = {
+			getItem: (k) => (k in store ? store[k] : null),
+			setItem: (k, v) => { store[k] = String(v); },
+			removeItem: (k) => { delete store[k]; },
+		};
+	}
+	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+	return ctx.window.MajesticTransport;
+}
+
+const iceServers = load(false).iceServers;
 
 const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 const is = (name, got, want) =>
@@ -71,5 +84,24 @@ is('half a credential is no credential',
 is('and the STUN entries beside it still survive that',
 	iceServers('stun:a:1,turn:b:2,stun:c:3', 'u', ''),
 	[{ urls: 'stun:a:1' }, { urls: 'stun:c:3' }]);
+
+group('the remembered Main/Sub choice');
+// Someone whose video0 is cropped, or whose substream is sized nothing like
+// the preview box, wants Main. The default is still Sub — that is the common
+// case — but the answer has to survive a page load or they re-pick it for ever.
+const t = load(true);
+check('nothing remembered to begin with', t.chosenStream() === null);
+t.chooseStream(0);
+check('Main is remembered', t.chosenStream() === 0);
+t.chooseStream(1);
+check('and so is Sub', t.chosenStream() === 1);
+
+// A private window, or a browser set to block site data. The module must come
+// back "no preference" rather than throw, or the preview does not start at all.
+const noStore = load(false);
+check('no storage reads as no preference', noStore.chosenStream() === null);
+let threw = false;
+try { noStore.chooseStream(1); } catch (e) { threw = true; }
+check('and writing without storage does not throw', !threw);
 
 done();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -675,7 +675,15 @@
 	// diverge is which transport to prefer and what to remember, and that is
 	// preview-transport.js.
 	function attachLivePreview(video) {
-		const stream = getDotted(state.config, 'video1.enabled') === true ? 1 : 0;
+		// The same channel the Preview page would open, remembered choice and
+		// all. This panel has no Main/Sub control of its own, so without the
+		// shared answer someone who chose Main there — because video0 is the
+		// cropped one, say — gets the substream here and no way to say
+		// otherwise.
+		const subAvailable = getDotted(state.config, 'video1.enabled') === true;
+		const remembered = window.MajesticTransport.chosenStream();
+		const stream = (remembered === null ? 1 : remembered) === 1 && subAvailable
+			? 1 : 0;
 
 		// Which attachment is the live one. MajesticWebRTC can report 'fallback'
 		// from inside attach() — it does exactly that when RTCPeerConnection or

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -396,8 +396,20 @@
 	// Whether the deadline won and we picked a stream without being told.
 	let attachedBlind = false;
 
+	// Which channel to open on: what this browser last chose, or the substream.
+	//
+	// A remembered choice outranks the default but not reality — a browser that
+	// picked Sub on a camera which has since lost video1 opens on Main rather
+	// than on nothing. Returns true if the channel moved off Main.
 	function chooseSub(cfg) {
-		if (mjGet(cfg, 'video1.enabled') !== true) return false;
+		const subAvailable = mjGet(cfg, 'video1.enabled') === true;
+		const remembered = MajesticTransport.chosenStream();
+		const want = remembered === null ? 1 : remembered;
+		if (want !== 1 || !subAvailable) {
+			stream = 0;
+			if (s0) s0.checked = true;
+			return false;
+		}
 		stream = 1;
 		if (s1) s1.checked = true;
 		return true;
@@ -452,8 +464,16 @@
 	// that is the one they want — would otherwise look identical to someone who
 	// pressed nothing, and a late config answer would move them to Sub. A click
 	// is an expression of intent whether or not it alters anything.
-	[s0, s1].forEach(el => {
-		if (el) el.addEventListener('click', () => { userPickedStream = true; });
+	// Recorded on click for the same reason the flag is: pressing the radio that
+	// is already selected is still an answer, and it is the one that has to be
+	// remembered — someone whose camera crops video0, or whose substream is
+	// sized nothing like the preview box, wants Main and should say so once
+	// rather than on every page load.
+	[s0, s1].forEach((el, n) => {
+		if (el) el.addEventListener('click', () => {
+			userPickedStream = true;
+			MajesticTransport.chooseStream(n);
+		});
 	});
 	if (s0) s0.addEventListener('change', () => {
 		stream = 0;

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -106,6 +106,36 @@ window.MajesticTransport = (function () {
 		return kind === 'webrtc' ? window.MajesticWebRTC : window.MajesticVideo;
 	}
 
+	// Which encoder channel the person last picked, or null if they never have.
+	//
+	// The default is the substream, which is right for the common case — the
+	// main channel carries the recording, the substream exists to be watched
+	// over whatever link is available. It is wrong for at least two:
+	//
+	//   - videoN.crop is per channel, so someone who has cropped video0 and
+	//     wants to see the result of that cropping needs the main stream
+	//     specifically. A substream preview shows a different picture, not a
+	//     smaller one.
+	//   - a substream sized well away from what the preview box wants, when
+	//     the main stream happens to be closer.
+	//
+	// Neither is a reason to change the default, and both are a reason to
+	// remember the answer: without this, anyone those cases apply to re-picks
+	// Main on every page load, for ever. Remembered per browser rather than on
+	// the camera because it is a viewing preference, like the transport beside
+	// it — the same camera watched from a phone and a desk may want different
+	// answers, and neither should overwrite the other.
+	const STREAM_KEY = 'mj-preview-stream';
+
+	function chosenStream() {
+		const v = read(STREAM_KEY);
+		return v === '0' ? 0 : v === '1' ? 1 : null;
+	}
+
+	function chooseStream(n) {
+		write(STREAM_KEY, (n | 0) === 1 ? '1' : '0');
+	}
+
 	// What the camera falls back to when webrtc.iceServers is unset, and every
 	// spelling of "I really do want none". More than one because YAML 1.1
 	// decides what these words mean before majestic sees them: `iceServers: off`
@@ -154,5 +184,7 @@ window.MajesticTransport = (function () {
 		demote: demote,
 		impl: impl,
 		iceServers: iceServers,
+		chosenStream: chosenStream,
+		chooseStream: chooseStream,
 	};
 })();


### PR DESCRIPTION
Closes the concrete half of the discussion on #184.

## The report

The preview opens on the substream. That is right for the common case — the main channel carries the recording, the substream exists to be watched over whatever link is available — and `usa-` pointed out two cases where it is wrong:

> if the user has configured cropping on the `Main stream`, they may specifically want Preview to show the result of that cropping

`videoN.crop` is configured per channel — `video0.crop` and `video1.crop` are separate settings — so this is exactly right: a substream preview is not a smaller version of that picture, it is a **different** one.

> if the current `Main stream` size is closer to the required Preview size than the current `Sub stream` size, I would expect Preview to use `Main`

Also fair.

And the part that makes both matter:

> If a user prefers the `Main stream`, they should be able to configure that preference once and have it remembered, rather than being forced to select `Main` every time they open Preview.

## What this does

Neither case is a reason to change the default; both are a reason to **remember the answer**. Without it, the people those cases apply to re-pick Main on every page load, for ever.

Per browser rather than on the camera, like the transport preference beside it — the same camera watched from a phone and from a desk may want different answers, and neither should overwrite the other. A remembered choice outranks the default but **not reality**: a browser that chose Sub on a camera which has since lost `video1` opens on Main rather than on nothing.

Recorded on **click**, not `change`, for the reason the guard flag next to it already is: pressing the radio that is already selected fires no change event, and it is still an answer.

**Live adjustments follows the same choice.** It has no Main/Sub control of its own, so without this someone who chose Main on the Preview page — the cropped-`video0` case — got the substream there with no way to say otherwise.

## What this deliberately does not do

The reporter also proposed a `Source: Main / Sub / Auto` setting where Auto picks by resolution match, plus `Adjust resolution` alongside `Adjust bitrate`. Those are answered in the thread rather than here — briefly, nothing in the WebUI adjusts a stream's *resolution*, so that switch would guard something that does not happen, and "Auto by size" is a larger design question that this change makes cheaper to defer rather than more urgent.

## Testing

`npm test`. The new cases cover the remembered choice, the no-storage path (a private window, or a browser blocking site data — reads as "no preference" and writing does not throw), and were verified by mutation: making `chosenStream()` always return null fails two of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
