### PR TITLE
Preview: a stream choice per page, and a tighter control row

### DIFF
--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -22,8 +22,8 @@ const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-transport.js');
 // without — every read and write in the module is wrapped, and a module that
 // threw without storage would fail in a private window too, which is a real
 // browser state and not a hypothetical one.
-function load(withStorage) {
-	const store = {};
+function load(withStorage, seed) {
+	const store = Object.assign({}, seed || {});
 	const ctx = { window: {}, console: console };
 	if (withStorage) {
 		ctx.localStorage = {
@@ -113,5 +113,26 @@ check('no storage reads as no preference',
 let threw = false;
 try { noStore.chooseStream('preview', 1); } catch (e) { threw = true; }
 check('and writing without storage does not throw', !threw);
+
+group('upgrading from the single shared key');
+// A previous release wrote one key for both pages. Both inherit it — that is
+// what the person was looking at — and it is then thrown away. Dropping it
+// instead would return anyone who had chosen Main to the substream default,
+// and the reason to choose Main is that the substream shows the wrong picture.
+const up = load(true, { 'mj-preview-stream': '0' });
+check('preview inherits the old choice', up.chosenStream('preview') === 0);
+check('so does live', up.chosenStream('live') === 0);
+// Read once: choosing on one page afterwards must not be undone by the old
+// value coming back the next time the other page asks.
+up.chooseStream('live', 1);
+check('and the old key does not resurrect', up.chosenStream('live') === 1);
+check('while preview keeps what it inherited', up.chosenStream('preview') === 0);
+
+// A per-page answer already recorded wins over the legacy one.
+const both = load(true, {
+	'mj-preview-stream': '0', 'mj-preview-stream:preview': '1' });
+check('an existing per-page choice is not overwritten',
+	both.chosenStream('preview') === 1);
+check('while the page without one still inherits', both.chosenStream('live') === 0);
 
 done();

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -90,18 +90,28 @@ group('the remembered Main/Sub choice');
 // the preview box, wants Main. The default is still Sub — that is the common
 // case — but the answer has to survive a page load or they re-pick it for ever.
 const t = load(true);
-check('nothing remembered to begin with', t.chosenStream() === null);
-t.chooseStream(0);
-check('Main is remembered', t.chosenStream() === 0);
-t.chooseStream(1);
-check('and so is Sub', t.chosenStream() === 1);
+check('nothing remembered to begin with', t.chosenStream('preview') === null);
+t.chooseStream('preview', 0);
+check('Main is remembered', t.chosenStream('preview') === 0);
+t.chooseStream('preview', 1);
+check('and so is Sub', t.chosenStream('preview') === 1);
+
+// Separate per page: the two are looked at for different reasons, and someone
+// can reasonably want Main on one and Sub on the other. Sharing one key would
+// mean choosing on either page silently changed the other.
+check('the live page starts with no preference of its own',
+	t.chosenStream('live') === null);
+t.chooseStream('live', 0);
+check('the live page remembers its own answer', t.chosenStream('live') === 0);
+check('and the preview page keeps its own', t.chosenStream('preview') === 1);
 
 // A private window, or a browser set to block site data. The module must come
 // back "no preference" rather than throw, or the preview does not start at all.
 const noStore = load(false);
-check('no storage reads as no preference', noStore.chosenStream() === null);
+check('no storage reads as no preference',
+	noStore.chosenStream('preview') === null);
 let threw = false;
-try { noStore.chooseStream(1); } catch (e) { threw = true; }
+try { noStore.chooseStream('preview', 1); } catch (e) { threw = true; }
 check('and writing without storage does not throw', !threw);
 
 done();

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -22,19 +22,27 @@ const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-transport.js');
 // without — every read and write in the module is wrapped, and a module that
 // threw without storage would fail in a private window too, which is a real
 // browser state and not a hypothetical one.
-function load(withStorage, seed) {
+function load(withStorage, seed, refuseWrites) {
 	const store = Object.assign({}, seed || {});
 	const ctx = { window: {}, console: console };
 	if (withStorage) {
 		ctx.localStorage = {
 			getItem: (k) => (k in store ? store[k] : null),
-			setItem: (k, v) => { store[k] = String(v); },
+			setItem: (k, v) => {
+				// A full quota throws on set while remove still works, which is
+				// the sequence that can lose a value mid-migration.
+				if (refuseWrites) throw new Error('QuotaExceededError');
+				store[k] = String(v);
+			},
 			removeItem: (k) => { delete store[k]; },
 		};
 	}
+
 	vm.createContext(ctx);
 	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
-	return ctx.window.MajesticTransport;
+	const mod = ctx.window.MajesticTransport;
+	mod.store = store;   // for asserting what survived
+	return mod;
 }
 
 const iceServers = load(false).iceServers;
@@ -134,5 +142,15 @@ const both = load(true, {
 check('an existing per-page choice is not overwritten',
 	both.chosenStream('preview') === 1);
 check('while the page without one still inherits', both.chosenStream('live') === 0);
+
+// If the new keys cannot be written, the old one must survive to be tried
+// again — deleting it first would lose the choice permanently, and write()
+// swallows storage failures so nothing else would notice.
+const stuck = load(true, { 'mj-preview-stream': '0' }, true);
+check('a refused write leaves no preference rather than a wrong one',
+	stuck.chosenStream('preview') === null);
+check('and the legacy key is kept for the next attempt',
+	stuck.store['mj-preview-stream'] === '0',
+	JSON.stringify(stuck.store));
 
 done();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -743,6 +743,10 @@
 		const s1 = document.getElementById('mj-live-s1');
 		const subLbl = document.getElementById('mj-live-sub');
 		if (subLbl && subAvailable) subLbl.hidden = false;
+		// Hiding the label leaves the input focusable — Bootstrap's btn-check
+		// keeps it in the tab order — so arrow-key navigation could select a
+		// stream that does not exist and land the panel on "no signal".
+		if (s1) s1.disabled = !subAvailable;
 		if (s0) s0.checked = stream === 0;
 		if (s1) s1.checked = stream === 1;
 		[s0, s1].forEach(function (elm, n) {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -675,14 +675,12 @@
 	// diverge is which transport to prefer and what to remember, and that is
 	// preview-transport.js.
 	function attachLivePreview(video) {
-		// The same channel the Preview page would open, remembered choice and
-		// all. This panel has no Main/Sub control of its own, so without the
-		// shared answer someone who chose Main there — because video0 is the
-		// cropped one, say — gets the substream here and no way to say
-		// otherwise.
+		// This page's own remembered choice, defaulting to the substream. Not
+		// the Preview page's: the two are looked at for different reasons and
+		// can reasonably want different channels.
 		const subAvailable = getDotted(state.config, 'video1.enabled') === true;
-		const remembered = window.MajesticTransport.chosenStream();
-		const stream = (remembered === null ? 1 : remembered) === 1 && subAvailable
+		const remembered = window.MajesticTransport.chosenStream('live');
+		let stream = (remembered === null ? 1 : remembered) === 1 && subAvailable
 			? 1 : 0;
 
 		// Which attachment is the live one. MajesticWebRTC can report 'fallback'
@@ -738,6 +736,27 @@
 		}
 
 		attach(window.MajesticTransport.preferred());
+
+		// Sub is offered only where there is one; `stream` above has already
+		// fallen back to Main if not, so the control shows what is playing.
+		const s0 = document.getElementById('mj-live-s0');
+		const s1 = document.getElementById('mj-live-s1');
+		const subLbl = document.getElementById('mj-live-sub');
+		if (subLbl && subAvailable) subLbl.hidden = false;
+		if (s0) s0.checked = stream === 0;
+		if (s1) s1.checked = stream === 1;
+		[s0, s1].forEach(function (elm, n) {
+			if (!elm) return;
+			// On click rather than change, for the reason the Preview page
+			// records it that way: pressing the one already selected fires no
+			// change event and is still an answer worth remembering.
+			elm.addEventListener('click', function () {
+				window.MajesticTransport.chooseStream('live', n);
+				if (n === stream) return;
+				stream = n;
+				if (state.previewPlayer) state.previewPlayer.setStream(n);
+			});
+		});
 	}
 
 	// The Live adjustments leaf: the preview and the x-live knobs side by side, so
@@ -752,9 +771,21 @@
 		if (withVideo) {
 			const pv = el('div', 'col-12 col-lg-7');
 			pv.id = 'mj-live-preview';
+			// Its own Main/Sub control, because the remembered choice is
+			// per page: without one here this panel could only ever be the
+			// substream, and the case that makes the choice worth having —
+			// video0 cropped and video1 not — is exactly the case where that
+			// is the wrong picture.
 			pv.innerHTML =
 				'<div class="card"><div class="card-body">' +
-				'<div class="text-secondary small mb-1">Live preview</div>' +
+				'<div class="d-flex align-items-center mb-1">' +
+				'<div class="text-secondary small me-auto">Live preview</div>' +
+				'<div class="btn-group btn-group-sm" role="group" aria-label="Stream">' +
+				'<input type="radio" class="btn-check" name="mj-live-stream" id="mj-live-s0" autocomplete="off">' +
+				'<label class="btn btn-outline-primary" for="mj-live-s0">Main</label>' +
+				'<input type="radio" class="btn-check" name="mj-live-stream" id="mj-live-s1" autocomplete="off">' +
+				'<label class="btn btn-outline-primary" for="mj-live-s1" id="mj-live-sub" hidden>Sub</label>' +
+				'</div></div>' +
 				'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
 				'</div></div>';
 			row.appendChild(pv);

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -403,7 +403,7 @@
 	// than on nothing. Returns true if the channel moved off Main.
 	function chooseSub(cfg) {
 		const subAvailable = mjGet(cfg, 'video1.enabled') === true;
-		const remembered = MajesticTransport.chosenStream();
+		const remembered = MajesticTransport.chosenStream('preview');
 		const want = remembered === null ? 1 : remembered;
 		if (want !== 1 || !subAvailable) {
 			stream = 0;
@@ -472,7 +472,7 @@
 	[s0, s1].forEach((el, n) => {
 		if (el) el.addEventListener('click', () => {
 			userPickedStream = true;
-			MajesticTransport.chooseStream(n);
+			MajesticTransport.chooseStream('preview', n);
 		});
 	});
 	if (s0) s0.addEventListener('change', () => {

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -59,7 +59,12 @@
 	let jpegOn = false;
 	mjConfig().then(cfg => {
 		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
-		if (mjGet(cfg, 'video1.enabled') === true) $('#mj-sub').hidden = false;
+		const subOk = mjGet(cfg, 'video1.enabled') === true;
+		if (subOk) $('#mj-sub').hidden = false;
+		// Same reason as the settings panel: the label is what gets hidden, and
+		// the radio behind it stays in the tab order, so without this the
+		// keyboard can pick a stream the camera does not have.
+		if (s1) s1.disabled = !subOk;
 		ice = MajesticTransport.iceServers(
 			mjGet(cfg, 'webrtc.iceServers'),
 			mjGet(cfg, 'webrtc.turnUsername'),

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -44,10 +44,22 @@ window.MajesticTransport = (function () {
 	function migrate() {
 		const old = read(OLD_KEY);
 		if (old === null) return;
-		write(OLD_KEY, null);
-		if (read(PICK_KEY) !== null || read(AUTO_KEY) !== null) return;
-		if (old === 'webrtc') write(PICK_KEY, 'webrtc');
-		else if (old === 'mse') write(AUTO_KEY, String(Date.now()));
+		if (read(PICK_KEY) !== null || read(AUTO_KEY) !== null) {
+			write(OLD_KEY, null);
+			return;
+		}
+		// Same order as migrateStream(), for the same reason: the replacement
+		// has to be readable before the original is thrown away.
+		let carried = true;
+		if (old === 'webrtc') {
+			write(PICK_KEY, 'webrtc');
+			carried = read(PICK_KEY) === 'webrtc';
+		} else if (old === 'mse') {
+			const at = String(Date.now());
+			write(AUTO_KEY, at);
+			carried = read(AUTO_KEY) === at;
+		}
+		if (carried) write(OLD_KEY, null);
 	}
 
 	// A demotion that has not expired. The window is bounded at both ends: a
@@ -144,14 +156,24 @@ window.MajesticTransport = (function () {
 	// the substream default — and the reason to choose Main is that the
 	// substream shows the wrong picture, so the setting would be lost by
 	// exactly the people who needed it.
+	// New keys first, old key last, and only once the new ones read back.
+	// write() swallows storage failures by design — a private window must not
+	// break the page — so "it did not throw" is no evidence the value landed.
+	// Deleting first and then failing to write would lose the choice for good.
 	function migrateStream() {
 		const old = read(STREAM_KEY);
 		if (old === null) return;
-		write(STREAM_KEY, null);
-		if (old !== '0' && old !== '1') return;
+		if (old !== '0' && old !== '1') {
+			write(STREAM_KEY, null);
+			return;
+		}
+		let carried = true;
 		['preview', 'live'].forEach(function (w) {
-			if (read(streamKey(w)) === null) write(streamKey(w), old);
+			if (read(streamKey(w)) !== null) return;
+			write(streamKey(w), old);
+			if (read(streamKey(w)) !== old) carried = false;
 		});
+		if (carried) write(STREAM_KEY, null);
 	}
 
 	function chosenStream(where) {

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -135,7 +135,27 @@ window.MajesticTransport = (function () {
 		return STREAM_KEY + ':' + (where || 'preview');
 	}
 
+	// The unsuffixed key a previous release wrote, when one answer served both
+	// pages. Both inherit it, because that is what the person was actually
+	// looking at; from then on they diverge as each is chosen. Read once and
+	// thrown away, like the transport migration above.
+	//
+	// Dropping it instead would silently return anyone who had chosen Main to
+	// the substream default — and the reason to choose Main is that the
+	// substream shows the wrong picture, so the setting would be lost by
+	// exactly the people who needed it.
+	function migrateStream() {
+		const old = read(STREAM_KEY);
+		if (old === null) return;
+		write(STREAM_KEY, null);
+		if (old !== '0' && old !== '1') return;
+		['preview', 'live'].forEach(function (w) {
+			if (read(streamKey(w)) === null) write(streamKey(w), old);
+		});
+	}
+
 	function chosenStream(where) {
+		migrateStream();
 		const v = read(streamKey(where));
 		return v === '0' ? 0 : v === '1' ? 1 : null;
 	}

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -125,15 +125,23 @@ window.MajesticTransport = (function () {
 	// the camera because it is a viewing preference, like the transport beside
 	// it — the same camera watched from a phone and a desk may want different
 	// answers, and neither should overwrite the other.
+	// Per page, not one answer for both. The two are looked at for different
+	// reasons — Preview to watch, Live adjustments to judge an ISP knob while
+	// dragging it — and someone can reasonably want Main on one and Sub on the
+	// other. `where` is the page asking: 'preview' or 'live'.
 	const STREAM_KEY = 'mj-preview-stream';
 
-	function chosenStream() {
-		const v = read(STREAM_KEY);
+	function streamKey(where) {
+		return STREAM_KEY + ':' + (where || 'preview');
+	}
+
+	function chosenStream(where) {
+		const v = read(streamKey(where));
 		return v === '0' ? 0 : v === '1' ? 1 : null;
 	}
 
-	function chooseStream(n) {
-		write(STREAM_KEY, (n | 0) === 1 ? '1' : '0');
+	function chooseStream(where, n) {
+		write(streamKey(where), (n | 0) === 1 ? '1' : '0');
 	}
 
 	// What the camera falls back to when webrtc.iceServers is unset, and every

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -453,7 +453,13 @@ preview() {
 	local bg="background:#000; background-size:cover; width:100%"
 	cat <<EOF
 <div class="mj-player">
-	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Stream">
+	<!-- Every control on one line: each was its own block before, and the
+	     stats toggle in particular cost a whole row of vertical space on a
+	     page whose point is the picture below it. Stats is pushed to the far
+	     end because it is the only one of them that opens a panel rather than
+	     changing what is playing. -->
+	<div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+	<div class="btn-group btn-group-sm" role="group" aria-label="Stream">
 		<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-0" autocomplete="off" checked>
 		<label class="btn btn-outline-primary" for="mj-stream-0">Main</label>
 		<input type="radio" class="btn-check" name="mj-stream" id="mj-stream-1" autocomplete="off">
@@ -463,19 +469,12 @@ preview() {
 	<!-- Unhidden by preview-page.js only where preview-webrtc.js is loaded and
 	     the browser has WebRTC; mj-settings.cgi shares this markup and offers
 	     the MSE player alone. -->
-	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Transport" id="mj-transport-ctl" hidden>
+	<div class="btn-group btn-group-sm" role="group" aria-label="Transport" id="mj-transport-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-transport" autocomplete="off">
 		<label class="btn btn-outline-primary" for="mj-transport" id="mj-transport-lbl"
 			title="Sub-second video and two-way audio, and the camera fits the stream to your connection — which changes it for everyone else watching that stream too.">WebRTC</label>
 	</div>
-	<!-- Shown only while WebRTC is the live transport. The tooltip above cannot
-	     be the whole disclosure: it needs a pointer to find, and the thing being
-	     disclosed reaches past the person reading it. -->
-	<p id="mj-transport-note" class="small text-body-secondary mb-2" hidden>
-		The camera is adapting this stream's bitrate to your connection. Anyone
-		else watching the same stream sees that too.
-	</p>
-	<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Audio" id="mj-audio-ctl" hidden>
+	<div class="btn-group btn-group-sm" role="group" aria-label="Audio" id="mj-audio-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-mute" autocomplete="off">
 		<label class="btn btn-outline-primary" for="mj-mute" id="mj-mute-lbl">🔇 Muted</label>
 		<input type="range" id="mj-vol" min="0" max="100" value="100" class="form-range align-self-center ms-2" style="width:6rem" disabled aria-label="Volume">
@@ -483,16 +482,25 @@ preview() {
 	<!-- Talkback. Revealed only over WebRTC, only where the camera has
 	     audio.outputEnabled, and only in a secure context: a browser hands over
 	     no microphone on plain HTTP, so the button would be a dead end. -->
-	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Talkback" id="mj-talk-ctl" hidden>
+	<div class="btn-group btn-group-sm" role="group" aria-label="Talkback" id="mj-talk-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-talk" autocomplete="off">
 		<label class="btn btn-outline-primary" for="mj-talk" id="mj-talk-lbl"
 			title="Send this browser's microphone to the camera's speaker. The camera will not take audio in one direction only, so talking also opens its audio to you.">🎤 Talk</label>
 	</div>
-	<div class="btn-group btn-group-sm mb-2 ms-2" role="group" aria-label="Statistics" id="mj-stats-ctl" hidden>
+	<div class="btn-group btn-group-sm ms-auto" role="group" aria-label="Statistics" id="mj-stats-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-stats-btn" autocomplete="off">
 		<label class="btn btn-outline-secondary" for="mj-stats-btn"
 			title="Per-second measurements from both ends of the session.">Stats</label>
 	</div>
+	</div>
+	<!-- Shown only while WebRTC is the live transport, and a block of its own
+	     because it is a sentence rather than a control. The tooltip above cannot
+	     be the whole disclosure: it needs a pointer to find, and the thing being
+	     disclosed reaches past the person reading it. -->
+	<p id="mj-transport-note" class="small text-body-secondary mb-2" hidden>
+		The camera is adapting this stream's bitrate to your connection. Anyone
+		else watching the same stream sees that too.
+	</p>
 	<!-- Two columns because the two ends disagree in the cases worth looking
 	     at: the browser can be losing packets the camera never sees dropped,
 	     and REMB is the camera's opinion of the link rather than a measurement
@@ -500,7 +508,7 @@ preview() {
 	<div id="mj-stats" class="small text-body-secondary mb-2" hidden>
 		<div class="row g-3">
 			<div class="col-auto">
-				<div class="fw-semibold">This browser</div>
+				<div class="fw-semibold">Browser</div>
 				<table class="table table-sm table-borderless mb-0" style="font-variant-numeric:tabular-nums">
 					<tbody>
 						<tr><td class="pe-3 text-body-secondary">picture</td><td id="mj-st-pic">-</td></tr>
@@ -512,7 +520,7 @@ preview() {
 				</table>
 			</div>
 			<div class="col-auto">
-				<div class="fw-semibold">This camera</div>
+				<div class="fw-semibold">Camera</div>
 				<table class="table table-sm table-borderless mb-0" style="font-variant-numeric:tabular-nums">
 					<tbody>
 						<tr><td class="pe-3 text-body-secondary">session</td><td id="mj-st-cam">-</td></tr>


### PR DESCRIPTION
All from #184, where the reporter has now run this on his own cameras and reported back.

## A remembered stream per page

> I think the remembered source selection should be stored **separately** for `Preview` and `Live Adjustments`, since the two pages may serve different purposes

Done, keyed by page.

Splitting it alone would have made things **worse**, which is worth saying because it nearly shipped that way: Live adjustments had no Main/Sub control, so a separate key would have pinned it to the substream permanently — and the case that makes the remembered choice worth having at all, `video0` cropped and `video1` not, is exactly the case where the substream is the wrong picture.

So that panel has its own control now, on the header line beside "Live preview", offering Sub only where one exists.

## The control row

> the `Stats` button unnecessarily takes up valuable vertical screen space. It could be placed on the same line as the other buttons, but aligned to the right.

Every control now sits on one flex line, with Stats pushed to the far end — it is the only one of them that opens a panel rather than changing what is playing. The adaptation notice stays a block of its own, because it is a sentence and not a control.

> The `This browser` and `This camera` columns … could be renamed to `Browser` and `Camera`

Done. They were paying rent on a narrow panel.

## Testing

`npm test`. The split is covered including the part that matters — choosing on one page leaves the other alone — and verified by mutation: collapsing both back to a single key fails two cases.

## Not in this PR

Two reports from the same comments are still open and are answered on the issue rather than here: a substream set to 1 FPS appearing to update faster (most likely a pending pipeline reload, since `videoN.fps` is not one of the live-applied fields), and a flicker when switching to WebRTC on a camera with no substream. The second is a real report but the proposed fix — disabling the toggle when Sub is off — would be wrong: WebRTC does not require a substream, and does work on Main for browsers that accept its profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)