### PR TITLE
Describe the camera's behaviour, not its source

### DIFF
--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -1,14 +1,14 @@
 // MajesticTransport.iceServers() — the browser's half of the camera's
 // STUN/TURN configuration.
 //
-// This exists because the camera used to build this list in C and had tests
-// for it there. The page that consumed it is gone, majestic_stun_ice_js() went
-// with it, and the rules moved here — so the coverage has to move too, or the
-// only thing standing between an operator's `iceServers` setting and a
+// This exists because the camera used to build this list itself, for the debug
+// page that has since been retired, and was tested where it was built. The
+// rules moved here with the job — so the coverage had to move too, or the only
+// thing standing between an operator's `iceServers` setting and an
 // RTCPeerConnection that throws is someone remembering.
 //
-// The rules mirror include/majestic/stun_default.h in the majestic tree.
-// Change one, change both; these are the cases that say what "both" means.
+// The camera still applies the same rules on its own side. Change one, change
+// both; these are the cases that say what "both" means.
 'use strict';
 
 const fs = require('fs');

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -122,9 +122,9 @@ window.MajesticTransport = (function () {
 	// but off one, neither end ever learns a routable address for the other and
 	// the session dies having negotiated perfectly.
 	//
-	// This mirrors majestic_stun_ice_js() in include/majestic/stun_default.h,
-	// which built the same list for the debug page this replaced. Keep the two
-	// in step: same default, same off-words, same rule about relays.
+	// The camera applies the same rules to the same setting on its own side,
+	// and used to build this very list for the debug page this replaced. Keep
+	// the two in step: same default, same off-words, same rule about relays.
 	function iceServers(configured, user, cred) {
 		configured = (configured === null || configured === undefined ||
 			configured === '') ? STUN_DEFAULT : String(configured);

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -256,13 +256,12 @@ window.MajesticWebRTC = (function () {
 
 		// ---- talkback ------------------------------------------------------
 		//
-		// The camera will not take a send-only audio section:
-		// rtc_sdp_dir_allows_us_to_send() accepts `recvonly` and `sendrecv` and
-		// refuses `sendonly`, because it reads the direction as what it may
-		// send into. So talkback is necessarily two-way — turning the
-		// microphone on opens the camera's audio as well, and setMic() unmutes
-		// to match rather than leaving the camera encoding Opus into a muted
-		// element.
+		// The camera will not take a send-only audio section. It reads the
+		// direction as what it may send into, so it answers `recvonly` and
+		// `sendrecv` and refuses `sendonly`. Talkback is therefore necessarily
+		// two-way — turning the microphone on opens the camera's audio as well,
+		// and setMic() unmutes to match rather than leaving the camera encoding
+		// Opus into a muted element.
 
 		// Did the camera accept what we offered to send? We offer `sendrecv`;
 		// a camera with audio.outputEnabled off answers `sendonly`, which lands


### PR DESCRIPTION
Three comments in this tree — two in `www/a/`, one in `tests/` — cited the camera firmware's internal source paths and function names as cross-references.

This repository is public and that one is not. Its file layout and symbol names do not belong here, however convenient the cross-reference is to whoever wrote the comment.

Every fact those comments were conveying is behavioural, and all of it stays: the camera refuses a send-only audio section because it reads the direction as what it may send *into*, and it applies the same rules to `webrtc.iceServers` on its own side that this tree applies on the browser's. Both are things a reader here can verify against a running camera. Neither needs a file name to be useful — arguably the behavioural phrasing is the more useful one, since it survives the other tree being refactored.

Public config keys and endpoints are untouched: `audio.outputEnabled`, `videoN.crop`, `webrtc.iceServers`, `/ws/webrtc` are the documented interface and belong in these comments.

Comments only — no code change. `npm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)