### PR TITLE
Settings: land on the section you picked, on mobile

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -476,6 +476,15 @@ pre#output[data-cmd] {
 	.mj-search .form-control {
 		font-size: 1rem;
 	}
+
+	/* Where a section lands when you pick it from the rail (#199). scrollIntoView
+	   aligns the border box, and the column's own 1.5rem row gutter is a margin
+	   outside it, so without this the card sits flush against the top edge of the
+	   screen. Nothing is fixed at the top here — the navbar scrolls away — so this
+	   is a breathing gap rather than a chrome offset. */
+	#mj-settings-form-col {
+		scroll-margin-top: 1rem;
+	}
 }
 
 /* search hits, in the tree and in the field labels/hints of the open section */

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -484,6 +484,13 @@ pre#output[data-cmd] {
 	   is a breathing gap rather than a chrome offset. */
 	#mj-settings-form-col {
 		scroll-margin-top: 1rem;
+		/* And the room to get there. The rail above the form is most of a screen,
+		   so a short section leaves too little page below it to scroll with, and
+		   the browser clamps you part of the way down: measured at 500x844 on an
+		   hi3516av300, half the sections stopped between 27 and 576px short of the
+		   top. Reserving a screen for the column costs some empty space under a
+		   short card and makes every section land in the same place. */
+		min-height: 100vh;
 	}
 }
 

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -358,11 +358,52 @@
 				const newTab = u.searchParams.get('tab');
 				if (!newTab) return;
 				ev.preventDefault();
-				if (newTab === state.sec) return;
+				// Picking the section that is already open is still a deliberate
+				// pick: below md it means "take me back down to it", and a control
+				// that does nothing at all reads as a dead one.
+				if (newTab === state.sec) { revealSection(); return; }
+				// Answering "no" to the prompt is choosing to stay, so nothing moves.
 				if (hasDirty() && !confirm('You have unsaved changes. Discard and switch sections?')) return;
-				load(newTab, /*push*/ true);
+				// After load(), never inside it: the section has to be in the document
+				// first, and buildNav() — which load() re-runs while a search is
+				// active, resizing the rail *above* the form — has to have finished.
+				load(newTab, /*push*/ true).then(revealSection);
 			});
 		});
+	}
+
+	// Put the person in front of the section they just picked. Below md the rail
+	// is stacked *above* the form rather than beside it, so a tap left them
+	// looking at navigation with the fields they asked for below the fold (#199).
+	// On >=md the rail is sticky-md-top and stays on screen at every offset, so
+	// there is nothing there to correct and nothing worth jumping for.
+	//
+	// The whole column rather than the section's card: the live leaf renders a
+	// row of two panels and no card at all, so there is no single card to aim at
+	// — and the column's top edge is what should end up near the top of the
+	// screen anyway. How far below the edge it lands is scroll-margin-top, in the
+	// stylesheet beside the rest of the below-md rail rules.
+	function revealSection() {
+		const form = document.getElementById('mj-settings-form');
+		const col = document.getElementById('mj-settings-form-col');
+		if (!form || !col) return;
+
+		// A tap that neither navigates nor moves focus says nothing to a screen
+		// reader, so the section's own heading takes it and announces the name.
+		// preventScroll because the scroll below is ours: focusing the live
+		// panel's heading would otherwise skip the preview sitting above it.
+		const h = form.querySelector('h3');
+		if (h) {
+			h.tabIndex = -1;
+			h.focus({ preventScroll: true });
+		}
+
+		// No behaviour argument: bootstrap's reboot already sets scroll-behavior
+		// on :root, inside @media (prefers-reduced-motion: no-preference), so a
+		// bare scrollIntoView() animates like every other scroll on the site and
+		// stops animating for anyone who asked it to. Naming 'smooth' or 'instant'
+		// here would opt this one navigation out of both.
+		if (!WIDE.matches) col.scrollIntoView();
 	}
 
 	function onPopState(ev) {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -288,6 +288,7 @@
 		if (!nav) return;
 		const q = state.q.trim();
 		const t = filterTree();
+		const cur = groupOf(state.sec);
 		nav.innerHTML = '';
 
 		if (!t.length) {
@@ -302,7 +303,7 @@
 			li.dataset.group = g.id;
 			// open on desktop (the whole tree stays visible), and on mobile only
 			// while a search is narrowing it or this is the group you are in
-			if (WIDE.matches || q) li.classList.add('mj-open');
+			if (WIDE.matches || q || (cur && cur.id === g.id)) li.classList.add('mj-open');
 
 			const cat = el('button', 'mj-tree-cat');
 			cat.type = 'button';


### PR DESCRIPTION
Reported in #199: on a phone, tapping a section in **Majestic → Settings** left you
looking at the navigation tree. Below `md` the two columns stack, so the rail — 22
sections across two accordion levels — sits *above* the form and fills the screen.

Measured on an hi3516av300 at 390×844 before this change: **all 22 sections started
between 683 and 991px down an 844px screen**, so every one of them was at or past the
fold at the moment you asked for it.

Tapping **Watchdog** from the rail, before and after, both at 390×844:

| | column top, relative to the top of the screen |
|---|---|
| before | **727px** — the whole screen is the tree, the card starts in the last 100px |
| after | **16px** |

Swept all 22 leaves afterwards: every one of them lands at 16px.

### What changed

**1. Land on the section you picked** — `revealSection()` runs from the nav click
handler and brings `#mj-settings-form-col` to just below the top of the screen.

* The hook is in the click handler, not in `load()`. `push` there means "add a history
  entry", not "a person pointed at this"; back/forward and the "no, keep my unsaved
  changes" answer must not move the page, and those two decisions already live in the
  handler. Picking the section that is *already* open scrolls too — it is a deliberate
  pick, and a control that does nothing reads as a dead one.
* It aims at the column rather than the section's card because the **Live** leaf renders
  a row of two panels and no card at all.
* No `behavior` argument. Bootstrap's reboot already sets `scroll-behavior: smooth` on
  `:root` inside `@media (prefers-reduced-motion: no-preference)`, so the bare call
  animates like every other scroll on the site and stops animating for anyone who asked
  it to. Naming a behaviour would opt this one navigation out of both.
* The section's `<h3>` takes focus, at every width — a tap that neither navigates nor
  moves focus says nothing to a screen reader. Verified with a real (trusted) pointer
  event that this does **not** raise a focus ring: `:focus-visible` does not match a
  programmatic focus that followed a tap.

**2. Room for a short section to get there** — scrolling only works if there is page
left below. There often isn't: the rail alone is 640–990px. Half the sections clamped
part-way. A `min-height: 100vh` on the column, in the same below-`md` block, takes all
22 to the same landing. The cost is empty space under a short card, which is what a
short page looks like anyway.

**3. Stop closing the category you are standing in** — `buildNav()`'s comment promised
"…or this is the group you are in" and `groupOf()` had been sitting unused since it was
written for exactly that, but the condition never asked. Clearing the search box shut
the tree on you. One condition; the code now says what the comment always did.

### Scope

Mobile only, gated on the same `WIDE` media query the accordion uses. On `≥md` the rail
is `sticky-md-top` and never leaves the screen, so the reported failure cannot happen
there. @usa- — would you want the same jump on a desktop browser when you switch
sections while scrolled deep into a long one? Lifting the gate is one line if so.

### Verification

`npm test` passes (untouched — the suite covers the WebRTC player and the transport
list, not DOM wiring; there is no jsdom and no dependency budget for one, so this change
gets no unit test).

Everything below ran against a real hi3516av300 through CDP at a 390×844 viewport, with
taps dispatched as trusted pointer events.

| check | result |
|---|---|
| initial page load | `scrollY` stays 0 — a load never scrolls |
| tap a section in a collapsed category | column top lands at 16px, `<h3>` focused, nav marks the new section |
| tap the section that is already open | scrolls again |
| unsaved changes → "Cancel" | nothing moves, nothing switches, focus unchanged |
| unsaved changes → "Discard" | switches and scrolls |
| desktop, 1280×900, scrolled to 400 | `scrollY` unchanged at 400; the `<h3>` still takes focus |
| all 22 sections swept | every one lands at 16px, none clamped |
