### PR TITLE
fw-reset: show the erase as it happens, and hand the camera back

### DIFF
--- a/www/a/fw-reset.js
+++ b/www/a/fw-reset.js
@@ -1,0 +1,175 @@
+// Factory reset: stream `sysupgrade -n --web` through j/run.cgi into the pane on
+// fw-reset.cgi, then wait for the camera to come back and hand the user over to
+// it. Vanilla JS; `$` and `termWriter` come from main.js.
+//
+// Not the /ws/upgrade socket fw-update.js uses: that endpoint exists to drive a
+// firmware flash, and a reset writes no image. run.cgi is the plain streaming
+// pipe this page has always used. What changed is what happens around it.
+//
+// The old version lived inline in the CGI and did two things that no longer
+// hold. It read the stream a line at a time and appended each one, which is
+// fine for `Stopping crond: OK` and useless for a meter that redraws itself
+// with a bare \r — hence the terminal writer. And when the stream ended it
+// navigated straight to fw-restart.cgi, on the assumption that sysupgrade had
+// been told -x and had left the rebooting to us. It hasn't for a while:
+// wiping rootfs_data rewrites the flash the camera is running from, so
+// sysupgrade reboots regardless and says so. Two things followed from that.
+// The hop landed on a camera that was already going down — and it would have
+// asked for a *second* reboot if it had arrived. And it never even ran: the
+// stream does not end, it dies with the camera, so the read rejects and the
+// navigation after the loop was never reached (issue #154). Hence the catch
+// below, and a watch that waits for the camera instead of racing it.
+(function () {
+	const out = $('#output');
+	if (!out) return;
+	const term = termWriter(out);
+	const dec = new TextDecoder('utf-8');
+
+	// Same two markers fw-update.js reads, for the same reasons. "Protected:
+	// flashing continues" is sysupgrade's point of no return, printed just before
+	// the erase; "Unconditional reboot" is it announcing the reboot it is about
+	// to take. die() prints "<reason> Aborting." — before the RAM pivot that
+	// leaves the camera untouched and running, so it is the one ending that must
+	// not start a reboot watch.
+	const flashMarker = /Protected: flashing/i;
+	const rebootMarker = /Unconditional reboot|Rebooting now/i;
+	const abortMarker = /Aborting\./;
+	let sawFlash = false, sawReboot = false, aborted = false;
+	// Whether a single byte ever arrived. Tells "the reset ran and ended" apart
+	// from "the request never got off the ground" — a lapsed session (majestic
+	// answers a bare 401), a camera already busy, a reload of this page while
+	// the previous run holds the lock. Those deserve their own wording rather
+	// than a verdict on a reset that never started.
+	let gotOutput = false;
+	// Markers can straddle two frames, so match against a rolling window rather
+	// than each chunk in isolation.
+	let recent = '';
+
+	function status(cls, msg) {
+		const s = $('#fw-reset-status');
+		s.className = 'alert alert-' + cls;
+		s.textContent = msg;
+	}
+
+	// Every tick forks a dozen processes and makes a loopback request into the
+	// majestic that is streaming this log. Fine on an idle camera, ruinous on one
+	// erasing its own flash — and it matters now in a way it did not before,
+	// because --web keeps majestic alive to be hammered (issue #154).
+	if (typeof stopHeartbeat === 'function') stopHeartbeat();
+
+	function append(t) {
+		// term.write() returns the chunk with ANSI stripped and nothing else done
+		// to it — the raw stream, not what ended up on screen. The markers are
+		// whole-line messages and must not depend on how the redraws rendered.
+		recent = (recent + term.write(t)).slice(-512);
+		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
+		if (!sawReboot && rebootMarker.test(recent)) sawReboot = true;
+		if (!aborted && abortMarker.test(recent)) aborted = true;
+	}
+
+	// rawFetch, not apiFetch, here and in ping() below — and never a bare fetch.
+	//
+	// Not apiFetch: the reset erases the overlay, and /etc/majestic.token with it,
+	// then reboots, so losing the session is the EXPECTED end of this page rather
+	// than an error. apiFetch would redirect to the login form on the 401 that
+	// follows, throwing the transcript away at the moment it matters most, and its
+	// never-settling promise would strand the watch before it could hand the user
+	// back.
+	//
+	// But rawFetch all the same, because the two halves are separate concerns:
+	// opting out of the redirect is not opting out of the header. This page runs
+	// precisely when the camera has just forgotten every session there was, so its
+	// requests are the ones that get answered 401 — and without
+	// X-Requested-With majestic attaches WWW-Authenticate to them and Safari
+	// raises the native dialog over the transcript, which is the bug #154 opened
+	// on in the first place.
+	async function stream() {
+		const r = await rawFetch('/cgi-bin/j/run.cgi?cmd=' + btoa(out.dataset.cmd));
+		// Not encodeURIComponent()'d: run.cgi eval()s QUERY_STRING as shell with
+		// only & → ; substituted, so nothing decodes percent-escapes on the way
+		// back out. base64's / and = survive a query string as they are.
+		if (!r.ok) throw new Error('run.cgi answered ' + r.status);
+		const rd = r.body.getReader();
+		for (;;) {
+			const { value, done } = await rd.read();
+			if (done) return;
+			gotOutput = true;
+			append(dec.decode(value, { stream: true }));
+		}
+	}
+
+	// Reachable at all, whatever it answers. A 401 is a camera that is serving
+	// again and has simply forgotten us, which is exactly what a wiped overlay
+	// leaves behind — so it counts as up, and the navigation that follows will
+	// collect the login page on its own.
+	function ping() {
+		const ctl = new AbortController();
+		const to = setTimeout(() => ctl.abort(), 2500);
+		return rawFetch('/?_=' + Date.now(), { cache: 'no-store', signal: ctl.signal })
+			.then(() => { clearTimeout(to); return true; })
+			.catch(() => { clearTimeout(to); return false; });
+	}
+
+	function goBack() {
+		status('success', 'The camera is back. Taking you to it…');
+		// A navigation, so majestic answers it with the login page rather than a
+		// bare 401 — and after a wipe it will, because the reboot cleared the
+		// in-RAM sessions and the erase took the stay-signed-in key with it.
+		// replace(), not href: this document is finished, and leaving it in
+		// history hands Back a page that looks alive and is not.
+		setTimeout(() => location.replace('/cgi-bin/status.cgi'), 1500);
+	}
+
+	// Confirm the camera actually went before declaring it back, so a poll that
+	// starts a moment too early cannot mistake the still-running camera for the
+	// rebooted one and navigate into a connection that is about to be cut.
+	function pollBack() {
+		let downSeen = false, tries = 0;
+		const DOWN_TRIES = 30;   // ~90s; reboot -d 1 -f follows the announcement at once
+		const UP_TRIES = 200;    // ~10 min; a first boot onto a fresh overlay is slow
+		status('warning', 'The camera is rebooting — waiting for it to come back…');
+		async function tick() {
+			const up = await ping();
+			if (!downSeen) {
+				if (!up) { downSeen = true; tries = 0; }
+				// Still answering well past the point it said it was rebooting. Either
+				// it came back while we were between polls or it never dropped a
+				// connection we noticed; either way it is serving now, so stop
+				// watching and go.
+				else if (++tries > DOWN_TRIES) { goBack(); return; }
+			} else if (up) {
+				goBack();
+				return;
+			} else if (++tries > UP_TRIES) {
+				status('danger', 'The camera has not come back. Check it manually — the reset itself finished, see the log above.');
+				return;
+			}
+			setTimeout(tick, 3000);
+		}
+		tick();
+	}
+
+	stream().then(() => false, () => true).then(streamFailed => {
+		// Tidy whatever redraw the stream stopped in the middle of.
+		term.commit();
+		if (sawReboot || (streamFailed && sawFlash)) {
+			term.note('--- connection to the camera ended here; it is rebooting ---');
+			pollBack();
+			return;
+		}
+		if (aborted) {
+			status('danger', 'The reset was aborted — see the log above. The camera is unchanged.');
+		} else if (!gotOutput) {
+			// Nothing came back at all, so there is no log to read and nothing was
+			// erased. Say that rather than passing judgement on a run that never
+			// started.
+			status('danger', 'Could not start the reset — the camera did not answer. Reload the page and try again.');
+		} else {
+			// No reboot announced and no abort. sysupgrade ran to the end of what it
+			// was asked to do without wiping anything, which is what happens when it
+			// finds nothing to do at all.
+			status('warning', 'The reset finished without rebooting the camera — see the log above.');
+		}
+		if (typeof startHeartbeat === 'function') startHeartbeat();
+	});
+})();

--- a/www/a/fw-reset.js
+++ b/www/a/fw-reset.js
@@ -12,8 +12,9 @@
 // with a bare \r — hence the terminal writer. And when the stream ended it
 // navigated straight to fw-restart.cgi, on the assumption that sysupgrade had
 // been told -x and had left the rebooting to us. It hasn't for a while:
-// wiping rootfs_data rewrites the flash the camera is running from, so
-// sysupgrade reboots regardless and says so. Two things followed from that.
+// rootfs_data is the upper layer of the overlay the running root is assembled
+// from, so erasing it takes the live filesystem with it and sysupgrade reboots
+// regardless, saying so as it goes. Two things followed from that.
 // The hop landed on a camera that was already going down — and it would have
 // asked for a *second* reboot if it had arrived. And it never even ran: the
 // stream does not end, it dies with the camera, so the read rejects and the
@@ -44,6 +45,9 @@
 	// Markers can straddle two frames, so match against a rolling window rather
 	// than each chunk in isolation.
 	let recent = '';
+	// Whether the watch for the camera's return has already been started, so the
+	// marker and the end of the stream can both ask for it.
+	let polling = false;
 
 	function status(cls, msg) {
 		const s = $('#fw-reset-status');
@@ -63,8 +67,21 @@
 		// whole-line messages and must not depend on how the redraws rendered.
 		recent = (recent + term.write(t)).slice(-512);
 		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
-		if (!sawReboot && rebootMarker.test(recent)) sawReboot = true;
 		if (!aborted && abortMarker.test(recent)) aborted = true;
+		// Start watching the moment sysupgrade says it is rebooting, not when the
+		// stream finally dies. Those are not the same instant: measured on a
+		// hi3516ev300 reset, "Unconditional reboot" arrived at 34.6s and the read
+		// did not reject until 81.2s — 46 seconds of a page still saying "do not
+		// navigate away" about a camera that had already gone. The socket only
+		// fails once something notices the connection is dead, which can be long
+		// after the camera stopped being on the other end of it.
+		//
+		// Starting early is free: pollBack() only watches, and it will not act on
+		// an "up" until it has seen the camera go down first.
+		if (!sawReboot && rebootMarker.test(recent)) {
+			sawReboot = true;
+			beginPollBack();
+		}
 	}
 
 	// rawFetch, not apiFetch, here and in ping() below — and never a bare fetch.
@@ -120,12 +137,23 @@
 		setTimeout(() => location.replace('/cgi-bin/status.cgi'), 1500);
 	}
 
-	// Confirm the camera actually went before declaring it back, so a poll that
-	// starts a moment too early cannot mistake the still-running camera for the
-	// rebooted one and navigate into a connection that is about to be cut.
+	// Whichever of the two triggers gets here first wins: sysupgrade announced the
+	// reboot, or the stream died. Tidies the half-drawn redraw the announcement
+	// interrupted, but does NOT declare the stream over — more output can still
+	// arrive, and usually does.
+	function beginPollBack() {
+		if (polling) return;
+		polling = true;
+		term.commit();
+		pollBack();
+	}
+
+	// Confirm the camera actually went before declaring it back, so a watch that
+	// starts while it is still serving cannot mistake that for the rebooted
+	// camera and navigate into a connection about to be cut.
 	function pollBack() {
 		let downSeen = false, tries = 0;
-		const DOWN_TRIES = 30;   // ~90s; reboot -d 1 -f follows the announcement at once
+		const DOWN_TRIES = 60;   // ~3 min; the announcement can lead the reboot by a while
 		const UP_TRIES = 200;    // ~10 min; a first boot onto a fresh overlay is slow
 		status('warning', 'The camera is rebooting — waiting for it to come back…');
 		async function tick() {
@@ -153,8 +181,12 @@
 		// Tidy whatever redraw the stream stopped in the middle of.
 		term.commit();
 		if (sawReboot || (streamFailed && sawFlash)) {
+			// Only here is the stream genuinely over, so only here may the transcript
+			// be closed off — beginPollBack() may have run a minute ago on the
+			// marker, and output that arrived since must not sit under a note
+			// claiming the connection had already ended.
 			term.note('--- connection to the camera ended here; it is rebooting ---');
-			pollBack();
+			beginPollBack();
 			return;
 		}
 		if (aborted) {

--- a/www/a/fw-update.js
+++ b/www/a/fw-update.js
@@ -7,7 +7,6 @@
 // --archive. Vanilla JS; `$` is the querySelector helper from main.js.
 (function () {
 	const out = $('#fw-output');
-	const ansi = /[][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 	const dec = new TextDecoder('utf-8');
 
 	// sysupgrade prints "Protected: flashing continues…" at its point of no
@@ -88,50 +87,15 @@
 	function resumeHeartbeat() {
 		if (typeof startHeartbeat === 'function') startHeartbeat();
 	}
-	// This pane is a <pre>, but everything writing into it assumes a terminal:
-	// curl's download meter and flashcp's progress both redraw one line in place
-	// with a bare \r. Appended verbatim, each redraw lands after the last instead
-	// of replacing it, and the bar smears across the pane in unreadable columns
-	// (issue #134). Stripping ANSI does not help — \r is a control character, not
-	// an escape sequence, so it survives the regex above.
-	//
-	// So be just enough of a terminal for that: \n commits the line, \r returns
-	// the cursor to column 0, anything else overwrites at the cursor. Overwriting
-	// rather than clearing matters — a redraw shorter than the one before it
-	// leaves the tail of the longer line visible, which is what a real terminal
-	// does and what makes curl's meter look right as it shrinks.
-	//
-	// Two text nodes keep it cheap: finished lines are appended once and never
-	// touched again, and only the line still being drawn is rewritten. The
-	// console page has an actual terminal (xterm.js) and needs none of this.
-	const doneNode = document.createTextNode('');
-	const lineNode = document.createTextNode('');
-	out.appendChild(doneNode);
-	out.appendChild(lineNode);
-	// The line being drawn is an array of characters, not a string: the cursor can
-	// land anywhere in it, and rebuilding a string per character (slice + concat +
-	// slice) is quadratic in the line length. curl's meter is short enough not to
-	// care, but a tool emitting a long line with no newline would have made this
-	// the slowest thing on the page.
-	let lineArr = [];   // the line currently being drawn, after the last \n
-	let col = 0;        // cursor position within it
+	// Rendered through the shared <pre>-as-terminal writer in main.js: the meters
+	// sysupgrade streams redraw one line in place with a bare \r, which a bare
+	// <pre> smears across the pane unless something plays the cursor back
+	// (issue #134).
+	const term = termWriter(out);
 
 	// Markers can straddle two frames, so match against a rolling window of the
 	// recent stream rather than each chunk in isolation.
 	let recent = '';
-	// The stream stops wherever the camera happened to die, which is almost never
-	// on a line boundary: flashcp redraws its meter with \r and no trailing
-	// newline, so the last thing written stays half-drawn ("Verifying kb:
-	// 4648/4836 (96%)") and the pane reads as hung rather than finished.
-	function commitLine() {
-		if (!lineArr.length) return;
-		doneNode.appendData(lineArr.join('') + '\n');
-		lineArr = [];
-		col = 0;
-		lineNode.data = '';
-		out.scrollTop = out.scrollHeight;
-	}
-
 	// Only ws.onclose knows the stream is really over. The reboot announcement
 	// and the silence heuristic both start the watch while the socket may still
 	// deliver more, so writing this there would let genuine output land
@@ -140,9 +104,7 @@
 	function endLog() {
 		if (logClosed) return;
 		logClosed = true;
-		commitLine();
-		doneNode.appendData('--- connection to the camera ended here; it is rebooting ---\n');
-		out.scrollTop = out.scrollHeight;
+		term.note('--- connection to the camera ended here; it is rebooting ---');
 	}
 
 	// Start watching for the camera to come back. Three things can get us here
@@ -161,7 +123,7 @@
 		if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
 		// Tidy the half-drawn meter, but do NOT declare the stream over: the
 		// socket can still be open here and more output may yet arrive.
-		commitLine();
+		term.commit();
 		// Getting here on silence rather than on a reboot announcement means the
 		// transcript stops mid-flash, at whatever byte the camera reached — issue
 		// #120 has it ending on "Verifying kb: 1056/4844 (21%)". That is expected:
@@ -175,9 +137,8 @@
 		// Worded as a gap, not as an ending: the socket may still be open, and
 		// output that resumes must not land under a note saying it had stopped.
 		if (quiet) {
-			doneNode.appendData('--- no output for ' + (QUIET_MS / 1000) +
-				's; the camera is busy flashing ---\n');
-			out.scrollTop = out.scrollHeight;
+			term.note('--- no output for ' + (QUIET_MS / 1000) +
+				's; the camera is busy flashing ---');
 		}
 		// "do not power off" is a warning about an interrupted flash, so do not
 		// say it when sysupgrade has already told us it wrote nothing.
@@ -189,29 +150,12 @@
 
 	function append(t) {
 		lastData = performance.now();
-		const s = t.replace(ansi, '');
-		let commit = '';
-		for (let i = 0; i < s.length; i++) {
-			const ch = s[i];
-			if (ch === '\n') {
-				commit += lineArr.join('') + '\n';
-				lineArr = [];
-				col = 0;
-			} else if (ch === '\r') {
-				col = 0;
-			} else {
-				lineArr[col++] = ch;
-			}
-		}
-		// One join per frame rather than a string rebuild per character; finished
-		// lines leave through appendData and are never re-copied.
-		if (commit) doneNode.appendData(commit);
-		lineNode.data = lineArr.join('');
-		out.scrollTop = out.scrollHeight;
-		// Deliberately still the raw stream: the markers below are whole-line
-		// messages, and matching them on what was received rather than on what
-		// survived the redraws keeps this decoupled from the rendering.
-		recent = (recent + s).slice(-512);
+		// term.write() hands back the chunk with ANSI stripped and nothing else
+		// done to it. Deliberately the raw stream, not what ended up on screen:
+		// the markers below are whole-line messages, and matching them on what was
+		// received rather than on what survived the redraws keeps this decoupled
+		// from the rendering.
+		recent = (recent + term.write(t)).slice(-512);
 		if (!sawFlash && flashMarker.test(recent)) sawFlash = true;
 		if (!noop && noopMarker.test(recent)) noop = true;
 		// Said out loud by sysupgrade immediately before it reboots, so there is
@@ -233,7 +177,7 @@
 				// ws.onclose may never fire. Nothing else will stop the quiet timer,
 				// and it would otherwise tick for the life of the tab.
 				if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
-				commitLine();
+				term.commit();
 				status('danger', 'The upgrade was aborted — see the log below. Nothing was written to flash, so the camera is unchanged.');
 				resumeHeartbeat();
 			}
@@ -295,7 +239,7 @@
 				// Gave up before touching flash; no reboot is coming, and the log
 				// above is the whole story.
 				if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
-				commitLine();
+				term.commit();
 				return;
 			}
 			// Usually last of the three triggers rather than first — by the time a

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -29,10 +29,10 @@ function sleep(ms) {
 // Deliberately NOT a patch over window.fetch. The pages that deliberately
 // outlive their own session must not be redirected out from under: fw-update.js
 // expects a 401 while the camera reboots mid-upgrade and handles it itself, with
-// wording that depends on knowing an upgrade was in flight, and
-// makeTextFileLineIterator below streams the factory reset that destroys the
-// session in the first place. A blanket redirect would race both and throw the
-// transcript away. Anything that wants this behaviour opts in.
+// wording that depends on knowing an upgrade was in flight, and fw-reset.js
+// streams the factory reset that destroys the session in the first place. A
+// blanket redirect would race both and throw the transcript away. Anything that
+// wants this behaviour opts in.
 //
 // Those pages still need the HEADER, though, and that is the half that was
 // missed: suppressing the dialog and redirecting on 401 are separate concerns,
@@ -120,66 +120,90 @@ function setProgressBar(id, value, name) {
 	}
 }
 
-// rawFetch, not apiFetch, and it has to stay that way. Its only caller is
-// runCmd() on fw-reset.cgi, which streams `sysupgrade -s -n -x --web` — the
-// factory reset that erases the overlay, /etc/majestic.token with it, and reboots.
-// Losing the session is the EXPECTED end of this request, not an error, and the
-// whole point of the page is to show the log until the camera goes. Redirecting
-// on a 401 here would blank the transcript at the moment it matters most, and
-// the never-settling promise apiFetch hands back would strand the loop below
-// before it could run the fw-restart.cgi hop at the end.
+// A <pre> is not a terminal, but everything sysupgrade streams into one assumes
+// it is: curl's download meter, flashcp's progress and flash_eraseall's erase
+// counter all redraw a single line in place with a bare \r. Appended verbatim,
+// each redraw lands after the last instead of replacing it, and the meter smears
+// across the pane in unreadable columns (issue #134). Stripping ANSI does not
+// help — \r is a control character, not an escape sequence, so it survives that
+// regex.
 //
-// rawFetch rather than a bare fetch, though: the wipe destroys the session this
-// stream is running on, so the reconnect after it is exactly the request that
-// gets a 401 — and without the header majestic attaches WWW-Authenticate to it
-// and Safari prompts on top of the transcript.
-async function* makeTextFileLineIterator(url) {
-	const td = new TextDecoder('utf-8');
-	const response = await rawFetch(url);
-	const rd = response.body.getReader();
-	let { value: chunk, done: readerDone } = await rd.read();
-	chunk = chunk ? td.decode(chunk) : '';
-	const re = /\r?\n/gm;
-	let startIndex = 0;
-	let result;
+// So be just enough of a terminal for that: \n commits the line, \r returns the
+// cursor to column 0, anything else overwrites at the cursor. Overwriting rather
+// than clearing matters — a redraw shorter than the one before it leaves the
+// tail of the longer line visible, which is what a real terminal does and what
+// makes curl's meter look right as it shrinks.
+//
+// Two text nodes keep it cheap: finished lines are appended once and never
+// touched again, and only the line still being drawn is rewritten. The console
+// page has an actual terminal (xterm.js) and needs none of this.
+//
+// Shared by the two pages that stream sysupgrade — fw-update.js over /ws/upgrade
+// and fw-reset.js over j/run.cgi. They render the identical output, so the
+// lesson above only wants learning once.
+function termWriter(el) {
+	// \u001b/\u009b escaped rather than written as the literal ESC and CSI bytes
+	// the two copies of this carried: an invisible control character in a source
+	// file survives only as long as nothing greps, copies or re-encodes the line.
+	const ansi = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+	const doneNode = document.createTextNode('');
+	const lineNode = document.createTextNode('');
+	el.appendChild(doneNode);
+	el.appendChild(lineNode);
+	// The line being drawn is an array of characters, not a string: the cursor can
+	// land anywhere in it, and rebuilding a string per character (slice + concat +
+	// slice) is quadratic in the line length. curl's meter is short enough not to
+	// care, but a tool emitting a long line with no newline would have made this
+	// the slowest thing on the page.
+	let lineArr = [];   // the line currently being drawn, after the last \n
+	let col = 0;        // cursor position within it
 
-	for (;;) {
-		result = re.exec(chunk);
-		if (!result) {
-			if (readerDone) {
-				break;
+	return {
+		// Returns the chunk with ANSI removed, so a caller matching markers can
+		// feed its rolling window the same text that was rendered rather than
+		// stripping the stream a second time.
+		write(t) {
+			const s = t.replace(ansi, '');
+			let commit = '';
+			for (let i = 0; i < s.length; i++) {
+				const ch = s[i];
+				if (ch === '\n') {
+					commit += lineArr.join('') + '\n';
+					lineArr = [];
+					col = 0;
+				} else if (ch === '\r') {
+					col = 0;
+				} else {
+					lineArr[col++] = ch;
+				}
 			}
-
-			let remainder = chunk.substr(startIndex);
-			({ value: chunk, done: readerDone } = await rd.read());
-			chunk = remainder + (chunk ? td.decode(chunk) : '');
-			startIndex = re.lastIndex = 0;
-			continue;
-		}
-
-		yield chunk.substring(startIndex, result.index);
-		startIndex = re.lastIndex;
-	}
-
-	if (startIndex < chunk.length) {
-		yield chunk.substr(startIndex);
-	}
-
-	if (el.dataset['reboot'] === "true") {
-		location.href = '/cgi-bin/fw-restart.cgi'
-	}
-
-	if ($('form input[type=submit]')) {
-		$('form input[type=submit]').disabled = false;
-	}
-}
-
-async function runCmd(msg) {
-	for await (let line of makeTextFileLineIterator('/cgi-bin/j/run.cgi?' + msg + '=' + btoa(el.dataset['cmd']))) {
-		const regex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
-		line = line.replace(regex, '');
-		el.innerHTML += line + '\n';
-	}
+			// One join per frame rather than a string rebuild per character; finished
+			// lines leave through appendData and are never re-copied.
+			if (commit) doneNode.appendData(commit);
+			lineNode.data = lineArr.join('');
+			el.scrollTop = el.scrollHeight;
+			return s;
+		},
+		// The stream stops wherever the camera happened to die, which is almost
+		// never on a line boundary: the meters redraw with \r and no trailing
+		// newline, so the last thing written stays half-drawn ("Verifying kb:
+		// 4648/4836 (96%)") and the pane reads as hung rather than finished.
+		commit() {
+			if (!lineArr.length) return;
+			doneNode.appendData(lineArr.join('') + '\n');
+			lineArr = [];
+			col = 0;
+			lineNode.data = '';
+			el.scrollTop = el.scrollHeight;
+		},
+		// A line of our own rather than the camera's. Commits whatever was
+		// half-drawn first, so a note cannot land in the middle of a redraw.
+		note(text) {
+			this.commit();
+			doneNode.appendData(text + '\n');
+			el.scrollTop = el.scrollHeight;
+		},
+	};
 }
 
 // Every tick spawns j/pulse.cgi, which forks a dozen more processes and makes a

--- a/www/cgi-bin/fw-reset.cgi
+++ b/www/cgi-bin/fw-reset.cgi
@@ -18,26 +18,36 @@
 	# touches majestic: that killall is the only one in the script, and -n
 	# rewrites rootfs_data, not the rootfs majestic runs from. So the log now
 	# survives all the way to the reboot.
-	c="/usr/sbin/sysupgrade -s -n -x --web"
-	r="true"
+	#
+	# What is NOT passed any more, and why:
+	#
+	#   -x (--no_reboot) — asked sysupgrade to leave the reboot to us, back when
+	#   this page hopped to fw-restart.cgi at the end to take it. sysupgrade
+	#   cannot honour that here: rootfs_data is the upper layer of the overlay
+	#   the running root is assembled from, so erasing it takes the live
+	#   filesystem with it and only a reboot puts one back. It says as much —
+	#   four lines of NOTICE and a five-second wait for a Ctrl-C nobody watching
+	#   a web page can send — and then reboots anyway. So the flag bought a
+	#   warning about itself and a stall, and asked for a reboot that had already
+	#   been decided (#154). fw-reset.js waits that reboot out rather than
+	#   ordering one.
+	#
+	#   -s — sysupgrade's silent mode, which pipes every progress meter through
+	#   `awk '{print NR, $1}'`. flash_eraseall redraws one line with a bare \r
+	#   and never emits a newline until it is done, so awk saw the whole erase as
+	#   a single record and printed the whole of it as "1 Erasing" — after the
+	#   fact. Dropping it puts the real meter back: one redraw per erase block,
+	#   about five a second, which on a camera whose overlay takes half a minute
+	#   to erase is the difference between progress and a frozen page (#154).
+	c="/usr/sbin/sysupgrade -n --web"
 %>
 
 <%in p/header.cgi %>
-<div class="alert alert-warning">Do not close, refresh, or navigate away from this page until the process finishes. The camera will reboot automatically.</div>
+<div id="fw-reset-status" class="alert alert-warning">Do not close, refresh, or navigate away from this page until the process finishes. The camera will reboot automatically.</div>
 <div class="card"><div class="card-body">
 	<h3>Progress</h3>
-	<pre id="output" class="mb-0" data-cmd="<%= $c %>" data-reboot="<%= $r %>"></pre>
+	<pre id="output" class="mb-0" data-cmd="<%= $c %>"></pre>
 </div></div>
 
-<script>
-	const el = $('pre#output');
-	// Stop the header heartbeat for the same reason fw-update.js does: every tick
-	// forks a dozen processes and makes a loopback request into the majestic that
-	// is streaming this log. Fine on an idle camera, ruinous on one erasing its
-	// own flash — and only now worth saying, because until --web above kept
-	// majestic alive these ticks died against a stopped server anyway. Keeping it
-	// running would trade one bug for a quieter one.
-	if (typeof stopHeartbeat === 'function') stopHeartbeat();
-	runCmd("cmd")
-</script>
+<script src="/a/fw-reset.js" defer></script>
 <%in p/footer.cgi %>


### PR DESCRIPTION
Closes the three trailing points on #154: the reset stalls for five seconds, shows no progress while it erases, and never takes you back to the UI afterwards.

All three come from the same place — `fw-reset.cgi` ran `sysupgrade -s -n -x --web`, and every one of those flags was written for a sysupgrade that no longer behaves that way.

### `-x` is inert and expensive

It used to mean "leave the reboot to me", back when this page hopped to `fw-restart.cgi` at the end to take it. sysupgrade refuses `--no_reboot` when the run rewrites the flash the camera runs from, and `-n` qualifies: `rootfs_data` is the upper layer of the overlay the running root is assembled from. So it prints four lines of NOTICE and `sleep 5` waiting for a Ctrl-C no web page can send, then reboots anyway.

### `-s` was hiding the erase meter

`set_progress()` is `busybox "$@" | awk '{print NR, $1}'` when silent mode is on. `flash_eraseall` redraws one line with a bare `\r` and emits no newline until it is done, so awk saw the whole erase as a single record and printed `1 Erasing` — once, after the fact. That is exactly the `1 Erasing` in the reporter's transcript. Dropping `-s` puts the real meter back: one redraw per erase block, ~5/s, ~30s of a 34s run on a 8.6 MB overlay. No firmware change needed.

### The hand-back was unreachable code

`makeTextFileLineIterator()` put `location.href = '/cgi-bin/fw-restart.cgi'` *after* its read loop. The stream does not end — it dies with the camera, so `rd.read()` rejects and everything after the loop is skipped. Even had it run it was wrong twice: it aimed at a camera already going down, and `fw-restart.cgi` issues its own `reboot -d1`.

`fw-reset.js` now streams the run, watches for `Protected: flashing` / `Unconditional reboot` / `Aborting.`, catches the stream error, waits for the camera to go and come back, and navigates to `status.cgi` — where majestic serves the login page itself, since a reset clears the session and takes the stay-signed-in key with it.

The second commit fixes something the hardware run exposed: the watch was armed by the stream ending, and on a real reset the announcement came at 34.6s while the read did not reject until 81.2s. Forty-six seconds of "do not navigate away" about a camera that had already gone. It is armed by the announcement now, the way `fw-update.js` has always done it, for the reason its comment gives.

### Shared terminal writer

Rendering a `\r` meter in a `<pre>` needs something that plays the cursor back, which `fw-update.js` already had (#134). Extracted as `termWriter()` in `main.js` and used by both. `runCmd()` and `makeTextFileLineIterator()` are gone — `fw-reset.cgi` was their only caller, and they reached for an `el` the page had to leak into global scope.

### Verification

Hardware, hi3516ev300 (`master+2f558d4`), real `sysupgrade -n --web` driven from a real browser:

```text
[ 4.6s] Erasing 64 Kibyte @ 10000 -   0% complete.
[33.1s] Erasing 64 Kibyte @ 860000 -  96% complete.
[34.6s] Unconditional reboot            <- status flips to "waiting for it to come back"
        camera back; navigation to status.cgi → 302 /login.html?next=%2Fcgi-bin%2Fstatus.cgi
```

No NOTICE, no stall, live meter, correct hand-off. Also exercised in a browser against a recorded 34s reset stream: the abort path (camera untouched, transcript kept, heartbeat resumed), the connection-dies-mid-erase path, and a socket that lingers 20s past the announcement.

`termWriter()` was checked byte-identical to the previous inline renderer over that recorded stream at eight different chunk boundaries, so the upgrade page renders exactly as before.
