### PR TITLE
Settings: no focus ring on a heading nobody focused

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -766,3 +766,17 @@ mark {
 .mj-push-end {
 	margin-left: auto;
 }
+
+/* revealSection() moves focus to the section's heading when you pick one, so
+   that a tap which neither navigates nor opens anything still announces the
+   section to a screen reader (#199). A heading is not a control, though, and a
+   pointer user has no reason to see a focus ring on it — it read as the title
+   having been selected, or as a stray border round the card (#184).
+
+   So the ring goes for pointer focus and stays for keyboard focus, which is the
+   one case where it is doing its job: :focus-visible is exactly that
+   distinction, and the heading is only ever focused programmatically, so
+   nothing else can put a ring here. */
+#mj-settings-form h3[tabindex]:focus:not(:focus-visible) {
+	outline: none;
+}


### PR DESCRIPTION
Reported on #184 as "immediately after opening the `Majestic → Settings` page, each section has a blue border around its title", with a screenshot of the **Image** section outlined like a text box.

## What it is

`revealSection()`, added in #200, moves focus to the section's heading when you pick one:

```js
const h = form.querySelector('h3');
if (h) { h.tabIndex = -1; h.focus({ preventScroll: true }); }
```

That is right and should stay. A tap that neither navigates nor opens anything says nothing to a screen reader otherwise, and the heading is the thing worth announcing.

What came with it is the browser's focus ring, drawn around a heading. A pointer user has no way to explain that: nothing was typed into, nothing is selected, and on a card-shaped section it reads as a stray border rather than as focus.

## The fix

A heading is not a control. The ring is worth having for a **keyboard** user — for them focus is the cursor and losing sight of it is losing their place — and worth nothing to someone who arrived by clicking. `:focus-visible` is precisely that distinction, so the outline goes for pointer focus and stays for keyboard focus:

```css
#mj-settings-form h3[tabindex]:focus:not(:focus-visible) { outline: none; }
```

Scoped to the heading the reveal focuses. It is only ever focused programmatically, so nothing else can draw a ring there and nothing else loses one — this does not touch the focus styling of any actual control.

## Checked

`npm run build:dist` passes and the rule survives minification intact:

```
#mj-settings-form h3[tabindex]:focus:not(:focus-visible){outline:0}
```

Worth noting for anyone adding CSS here: Bootstrap's own margin utilities are **not** in the trimmed build this tree ships, so a class like `ms-auto` is inert. That cost a round trip on #201 already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
