### PR TITLE
Preview: try a transport before committing the screen to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js"
+    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -15,7 +15,10 @@ const path = require('path');
 const vm = require('vm');
 const { check, group, done } = require('./assert');
 
-const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-page.js');
+const A = (f) => path.join(__dirname, '..', 'www', 'a', f);
+// The swap machinery is a module of its own now; the page is what decides what
+// its outcomes mean, and that division is part of what these check.
+const SRCS = [A('preview-swap.js'), A('preview-page.js')];
 
 const IDS = [
 	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
@@ -79,6 +82,7 @@ function load(pickedTransport) {
 
 	const ctx = {
 		window: win,
+		MajesticSwap: null,   // preview-swap.js assigns it onto window below
 		console: console,
 		MajesticVideo: impls.mse,
 		MajesticWebRTC: impls.webrtc,
@@ -93,7 +97,11 @@ function load(pickedTransport) {
 		Promise: Promise,
 	};
 	vm.createContext(ctx);
-	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+	vm.runInContext(fs.readFileSync(SRCS[0], 'utf8'), ctx);
+	// The browser reaches window.MajesticSwap through the global scope; a vm
+	// context has no such link, so hand it over explicitly.
+	ctx.MajesticSwap = win.MajesticSwap;
+	vm.runInContext(fs.readFileSync(SRCS[1], 'utf8'), ctx);
 	env.el = (id) => env.els['#' + id];
 	return env;
 }

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -46,9 +46,16 @@ function makePlayers(env) {
 	function impl(kind) {
 		return {
 			attach(el, opts) {
+				// The real MSE player replaces its element on every reconnect
+				// (cloneNode plus replaceChild, keeping the id), so anything
+				// holding the old node is holding a detached one. Model that.
+				if (kind === 'mse') el = env.replaceNode(el.id);
 				const p = {
 					kind: kind, el: el, destroyed: false, opts: opts,
-					setStream() {}, setVolume() {}, setAudio() {}, setMic() {},
+					streamSet: null, audioCalls: 0,
+					setStream(n) { this.streamSet = n; },
+					setVolume() {}, setMic() {},
+					setAudio() { this.audioCalls++; },
 					audioSupported: () => true, micSupported: () => true,
 					destroy() { this.destroyed = true; },
 					say(state, detail) { opts.onState(state, detail); },
@@ -65,6 +72,13 @@ function makePlayers(env) {
 function load(pickedTransport) {
 	const env = { made: [], els: {} };
 	IDS.forEach((id) => { env.els['#' + id] = makeEl(id); });
+	// Swap in a fresh node under the same id, as replaceChild does.
+	env.replaceNode = (id) => {
+		const fresh = makeEl(id);
+		fresh.style = Object.assign({}, env.els['#' + id].style);
+		env.els['#' + id] = fresh;
+		return fresh;
+	};
 	const impls = makePlayers(env);
 
 	const win = {
@@ -222,6 +236,69 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		check('and the page falls through to MJPEG',
 			env.el('mj-badge').textContent === 'MJPEG',
 			env.el('mj-badge').textContent);
+	}
+
+	group('a cloned MSE element does not strand the swap');
+	{
+		const env = load('mse');
+		await tick();
+		const first = env.made[0];
+		first.say('playing');
+		// MSE has since replaced its node; the swap must not be holding the
+		// detached one when it picks a spare.
+		check('the live player is on the current node',
+			first.el === env.el('live-video'), 'stale');
+
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+		const trial = env.made[1];
+		check('the trial went to the spare, not the visible element',
+			trial.el.id === 'live-video-b', trial.el.id);
+
+		trial.say('playing');
+		check('and the promoted one is visible',
+			env.el('live-video-b').style.display === '',
+			env.el('live-video-b').style.display);
+		check('while the old node is hidden',
+			env.el('live-video').style.display === 'none',
+			env.el('live-video').style.display);
+	}
+
+	group('a trial is opened with the audio already wanted');
+	{
+		const env = load('mse');
+		await tick();
+		env.made[0].say('playing');
+		// The viewer is listening.
+		env.el('mj-mute').checked = true;
+		env.el('mj-mute').fire('change');
+
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+		const trial = env.made[1];
+		check('the trial negotiates audio from the start',
+			trial.opts.audio === true, JSON.stringify(trial.opts.audio));
+		trial.say('playing');
+		// setAudio after promotion would renegotiate a session that just
+		// proved itself, which is the flicker coming back by another route.
+		check('and is not told to turn audio on afterwards',
+			trial.audioCalls === undefined || trial.audioCalls === 0,
+			String(trial.audioCalls));
+	}
+
+	group('a stream change reaches the trial as well');
+	{
+		const env = load('mse');
+		await tick();
+		env.made[0].say('playing');
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+		const trial = env.made[1];
+		env.el('mj-stream-1').fire('change');
+		check('the live player followed the viewer to Sub',
+			env.made[0].streamSet === 1, 'live=' + env.made[0].streamSet);
+		check('the trial followed the viewer to Sub',
+			trial.streamSet === 1, 'trial=' + trial.streamSet);
 	}
 
 	done();

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -1,0 +1,220 @@
+// preview-page.js's transport switch, driven against stub players.
+//
+// The rule under test is one sentence: nothing on screen changes until the
+// replacement has a picture. Everything here is a way of checking that the
+// page does not tear down a working player before it knows.
+//
+// It is worth the harness because this page has twice shipped the opposite
+// bug — a fallback burying the player that was working — and both times the
+// picture looked right while the handle was wrong, which is exactly what a
+// human glance cannot catch.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-page.js');
+
+const IDS = [
+	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
+	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-note', 'mj-stats',
+	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1', 'mj-sub',
+	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-transport',
+	'mj-transport-ctl', 'mj-transport-lbl', 'mj-transport-note', 'mj-vol',
+	'toggle-ircut', 'toggle-light', 'toggle-night',
+];
+
+function makeEl(id) {
+	return {
+		id: id, style: {}, hidden: false, checked: false, disabled: false,
+		textContent: '', title: '', value: 100, src: '', srcObject: null,
+		handlers: {},
+		addEventListener(ev, fn) { (this.handlers[ev] = this.handlers[ev] || []).push(fn); },
+		removeAttribute() { this.src = ''; },
+		fire(ev) { (this.handlers[ev] || []).forEach((f) => f()); },
+	};
+}
+
+// A player stub that records what was done to it and lets the test drive its
+// state callbacks by hand — the states are the whole subject here.
+function makePlayers(env) {
+	function impl(kind) {
+		return {
+			attach(el, opts) {
+				const p = {
+					kind: kind, el: el, destroyed: false, opts: opts,
+					setStream() {}, setVolume() {}, setAudio() {}, setMic() {},
+					audioSupported: () => true, micSupported: () => true,
+					destroy() { this.destroyed = true; },
+					say(state, detail) { opts.onState(state, detail); },
+				};
+				env.made.push(p);
+				return p;
+			},
+			available: kind === 'webrtc',
+		};
+	}
+	return { mse: impl('mse'), webrtc: impl('webrtc') };
+}
+
+function load(pickedTransport) {
+	const env = { made: [], els: {} };
+	IDS.forEach((id) => { env.els['#' + id] = makeEl(id); });
+	const impls = makePlayers(env);
+
+	const win = {
+		MajesticVideo: impls.mse,
+		MajesticWebRTC: impls.webrtc,
+		MajesticTransport: {
+			available: () => true,
+			preferred: () => pickedTransport || 'mse',
+			choose() {}, demote() { env.demoted = true; },
+			impl: (k) => (k === 'webrtc' ? impls.webrtc : impls.mse),
+			iceServers: () => [],
+			chosenStream: () => null, chooseStream() {},
+		},
+	};
+
+	const ctx = {
+		window: win,
+		console: console,
+		MajesticVideo: impls.mse,
+		MajesticWebRTC: impls.webrtc,
+		MajesticTransport: win.MajesticTransport,
+		$: (sel) => env.els[sel],
+		// Never resolves: every test here drives the players directly, and a
+		// config that landed would re-attach underneath them.
+		mjConfig: () => new Promise(() => {}),
+		mjGet: () => undefined,
+		apiFetch: () => Promise.reject(new Error('no network in tests')),
+		setTimeout, clearTimeout, setInterval, clearInterval,
+		Promise: Promise,
+	};
+	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+	env.el = (id) => env.els['#' + id];
+	return env;
+}
+
+// Longer than preview-page.js's CONFIG_WAIT_MS: the first attach waits for
+// the config fetch or that deadline, whichever comes first, and here the fetch
+// never lands on purpose.
+const tick = () => new Promise((r) => setTimeout(r, 1700));
+
+(async () => {
+	// The first attach has nothing to protect, so it goes straight on screen.
+	group('the first attach goes live immediately');
+	{
+		const env = load('mse');
+		await tick();
+		check('one player was made', env.made.length === 1, env.made.length + '');
+		check('it took the visible element',
+			env.made[0] && env.made[0].el.id === 'live-video');
+	}
+
+	group('switching transport does not disturb what is playing');
+	{
+		const env = load('mse');
+		await tick();
+		const first = env.made[0];
+		first.say('playing');
+
+		// The user ticks WebRTC.
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+
+		check('a second player was made', env.made.length === 2);
+		const trial = env.made[1];
+		check('on the spare element, not the visible one',
+			trial && trial.el.id === 'live-video-b', trial && trial.el.id);
+		check('the working player is still alive', !first.destroyed);
+		check('and still owns the visible element', first.el.id === 'live-video');
+
+		// Everything short of success must stay invisible.
+		trial.say('connecting');
+		trial.say('nosignal');
+		check('a trial connecting changes nothing', !first.destroyed);
+		check('and does not touch the badge',
+			env.el('mj-badge').textContent === '', env.el('mj-badge').textContent);
+	}
+
+	group('a trial that fails leaves the screen alone');
+	{
+		const env = load('mse');
+		await tick();
+		const first = env.made[0];
+		first.say('playing');
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+		const trial = env.made[1];
+
+		trial.say('fallback', 'no usable H.264 in the offer');
+		check('the trial was destroyed', trial.destroyed);
+		check('the working player was NOT', !first.destroyed);
+		check('the toggle came back off', env.el('mj-transport').checked === false);
+		check('and the reason is on the label',
+			/no usable H.264/.test(env.el('mj-transport-lbl').title),
+			env.el('mj-transport-lbl').title);
+		check('a refusal is remembered', env.demoted === true);
+	}
+
+	group('a trial that works takes over, and only then');
+	{
+		const env = load('mse');
+		await tick();
+		const first = env.made[0];
+		first.say('playing');
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+		const trial = env.made[1];
+
+		check('nothing destroyed yet', !first.destroyed);
+		trial.say('playing');
+		check('now the old player goes', first.destroyed);
+		check('the trial survives', !trial.destroyed);
+		check('the old element is hidden',
+			first.el.style.display === 'none', first.el.style.display);
+		check('and the new one is shown',
+			trial.el.style.display === '', trial.el.style.display);
+	}
+
+	group('a busy camera is not remembered as a refusal');
+	{
+		const env = load('mse');
+		await tick();
+		env.made[0].say('playing');
+		env.el('mj-transport').checked = true;
+		env.el('mj-transport').fire('change');
+		env.made[1].say('busy', 'the camera is serving as many viewers as it can');
+		check('the working player is untouched', !env.made[0].destroyed);
+		check('and no demotion was recorded', env.demoted !== true);
+	}
+
+	group('when the live player dies and its replacement fails too');
+	{
+		const env = load('webrtc');
+		await tick();
+		const first = env.made[0];
+		check('started on WebRTC', first.kind === 'webrtc', first.kind);
+		first.say('playing');
+
+		// The session dies mid-watch.
+		first.say('fallback', 'media stopped arriving');
+		check('a replacement was staged', env.made.length === 2);
+		const second = env.made[1];
+		check('the replacement is MSE', second.kind === 'mse', second.kind);
+		check('the dead player still holds the screen for now', !first.destroyed);
+
+		// And MSE cannot run either.
+		second.say('mjpeg');
+		check('the dead player is finally released', first.destroyed);
+		check('the failed replacement too', second.destroyed);
+		check('and the page falls through to MJPEG',
+			env.el('mj-badge').textContent === 'MJPEG',
+			env.el('mj-badge').textContent);
+	}
+
+	done();
+})();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -742,11 +742,22 @@
 		// second copy of it would drift in ways that look like a picture rather
 		// than an error.
 		const swap = window.MajesticSwap({
-			elements: [video, document.getElementById('mj-live-video-b')],
+			// Getters, not nodes: the MSE player replaces its element on every
+			// reconnect (cloneNode plus replaceChild, keeping the id), so a
+			// captured node is detached within a session and every show or hide
+			// afterwards writes to something nobody can see.
+			elements: [
+				() => document.getElementById('mj-live-video'),
+				() => document.getElementById('mj-live-video-b'),
+			],
 			open: (kind, el, id, onState) => {
 				const impl = window.MajesticTransport.impl(kind);
 				return impl.attach(el, {
 					stream: stream,
+					// Opened with the volume it should have rather than given
+					// it afterwards; see preview-swap.js on why applying
+					// preferences post-promotion undoes the staging.
+					volume: 1,
 					// Same list the Preview page builds, and for the same
 					// reason: without it the browser offers host candidates
 					// only, and a session opened from anywhere but the same LAN
@@ -815,6 +826,11 @@
 				if (n === stream) return;
 				stream = n;
 				if (state.previewPlayer) state.previewPlayer.setStream(n);
+				// And the trial, if one is being judged: it keeps the stream it
+				// was opened with, so it would otherwise be promoted onto the
+				// channel just moved away from.
+				const t = swap.trial();
+				if (t) t.setStream(n);
 			});
 		});
 	}

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -508,6 +508,16 @@
 	}
 
 	function stopLivePreview() {
+		// Through the swap, which closes the trial as well as the player on
+		// screen. Destroying only state.previewPlayer would leave a transport
+		// still being judged behind on every visit — a live socket nobody has a
+		// handle to, which is the leak this used to exist to prevent.
+		if (state.previewSwap) {
+			try { state.previewSwap.stop(); } catch (e) {}
+			state.previewSwap = null;
+			state.previewPlayer = null;
+			return;
+		}
 		if (state.previewPlayer) {
 			state.previewPlayer.destroy();
 			state.previewPlayer = null;
@@ -725,57 +735,61 @@
 		let stream = (remembered === null ? 1 : remembered) === 1 && subAvailable
 			? 1 : 0;
 
-		// Which attachment is the live one. MajesticWebRTC can report 'fallback'
-		// from inside attach() — it does exactly that when RTCPeerConnection or
-		// addTransceiver throws — so the handler below runs, installs MSE, and
-		// then the outer assignment completes and buries it under the façade
-		// that just failed. The picture would look right and the handle would be
-		// wrong, which is worse: state.previewPlayer is what the tab teardown
-		// destroys, so every visit would leave a live socket behind.
-		let gen = 0;
-
-		function attach(kind) {
-			const mine = ++gen;
-
-			// Whatever is running loses its handle here, so it has to be closed
-			// here. In the synchronous case there is nothing yet to close.
-			if (state.previewPlayer) {
-				try { state.previewPlayer.destroy(); } catch (e) {}
+		// The same swap the Preview page uses, for the same reason: a transport
+		// that cannot run must not cost the viewer the picture that could. This
+		// panel wants less from the outcome — there is no badge, no MJPEG and
+		// no toggle here — but the machinery underneath is identical, and a
+		// second copy of it would drift in ways that look like a picture rather
+		// than an error.
+		const swap = window.MajesticSwap({
+			elements: [video, document.getElementById('mj-live-video-b')],
+			open: (kind, el, id, onState) => {
+				const impl = window.MajesticTransport.impl(kind);
+				return impl.attach(el, {
+					stream: stream,
+					// Same list the Preview page builds, and for the same
+					// reason: without it the browser offers host candidates
+					// only, and a session opened from anywhere but the same LAN
+					// negotiates cleanly and then never carries a packet.
+					iceServers: () => window.MajesticTransport.iceServers(
+						getDotted(state.config, 'webrtc.iceServers'),
+						getDotted(state.config, 'webrtc.turnUsername'),
+						getDotted(state.config, 'webrtc.turnCredential')),
+					onState: onState,
+				});
+			},
+			// state.previewPlayer is what the tab teardown closes, so it has to
+			// name whatever is actually on screen — a stale handle there leaves
+			// a live socket behind on every visit.
+			onPromoted: () => { state.previewPlayer = swap.player(); },
+			onFailed: (kind, why, permanent) => {
+				// 'fallback' is durable and worth remembering; 'busy' says the
+				// camera is full, which it will not be for long.
+				if (kind === 'webrtc' && permanent) {
+					window.MajesticTransport.demote();
+				}
+			},
+			// Nothing on screen left to protect. MSE is the last thing to try;
+			// past that this panel simply has no preview, which is what its
+			// empty element already shows.
+			onExhausted: (kind) => {
 				state.previewPlayer = null;
-			}
+				if (kind === 'webrtc') swap.start('mse');
+			},
+			onLive: (st, d, kind) => {
+				if (kind !== 'webrtc') return;
+				if (st === 'fallback' || st === 'busy') {
+					if (st === 'fallback') window.MajesticTransport.demote();
+					// Its picture is frozen from here; the replacement is
+					// staged over it rather than blanking the panel.
+					swap.retire();
+					swap.start('mse');
+				}
+			},
+		});
+		state.previewSwap = swap;
 
-			const impl = window.MajesticTransport.impl(kind);
-			if (!impl) return;
-
-			const p = impl.attach(video, {
-				stream: stream,
-				// Same list the Preview page builds, and for the same reason:
-				// without it the browser offers host candidates only, and a
-				// session opened from anywhere but the same LAN negotiates
-				// cleanly and then never carries a packet.
-				iceServers: () => window.MajesticTransport.iceServers(
-					getDotted(state.config, 'webrtc.iceServers'),
-					getDotted(state.config, 'webrtc.turnUsername'),
-					getDotted(state.config, 'webrtc.turnCredential')),
-				onState: (st) => {
-					if (mine !== gen || kind !== 'webrtc') return;
-					// 'fallback' is durable and worth remembering; 'busy' says
-					// the camera is full, which it will not be for long.
-					if (st === 'fallback' || st === 'busy') {
-						if (st === 'fallback') window.MajesticTransport.demote();
-						attach('mse');
-					}
-				},
-			});
-
-			// Superseded while attach() was still running: something else is
-			// playing now, so drop what we just built rather than bury it.
-			if (mine !== gen) {
-				try { p.destroy(); } catch (e) {}
-				return;
-			}
-			state.previewPlayer = p;
-		}
+		function attach(kind) { swap.start(kind); }
 
 		attach(window.MajesticTransport.preferred());
 
@@ -833,6 +847,7 @@
 				'<label class="btn btn-outline-primary" for="mj-live-s1" id="mj-live-sub" hidden>Sub</label>' +
 				'</div></div>' +
 				'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
+				'<video id="mj-live-video-b" autoplay muted playsinline class="mj-live-video" style="display:none"></video>' +
 				'</div></div>';
 			row.appendChild(pv);
 			attachLivePreview(pv.querySelector('#mj-live-video'));

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -70,7 +70,10 @@
 			mjGet(cfg, 'webrtc.turnUsername'),
 			mjGet(cfg, 'webrtc.turnCredential'));
 	});
-	const cur = () => $('#live-video');
+	// The element the visible player owns. Swapped, not reassigned to a fixed
+	// id, because both elements are real and either can be the live one.
+	let liveEl = $('#live-video'), spareEl = $('#live-video-b');
+	const cur = () => liveEl;
 
 	const BARS = '#000 url(/a/preview.svg)';
 	function showVideo() {
@@ -132,7 +135,22 @@
 	const rememberTransport = t => MajesticTransport.choose(t);
 	const rememberDemotion = () => MajesticTransport.demote();
 
+	// What is on screen, and what is being tried out of sight.
+	//
+	// A transport switch used to tear down the working player before anything
+	// knew whether its replacement would run, so a refusal cost a blank element
+	// and a visible reconnect on the way back. Now the new player attaches to
+	// the idle element and the old one keeps playing until the new one has a
+	// picture: a success looks like nothing happened, and a failure looks like
+	// nothing happened either, because nothing did.
+	//
+	// Each attachment carries its own id rather than sharing one counter. Both
+	// players are live at once during a swap, and the outgoing one has to go on
+	// working — a single "is this the current generation" test cannot say that
+	// about two things at the same time.
 	let player = null, usingWebRTC = false;
+	let attach = null;   // { id, p, el, webrtc } — on screen
+	let staging = null;  // { id, p, el, webrtc } — on trial, hidden
 	// Carried across a transport switch, because a new player starts from its
 	// defaults and the user's choices should outlive the machinery.
 	let stream = 0, audioOn = false, vol = 1;
@@ -242,66 +260,148 @@
 	// Rebuilt rather than mutated when the transport changes: the two players
 	// own different machinery, and the state worth carrying over is three
 	// values.
-	function attachPlayer(webrtc) {
-		const gen = ++attachSeq;
-		if (player) { try { player.destroy(); } catch (e) {} player = null; }
-		usingWebRTC = !!webrtc;
-		// MSE leaves a MediaSource object URL on the element; WebRTC's
-		// srcObject would win anyway, but an element carrying both is a
-		// confusing thing to debug.
-		const v = cur();
-		try { v.removeAttribute('src'); v.srcObject = null; } catch (e) {}
-		const impl = usingWebRTC ? MajesticWebRTC : MajesticVideo;
-		const p = impl.attach(v, Object.assign(
-			{ stream: stream, iceServers: () => ice }, handlersFor(gen)));
-		// attach() reported 'fallback' before returning and something else is
-		// now playing. Drop what we just built rather than letting this
-		// assignment bury it.
-		if (gen !== attachSeq) {
-			try { p.destroy(); } catch (e) {}
-			return;
-		}
-		player = p;
+	// Apply the preferences a fresh player does not know about, and put the
+	// controls into the state it is actually in.
+	function settle() {
+		if (!player) return;
 		if (audioOn && player.audioSupported()) player.setAudio(true);
 		player.setVolume(vol);
 		syncAudioCtl();
-		// The old player's destroy() released the microphone, so the control
-		// has to come back up in the state the new one is actually in.
+		// The outgoing player's destroy() released the microphone, so talkback
+		// comes back up off whatever the new one is doing.
 		syncTalkCtl();
 		syncStatsCtl();
 		syncTransportNote();
 	}
 
-	function handlersFor(gen) {
-		const live = () => gen === attachSeq;
+	// Take over the screen. The outgoing player is destroyed only here, once
+	// its replacement has a picture — which is the whole point.
+	function promote() {
+		const s = staging;
+		staging = null;
+		if (attach) {
+			try { attach.p.destroy(); } catch (e) {}
+			attach.el.style.display = 'none';
+		}
+		attach = s;
+		player = s.p;
+		usingWebRTC = s.webrtc;
+		liveEl = s.el;
+		spareEl = (s.el === $('#live-video')) ? $('#live-video-b') : $('#live-video');
+		settle();
+		showVideo();
+	}
+
+	// The trial failed. Throw it away and leave the screen exactly as it was —
+	// unless what is on screen is already dead, in which case there is nothing
+	// left to protect and this is the end of the chain.
+	function dropStaging(why, permanent) {
+		const s = staging;
+		staging = null;
+		if (s) { try { s.p.destroy(); } catch (e) {} }
+		if (s && s.webrtc) {
+			if (transportCtl) transportCtl.checked = false;
+			// The reason first, because it is the news, then the standing
+			// explanation — the tooltip is the only place either of them lives.
+			if (transportLbl) {
+				transportLbl.title =
+					'WebRTC: ' + (why || 'unavailable') + '\n\n' + TRANSPORT_TITLE;
+			}
+			// 'busy' says the camera is full, which will not be true for long.
+			// Only a real refusal is worth remembering, and even that expires.
+			if (permanent) rememberDemotion();
+		}
+		// Is there still something worth keeping? Two ways there is not: the
+		// first attach failed, so nothing ever played; or the live player gave
+		// up and this was its replacement, so the picture on screen is a frozen
+		// last frame rather than a running session.
+		if (attach && !attach.dead) return;
+		if (attach) {
+			try { attach.p.destroy(); } catch (e) {}
+			attach = null;
+			player = null;
+		}
+		// Try the other transport, and MJPEG if that already was the other one.
+		if (s && s.webrtc) attachPlayer(false);
+		else showFallback();
+	}
+
+	function attachPlayer(webrtc) {
+		// One trial at a time: a second click while the first is still being
+		// judged would leave the first running with nothing tracking it.
+		if (staging) { try { staging.p.destroy(); } catch (e) {} staging = null; }
+
+		const id = ++attachSeq;
+		const el = attach ? spareEl : liveEl;
+		const impl = webrtc ? MajesticWebRTC : MajesticVideo;
+		// MSE leaves a MediaSource object URL behind and WebRTC uses srcObject;
+		// an element carrying both is a confusing thing to debug, and this one
+		// may have been used by the other transport a moment ago.
+		try { el.removeAttribute('src'); el.srcObject = null; } catch (e) {}
+
+		staging = { id: id, p: null, el: el, webrtc: !!webrtc };
+		const p = impl.attach(el, Object.assign(
+			{ stream: stream, iceServers: () => ice }, handlersFor(id)));
+
+		// attach() can report 'fallback' before returning — MajesticWebRTC does
+		// exactly that when RTCPeerConnection or addTransceiver throws — so the
+		// handler has already run and thrown this attempt away. Assigning now
+		// would resurrect it.
+		if (!staging || staging.id !== id) {
+			try { p.destroy(); } catch (e) {}
+			return;
+		}
+		staging.p = p;
+
+		// Nothing on screen to protect: this is the first attach, so the trial
+		// is the live player and the usual state applies to it immediately.
+		if (!attach) {
+			promote();
+		}
+	}
+	function handlersFor(id) {
+		const isLive = () => attach !== null && attach.id === id;
+		const isStaged = () => staging !== null && staging.id === id;
 		return {
+			// A staged player owns nothing on screen, so it reports only two
+			// things that matter: it worked, or it did not. Everything in
+			// between — connecting, no signal, reconnecting — is exactly what
+			// must NOT reach the page, because the whole point is that trying
+			// costs the viewer nothing until it succeeds.
 			onState: (s, d) => {
-				if (!live()) return;
+				if (isStaged()) {
+					if (s === 'playing') promote();
+					else if (s === 'fallback' || s === 'busy' || s === 'mjpeg') {
+						// 'mjpeg' is MSE saying it is out of options, which for
+						// a trial is just another way of failing.
+						dropStaging(d, s === 'fallback');
+					}
+					return;
+				}
+				if (!isLive()) return;
 				if (s === 'playing') showVideo();
 				else if (s === 'nosignal') showNoSignal();
 				else if (s === 'mjpeg') showFallback();
 				else if (s === 'fallback' || s === 'busy') {
-					// WebRTC gave up. Drop to MSE rather than to MJPEG: MSE
-					// plays what this browser's decoder takes rather than what
-					// its WebRTC stack will negotiate, which is a strictly
-					// larger set.
+					// The live player gave up mid-session. Try the other
+					// transport — from WebRTC that means MSE, which plays what
+					// this browser's decoder takes rather than what its WebRTC
+					// stack will negotiate, a strictly larger set.
+					//
+					// Staged like any other switch, so the last frame stays
+					// until the replacement has one. If MSE cannot run either,
+					// its own trial fails and lands on MJPEG.
 					if (usingWebRTC) {
-						const why = d || 'unavailable';
-						if (transportCtl) {
-							transportCtl.checked = false;
-						}
-						// The reason first, because it is the news, then the
-						// standing explanation — the tooltip is the only place
-						// either of them lives.
+						if (transportCtl) transportCtl.checked = false;
 						if (transportLbl) {
-							transportLbl.title =
-								'WebRTC: ' + why + '\n\n' + TRANSPORT_TITLE;
+							transportLbl.title = 'WebRTC: ' +
+								(d || 'unavailable') + '\n\n' + TRANSPORT_TITLE;
 						}
-						// 'busy' says the camera is full, which will not be
-						// true for long — take MSE now and try WebRTC again on
-						// the next load. Only a real refusal is worth
-						// remembering, and even that one expires.
 						if (s === 'fallback') rememberDemotion();
+						// Its picture is a frozen frame from here on. Say so,
+						// or a replacement that also fails would leave it on
+						// screen for ever with nothing to move it to MJPEG.
+						attach.dead = true;
 						attachPlayer(false);
 					} else {
 						showFallback();
@@ -310,7 +410,7 @@
 				else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
 			},
 			onCodec: (codec, cs, w, h) => {
-				if (!live()) return;
+				if (!isLive()) return;
 				if (badge) {
 					badge.textContent = codec.toUpperCase() + ' ' + w + '×' + h +
 						(usingWebRTC ? ' · WebRTC' : '');
@@ -320,7 +420,7 @@
 			// off or not producing). Reflect that on the control rather than
 			// leaving the user staring at an unmute button that does nothing.
 			onAudio: (codec) => {
-				if (!live() || !mute) return;
+				if (!isLive() || !mute) return;
 				if (mute.checked && !codec) {
 					muteLbl.textContent = '🔇 No audio';
 					mute.checked = false;
@@ -344,7 +444,7 @@
 			// microphone is running by then, and a control that cannot stop a
 			// running microphone is the wrong control.
 			onMic: (state, why) => {
-				if (!live() || !talk) return;
+				if (!isLive() || !talk) return;
 				talk.checked = state === 'on' || state === 'live';
 				talk.disabled = state === 'asking';
 				if (talkLbl) {
@@ -365,7 +465,7 @@
 				}
 			},
 			onStats: (s) => {
-				if (!live() || !statsBox || statsBox.hidden) return;
+				if (!isLive() || !statsBox || statsBox.hidden) return;
 				showStats(s);
 			},
 		};

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -135,22 +135,10 @@
 	const rememberTransport = t => MajesticTransport.choose(t);
 	const rememberDemotion = () => MajesticTransport.demote();
 
-	// What is on screen, and what is being tried out of sight.
-	//
-	// A transport switch used to tear down the working player before anything
-	// knew whether its replacement would run, so a refusal cost a blank element
-	// and a visible reconnect on the way back. Now the new player attaches to
-	// the idle element and the old one keeps playing until the new one has a
-	// picture: a success looks like nothing happened, and a failure looks like
-	// nothing happened either, because nothing did.
-	//
-	// Each attachment carries its own id rather than sharing one counter. Both
-	// players are live at once during a swap, and the outgoing one has to go on
-	// working — a single "is this the current generation" test cannot say that
-	// about two things at the same time.
+	// The player on screen and which transport it is, both kept in step by the
+	// swap's onPromoted. Read by the controls, which act on what is playing
+	// rather than on what is being tried.
 	let player = null, usingWebRTC = false;
-	let attach = null;   // { id, p, el, webrtc } — on screen
-	let staging = null;  // { id, p, el, webrtc } — on trial, hidden
 	// Carried across a transport switch, because a new player starts from its
 	// defaults and the user's choices should outlive the machinery.
 	let stream = 0, audioOn = false, vol = 1;
@@ -274,32 +262,26 @@
 		syncTransportNote();
 	}
 
-	// Take over the screen. The outgoing player is destroyed only here, once
-	// its replacement has a picture — which is the whole point.
-	function promote() {
-		const s = staging;
-		staging = null;
-		if (attach) {
-			try { attach.p.destroy(); } catch (e) {}
-			attach.el.style.display = 'none';
-		}
-		attach = s;
-		player = s.p;
-		usingWebRTC = s.webrtc;
-		liveEl = s.el;
-		spareEl = (s.el === $('#live-video')) ? $('#live-video-b') : $('#live-video');
-		settle();
-		showVideo();
-	}
-
-	// The trial failed. Throw it away and leave the screen exactly as it was —
-	// unless what is on screen is already dead, in which case there is nothing
-	// left to protect and this is the end of the chain.
-	function dropStaging(why, permanent) {
-		const s = staging;
-		staging = null;
-		if (s) { try { s.p.destroy(); } catch (e) {} }
-		if (s && s.webrtc) {
+	// The swap itself lives in preview-swap.js — two elements, a trial that
+	// costs the viewer nothing until it works. Everything below is what this
+	// page does about the outcome, which is the part the settings panel does
+	// differently.
+	const swap = MajesticSwap({
+		elements: [$('#live-video'), $('#live-video-b')],
+		open: (kind, el, id, onState) => MajesticVideoImpl(kind).attach(
+			el, Object.assign({ stream: stream, iceServers: () => ice },
+				handlersFor(id, onState))),
+		onPromoted: (kind) => {
+			player = swap.player();
+			usingWebRTC = kind === 'webrtc';
+			liveEl = swap.element();
+			settle();
+			showVideo();
+		},
+		// A trial was dropped and the screen is untouched. All that changes is
+		// the toggle, which has to come back up carrying the reason.
+		onFailed: (kind, why, permanent) => {
+			if (kind !== 'webrtc') return;
 			if (transportCtl) transportCtl.checked = false;
 			// The reason first, because it is the news, then the standing
 			// explanation — the tooltip is the only place either of them lives.
@@ -310,105 +292,55 @@
 			// 'busy' says the camera is full, which will not be true for long.
 			// Only a real refusal is worth remembering, and even that expires.
 			if (permanent) rememberDemotion();
-		}
-		// Is there still something worth keeping? Two ways there is not: the
-		// first attach failed, so nothing ever played; or the live player gave
-		// up and this was its replacement, so the picture on screen is a frozen
-		// last frame rather than a running session.
-		if (attach && !attach.dead) return;
-		if (attach) {
-			try { attach.p.destroy(); } catch (e) {}
-			attach = null;
+		},
+		// Nothing left on screen worth keeping. Try the other transport — from
+		// WebRTC that means MSE, which plays what this browser's decoder takes
+		// rather than what its WebRTC stack will negotiate, a strictly larger
+		// set — and MJPEG if that already was the other transport.
+		onExhausted: (kind) => {
 			player = null;
-		}
-		// Try the other transport, and MJPEG if that already was the other one.
-		if (s && s.webrtc) attachPlayer(false);
-		else showFallback();
-	}
+			if (kind === 'webrtc') attachPlayer(false);
+			else showFallback();
+		},
+		onLive: (s, d) => {
+			if (s === 'playing') showVideo();
+			else if (s === 'nosignal') showNoSignal();
+			else if (s === 'mjpeg') showFallback();
+			else if (s === 'fallback' || s === 'busy') {
+				// The live player gave up mid-session. Staged like any other
+				// switch, so its last frame stays until the replacement has one
+				// of its own.
+				if (usingWebRTC) {
+					if (transportCtl) transportCtl.checked = false;
+					if (transportLbl) {
+						transportLbl.title = 'WebRTC: ' + (d || 'unavailable') +
+							'\n\n' + TRANSPORT_TITLE;
+					}
+					if (s === 'fallback') rememberDemotion();
+					swap.retire();
+					attachPlayer(false);
+				} else {
+					showFallback();
+				}
+			}
+			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+		},
+	});
+
+	const MajesticVideoImpl = (kind) =>
+		kind === 'webrtc' ? MajesticWebRTC : MajesticVideo;
 
 	function attachPlayer(webrtc) {
-		// One trial at a time: a second click while the first is still being
-		// judged would leave the first running with nothing tracking it.
-		if (staging) { try { staging.p.destroy(); } catch (e) {} staging = null; }
-
-		const id = ++attachSeq;
-		const el = attach ? spareEl : liveEl;
-		const impl = webrtc ? MajesticWebRTC : MajesticVideo;
-		// MSE leaves a MediaSource object URL behind and WebRTC uses srcObject;
-		// an element carrying both is a confusing thing to debug, and this one
-		// may have been used by the other transport a moment ago.
-		try { el.removeAttribute('src'); el.srcObject = null; } catch (e) {}
-
-		staging = { id: id, p: null, el: el, webrtc: !!webrtc };
-		const p = impl.attach(el, Object.assign(
-			{ stream: stream, iceServers: () => ice }, handlersFor(id)));
-
-		// attach() can report 'fallback' before returning — MajesticWebRTC does
-		// exactly that when RTCPeerConnection or addTransceiver throws — so the
-		// handler has already run and thrown this attempt away. Assigning now
-		// would resurrect it.
-		if (!staging || staging.id !== id) {
-			try { p.destroy(); } catch (e) {}
-			return;
-		}
-		staging.p = p;
-
-		// Nothing on screen to protect: this is the first attach, so the trial
-		// is the live player and the usual state applies to it immediately.
-		if (!attach) {
-			promote();
-		}
+		swap.start(webrtc ? 'webrtc' : 'mse');
 	}
-	function handlersFor(id) {
-		const isLive = () => attach !== null && attach.id === id;
-		const isStaged = () => staging !== null && staging.id === id;
+
+	// The page's own callbacks, all of which belong to the player on screen: a
+	// trial has no badge, no audio control and no talkback button to report to.
+	// onState is the swap's, unchanged — it decides what a trial's states mean.
+	function handlersFor(id, onState) {
+		const isLive = () => swap.isLive(id);
 		return {
-			// A staged player owns nothing on screen, so it reports only two
-			// things that matter: it worked, or it did not. Everything in
-			// between — connecting, no signal, reconnecting — is exactly what
-			// must NOT reach the page, because the whole point is that trying
-			// costs the viewer nothing until it succeeds.
-			onState: (s, d) => {
-				if (isStaged()) {
-					if (s === 'playing') promote();
-					else if (s === 'fallback' || s === 'busy' || s === 'mjpeg') {
-						// 'mjpeg' is MSE saying it is out of options, which for
-						// a trial is just another way of failing.
-						dropStaging(d, s === 'fallback');
-					}
-					return;
-				}
-				if (!isLive()) return;
-				if (s === 'playing') showVideo();
-				else if (s === 'nosignal') showNoSignal();
-				else if (s === 'mjpeg') showFallback();
-				else if (s === 'fallback' || s === 'busy') {
-					// The live player gave up mid-session. Try the other
-					// transport — from WebRTC that means MSE, which plays what
-					// this browser's decoder takes rather than what its WebRTC
-					// stack will negotiate, a strictly larger set.
-					//
-					// Staged like any other switch, so the last frame stays
-					// until the replacement has one. If MSE cannot run either,
-					// its own trial fails and lands on MJPEG.
-					if (usingWebRTC) {
-						if (transportCtl) transportCtl.checked = false;
-						if (transportLbl) {
-							transportLbl.title = 'WebRTC: ' +
-								(d || 'unavailable') + '\n\n' + TRANSPORT_TITLE;
-						}
-						if (s === 'fallback') rememberDemotion();
-						// Its picture is a frozen frame from here on. Say so,
-						// or a replacement that also fails would leave it on
-						// screen for ever with nothing to move it to MJPEG.
-						attach.dead = true;
-						attachPlayer(false);
-					} else {
-						showFallback();
-					}
-				}
-				else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
-			},
+			onState: onState,
 			onCodec: (codec, cs, w, h) => {
 				if (!isLive()) return;
 				if (badge) {

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -252,7 +252,8 @@
 	// controls into the state it is actually in.
 	function settle() {
 		if (!player) return;
-		if (audioOn && player.audioSupported()) player.setAudio(true);
+		// No setAudio() here: the player was opened with it. Calling it now
+		// would be a no-op at best and a renegotiation at worst.
 		player.setVolume(vol);
 		syncAudioCtl();
 		// The outgoing player's destroy() released the microphone, so talkback
@@ -267,9 +268,19 @@
 	// page does about the outcome, which is the part the settings panel does
 	// differently.
 	const swap = MajesticSwap({
-		elements: [$('#live-video'), $('#live-video-b')],
+		// Resolved on every use, never stored: the MSE player replaces its
+		// element on each reconnect, so a node captured here would be detached
+		// within a session and every show/hide would write to nothing.
+		elements: [() => $('#live-video'), () => $('#live-video-b')],
+		// audio and volume go in at attach rather than after promotion.
+		// Applying them later means renegotiating a session that has just
+		// proved itself, which blanks the picture for anyone who was listening
+		// — the flicker this whole change removes, reintroduced at the last
+		// step.
 		open: (kind, el, id, onState) => MajesticVideoImpl(kind).attach(
-			el, Object.assign({ stream: stream, iceServers: () => ice },
+			el, Object.assign(
+				{ stream: stream, iceServers: () => ice,
+					audio: audioOn, volume: vol },
 				handlersFor(id, onState))),
 		onPromoted: (kind) => {
 			player = swap.player();
@@ -281,7 +292,18 @@
 		// A trial was dropped and the screen is untouched. All that changes is
 		// the toggle, which has to come back up carrying the reason.
 		onFailed: (kind, why, permanent) => {
-			if (kind !== 'webrtc') return;
+			// The trial is gone and the live player is whatever it was. The
+			// toggle has to describe that, not the transport that just failed
+			// — including when the failure was MSE and WebRTC is still playing,
+			// where leaving it unchecked would report the opposite of the truth
+			// and make the stored preference retry the failure next load.
+			if (kind !== 'webrtc') {
+				if (swap.kind() === 'webrtc' && transportCtl) {
+					transportCtl.checked = true;
+					rememberTransport('webrtc');
+				}
+				return;
+			}
 			if (transportCtl) transportCtl.checked = false;
 			// The reason first, because it is the news, then the standing
 			// explanation — the tooltip is the only place either of them lives.
@@ -478,7 +500,12 @@
 		// finding out, which is exactly the sequence that demotes a browser to
 		// MSE. Skipped when setStream() has already reopened for the stream
 		// change, and when there is nothing to apply.
-		if (!moved && player && usingWebRTC && ice.length) attachPlayer(true);
+		// Not while a trial is being judged: that trial is the viewer's own
+		// choice in flight, and it was opened after `ice` was filled anyway, so
+		// restarting WebRTC here would both undo their click and re-do work.
+		if (!moved && player && !swap.trial() && usingWebRTC && ice.length) {
+			attachPlayer(true);
+		}
 	});
 
 	if (transportCtl && transportGrp && webrtcAvailable) {
@@ -512,14 +539,17 @@
 			MajesticTransport.chooseStream('preview', n);
 		});
 	});
-	if (s0) s0.addEventListener('change', () => {
-		stream = 0;
-		if (player) player.setStream(0);
-	});
-	if (s1) s1.addEventListener('change', () => {
-		stream = 1;
-		if (player) player.setStream(1);
-	});
+	// Both the player on screen and any trial being judged. A trial keeps the
+	// stream it was opened with, so without this it would be promoted onto the
+	// channel the viewer had already moved away from.
+	function goToStream(n) {
+		stream = n;
+		if (player) player.setStream(n);
+		const t = swap.trial();
+		if (t) t.setStream(n);
+	}
+	if (s0) s0.addEventListener('change', () => goToStream(0));
+	if (s1) s1.addEventListener('change', () => goToStream(1));
 
 	// Audio: revealed only when the camera has it configured and the transport
 	// in use can carry it — otherwise the button is a dead end.

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -1,0 +1,153 @@
+// Changing transport without the viewer paying for the attempt.
+//
+// A player cannot be swapped in place. MSE drives a video element through
+// `src` and WebRTC through `srcObject`, so the incoming one has to evict the
+// outgoing one before anybody knows whether it will run — and a refusal then
+// costs a blank frame, a visible reconnect and a trip back to what was already
+// working. That was the flicker on OpenIPC/majestic-webui#184, and the rule the
+// reporter stated for it is the one implemented here:
+//
+//     nothing on screen changes until the replacement is known to work.
+//
+// So: two elements, only ever one visible. A trial attaches to whichever is
+// idle and the live player keeps going. The picture changes exactly once, when
+// the trial reports that it is playing. A trial that fails is destroyed and the
+// screen never learns it happened.
+//
+// WHY THIS IS SHARED, when the fall-back dance next to it deliberately is not.
+// That dance is a dozen lines and the two pages want different things from it —
+// one has a badge, an MJPEG fallback and a toggle to keep in step, the other a
+// bare video element. This is not that. It is a state machine with invariants
+// that are not obvious and are wrong in quiet ways: two players live at once,
+// an id per attachment because "is this the current generation" cannot describe
+// two current things, and a dead player that must be marked or its last frame
+// sits on screen for ever. A second copy would drift, and the drift would look
+// like a picture rather than an error.
+//
+// What stays with the caller is every decision: what to try next, what to put
+// on the badge, what a failure means. This owns only the swap.
+window.MajesticSwap = function (opts) {
+	// opts.elements   [visible, spare] — two video elements, the second hidden
+	// opts.open       (kind, el, id, onState) -> player
+	// opts.onLive     (state, detail, kind) — from the player on screen
+	// opts.onPromoted (kind) — a trial has taken over
+	// opts.onFailed   (kind, detail, permanent) — trial dropped, screen intact
+	// opts.onExhausted(kind, detail, permanent) — trial dropped, nothing left
+	const els = opts.elements;
+	let live = null;     // { id, p, el, kind, dead }
+	let staging = null;  // { id, p, el, kind }
+	let seq = 0;
+
+	// Which callbacks a caller's own handlers should answer to. Everything but
+	// the state feed belongs to the player on screen alone: a trial has no
+	// badge, no audio control and no talkback button to report to.
+	function isLive(id) { return live !== null && live.id === id; }
+	function isStaging(id) { return staging !== null && staging.id === id; }
+
+	function spare() {
+		return live && live.el === els[0] ? els[1] : els[0];
+	}
+
+	function show(el, on) {
+		try { el.style.display = on ? '' : 'none'; } catch (e) {}
+	}
+
+	function kill(entry) {
+		if (entry && entry.p) { try { entry.p.destroy(); } catch (e) {} }
+	}
+
+	function promote() {
+		const s = staging;
+		staging = null;
+		if (live) {
+			kill(live);
+			show(live.el, false);
+		}
+		live = s;
+		show(s.el, true);
+		opts.onPromoted(s.kind);
+	}
+
+	// The trial failed. Leave the screen exactly as it was — unless what is on
+	// screen is already dead, in which case there is nothing left to protect
+	// and the caller has to decide where to go instead.
+	function drop(detail, permanent) {
+		const s = staging;
+		staging = null;
+		kill(s);
+		if (opts.onFailed) opts.onFailed(s.kind, detail, permanent);
+		if (live && !live.dead) return;
+		if (live) { kill(live); live = null; }
+		if (opts.onExhausted) opts.onExhausted(s.kind, detail, permanent);
+	}
+
+	// Try `kind`. If something is playing it keeps playing until this works.
+	function start(kind) {
+		// One trial at a time: a second click while the first is being judged
+		// would leave the first running with nothing tracking it.
+		if (staging) { kill(staging); staging = null; }
+
+		const id = ++seq;
+		const el = live ? spare() : els[0];
+		// The other transport may have used this element a moment ago, and an
+		// element carrying both a MediaSource url and a srcObject is a
+		// confusing thing to debug.
+		try { el.removeAttribute('src'); el.srcObject = null; } catch (e) {}
+
+		staging = { id: id, p: null, el: el, kind: kind };
+
+		const onState = function (state, detail) {
+			if (isStaging(id)) {
+				// A trial owns nothing on screen, so only two things it can say
+				// matter: it worked, or it did not. Everything in between —
+				// connecting, no signal, reconnecting — is exactly what must
+				// not reach the page, because the point is that trying costs
+				// the viewer nothing until it succeeds.
+				if (state === 'playing') promote();
+				else if (state === 'fallback' || state === 'busy' ||
+					state === 'mjpeg') {
+					drop(detail, state === 'fallback');
+				}
+				return;
+			}
+			if (!isLive(id)) return;
+			opts.onLive(state, detail, live.kind);
+		};
+
+		const p = opts.open(kind, el, id, onState);
+
+		// open() can report a failure before returning — MajesticWebRTC does
+		// exactly that when RTCPeerConnection or addTransceiver throws — so the
+		// handler has already run and thrown this attempt away. Assigning now
+		// would resurrect it.
+		if (!staging || staging.id !== id) {
+			try { p.destroy(); } catch (e) {}
+			return;
+		}
+		staging.p = p;
+
+		// Nothing on screen to protect: this is the first attach, so the trial
+		// is the live player and the caller hears about it immediately.
+		if (!live) promote();
+	}
+
+	// The player on screen has given up. Its picture is a frozen frame from
+	// here on; say so, or a replacement that also fails would leave it there
+	// with nothing left to move it.
+	function retire() { if (live) live.dead = true; }
+
+	function stop() {
+		kill(staging); staging = null;
+		kill(live); live = null;
+	}
+
+	return {
+		start: start,
+		retire: retire,
+		stop: stop,
+		isLive: isLive,
+		player: function () { return live && live.p; },
+		element: function () { return live && live.el; },
+		kind: function () { return live && live.kind; },
+	};
+};

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -27,16 +27,23 @@
 // What stays with the caller is every decision: what to try next, what to put
 // on the badge, what a failure means. This owns only the swap.
 window.MajesticSwap = function (opts) {
-	// opts.elements   [visible, spare] — two video elements, the second hidden
+	// opts.elements   [get, get] — two functions, each returning a video
+	//                 element. Functions rather than nodes: the MSE player
+	//                 replaces its element on every reconnect (cloneNode plus
+	//                 replaceChild, keeping the id), so a stored reference
+	//                 becomes a detached node that can still be written to and
+	//                 shows nothing. Everything here resolves by slot instead.
 	// opts.open       (kind, el, id, onState) -> player
 	// opts.onLive     (state, detail, kind) — from the player on screen
 	// opts.onPromoted (kind) — a trial has taken over
 	// opts.onFailed   (kind, detail, permanent) — trial dropped, screen intact
 	// opts.onExhausted(kind, detail, permanent) — trial dropped, nothing left
 	const els = opts.elements;
-	let live = null;     // { id, p, el, kind, dead }
-	let staging = null;  // { id, p, el, kind }
+	let live = null;     // { id, p, slot, kind, dead }
+	let staging = null;  // { id, p, slot, kind }
 	let seq = 0;
+
+	function node(slot) { return els[slot](); }
 
 	// Which callbacks a caller's own handlers should answer to. Everything but
 	// the state feed belongs to the player on screen alone: a trial has no
@@ -44,12 +51,11 @@ window.MajesticSwap = function (opts) {
 	function isLive(id) { return live !== null && live.id === id; }
 	function isStaging(id) { return staging !== null && staging.id === id; }
 
-	function spare() {
-		return live && live.el === els[0] ? els[1] : els[0];
-	}
+	function spareSlot() { return live && live.slot === 0 ? 1 : 0; }
 
-	function show(el, on) {
-		try { el.style.display = on ? '' : 'none'; } catch (e) {}
+	function show(slot, on) {
+		const el = node(slot);
+		if (el) { try { el.style.display = on ? '' : 'none'; } catch (e) {} }
 	}
 
 	function kill(entry) {
@@ -61,10 +67,10 @@ window.MajesticSwap = function (opts) {
 		staging = null;
 		if (live) {
 			kill(live);
-			show(live.el, false);
+			show(live.slot, false);
 		}
 		live = s;
-		show(s.el, true);
+		show(s.slot, true);
 		opts.onPromoted(s.kind);
 	}
 
@@ -88,13 +94,14 @@ window.MajesticSwap = function (opts) {
 		if (staging) { kill(staging); staging = null; }
 
 		const id = ++seq;
-		const el = live ? spare() : els[0];
+		const slot = live ? spareSlot() : 0;
+		const el = node(slot);
 		// The other transport may have used this element a moment ago, and an
 		// element carrying both a MediaSource url and a srcObject is a
 		// confusing thing to debug.
 		try { el.removeAttribute('src'); el.srcObject = null; } catch (e) {}
 
-		staging = { id: id, p: null, el: el, kind: kind };
+		staging = { id: id, p: null, slot: slot, kind: kind };
 
 		const onState = function (state, detail) {
 			if (isStaging(id)) {
@@ -147,7 +154,12 @@ window.MajesticSwap = function (opts) {
 		stop: stop,
 		isLive: isLive,
 		player: function () { return live && live.p; },
-		element: function () { return live && live.el; },
+		// Resolved now, not remembered: see the note on opts.elements.
+		element: function () { return live && node(live.slot); },
 		kind: function () { return live && live.kind; },
+		// The trial, for a caller that has to keep it in step with a control
+		// the viewer moved while it was being judged — a stream change applied
+		// only to the visible player would be promoted away a moment later.
+		trial: function () { return staging && staging.p; },
 	};
 };

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -8,11 +8,16 @@
 // merely busy. Divergence there would show up as "the preview behaves
 // differently on the settings page", which is the kind of bug nobody files.
 //
-// What is deliberately NOT here is the attach-and-fall-back dance. The two
-// pages want different things from it — one has a badge, an MJPEG fallback and
-// a transport toggle to keep in step, the other has a bare video element — and
-// a shared version would be an abstraction over two callers with one of them
-// bent to fit. The dance is a dozen lines; the rules below are not.
+// What is deliberately NOT here is the attach-and-fall-back dance: what to try
+// next, what to put on the badge, what a failure means. The two pages want
+// different things from it — one has a badge, an MJPEG fallback and a transport
+// toggle to keep in step, the other a bare video element — and a shared version
+// would be an abstraction over two callers with one of them bent to fit.
+//
+// The swap underneath it is shared, in preview-swap.js, and the line between
+// them is worth stating: that is a state machine with invariants that are not
+// obvious, this is a set of rules, and the dance in between is a dozen lines of
+// each page's own judgement.
 window.MajesticTransport = (function () {
 	// What the person chose. Permanent until they choose again.
 	const PICK_KEY = 'mj-transport-pick';

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -59,7 +59,13 @@ window.MajesticWebRTC = (function () {
 		let pc = null, ws = null, statsTimer = null, signalTimer = null;
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let failCount = 0, gotMedia = false;
-		let wantAudio = false, volume = 1;
+		// From the caller, not fixed at false: a player staged as a replacement
+		// has to negotiate the audio the outgoing one already had. Applying it
+		// after the swap instead would have setAudio() renegotiate a session
+		// that had just proved itself, blanking the picture — the very flicker
+		// staging exists to remove.
+		let wantAudio = !!opts.audio;
+		let volume = opts.volume === undefined ? 1 : opts.volume;
 		let lastCodec = '', lastW = 0, lastH = 0;
 
 		// Talkback. micTrack is the capture; wantMic is what the person asked

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -27,7 +27,11 @@ window.MajesticVideo = (function () {
 		let queue = [], started = false, mime = null;
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let gotSignal = false, signalTimer = null, failCount = 0;
-		let wantAudio = false, volume = 1;
+		// From the caller: this player is also staged as a replacement now, and
+		// a session that proved itself must not be reopened just to turn on the
+		// audio the outgoing one already had. See preview-swap.js.
+		let wantAudio = !!opts.audio;
+		let volume = opts.volume === undefined ? 1 : opts.volume;
 
 		const mseOk = ('MediaSource' in window);
 		const NO_SIGNAL_MS = 4000;

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -83,6 +83,7 @@ fi
 
 <script src="/a/preview.js"></script>
 <script src="/a/preview-webrtc.js"></script>
+<script src="/a/preview-swap.js"></script>
 <script src="/a/preview-transport.js"></script>
 <script src="/a/mj-settings.js" defer></script>
 

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -533,7 +533,14 @@ preview() {
 			</div>
 		</div>
 	</div>
+	<!-- Two, and only ever one of them visible. A transport switch attaches the
+	     new player to whichever is idle and leaves the other playing, so the
+	     picture only changes once the replacement has one of its own. One
+	     element cannot do that: MSE drives it through src and WebRTC through
+	     srcObject, so the incoming player would have to evict the outgoing one
+	     before anybody knows whether it works. -->
 	<video id="live-video" autoplay muted playsinline style="$bg"></video>
+	<video id="live-video-b" autoplay muted playsinline style="$bg; display:none"></video>
 	<img id="live-mjpeg" alt="" style="display:none; $bg">
 	<p id="mj-note" class="alert alert-warning" style="display:none">
 		Your browser can't play the live H.264/H.265 stream.

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -36,6 +36,7 @@
 
 <script src="/a/preview.js"></script>
 <script src="/a/preview-webrtc.js"></script>
+<script src="/a/preview-swap.js"></script>
 <script src="/a/preview-transport.js"></script>
 <script src="/a/preview-page.js"></script>
 


### PR DESCRIPTION
Fixes the flicker reported three times on #184, using the reporter's own rule:

> nothing on the screen should change until it is known that WebRTC is actually available

## What it did

A transport switch destroyed the running player, cleared the video element, and attached the replacement to it. So clicking **WebRTC** on a camera that could not serve this browser cost a blank frame, a visible reconnect and a trip back to MSE — for a session that never worked.

The fix originally proposed, disabling the button when no substream exists, would have been wrong: WebRTC does not require a substream and runs on the main channel for any browser that accepts its profile. Hiding the control would have removed a working feature from them.

## What it does now

One element cannot hold two players — MSE drives it through `src`, WebRTC through `srcObject` — so there are two, and only ever one visible. A switch attaches the new player to whichever is idle and **leaves the other playing**. The picture changes exactly once, when the trial reports that it is playing.

A trial that fails is destroyed and the screen never learns it happened, beyond the toggle coming back up with the reason in its tooltip. Everything a trial says short of `playing` is dropped on purpose — `connecting`, `nosignal`, `error` are precisely the states that used to leak onto the badge while a switch flailed.

**The chain still ends at MJPEG.** When the live player dies its replacement is staged like any other switch, and the dead one keeps its last frame rather than blanking. If that replacement also fails, both are released and the page falls through. Marking the dead one is load-bearing: without it a second failure would leave a frozen frame on screen with nothing left to move it.

## Both players, one implementation

Live adjustments had the same shape and needed the same fix — less visible there, since that panel has no toggle and only ever switches automatically, but the same thing happens when a WebRTC session dies mid-watch.

Writing it twice was the obvious next move and the wrong one, so the swap is now `preview-swap.js` and both pages use it. The note in `preview-transport.js` explaining why the fall-back dance is *not* shared said "the dance is a dozen lines; the rules below are not" — true of a dozen lines, not of a state machine where two players are live at once, each attachment needs its own id because "is this the current generation" cannot describe two current things, and a dead player must be marked or its last frame stays for ever.

What stays with each caller is every decision: what to try next, what to put on the badge, what a failure means. The Preview page falls through to MJPEG and keeps its toggle in step; the panel has neither and stops at MSE.

Teardown on the settings page goes through the swap now. Destroying only the visible player would leave a transport still being judged behind on every visit — a live socket with no handle, which is the leak `state.previewPlayer` was tracked to prevent in the first place.

## Testing

A new suite drives the switch against stub players — 27 checks, including the two that matter most:

- a failed trial does **not** destroy the working player
- a trial in any non-playing state does **not** touch the badge

Verified by mutation, not by going green. Restoring the old tear-down-first order fails ten checks; letting a trial report to the badge fails the state-leak one. The same 27 pass unchanged after the extraction, which is what made sharing the code safe to do rather than a rewrite to be careful about.

This page has twice shipped the opposite bug — a fallback burying the player that was working — and both times the picture looked right while the handle was wrong, which is exactly what looking at it cannot catch. That is why the harness exists rather than a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
