### PR TITLE
Preview: right-align Stats for real, and stop the note claiming what is pinned

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -757,3 +757,12 @@ mark {
 	border-color: var(--bs-danger);
 	box-shadow: 0 0 0 .25rem rgba(var(--bs-danger-rgb), .25);
 }
+
+/* Pushes a flex item to the far end of its row. Bootstrap's own ms-auto is not
+   in the trimmed build this tree ships, so the class silently did nothing —
+   the stats toggle sat against the buttons it was supposed to be separated
+   from. Named for the job rather than the direction, since the row is the only
+   place it is used. */
+.mj-push-end {
+	margin-left: auto;
+}

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -453,6 +453,11 @@
 		// correcting a default is helpful, overriding a decision is not.
 		const moved = !userPickedStream && chooseSub(cfg);
 		if (moved && player) player.setStream(stream);
+		// The note follows the channel, and this is the one path that changes
+		// the channel without going through attachPlayer(). A camera whose two
+		// channels differ would otherwise disclose Main's setting while playing
+		// Sub, until something else happened to re-sync it.
+		syncTransportNote();
 
 		// The ICE list, unconditionally. A blind attach opened with an empty
 		// one, and the getter is only read when a session opens — so without

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -65,6 +65,14 @@
 		// the radio behind it stays in the tab order, so without this the
 		// keyboard can pick a stream the camera does not have.
 		if (s1) s1.disabled = !subOk;
+		// Whether each channel will actually be adapted. Absent means an older
+		// camera that has no such setting and always adapted, so only an
+		// explicit false counts as pinned.
+		adapts = [
+			mjGet(cfg, 'video0.adjustBitrate') !== false,
+			mjGet(cfg, 'video1.adjustBitrate') !== false,
+		];
+		syncTransportNote();
 		ice = MajesticTransport.iceServers(
 			mjGet(cfg, 'webrtc.iceServers'),
 			mjGet(cfg, 'webrtc.turnUsername'),
@@ -115,8 +123,13 @@
 	// only while it is actually happening — a tooltip needs a pointer to find,
 	// and this is not a detail for people who happen to own a mouse.
 	function syncTransportNote() {
+		// Only while it is true. The note is a disclosure, and a disclosure that
+		// fires when nothing is happening teaches people to ignore it — the
+		// camera does not touch a channel whose adjustBitrate is off, so saying
+		// it is adapting that stream is simply wrong. Per channel, because the
+		// two settings are independent and Main/Sub is one click apart.
 		if (transportNote) {
-			transportNote.hidden = !usingWebRTC;
+			transportNote.hidden = !(usingWebRTC && adapts[stream ? 1 : 0]);
 		}
 		if (transportLbl && usingWebRTC) {
 			transportLbl.title = TRANSPORT_TITLE;
@@ -141,6 +154,9 @@
 	// corrected by the first reconnect rather than staying host-candidates-only
 	// for the life of the page.
 	let ice = [];
+	// Per channel, filled when the config lands; true until then, which is what
+	// a camera without the setting does.
+	let adapts = [true, true];
 	// Talkback is deliberately NOT carried across a transport switch or a
 	// reattach. Everything else here is a preference; this one holds a live
 	// microphone, and silently reopening it because the page rebuilt a player
@@ -483,10 +499,12 @@
 	if (s0) s0.addEventListener('change', () => {
 		stream = 0;
 		if (player) player.setStream(0);
+		syncTransportNote();
 	});
 	if (s1) s1.addEventListener('change', () => {
 		stream = 1;
 		if (player) player.setStream(1);
+		syncTransportNote();
 	});
 
 	// Audio: revealed only when the camera has it configured and the transport

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -487,7 +487,7 @@ preview() {
 		<label class="btn btn-outline-primary" for="mj-talk" id="mj-talk-lbl"
 			title="Send this browser's microphone to the camera's speaker. The camera will not take audio in one direction only, so talking also opens its audio to you.">🎤 Talk</label>
 	</div>
-	<div class="btn-group btn-group-sm ms-auto" role="group" aria-label="Statistics" id="mj-stats-ctl" hidden>
+	<div class="btn-group btn-group-sm mj-push-end" role="group" aria-label="Statistics" id="mj-stats-ctl" hidden>
 		<input type="checkbox" class="btn-check" id="mj-stats-btn" autocomplete="off">
 		<label class="btn btn-outline-secondary" for="mj-stats-btn"
 			title="Per-second measurements from both ends of the session.">Stats</label>


### PR DESCRIPTION
Two from #184.

## The Stats button was never right-aligned

> The `Stats` button is now on the same line as the other buttons, but it is attached to the left of them.

He is right, and the reason is worth recording: **`ms-auto` is not in the Bootstrap build this tree ships.** The bundled `bootstrap.min.css` is trimmed and contains zero occurrences of it, so the class was inert — valid-looking markup doing nothing at all.

```
$ grep -c ms-auto www/a/bootstrap.min.css
0
```

That is a trap for anything else reaching for a Bootstrap utility from memory. There is a real rule in `bootstrap.override.css` now, named for the job rather than the direction since the control row is the only place it is used.

## The adaptation notice claimed what was not happening

> even when `Adjust bitrate to WebRTC viewers` is disabled for both streams, clicking the `WebRTC` button … displays: *The camera is adapting this stream's bitrate to your connection.*

A real bug, and ours. The note has been gated on the transport since it was written — `adjustBitrate` did not exist then. Now that it does, and now that the main channel ships **pinned by default**, the disclosure was telling people about something the camera was not doing. A disclosure that fires when nothing is happening is worse than none, because it teaches people to ignore it.

It now follows the current channel's setting, and therefore also follows a Main/Sub switch, since the two channels are independent and one click apart.

Absent counts as on: a camera too old to have the setting always adapted, so only an explicit `false` hides the note.

## Also answered on the issue, not here

His remaining points: the `Adapt` → `Adjust` rename and the shorter shared hint (camera-side, separate change); cropping versus `Source = Auto`, where his rebuttal is correct and I have conceded; the cross-tab substream case, which he and I agree is not worth solving; and the WebRTC flicker, which needs a real change to how a transport switch is staged rather than a patch, and is being done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)