### PR TITLE
Recordings: browse the archive as a day, not a folder of MP4s

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js"
+    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/mp4index.test.js
+++ b/tests/mp4index.test.js
@@ -83,9 +83,22 @@ function tfhdDefaultDuration(d) {
 	return box('tfhd', u32(0x000008, 1, d));
 }
 
-function moof(seq, tfhdBox, trunBox) {
+// tfdt is a FullBox: version 1 then a 64-bit baseMediaDecodeTime, which is
+// what majestic writes. Optional here so the same builder produces both a
+// current recording and one written before the box existed.
+function tfdt(ticks) {
+	const p = Buffer.alloc(12);
+	p.writeUInt32BE(0x01000000, 0);          // version 1, flags 0
+	p.writeBigUInt64BE(BigInt(ticks), 4);
+	return box('tfdt', p);
+}
+
+function moof(seq, tfhdBox, trunBox, decodeTicks) {
 	const mfhd = box('mfhd', u32(0, seq));
-	return box('moof', Buffer.concat([mfhd, box('traf', Buffer.concat([tfhdBox, trunBox]))]));
+	const traf = decodeTicks === null
+		? [tfhdBox, trunBox]
+		: [tfhdBox, tfdt(decodeTicks), trunBox];
+	return box('moof', Buffer.concat([mfhd, box('traf', Buffer.concat(traf))]));
 }
 function mdat(len, fill) {
 	const p = Buffer.alloc(Math.max(0, len - 8), fill === undefined ? 0x41 : fill);
@@ -94,15 +107,21 @@ function mdat(len, fill) {
 
 // A whole clip. `specs` is one entry per fragment:
 //   { seq, durations:[ticks…], payload:bytes, defaultDur? }
-function clip(timescale, specs) {
+// `withTfdt` false builds a pre-tfdt recording, the shape majestic wrote when
+// records were enabled — still on plenty of cards, so both paths need cover.
+function clip(timescale, specs, withTfdt) {
 	const parts = [ftyp(), moov(timescale)];
+	let ticks = 0;
 	specs.forEach(s => {
 		const tf = s.defaultDur ? tfhdDefaultDuration(s.defaultDur) : tfhdPlain();
 		const tr = s.defaultDur
 			? box('trun', u32(0x000005, s.count, 0, 0x02000000))   // no per-sample durations
 			: trun(s.durations);
-		parts.push(moof(s.seq, tf, tr));
+		parts.push(moof(s.seq, tf, tr, withTfdt === false ? null : ticks));
 		parts.push(mdat(s.payload, s.fill));
+		ticks += s.defaultDur
+			? s.defaultDur * s.count
+			: s.durations.reduce((a, b) => a + b, 0);
 	});
 	return Buffer.concat(parts);
 }
@@ -345,75 +364,121 @@ function runCheap() {
 	group('durationHint — how long is this clip, in two reads');
 
 	const n = 250;
+	// The write counter drifts from the fragment ordinal on a real camera, so
+	// the pre-tfdt fixture drifts too — otherwise the fallback would look far
+	// better here than it is on hardware.
 	const seqs = [];
-	for (let i = 0, s = 0; i < n; i++) { seqs.push(s); if (i !== 5) s++; }
-	const buf = clip(1000000, evenSpecs(n, { seqs: seqs }));
-	const init = M.parseInit(u8of(buf));
-	const log = [];
-	const read = readerFor(buf, log);
+	for (let i = 0, k = 0; i < n; i++) { seqs.push(k); k += (i % 4 === 0) ? 2 : 1; }
 
-	return M.durationHint(read, buf.length, init).then(h => {
+	const withT = clip(1000000, evenSpecs(n, { seqs: seqs }));
+	const initT = M.parseInit(u8of(withT));
+	const log = [];
+
+	return M.durationHint(readerFor(withT, log), withT.length, initT).then(h => {
 		check('costs exactly two reads, whatever the clip length',
 			log.length === 2, 'reads: ' + log.length);
 		check('reports how long one fragment lasts', h.perFragment === 1,
 			'perFragment ' + h.perFragment);
-		// one plateau in the sequence numbers, so it reads one second short
-		check('lands within a fragment of the true length',
-			Math.abs(h.seconds - n) <= 2, 'got ' + h.seconds + ' want ~' + n);
-		check('and says it is approximate', h.approximate === true);
-		check('never over-reports — a hint that runs past the end would let the '
-			+ 'timeline offer footage that is not there', h.seconds <= n);
+		// tfdt says where the last fragment starts and trun how long it runs,
+		// so the two together are the length — not an estimate of it.
+		check('is exact when the fragments carry tfdt', h.seconds === n,
+			'got ' + h.seconds + ' want ' + n);
+		check('and does not claim to be approximate', h.approximate === false);
 
-		const tiny = clip(1000000, evenSpecs(1));
-		return M.durationHint(readerFor(tiny), tiny.length, M.parseInit(u8of(tiny)));
+		const old = clip(1000000, evenSpecs(n, { seqs: seqs }), false);
+		return M.durationHint(readerFor(old), old.length, M.parseInit(u8of(old)));
 	}).then(h => {
-		check('a single-fragment clip is one fragment long', h.seconds === 1, 'got ' + h.seconds);
+		check('a pre-tfdt recording still gets an answer', h.seconds > 0);
+		check('but says it is approximate', h.approximate === true);
+		check('and it really is wrong, because the write counter drifts',
+			h.seconds !== n, 'got ' + h.seconds + ' — suspiciously exact');
+		return null;
+	}).then(runLocateExact).then(runSpan);
+}
 
-		group('spanFrom — index only what is being exported');
+function runLocateExact() {
+	group('locate — finding the byte for a moment');
 
-		const specs = evenSpecs(300);
-		const b2 = clip(1000000, specs);
-		const i2 = M.parseInit(u8of(b2));
-		const l2 = [];
-		const r2 = readerFor(b2, l2);
+	const n = 400;
+	const sizes = [];
+	for (let i = 0; i < n; i++) sizes.push(20000 + (i % 7) * 9000);
+	const buf = clip(1000000, evenSpecs(n, { sizes: sizes }));
+	const init = M.parseInit(u8of(buf));
+	const log = [];
+	const read = readerFor(buf, log);
 
-		// walk the whole thing once to learn where second 100 really starts
-		return M.buildIndex(r2, b2.length, i2).then(full => {
-			const at100 = M.fragmentAt(full, 100);
-			l2.length = 0;
-			return M.spanFrom(r2, b2.length, i2, at100.off, 10).then(span => {
-				check('covers the seconds asked for', span.duration >= 10,
-					'got ' + span.duration);
-				check('and does not run far past them', span.duration <= 11,
-					'got ' + span.duration);
-				check('costs reads proportional to the span, not the clip',
-					l2.length <= 12, 'reads: ' + l2.length + ' for 10 s of a 300 s clip');
-				check('starts exactly where it was pointed',
-					span.fragments[0].off === at100.off);
-				check('carries the header length so exportRanges can use it',
-					span.headerLength === i2.headerLength);
+	return M.buildIndex(read, buf.length, init).then(full => {
+		log.length = 0;
+		return M.locate(read, buf.length, init, 300, 1).then(hit => {
+			const exact = M.fragmentAt(full, 300);
+			check('lands on exactly the fragment holding that second',
+				hit.off === exact.off, 'off ' + hit.off + ' want ' + exact.off);
+			check('and reports that fragment\'s real start time',
+				hit.approxSec === exact.t, hit.approxSec + ' vs ' + exact.t);
+			check('and says the answer is exact', hit.exact === true);
+			check('without walking the file', log.length < 20, 'reads: ' + log.length);
+		}).then(() => M.locate(read, buf.length, init, 300.4, 1)).then(hit => {
+			// never overshoot: starting after the moment asked for reads as the
+			// seek having been ignored, where a moment early is just lead-in
+			check('a moment mid-fragment lands on that fragment, not the next',
+				hit.approxSec === 300, 'got ' + hit.approxSec);
+		}).then(() => M.locate(read, buf.length, init, 0, 1)).then(hit => {
+			check('seeking to zero returns the first fragment',
+				hit.off === init.firstMoof, 'got ' + hit.off);
+		});
+	}).then(() => {
+		const old = clip(1000000, evenSpecs(400, { sizes: sizes }), false);
+		const oi = M.parseInit(u8of(old));
+		return M.locate(readerFor(old), old.length, oi, 300, 1).then(hit => {
+			check('a pre-tfdt recording still resolves to a fragment', hit.off > 0);
+			check('but does not claim to be exact', hit.exact === false);
+		});
+	});
+}
 
-				const r = M.exportRanges(span, 0, span.duration);
-				check('the span exports as a whole from its own first fragment',
-					r.body.start === at100.off);
-				check('and ends on a fragment boundary',
-					r.body.end === span.fragments[span.fragments.length - 1].off +
-						span.fragments[span.fragments.length - 1].len);
-				// byte-for-byte agreement with what a full index would have said
-				const fullR = M.exportRanges(full, 100, 100 + span.duration);
-				check('agrees byte-for-byte with a full-clip index',
-					fullR.body.start === r.body.start && fullR.body.end === r.body.end,
-					fullR.body.start + '..' + fullR.body.end + ' vs ' + r.body.start + '..' + r.body.end);
-			});
-		}).then(() => {
-			// asking for more than is left must stop at the end, not spin
-			const b3 = clip(1000000, evenSpecs(5));
-			const i3 = M.parseInit(u8of(b3));
-			return M.spanFrom(readerFor(b3), b3.length, i3, i3.firstMoof, 9999).then(span => {
-				check('a span running past the end stops at the last whole fragment',
-					span.fragments.length === 5 && span.duration === 5,
-					span.fragments.length + '/' + span.duration);
-			});
+function runSpan() {
+	group('spanFrom — index only what is being exported');
+
+	const buf = clip(1000000, evenSpecs(300));
+	const init = M.parseInit(u8of(buf));
+	const log = [];
+	const read = readerFor(buf, log);
+
+	return M.buildIndex(read, buf.length, init).then(full => {
+		const at100 = M.fragmentAt(full, 100);
+		log.length = 0;
+		return M.spanFrom(read, buf.length, init, at100.off, 10).then(span => {
+			check('covers the seconds asked for', span.duration >= 10,
+				'got ' + span.duration);
+			check('and does not run far past them', span.duration <= 11,
+				'got ' + span.duration);
+			check('costs reads proportional to the span, not the clip',
+				log.length <= 12, 'reads: ' + log.length + ' for 10 s of a 300 s clip');
+			check('starts exactly where it was pointed',
+				span.fragments[0].off === at100.off);
+			check('carries the header length so exportRanges can use it',
+				span.headerLength === init.headerLength);
+
+			const r = M.exportRanges(span, 0, span.duration);
+			check('the span exports as a whole from its own first fragment',
+				r.body.start === at100.off);
+			check('and ends on a fragment boundary',
+				r.body.end === span.fragments[span.fragments.length - 1].off +
+					span.fragments[span.fragments.length - 1].len);
+			// byte-for-byte agreement with what a full index would have said
+			const fullR = M.exportRanges(full, 100, 100 + span.duration);
+			check('agrees byte-for-byte with a full-clip index',
+				fullR.body.start === r.body.start && fullR.body.end === r.body.end,
+				fullR.body.start + '..' + fullR.body.end + ' vs ' + r.body.start + '..' + r.body.end);
+		});
+	}).then(() => {
+		// asking for more than is left must stop at the end, not spin
+		const b3 = clip(1000000, evenSpecs(5));
+		const i3 = M.parseInit(u8of(b3));
+		return M.spanFrom(readerFor(b3), b3.length, i3, i3.firstMoof, 9999).then(span => {
+			check('a span running past the end stops at the last whole fragment',
+				span.fragments.length === 5 && span.duration === 5,
+				span.fragments.length + '/' + span.duration);
 		});
 	});
 }

--- a/tests/mp4index.test.js
+++ b/tests/mp4index.test.js
@@ -393,7 +393,32 @@ function runCheap() {
 		check('and it really is wrong, because the write counter drifts',
 			h.seconds !== n, 'got ' + h.seconds + ' — suspiciously exact');
 		return null;
-	}).then(runLocateExact).then(runBigFragments).then(runSpan);
+	}).then(runLiveTail).then(runLocateExact).then(runBigFragments).then(runSpan);
+}
+
+// A clip still being recorded ends with a fragment whose moof is on the card
+// and whose mdat is not. Counting it would put footage on the timeline that
+// cannot be played or exported — and the cheap probe must not be more
+// optimistic than the exact walk, which already refuses it.
+function runLiveTail() {
+	group('durationHint on a clip that is still being written');
+
+	const whole = clip(1000000, evenSpecs(8));
+	const init = M.parseInit(u8of(whole));
+	// lop the payload off the last fragment, leaving its header behind
+	const partial = whole.subarray(0, whole.length - 20000);
+
+	return M.durationHint(readerFor(partial), partial.length, init).then(h => {
+		check('stops at the last fragment that is completely on the card',
+			h !== null && h.seconds === 7, 'got ' + (h && h.seconds) + ' want 7');
+		check('and still reports that as exact — it is measured, just shorter',
+			h.approximate === false);
+
+		return M.buildIndex(readerFor(partial), partial.length, init);
+	}).then(idx => {
+		check('which is exactly what the full walk says too',
+			idx.duration === 7, 'walk says ' + idx.duration);
+	});
 }
 
 function runLocateExact() {

--- a/tests/mp4index.test.js
+++ b/tests/mp4index.test.js
@@ -393,7 +393,7 @@ function runCheap() {
 		check('and it really is wrong, because the write counter drifts',
 			h.seconds !== n, 'got ' + h.seconds + ' — suspiciously exact');
 		return null;
-	}).then(runLocateExact).then(runSpan);
+	}).then(runLocateExact).then(runBigFragments).then(runSpan);
 }
 
 function runLocateExact() {
@@ -432,6 +432,47 @@ function runLocateExact() {
 		return M.locate(readerFor(old), old.length, oi, 300, 1).then(hit => {
 			check('a pre-tfdt recording still resolves to a fragment', hit.off > 0);
 			check('but does not claim to be exact', hit.exact === false);
+		});
+	});
+}
+
+// The window a probe reads only answers if a moof falls inside it, and a
+// fragment is not a fixed size: 730 KB on one clip from an av300, 1.1 MB on the
+// next from the same camera at a higher bitrate. A window sized from a sample
+// silently contains no boundary at all, and every lookup built on it returns
+// nothing — which is exactly what happened before the window learned to widen.
+function runBigFragments() {
+	group('fragments wider than the probe window');
+
+	// 1.2 MB of payload each, comfortably past the 768 KB starting window
+	const specs = evenSpecs(6);
+	specs.forEach(f => { f.payload = 1200000; });
+	const buf = clip(1000000, specs);
+	const init = M.parseInit(u8of(buf));
+	const log = [];
+	const read = readerFor(buf, log);
+
+	return M.buildIndex(read, buf.length, init).then(full => {
+		check('the fixture really is wider than the starting window',
+			full.fragments[0].len > 768 * 1024, 'len ' + full.fragments[0].len);
+
+		log.length = 0;
+		return M.durationHint(read, buf.length, init).then(h => {
+			check('durationHint still finds the last fragment',
+				h !== null && h.seconds === 6, 'got ' + (h && h.seconds));
+			check('and still reports it as exact', h && h.approximate === false);
+			check('paying only a couple of extra reads to widen',
+				log.length <= 5, 'reads: ' + log.length);
+		});
+	}).then(() => {
+		return M.buildIndex(read, buf.length, init).then(full => {
+			log.length = 0;
+			return M.locate(read, buf.length, init, 3, 1).then(hit => {
+				const exact = M.fragmentAt(full, 3);
+				check('locate finds the fragment despite the narrow first window',
+					hit.off === exact.off, 'off ' + hit.off + ' want ' + exact.off);
+				check('and it is still exact', hit.exact === true);
+			});
 		});
 	});
 }

--- a/tests/mp4index.test.js
+++ b/tests/mp4index.test.js
@@ -1,0 +1,419 @@
+// MajesticMp4Index — recovering byte<->time from a recording that carries no
+// index of its own.
+//
+// This is exactly the kind of thing the suite in this repo is for: it is pure
+// binary parsing whose failure mode is silent. A wrong offset does not throw,
+// it seeks to the wrong moment; a mis-summed duration does not throw, it makes
+// a timeline that lies. Neither is something a browser can be made to
+// reproduce on demand, and neither is visible in a screenshot.
+//
+// The fixtures below are built to the shape majestic actually writes, measured
+// off a real clip on an hi3516av300: ftyp(36) + moov, then moof+mdat pairs
+// whose moof holds mfhd + traf{tfhd,trun}, with per-sample durations in trun
+// and NO tfdt anywhere. The awkward cases are real too — the repeated
+// sequence_number, and the half-written fragment at the end of a clip that is
+// still recording.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'mp4index.js');
+
+function load() {
+	const ctx = {
+		window: {},
+		console: console,
+		Promise: Promise,
+		// referenced only inside reader(), which these tests never call
+		apiFetch: function () { throw new Error('no network in tests'); },
+	};
+	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+	return ctx.window.MajesticMp4Index;
+}
+
+const M = load();
+
+// ---- fixture builders --------------------------------------------------
+
+function box(type, payload) {
+	const b = Buffer.alloc(8 + payload.length);
+	b.writeUInt32BE(8 + payload.length, 0);
+	b.write(type, 4, 'latin1');
+	payload.copy(b, 8);
+	return b;
+}
+function u32(...vals) {
+	const b = Buffer.alloc(4 * vals.length);
+	vals.forEach((v, i) => b.writeUInt32BE(v >>> 0, i * 4));
+	return b;
+}
+
+// mdhd v0: version+flags, creation, modification, timescale, duration, lang+pre
+function mdhd(timescale) {
+	return box('mdhd', Buffer.concat([u32(0, 0, 0, timescale, 0), u32(0)]));
+}
+function moov(timescale) {
+	return box('moov', box('trak', box('mdia', mdhd(timescale))));
+}
+function ftyp() {
+	const p = Buffer.alloc(28);
+	p.write('isom', 0, 'latin1');
+	p.writeUInt32BE(0x200, 4);
+	p.write('isomiso2avc1iso6', 8, 'latin1');
+	return box('ftyp', p);
+}
+
+// trun with flags 0x000305: data-offset + first-sample-flags + per-sample
+// duration + per-sample size. This is what majestic emits.
+function trun(durations) {
+	const per = Buffer.alloc(durations.length * 8);
+	durations.forEach((d, i) => {
+		per.writeUInt32BE(d >>> 0, i * 8);
+		per.writeUInt32BE(1000, i * 8 + 4);   // sample size, unused here
+	});
+	return box('trun', Buffer.concat([u32(0x000305, durations.length, 0, 0x02000000), per]));
+}
+function tfhdPlain() { return box('tfhd', u32(0x020030, 1)); }
+function tfhdDefaultDuration(d) {
+	// flags 0x08 = default_sample_duration_present
+	return box('tfhd', u32(0x000008, 1, d));
+}
+
+function moof(seq, tfhdBox, trunBox) {
+	const mfhd = box('mfhd', u32(0, seq));
+	return box('moof', Buffer.concat([mfhd, box('traf', Buffer.concat([tfhdBox, trunBox]))]));
+}
+function mdat(len, fill) {
+	const p = Buffer.alloc(Math.max(0, len - 8), fill === undefined ? 0x41 : fill);
+	return box('mdat', p);
+}
+
+// A whole clip. `specs` is one entry per fragment:
+//   { seq, durations:[ticks…], payload:bytes, defaultDur? }
+function clip(timescale, specs) {
+	const parts = [ftyp(), moov(timescale)];
+	specs.forEach(s => {
+		const tf = s.defaultDur ? tfhdDefaultDuration(s.defaultDur) : tfhdPlain();
+		const tr = s.defaultDur
+			? box('trun', u32(0x000005, s.count, 0, 0x02000000))   // no per-sample durations
+			: trun(s.durations);
+		parts.push(moof(s.seq, tf, tr));
+		parts.push(mdat(s.payload, s.fill));
+	});
+	return Buffer.concat(parts);
+}
+
+// The default shape: 20 samples of 50000 ticks at timescale 1e6 = 1.000 s.
+function evenSpecs(n, opts) {
+	const o = opts || {};
+	const out = [];
+	for (let i = 0; i < n; i++) {
+		out.push({
+			seq: o.seqs ? o.seqs[i] : i,
+			durations: new Array(20).fill(50000),
+			payload: o.sizes ? o.sizes[i] : 40000,
+		});
+	}
+	return out;
+}
+
+// read(start, endInclusive) over a Buffer, as majestic's Range serving behaves.
+function readerFor(buf, log) {
+	return function (start, end) {
+		if (log) log.push([start, end]);
+		return Promise.resolve(new Uint8Array(buf.subarray(start, Math.min(end + 1, buf.length))));
+	};
+}
+
+const u8of = b => new Uint8Array(b);
+
+// ---- init ---------------------------------------------------------------
+
+group('the init segment — everything before the first moof');
+
+{
+	const buf = clip(1000000, evenSpecs(3));
+	const init = M.parseInit(u8of(buf));
+	const expectedHeader = ftyp().length + moov(1000000).length;
+
+	check('timescale comes off mdhd', init.timescale === 1000000, 'got ' + init.timescale);
+	check('firstMoof is where moov ends', init.firstMoof === expectedHeader,
+		'got ' + init.firstMoof + ' want ' + expectedHeader);
+	check('headerLength is the init segment to prepend on export',
+		init.headerLength === expectedHeader);
+	check('a file with no moov yields nothing to index',
+		M.parseInit(u8of(ftyp())) === null);
+}
+
+// ---- fragment parsing ---------------------------------------------------
+
+group('one step of the moof/mdat chain');
+
+{
+	const buf = clip(1000000, evenSpecs(2));
+	const init = M.parseInit(u8of(buf));
+	const f = M.parseFragment(u8of(buf.subarray(init.firstMoof, init.firstMoof + M.STEP)));
+
+	check('reads the moof size', f.moofSize > 16);
+	check('reads the mdat size', f.mdatSize === 40000, 'got ' + f.mdatSize);
+	check('total is the stride to the next fragment', f.total === f.moofSize + 40000);
+	check('picks sequence_number out of mfhd', f.seq === 0, 'got ' + f.seq);
+	check('sums per-sample durations from trun', f.durTicks === 20 * 50000,
+		'got ' + f.durTicks);
+}
+
+{
+	// the other legal way to state duration: tfhd default x sample count
+	const buf = clip(90000, [{ seq: 0, defaultDur: 3000, count: 30, payload: 1000 }]);
+	const init = M.parseInit(u8of(buf));
+	const f = M.parseFragment(u8of(buf.subarray(init.firstMoof, init.firstMoof + M.STEP)));
+	check('falls back to tfhd default_sample_duration when trun omits durations',
+		f.durTicks === 3000 * 30, 'got ' + f.durTicks);
+}
+
+{
+	const buf = clip(1000000, evenSpecs(1));
+	const init = M.parseInit(u8of(buf));
+	// a read too short to reach the mdat header must say so, not guess
+	const f = M.parseFragment(u8of(buf.subarray(init.firstMoof, init.firstMoof + 20)));
+	check('a short read reports how much it needed', f && f.short > 20, JSON.stringify(f));
+	check('garbage is rejected outright',
+		M.parseFragment(new Uint8Array(32)) === null);
+}
+
+// ---- finding a moof in the middle of a file -----------------------------
+
+group('finding a fragment boundary from an arbitrary offset');
+
+{
+	// mdat payload that literally spells "moof" — this happens by chance
+	// several times a minute in real video, and a substring search lands in it
+	const evil = Buffer.from('moof');
+	const specs = evenSpecs(3);
+	specs[1].payload = 4096;
+	const buf = clip(1000000, specs);
+	const init = M.parseInit(u8of(buf));
+	const f0 = M.parseFragment(u8of(buf.subarray(init.firstMoof, init.firstMoof + M.STEP)));
+	// plant it inside the first mdat
+	evil.copy(buf, init.firstMoof + f0.moofSize + 64);
+
+	// search from past the first fragment's own header, the way locate() scans
+	// forward from a probe that landed mid-file
+	const found = M.findMoof(u8of(buf), init.firstMoof + 8);
+	const second = init.firstMoof + f0.total;
+	check('skips a "moof" that is only mdat payload', found === second,
+		'got ' + found + ' want ' + second);
+	check('returns -1 when there is no fragment left',
+		M.findMoof(u8of(Buffer.alloc(4096, 0x41)), 0) === -1);
+}
+
+// ---- the exact index ----------------------------------------------------
+
+group('buildIndex — the exact walk');
+
+{
+	const buf = clip(1000000, evenSpecs(5));
+	const init = M.parseInit(u8of(buf));
+	const log = [];
+
+	M.buildIndex(readerFor(buf, log), buf.length, init).then(idx => {
+		check('finds every fragment', idx.fragments.length === 5,
+			'got ' + idx.fragments.length);
+		check('duration is the sum of the fragments', idx.duration === 5,
+			'got ' + idx.duration);
+		check('times are cumulative and exact',
+			idx.fragments.map(f => f.t).join(',') === '0,1,2,3,4',
+			idx.fragments.map(f => f.t).join(','));
+		check('offsets step by the fragment length',
+			idx.fragments[1].off === idx.fragments[0].off + idx.fragments[0].len);
+		check('one read per fragment, not two',
+			log.length === 5 || log.length === 6, 'reads: ' + log.length);
+		check('reads are small — headers only, never payload',
+			log.every(r => r[1] - r[0] < 1024), JSON.stringify(log[0]));
+		check('a fully walked clip reports complete', idx.complete === true);
+
+		// ---- still-recording clip: the tail is half written -------------
+		const partial = buf.subarray(0, buf.length - 12000);
+		return M.buildIndex(readerFor(partial), partial.length, init);
+	}).then(idx => {
+		check('a clip still being written indexes its complete fragments',
+			idx.fragments.length === 4, 'got ' + idx.fragments.length);
+		check('and reports the duration it can actually offer',
+			idx.duration === 4, 'got ' + idx.duration);
+		check('and does not claim to be complete', idx.complete === false);
+
+		return runLocate();
+	}).then(runExport).then(runCheap).then(() => done());
+}
+
+// ---- the approximate seek ----------------------------------------------
+
+function runLocate() {
+	group('locate — binary search before the index exists');
+
+	// 400 fragments, and the repeated sequence_number majestic really emits:
+	// 0,1,2,2,3,4,... Monotonic but not an ordinal.
+	const n = 400;
+	const seqs = [];
+	for (let i = 0, s = 0; i < n; i++) {
+		seqs.push(s);
+		if (i !== 2) s++;            // the plateau, exactly where it was observed
+	}
+	const sizes = [];
+	for (let i = 0; i < n; i++) sizes.push(20000 + (i % 7) * 9000);   // variable, as real fragments are
+
+	const buf = clip(1000000, evenSpecs(n, { seqs: seqs, sizes: sizes }));
+	const init = M.parseInit(u8of(buf));
+	const log = [];
+	const read = readerFor(buf, log);
+
+	return M.buildIndex(read, buf.length, init).then(idx => {
+		log.length = 0;
+		return M.locate(read, buf.length, init, 300, 1).then(hit => {
+			const exact = M.fragmentAt(idx, 300);
+			check('lands within a few fragments of the target',
+				Math.abs(hit.approxSec - 300) <= 5,
+				'approxSec ' + hit.approxSec);
+			check('lands on a real fragment boundary',
+				idx.fragments.some(f => f.off === hit.off),
+				'off ' + hit.off);
+			check('does not walk the file to get there', log.length < 20,
+				'probes: ' + log.length);
+			check('the exact index still knows better',
+				exact.t === 300, 'exact ' + exact.t);
+		});
+	}).then(() => {
+		const buf2 = clip(1000000, evenSpecs(20));
+		const init2 = M.parseInit(u8of(buf2));
+		return M.locate(readerFor(buf2), buf2.length, init2, 0, 1).then(hit => {
+			check('seeking to zero returns the first fragment',
+				hit.off === init2.firstMoof, 'got ' + hit.off);
+		});
+	});
+}
+
+// ---- export -------------------------------------------------------------
+
+function runExport() {
+	group('exportRanges — a clip is a byte concatenation, not a re-encode');
+
+	const buf = clip(1000000, evenSpecs(10));
+	const init = M.parseInit(u8of(buf));
+
+	return M.buildIndex(readerFor(buf), buf.length, init).then(idx => {
+		const r = M.exportRanges(idx, 3, 6);
+
+		check('the header range is the init segment',
+			r.header.start === 0 && r.header.end === init.headerLength);
+		check('the body starts at the fragment holding t0',
+			r.body.start === idx.fragments[3].off,
+			r.body.start + ' vs ' + idx.fragments[3].off);
+		check('boundaries snap outward to whole fragments — half a fragment does not decode',
+			r.from === 3 && r.to === 6, r.from + '..' + r.to);
+		check('the byte count is what the viewer is about to be handed',
+			r.bytes === init.headerLength + (r.body.end - r.body.start),
+			'got ' + r.bytes);
+		check('fragment count matches the span', r.fragments === 3, 'got ' + r.fragments);
+
+		const rev = M.exportRanges(idx, 6, 3);
+		check('a backwards drag selects the same range',
+			rev.body.start === r.body.start && rev.body.end === r.body.end);
+
+		const past = M.exportRanges(idx, 9.5, 99);
+		check('a selection running past the end clamps to the last fragment',
+			past.body.end === idx.fragments[9].off + idx.fragments[9].len);
+
+		check('fragmentAt finds the fragment covering a moment',
+			M.fragmentAt(idx, 4.5).t === 4, 'got ' + M.fragmentAt(idx, 4.5).t);
+		check('fragmentAt clamps below zero to the first fragment',
+			M.fragmentAt(idx, -10).t === 0);
+	});
+}
+
+// ---- the cheap paths ----------------------------------------------------
+
+// These carry the real load. Measured against an av300 over HTTP, one range
+// request costs 32-50 ms, so a full walk of a 20-minute clip is ~1100 requests
+// and about 55 seconds. Far too much to spend opening a clip — so the page
+// asks these two instead, and only pays for a walk over the span an export
+// actually needs.
+function runCheap() {
+	group('durationHint — how long is this clip, in two reads');
+
+	const n = 250;
+	const seqs = [];
+	for (let i = 0, s = 0; i < n; i++) { seqs.push(s); if (i !== 5) s++; }
+	const buf = clip(1000000, evenSpecs(n, { seqs: seqs }));
+	const init = M.parseInit(u8of(buf));
+	const log = [];
+	const read = readerFor(buf, log);
+
+	return M.durationHint(read, buf.length, init).then(h => {
+		check('costs exactly two reads, whatever the clip length',
+			log.length === 2, 'reads: ' + log.length);
+		check('reports how long one fragment lasts', h.perFragment === 1,
+			'perFragment ' + h.perFragment);
+		// one plateau in the sequence numbers, so it reads one second short
+		check('lands within a fragment of the true length',
+			Math.abs(h.seconds - n) <= 2, 'got ' + h.seconds + ' want ~' + n);
+		check('and says it is approximate', h.approximate === true);
+		check('never over-reports — a hint that runs past the end would let the '
+			+ 'timeline offer footage that is not there', h.seconds <= n);
+
+		const tiny = clip(1000000, evenSpecs(1));
+		return M.durationHint(readerFor(tiny), tiny.length, M.parseInit(u8of(tiny)));
+	}).then(h => {
+		check('a single-fragment clip is one fragment long', h.seconds === 1, 'got ' + h.seconds);
+
+		group('spanFrom — index only what is being exported');
+
+		const specs = evenSpecs(300);
+		const b2 = clip(1000000, specs);
+		const i2 = M.parseInit(u8of(b2));
+		const l2 = [];
+		const r2 = readerFor(b2, l2);
+
+		// walk the whole thing once to learn where second 100 really starts
+		return M.buildIndex(r2, b2.length, i2).then(full => {
+			const at100 = M.fragmentAt(full, 100);
+			l2.length = 0;
+			return M.spanFrom(r2, b2.length, i2, at100.off, 10).then(span => {
+				check('covers the seconds asked for', span.duration >= 10,
+					'got ' + span.duration);
+				check('and does not run far past them', span.duration <= 11,
+					'got ' + span.duration);
+				check('costs reads proportional to the span, not the clip',
+					l2.length <= 12, 'reads: ' + l2.length + ' for 10 s of a 300 s clip');
+				check('starts exactly where it was pointed',
+					span.fragments[0].off === at100.off);
+				check('carries the header length so exportRanges can use it',
+					span.headerLength === i2.headerLength);
+
+				const r = M.exportRanges(span, 0, span.duration);
+				check('the span exports as a whole from its own first fragment',
+					r.body.start === at100.off);
+				check('and ends on a fragment boundary',
+					r.body.end === span.fragments[span.fragments.length - 1].off +
+						span.fragments[span.fragments.length - 1].len);
+				// byte-for-byte agreement with what a full index would have said
+				const fullR = M.exportRanges(full, 100, 100 + span.duration);
+				check('agrees byte-for-byte with a full-clip index',
+					fullR.body.start === r.body.start && fullR.body.end === r.body.end,
+					fullR.body.start + '..' + fullR.body.end + ' vs ' + r.body.start + '..' + r.body.end);
+			});
+		}).then(() => {
+			// asking for more than is left must stop at the end, not spin
+			const b3 = clip(1000000, evenSpecs(5));
+			const i3 = M.parseInit(u8of(b3));
+			return M.spanFrom(readerFor(b3), b3.length, i3, i3.firstMoof, 9999).then(span => {
+				check('a span running past the end stops at the last whole fragment',
+					span.fragments.length === 5 && span.duration === 5,
+					span.fragments.length + '/' + span.duration);
+			});
+		});
+	});
+}

--- a/tests/timeline.test.js
+++ b/tests/timeline.test.js
@@ -113,6 +113,11 @@ group('how long a clip is, before anything has been indexed');
 
 {
 	const day = T.buildDay([clip('12-04.mp4')], { splitSec: SPLIT, nowSec: 13 * HOUR });
+	check('a measured duration that is only a guess keeps saying so — the clip '
+		+ 'list marks it, and losing the marker presents a guess as a fact',
+		T.applyExactDuration(day, '12-04.mp4', 900, false) &&
+		day.clips[0].dur === 900 && day.clips[0].estimated === true,
+		'estimated ' + day.clips[0].estimated);
 	check('an exact duration from the index replaces the estimate',
 		T.applyExactDuration(day, '12-04.mp4', 1112) &&
 		day.clips[0].dur === 1112 && day.clips[0].estimated === false,

--- a/tests/timeline.test.js
+++ b/tests/timeline.test.js
@@ -1,0 +1,222 @@
+// MajesticTimeline — the day model the recordings ribbon is drawn from.
+//
+// Here for the same reason as the mp4 index: every failure is silent and
+// convincing. A clip placed at the wrong minute draws a ribbon that looks
+// right, a gap that fails to appear is indistinguishable from a camera that
+// never stopped, and an estimated duration presented as exact is a timeline
+// that lies about what is on the card. None of that throws, and none of it is
+// visible in a screenshot.
+//
+// The cases are the ones a real card produces: majestic names clips %H-%M so
+// starts are minute-resolution, the newest clip of today is still being
+// written, the camera gets restarted leaving holes, and a recording running
+// over midnight is cut at the date change.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'timeline.js');
+
+function load() {
+	const ctx = { window: {}, console: console };
+	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+	return ctx.window.MajesticTimeline;
+}
+
+const T = load();
+const HOUR = 3600;
+const clip = (name, size) => ({ name: name, size: size || 400000000, mtime: 0 });
+const SPLIT = 1200;   // records.split 20, in seconds
+
+// ---- placing clips ------------------------------------------------------
+
+group('reading a clip start out of its filename');
+
+check('%H-%M is the default records.filename',
+	T.startOfName('12-04.mp4') === 12 * HOUR + 4 * 60,
+	'got ' + T.startOfName('12-04.mp4'));
+check('%H-%M-%S is the other spelling people set',
+	T.startOfName('12-04-30.mp4') === 12 * HOUR + 4 * 60 + 30);
+check('midnight places at zero, not at the end of the day',
+	T.startOfName('00-00.mp4') === 0);
+check('an impossible hour is declined rather than wrapped',
+	T.startOfName('25-00.mp4') === null);
+check('an impossible minute is declined too',
+	T.startOfName('12-99.mp4') === null);
+check('a name in some other scheme is declined, not guessed',
+	T.startOfName('recording_004.mp4') === null);
+
+{
+	const day = T.buildDay([clip('12-04.mp4'), clip('weird-name.mp4')], { splitSec: SPLIT });
+	check('an unplaceable clip stays listed but off the ribbon',
+		day.clips.length === 1 && day.unplaced.length === 1,
+		day.clips.length + '/' + day.unplaced.length);
+	check('and is still identifiable by name',
+		day.unplaced[0].name === 'weird-name.mp4');
+}
+
+// ---- durations ----------------------------------------------------------
+
+group('how long a clip is, before anything has been indexed');
+
+{
+	// three back-to-back clips, then the camera was off, then one more
+	const day = T.buildDay([
+		clip('08-00.mp4'), clip('08-20.mp4'), clip('08-40.mp4'),
+		clip('11-47.mp4'),
+	], { splitSec: SPLIT });
+
+	check('a clip that is followed immediately ends where the next begins',
+		day.clips[0].dur === SPLIT, 'got ' + day.clips[0].dur);
+	check('and that is exact, not an estimate — the next file opening IS this one closing',
+		day.clips[0].estimated === false);
+	check('the clip before a gap falls back to the configured split',
+		day.clips[2].dur === SPLIT, 'got ' + day.clips[2].dur);
+	check('and says so', day.clips[2].estimated === true);
+	check('a lone trailing clip on a past day gets the split too',
+		day.clips[3].dur === SPLIT && day.clips[3].estimated === true);
+}
+
+{
+	// the camera restarted 7 minutes into a slot, so the clip is short
+	const day = T.buildDay([clip('09-00.mp4'), clip('09-07.mp4')], { splitSec: SPLIT });
+	check('a short clip is measured by the next one, not by the split',
+		day.clips[0].dur === 7 * 60, 'got ' + day.clips[0].dur);
+}
+
+{
+	// today: the newest clip is still being written
+	const now = 13 * HOUR + 12 * 60;
+	const day = T.buildDay([clip('12-24.mp4'), clip('13-04.mp4')], {
+		splitSec: SPLIT, nowSec: now,
+	});
+	const last = day.clips[1];
+	check('the newest clip of today ends at now, not a full split later',
+		last.end === now, 'got ' + last.end);
+	check('and is flagged as still recording', last.recording === true);
+	check('an earlier clip today is not flagged as recording',
+		!day.clips[0].recording);
+}
+
+{
+	// yesterday: nothing is being written, so nothing may be flagged live
+	const day = T.buildDay([clip('23-50.mp4')], { splitSec: SPLIT });
+	check('a clip running past midnight is cut at the date change',
+		day.clips[0].end === T.DAY, 'got ' + day.clips[0].end);
+	check('nothing on a past day claims to be recording',
+		!day.clips[0].recording);
+}
+
+{
+	const day = T.buildDay([clip('12-04.mp4')], { splitSec: SPLIT, nowSec: 13 * HOUR });
+	check('an exact duration from the index replaces the estimate',
+		T.applyExactDuration(day, '12-04.mp4', 1112) &&
+		day.clips[0].dur === 1112 && day.clips[0].estimated === false,
+		'dur ' + day.clips[0].dur);
+	check('and a clip that is not there is not invented',
+		T.applyExactDuration(day, 'nope.mp4', 100) === false);
+}
+
+// ---- coverage and gaps --------------------------------------------------
+
+group('coverage — what the ribbon actually draws');
+
+{
+	const day = T.buildDay([
+		clip('06-00.mp4'), clip('06-20.mp4'), clip('06-40.mp4'),   // 06:00-07:00
+		clip('09-35.mp4'),                                          // 09:35-09:55
+	], { splitSec: SPLIT });
+	const cov = T.coverage(day);
+
+	check('abutting clips merge into one stretch of footage',
+		cov.length === 2, 'got ' + cov.length + ' segments');
+	check('the merged stretch spans all of them',
+		cov[0].from === 6 * HOUR && cov[0].to === 7 * HOUR,
+		cov[0].from + '..' + cov[0].to);
+	check('and remembers which clips it came from',
+		cov[0].clips.length === 3);
+
+	const g = T.gaps(day);
+	check('the hole between them is a gap', g.length === 1);
+	check('the gap is exactly the time not recorded',
+		g[0].from === 7 * HOUR && g[0].to === 9 * HOUR + 35 * 60,
+		g[0].from + '..' + g[0].to);
+}
+
+{
+	const day = T.buildDay([clip('06-00.mp4')], { splitSec: SPLIT });
+	check('time before the first clip is not a gap — nothing was missed there',
+		T.gaps(day).length === 0);
+}
+
+{
+	const day = T.buildDay([], { splitSec: SPLIT });
+	check('an empty day has no coverage', T.coverage(day).length === 0);
+	check('and no gaps either', T.gaps(day).length === 0);
+}
+
+// ---- hit testing --------------------------------------------------------
+
+group('scrubbing');
+
+{
+	const day = T.buildDay([clip('06-00.mp4'), clip('09-35.mp4')], { splitSec: SPLIT });
+
+	const hit = T.at(day, 6 * HOUR + 90);
+	check('a moment inside a clip resolves to that clip and an offset',
+		hit && hit.clip.name === '06-00.mp4' && hit.offset === 90,
+		JSON.stringify(hit && { n: hit.clip.name, o: hit.offset }));
+	check('the first frame of a clip belongs to it',
+		T.at(day, 6 * HOUR).offset === 0);
+	check('the instant a clip ends belongs to the next one, not this one',
+		T.at(day, 6 * HOUR + SPLIT) === null);
+	check('a moment in a gap resolves to nothing rather than snapping',
+		T.at(day, 8 * HOUR) === null);
+
+	check('skipping forward from a gap lands on the next footage',
+		T.nextCovered(day, 8 * HOUR) === 9 * HOUR + 35 * 60,
+		'got ' + T.nextCovered(day, 8 * HOUR));
+	check('skipping from inside footage stays put',
+		T.nextCovered(day, 6 * HOUR + 10) === 6 * HOUR + 10);
+	check('past the last footage there is nowhere to skip to',
+		T.nextCovered(day, 23 * HOUR) === null);
+}
+
+// ---- the detail window --------------------------------------------------
+
+group('the zoom window can never leave the day');
+
+{
+	const w = T.window(12 * HOUR + 30 * 60, HOUR);
+	check('centres on the playhead', w.from === 12 * HOUR && w.to === 13 * HOUR,
+		w.from + '..' + w.to);
+
+	const early = T.window(5 * 60, HOUR);
+	check('clamps at midnight instead of going negative',
+		early.from === 0 && early.width === HOUR, early.from + '/' + early.width);
+
+	const late = T.window(T.DAY - 60, HOUR);
+	check('clamps at the end of the day', late.to === T.DAY, 'got ' + late.to);
+
+	const huge = T.window(12 * HOUR, T.DAY * 3);
+	check('a window wider than a day is the day', huge.width === T.DAY);
+}
+
+// ---- formatting ---------------------------------------------------------
+
+group('what the numbers read as');
+
+check('clock is wall time, zero padded', T.clock(12 * HOUR + 4 * 60 + 7) === '12:04:07');
+check('hhmm drops the seconds', T.hhmm(12 * HOUR + 4 * 60 + 7) === '12:04');
+check('duration under a minute is seconds', T.duration(42) === '42 s');
+check('duration reads like the clip list', T.duration(1112) === '18 min 32 s');
+check('a whole number of minutes drops the seconds', T.duration(1200) === '20 min');
+check('hours read as hours', T.duration(3 * HOUR + 25 * 60) === '3 h 25 min');
+check('bytes match the size on the card', T.bytes(373011831) === '356 MB');
+check('gigabytes get a decimal', T.bytes(11 * 1073741824) === '11.0 GB');
+
+done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -780,3 +780,254 @@ mark {
 #mj-settings-form h3[tabindex]:focus:not(:focus-visible) {
 	outline: none;
 }
+
+/* ── recordings browser (tool-recordings.cgi) ──────────────────────────────
+   Everything here is theme-driven through Bootstrap's own custom properties,
+   because the timeline has to stay legible on both grounds: the coverage bar
+   is the accent, and the playhead and selection are drawn in the body colour,
+   which is near-white on dark and near-black on light. Hard-coding either way
+   round produces a playhead that vanishes into the bar it sits on.
+
+   These are .rec-* rather than Bootstrap utilities because the utilities they
+   would need — position-relative, overflow-hidden, w-100 — are not in the
+   PurgeCSS subset this tree ships (see tools/purgecss.config.cjs), so they
+   would silently do nothing. Same reason .mj-push-end exists above. */
+.rec-stage {
+	position: relative;
+	aspect-ratio: 16 / 9;
+	background: #000;
+	border-radius: var(--bs-border-radius);
+	overflow: hidden;
+}
+
+.rec-video {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+.rec-lbl {
+	display: block;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+	color: var(--bs-secondary-color);
+	margin-bottom: 0.3rem;
+}
+
+/* the whole day, as a map you move the detail window across */
+.rec-strip {
+	position: relative;
+	height: 18px;
+	border-radius: var(--bs-border-radius-sm);
+	background: var(--bs-secondary-bg);
+	overflow: hidden;
+	cursor: pointer;
+}
+
+.rec-strip .seg,
+.rec-band .seg {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	background: var(--bs-primary);
+}
+
+.rec-band .seg {
+	opacity: 0.55;
+}
+
+.rec-win {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	border: 2px solid var(--bs-body-color);
+	border-radius: 3px;
+	background: rgba(var(--bs-body-color-rgb), 0.14);
+	/* a window narrower than its own border reads as a line, not a window */
+	min-width: 6px;
+}
+
+.rec-hours,
+.rec-ticks {
+	display: flex;
+	justify-content: space-between;
+	font-family: var(--bs-font-monospace);
+	font-size: 0.65rem;
+	font-variant-numeric: tabular-nums;
+	color: var(--bs-secondary-color);
+	margin-top: 0.25rem;
+}
+
+/* the hour (or whatever the zoom says) where the playhead and the export
+   handles actually live — a five-minute selection on a 24-hour ribbon is
+   three pixels wide, which is why this band exists at all */
+.rec-band {
+	position: relative;
+	height: 46px;
+	border-radius: var(--bs-border-radius);
+	background: var(--bs-secondary-bg);
+	overflow: hidden;
+	cursor: ew-resize;
+	touch-action: none;
+}
+
+.rec-edge {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 1px;
+	/* the same colour as the track, so a boundary reads as a notch cut out of
+	   the coverage bar — and correctly disappears where there is no footage */
+	background: var(--bs-secondary-bg);
+}
+
+.rec-sel {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	background: rgba(var(--bs-body-color-rgb), 0.28);
+	border-left: 2px solid var(--bs-body-color);
+	border-right: 2px solid var(--bs-body-color);
+}
+
+.rec-head {
+	position: absolute;
+	top: -3px;
+	bottom: -3px;
+	width: 2px;
+	background: var(--bs-body-color);
+	pointer-events: none;
+}
+
+.rec-head-t {
+	position: absolute;
+	top: 12px;
+	left: 50%;
+	transform: translateX(-50%);
+	background: var(--bs-body-color);
+	color: var(--bs-body-bg);
+	font-family: var(--bs-font-monospace);
+	font-size: 0.7rem;
+	font-weight: 700;
+	padding: 2px 6px;
+	border-radius: var(--bs-border-radius-sm);
+	white-space: nowrap;
+}
+
+/* Reserved and empty on purpose. Majestic's motion detection is hardware
+   assisted but is never written to the card, so there is no event data to
+   draw — an empty labelled lane is honest where a missing one would imply
+   the feature is simply absent. */
+.rec-motion {
+	height: 14px;
+	margin-top: 0.35rem;
+	border-radius: 3px;
+	border: 1px dashed var(--bs-border-color);
+	background: repeating-linear-gradient(135deg,
+		transparent, transparent 5px,
+		rgba(var(--bs-body-color-rgb), 0.05) 5px,
+		rgba(var(--bs-body-color-rgb), 0.05) 10px);
+}
+
+.rec-export {
+	display: flex;
+	align-items: center;
+	gap: 0.875rem;
+	margin-top: 0.875rem;
+	padding: 0.75rem 0.875rem;
+	border-radius: var(--bs-border-radius);
+	background: rgba(var(--bs-primary-rgb), 0.12);
+	border: 1px solid rgba(var(--bs-primary-rgb), 0.45);
+}
+
+.rec-daypick {
+	width: auto;
+	min-width: 14rem;
+}
+
+/* ── clip list ──────────────────────────────────────────────────────────── */
+.rec-clip {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	width: 100%;
+	text-align: left;
+	padding: 0.5rem;
+	border: 1px solid transparent;
+	border-radius: var(--bs-border-radius);
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	transition: background-color var(--mj-ease), border-color var(--mj-ease);
+}
+
+.rec-clip:hover {
+	background: var(--bs-secondary-bg);
+}
+
+.rec-clip.active {
+	background: rgba(var(--bs-primary-rgb), 0.12);
+	border-color: var(--bs-primary);
+}
+
+.rec-clip-m {
+	display: flex;
+	flex-direction: column;
+	line-height: 1.35;
+}
+
+/* No poster yet: there is no ffmpeg on the camera to cut one, and decoding a
+   frame per clip in the browser costs a whole fragment each. The tile carries
+   the clip's start time so the row is still scannable, and turns into a real
+   thumbnail the day majestic writes a JPEG beside each recording. */
+.rec-poster {
+	position: relative;
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 84px;
+	height: 48px;
+	border-radius: var(--bs-border-radius-sm);
+	background: var(--bs-secondary-bg);
+	border: 1px solid var(--bs-border-color);
+}
+
+.rec-poster-t {
+	font-family: var(--bs-font-monospace);
+	font-size: 0.7rem;
+	color: var(--bs-secondary-color);
+}
+
+.rec-poster[data-live]::after {
+	content: "";
+	position: absolute;
+	left: 5px;
+	bottom: 5px;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--bs-danger);
+}
+
+/* A hole in the day is information — it says the camera was not recording,
+   which a simply-absent row does not. */
+.rec-gap {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	padding: 0.4rem 0.5rem;
+	font-size: 0.75rem;
+	color: var(--bs-secondary-color);
+}
+
+.rec-gap::before,
+.rec-gap::after {
+	content: "";
+	flex: 1;
+	height: 1px;
+	background: var(--bs-border-color);
+}

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -1,0 +1,496 @@
+// Byte<->time for the fragmented MP4s majestic records to the SD card.
+//
+// Why this file exists at all: the clips are fragmented MP4 — ftyp, moov, then
+// a moof+mdat pair per GOP — but majestic writes no random-access index. There
+// is no `sidx`, no `mfra`/`mfro` trailer, and no `tfdt` in any fragment (the
+// boxes present are mfhd, traf, tfhd, trun and nothing else). So nothing in the
+// file says which byte a given second starts at, and a browser told to seek has
+// to walk the fragment chain from the beginning. That is the whole reason
+// dragging the scrub bar on a 400 MB recording behaves the way it does.
+//
+// Everything here is therefore about recovering that index from outside the
+// file, over HTTP Range — which majestic does serve properly (206 with
+// Content-Range, sendfile) for an authenticated request.
+//
+// WHAT IT COSTS decides which route the page takes. Measured against an
+// hi3516av300: one range request is 32-50 ms whether it asks for 256 bytes or
+// 256 KiB, and a bulk read runs at ~10 MiB/s. So the price of an answer is the
+// number of REQUESTS, not the bytes. A 20-minute clip holds ~1100 fragments,
+// which makes a full walk ~55 seconds — far too much to spend opening a clip.
+// Hence four routes, and the page uses the cheapest that answers its question:
+//
+//   durationHint()  how long is this clip?          2 requests
+//   locate()        which byte is second N at?      ~10 requests, approximate
+//   spanFrom()      index just this selection       ~1 per second exported
+//   buildIndex()    index the whole clip, exactly   ~1 per second of clip
+//
+// buildIndex is the reference the other three are measured against — the tests
+// assert that spanFrom agrees with it byte-for-byte — but nothing on the page's
+// hot path calls it.
+//
+// No dependencies: it is handed a `read(start, endInclusive) -> Promise<u8>`
+// rather than calling fetch itself, so the whole module is exercised against a
+// synthetic file in tests/mp4index.test.js without a network or a camera.
+window.MajesticMp4Index = (function () {
+	'use strict';
+
+	// A fragment's moof is 160-240 bytes on everything majestic writes. 256
+	// covers the largest observed moof plus the 8-byte mdat header that follows
+	// it, which is all a walk step needs — so one read per fragment, not two.
+	// parseFragment() reports when it was not enough rather than guessing.
+	const STEP = 256;
+	// Widest fragment seen on an av300 at 4K/20fps is ~730 KB; a probe window
+	// has to be wide enough that a moof is certain to fall inside it.
+	const PROBE = 768 * 1024;
+
+	function be32(u8, i) {
+		return (u8[i] << 24 | u8[i + 1] << 16 | u8[i + 2] << 8 | u8[i + 3]) >>> 0;
+	}
+	function fourcc(u8, i) {
+		return String.fromCharCode(u8[i], u8[i + 1], u8[i + 2], u8[i + 3]);
+	}
+
+	// Walk the box list at `from`, returning [offset, end] of the first child of
+	// type `type`, or null. Bounded by `end` so a nested walk cannot run past its
+	// parent into a sibling.
+	function findBox(u8, from, end, type) {
+		let off = from;
+		while (off + 8 <= end) {
+			const size = be32(u8, off);
+			if (size < 8 || off + size > end) return null;
+			if (fourcc(u8, off + 4) === type) return [off, off + size];
+			off += size;
+		}
+		return null;
+	}
+
+	// Descend a path of box types from `from`, e.g. ['moov','trak','mdia','mdhd'].
+	// Containers carry no fields of their own, so every step starts 8 bytes in.
+	function descend(u8, from, end, path) {
+		let a = from, b = end;
+		for (let i = 0; i < path.length; i++) {
+			const box = findBox(u8, a, b, path[i]);
+			if (!box) return null;
+			a = box[0] + 8;
+			b = box[1];
+		}
+		return [a, b];
+	}
+
+	// ---- init segment ----------------------------------------------------
+
+	// Everything before the first moof: ftyp + moov. That byte range IS the init
+	// segment — prepend it to any run of fragments and the result is a playable
+	// file, which is what makes clip export a byte concatenation rather than a
+	// re-encode.
+	//
+	// timescale comes from the media header of the first track. Fragment
+	// durations in trun are in those ticks, so without it a walk can count
+	// fragments but not seconds.
+	function parseInit(u8) {
+		const moov = findBox(u8, 0, u8.length, 'moov');
+		if (!moov) return null;
+
+		// The first moof starts where moov ends — unless the file is truncated
+		// mid-header, in which case there is nothing to index yet.
+		const firstMoof = moov[1];
+		let timescale = 0;
+		const mdhd = descend(u8, moov[0] + 8, moov[1], ['trak', 'mdia', 'mdhd']);
+		if (mdhd) {
+			// mdhd: version(1) flags(3), then times. v0 has 32-bit creation and
+			// modification before timescale, v1 has 64-bit.
+			const v = u8[mdhd[0]];
+			timescale = be32(u8, mdhd[0] + (v === 1 ? 20 : 12));
+		}
+		return {
+			firstMoof: firstMoof,
+			headerLength: firstMoof,
+			timescale: timescale || 0,
+		};
+	}
+
+	// ---- fragments -------------------------------------------------------
+
+	// mfhd is required to be moof's first child, and its sequence_number sits at
+	// a fixed offset. Verified rather than assumed: a file that puts something
+	// else first reports null and the caller falls back to the exact walk.
+	//
+	// CAVEAT, and it is the reason locate() is only ever an approximation:
+	// majestic's sequence_number is monotonic but NOT strictly increasing — a
+	// walk over a real clip saw 0, 1, 2, 2, 3, 4 at consecutive moofs, where
+	// ISO 14496-12 wants strictly increasing. Binary search tolerates a plateau
+	// (it only needs monotonicity), but the value cannot be trusted as an exact
+	// fragment ordinal, so exact times come from the walk instead.
+	function moofSeq(u8, at) {
+		if (at + 24 > u8.length) return null;
+		if (fourcc(u8, at + 4) !== 'moof') return null;
+		if (fourcc(u8, at + 12) !== 'mfhd') return null;
+		return be32(u8, at + 20);
+	}
+
+	// Sum the sample durations of a fragment, in timescale ticks.
+	//
+	// trun carries them per sample when flag 0x100 is set, which is what
+	// majestic writes; the fallback is tfhd's default_sample_duration (flag
+	// 0x08) times the sample count, which is the other legal way to say it.
+	function fragDurationTicks(u8, moofAt, moofEnd) {
+		const traf = findBox(u8, moofAt + 8, moofEnd, 'traf');
+		if (!traf) return null;
+
+		let defDur = 0;
+		const tfhd = findBox(u8, traf[0] + 8, traf[1], 'tfhd');
+		if (tfhd) {
+			const flags = be32(u8, tfhd[0] + 8) & 0xffffff;
+			// track_ID(4), then the optional fields in flag order
+			let p = tfhd[0] + 16;
+			if (flags & 0x01) p += 8;   // base_data_offset
+			if (flags & 0x02) p += 4;   // sample_description_index
+			if (flags & 0x08) { defDur = be32(u8, p); }
+		}
+
+		const trun = findBox(u8, traf[0] + 8, traf[1], 'trun');
+		if (!trun) return null;
+		const tf = be32(u8, trun[0] + 8) & 0xffffff;
+		const count = be32(u8, trun[0] + 12);
+		let p = trun[0] + 16;
+		if (tf & 0x001) p += 4;         // data_offset
+		if (tf & 0x004) p += 4;         // first_sample_flags
+
+		if (!(tf & 0x100)) return defDur ? defDur * count : null;
+
+		// per-sample records, in flag order; we only want the duration field
+		const stride = 4
+			+ ((tf & 0x200) ? 4 : 0)
+			+ ((tf & 0x400) ? 4 : 0)
+			+ ((tf & 0x800) ? 4 : 0);
+		let total = 0;
+		for (let i = 0; i < count; i++) {
+			const at = p + i * stride;
+			if (at + 4 > trun[1]) return null;   // truncated: refuse to guess
+			total += be32(u8, at);
+		}
+		return total;
+	}
+
+	// One step of the chain. `u8` must start exactly at a moof and hold enough
+	// of it to reach the following mdat's size field.
+	function parseFragment(u8) {
+		if (u8.length < 16) return null;
+		const moofSize = be32(u8, 0);
+		if (moofSize < 16 || fourcc(u8, 4) !== 'moof') return null;
+		// Not an error — just too small a read. The caller widens and retries.
+		if (moofSize + 8 > u8.length) return { short: moofSize + 8 };
+
+		const mdatSize = be32(u8, moofSize);
+		if (mdatSize < 8 || fourcc(u8, moofSize + 4) !== 'mdat') return null;
+
+		return {
+			moofSize: moofSize,
+			mdatSize: mdatSize,
+			total: moofSize + mdatSize,
+			seq: moofSeq(u8, 0),
+			durTicks: fragDurationTicks(u8, 0, Math.min(moofSize, u8.length)),
+		};
+	}
+
+	// Offset of the next moof box header at or after `from`, or -1.
+	//
+	// Searches for the type field and checks the size in front of it, because
+	// mdat payload spells 'moof' by chance often enough to matter — a plain
+	// substring search lands in the middle of a picture several times a minute.
+	function findMoof(u8, from) {
+		for (let i = Math.max(4, from | 0); i + 24 <= u8.length; i++) {
+			if (u8[i] !== 0x6d || u8[i + 1] !== 0x6f || u8[i + 2] !== 0x6f || u8[i + 3] !== 0x66) continue;
+			const at = i - 4;
+			const size = be32(u8, at);
+			// a moof is small and its first child must be mfhd
+			if (size < 16 || size > 65536) continue;
+			if (fourcc(u8, at + 12) !== 'mfhd') continue;
+			return at;
+		}
+		return -1;
+	}
+
+	// ---- the index -------------------------------------------------------
+
+	// Walk the whole chain. Resolves { fragments, duration, timescale }, where
+	// each fragment is { off, len, t, dur } with t/dur in seconds.
+	//
+	// onProgress(done, total) is called with bytes, so a caller can show real
+	// progress without knowing the fragment count in advance.
+	function buildIndex(read, size, init, onProgress, shouldStop) {
+		const frags = [];
+		let off = init.firstMoof;
+		let ticks = 0;
+		let stopped = false;
+		const ts = init.timescale || 1;
+
+		function step() {
+			if (off + 16 > size) return finish();
+			// Abandoned by the caller (they opened another clip). Distinct from
+			// running out of fragments: an abandoned walk is not an index and
+			// must not be cached as one.
+			if (shouldStop && shouldStop()) { stopped = true; return finish(); }
+			const want = Math.min(STEP, size - off);
+			return read(off, off + want - 1).then(function (buf) {
+				let f = parseFragment(buf);
+				if (f && f.short) {
+					// an unusually large moof; widen once and take what we get
+					const w = Math.min(f.short, size - off);
+					return read(off, off + w - 1).then(function (b2) {
+						return advance(parseFragment(b2));
+					});
+				}
+				return advance(f);
+			});
+		}
+
+		function advance(f) {
+			// A clip still being recorded ends in a partial fragment. That is
+			// not corruption — stop cleanly and report what is complete, so the
+			// timeline shows footage up to the last whole second on the card.
+			if (!f || f.short || !f.total) return finish();
+			// The headers of that partial fragment are usually already on disk
+			// while its payload is not, so the sizes parse fine and the fragment
+			// looks whole. Only its extent gives it away. Counting it would put
+			// a fragment on the timeline that cannot be played or exported.
+			if (off + f.total > size) return finish();
+			frags.push({
+				off: off,
+				len: f.total,
+				t: ticks / ts,
+				dur: (f.durTicks || 0) / ts,
+				seq: f.seq,
+			});
+			ticks += f.durTicks || 0;
+			off += f.total;
+			if (onProgress) onProgress(off, size);
+			return step();
+		}
+
+		function finish() {
+			return {
+				fragments: frags,
+				duration: ticks / ts,
+				timescale: init.timescale,
+				headerLength: init.headerLength,
+				complete: off >= size,
+				stopped: stopped,
+				indexedBytes: off,
+			};
+		}
+
+		return Promise.resolve().then(step);
+	}
+
+	// Binary-search the file for the fragment covering `targetSec`, without a
+	// walk. Approximate by construction: it reads sequence_number, which is
+	// monotonic but not a reliable ordinal (see moofSeq), and it assumes
+	// fragments are of roughly equal duration. Good enough to start playback
+	// somewhere sensible while buildIndex() catches up; not good enough to
+	// label a timeline with.
+	function locate(read, size, init, targetSec, secPerFrag) {
+		const per = secPerFrag > 0 ? secPerFrag : 1;
+		const target = Math.max(0, targetSec) / per;
+
+		let lo = init.firstMoof, hi = size, best = null;
+
+		function probeAt(pos) {
+			const start = Math.max(init.firstMoof, Math.min(pos, size - 1));
+			const want = Math.min(PROBE, size - start);
+			return read(start, start + want - 1).then(function (buf) {
+				const i = findMoof(buf, 0);
+				if (i < 0) return null;
+				return { off: start + i, seq: moofSeq(buf, i) };
+			});
+		}
+
+		function loop() {
+			if (hi - lo <= PROBE) return probeAt(lo).then(settle);
+			const mid = lo + Math.floor((hi - lo) / 2);
+			return probeAt(mid).then(function (p) {
+				if (!p || p.seq === null) { hi = mid; return loop(); }
+				if (p.seq > target) { hi = mid; } else { lo = p.off; best = p; }
+				if (p.seq === target) return settle(p);
+				return loop();
+			});
+		}
+
+		function settle(p) {
+			const hit = p || best;
+			if (!hit) return { off: init.firstMoof, approxSec: 0 };
+			return { off: hit.off, approxSec: (hit.seq || 0) * per };
+		}
+
+		return Promise.resolve().then(loop);
+	}
+
+	// ---- cheap answers, for when a full walk is too expensive -------------
+
+	// Measured against a real camera: a range request costs 32-50 ms, so
+	// walking a 20-minute clip's ~1100 fragments takes about 55 seconds and
+	// 1100 requests. Far too much to spend on opening a clip. These two give
+	// the page what it actually needs for a fraction of that.
+
+	// Roughly how long the clip runs, in two reads.
+	//
+	// The last moof in the file carries a sequence_number that is very nearly
+	// the fragment ordinal, and the first fragment says how long a fragment
+	// lasts — so duration is (lastSeq + 1) x fragmentDuration. It is a hint,
+	// not a measurement: sequence_number plateaus (see moofSeq) so this reads a
+	// little short, and it assumes fragments are of equal length, which is true
+	// for a fixed GOP and not guaranteed in general.
+	function durationHint(read, size, init) {
+		const tailFrom = Math.max(init.firstMoof, size - PROBE);
+		return Promise.all([
+			read(init.firstMoof, init.firstMoof + STEP - 1),
+			read(tailFrom, size - 1),
+		]).then(function (r) {
+			const first = parseFragment(r[0]);
+			if (!first || first.short || !first.durTicks || !init.timescale) return null;
+			const per = first.durTicks / init.timescale;
+
+			const tail = r[1];
+			let last = -1, at = 0;
+			for (;;) {
+				const i = findMoof(tail, at);
+				if (i < 0) break;
+				last = i;
+				// Past this box's type field. findMoof takes the offset to start
+				// looking for the *type* at, and this box's type sits at i + 4 —
+				// so anything less than i + 8 finds the same box forever.
+				at = i + 8;
+			}
+			if (last < 0) return null;
+			const seq = moofSeq(tail, last);
+			if (seq === null) return null;
+			return { seconds: (seq + 1) * per, perFragment: per, approximate: true };
+		}).catch(function () { return null; });
+	}
+
+	// Walk forward from a known fragment boundary until `seconds` of media has
+	// been covered, and no further. This is what an export needs: the cost is
+	// proportional to the length of the selection, not to the length of the
+	// clip — a one-minute cut is ~60 reads, not 1100.
+	function spanFrom(read, size, init, startOff, seconds, onProgress) {
+		const frags = [];
+		let off = startOff, ticks = 0;
+		const ts = init.timescale || 1;
+		const want = Math.max(0, seconds);
+
+		function step() {
+			if (off + 16 > size) return finish();
+			if (ticks / ts >= want && frags.length) return finish();
+			return read(off, Math.min(off + STEP, size) - 1).then(function (buf) {
+				const f = parseFragment(buf);
+				if (f && f.short) {
+					const w = Math.min(f.short, size - off);
+					return read(off, off + w - 1).then(function (b2) { return advance(parseFragment(b2)); });
+				}
+				return advance(f);
+			});
+		}
+		function advance(f) {
+			if (!f || f.short || !f.total || off + f.total > size) return finish();
+			frags.push({ off: off, len: f.total, t: ticks / ts, dur: (f.durTicks || 0) / ts, seq: f.seq });
+			ticks += f.durTicks || 0;
+			off += f.total;
+			if (onProgress) onProgress(ticks / ts, want);
+			return step();
+		}
+		// Same shape buildIndex returns, so exportRanges reads either one.
+		function finish() {
+			return {
+				fragments: frags,
+				duration: ticks / ts,
+				headerLength: init.headerLength,
+				timescale: init.timescale,
+				complete: off >= size,
+				stopped: false,
+			};
+		}
+		return Promise.resolve().then(step);
+	}
+
+	// ---- export ----------------------------------------------------------
+
+	// The byte ranges that make up a clip covering [t0, t1).
+	//
+	// Fragments are self-contained, so a valid playable file is literally the
+	// init segment followed by whole fragments — no transcoding, no remuxing,
+	// and the camera only ever sendfiles the ranges. Boundaries snap outward to
+	// whole fragments, because half a fragment is not decodable.
+	function exportRanges(index, t0, t1) {
+		const f = index.fragments;
+		if (!f || !f.length) return null;
+		const a = Math.min(t0, t1), b = Math.max(t0, t1);
+
+		let i = 0;
+		while (i < f.length - 1 && f[i].t + f[i].dur <= a) i++;
+		let j = i;
+		while (j < f.length - 1 && f[j].t + f[j].dur < b) j++;
+
+		const start = f[i].off;
+		const end = f[j].off + f[j].len;      // exclusive
+		return {
+			header: { start: 0, end: index.headerLength },   // exclusive
+			body: { start: start, end: end },
+			from: f[i].t,
+			to: f[j].t + f[j].dur,
+			fragments: j - i + 1,
+			bytes: index.headerLength + (end - start),
+		};
+	}
+
+	// The fragment covering `sec`, for a seek once the index exists.
+	function fragmentAt(index, sec) {
+		const f = index.fragments;
+		if (!f || !f.length) return null;
+		let lo = 0, hi = f.length - 1;
+		while (lo < hi) {
+			const mid = (lo + hi + 1) >> 1;
+			if (f[mid].t <= sec) lo = mid; else hi = mid - 1;
+		}
+		return f[lo];
+	}
+
+	// ---- transport -------------------------------------------------------
+
+	// A `read` bound to one URL. Kept out of the functions above so they stay
+	// testable; apiFetch (main.js) carries the session cookie and sends a lapsed
+	// session to the login page rather than failing silently.
+	function reader(url) {
+		return function (start, end) {
+			return apiFetch(url, {
+				credentials: 'same-origin',
+				cache: 'no-store',
+				headers: { Range: 'bytes=' + start + '-' + end },
+			}).then(function (r) {
+				if (!r.ok) throw new Error('range ' + start + '-' + end + ' answered ' + r.status);
+				return r.arrayBuffer();
+			}).then(function (b) {
+				// A server that ignores Range answers 200 with the whole file.
+				// Trimming keeps every parser above honest about what it got.
+				const u8 = new Uint8Array(b);
+				return u8.length > (end - start + 1) ? u8.subarray(0, end - start + 1) : u8;
+			});
+		};
+	}
+
+	return {
+		parseInit: parseInit,
+		parseFragment: parseFragment,
+		fragDurationTicks: fragDurationTicks,
+		moofSeq: moofSeq,
+		findMoof: findMoof,
+		findBox: findBox,
+		buildIndex: buildIndex,
+		durationHint: durationHint,
+		spanFrom: spanFrom,
+		locate: locate,
+		exportRanges: exportRanges,
+		fragmentAt: fragmentAt,
+		reader: reader,
+		STEP: STEP,
+	};
+})();

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -352,7 +352,7 @@ window.MajesticMp4Index = (function () {
 		}
 
 		function probeAt(pos, win) {
-			const w = win || PROBE;
+			const w = Math.min(win || PROBE, PROBE_MAX);
 			const start = Math.max(init.firstMoof, Math.min(pos, size - 1));
 			const want = Math.min(w, size - start);
 			return read(start, start + want - 1).then(function (buf) {
@@ -361,7 +361,8 @@ window.MajesticMp4Index = (function () {
 					// No fragment boundary in the window — it is narrower than a
 					// fragment. Widen rather than report "nothing here", which
 					// would walk the search off in the wrong direction.
-					if (w < PROBE_MAX && start + want < size) return probeAt(pos, w * 2);
+					if (w < PROBE_MAX && start + want < size)
+						return probeAt(pos, Math.min(w * 2, PROBE_MAX));
 					return null;
 				}
 				const t = timeAt(buf, i);
@@ -384,12 +385,12 @@ window.MajesticMp4Index = (function () {
 		// answer is only ever as precise as PROBE is wide, which is a couple of
 		// seconds on a real recording and much worse on small fragments.
 		function refine(win) {
-			const w = win || PROBE;
+			const w = Math.min(win || PROBE, PROBE_MAX);
 			const start = Math.max(init.firstMoof, Math.min(lo, size - 1));
 			const want = Math.min(w, size - start);
 			return read(start, start + want - 1).then(function (buf) {
 				if (findMoof(buf, 0) < 0 && w < PROBE_MAX && start + want < size)
-					return refine(w * 2);
+					return refine(Math.min(w * 2, PROBE_MAX));
 				let at = findMoof(buf, 0);
 				while (at >= 0 && at + 16 <= buf.length) {
 					const t = timeAt(buf, at);
@@ -439,19 +440,24 @@ window.MajesticMp4Index = (function () {
 			const per = first.durTicks / init.timescale;
 			// The first fragment is the best available guess at how wide the
 			// tail window must be, and it has already been read.
-			return tail(Math.max(PROBE, (first.total || 0) * 2)).then(function (buf) {
+			return tail(Math.min(Math.max(PROBE, (first.total || 0) * 2), PROBE_MAX))
+				.then(function (buf) {
 				if (!buf) return null;
 
-				// The LAST moof in the file: where it starts plus how long it
-				// runs is the clip's length, exactly.
+				// The last COMPLETE moof in the file: where it starts plus how
+				// long it runs is the clip's length. Complete matters — a clip
+				// still being recorded ends with a fragment whose header is on
+				// the card and whose payload is not, and counting that one puts
+				// footage on the timeline that cannot be played or exported.
+				// buildIndex() applies the same rule; the cheap path must not
+				// be more optimistic than the exact one.
+				const base = size - buf.length;      // where this window starts
 				let last = -1, at = 0;
 				for (;;) {
 					const i = findMoof(buf, at);
 					if (i < 0) break;
-					last = i;
-					// Past this box's type field: findMoof takes the offset to
-					// start looking for the *type* at, and this box's type sits
-					// at i + 4, so anything less than i + 8 finds it forever.
+					const f = parseFragment(buf.subarray(i));
+					if (f && !f.short && f.total && base + i + f.total <= size) last = i;
 					at = i + 8;
 				}
 				if (last < 0) return null;
@@ -475,7 +481,7 @@ window.MajesticMp4Index = (function () {
 				return read(from, size - 1).then(function (buf) {
 					if (findMoof(buf, 0) >= 0) return buf;
 					if (win >= PROBE_MAX || from <= init.firstMoof) return buf;
-					return tail(win * 2);
+					return tail(Math.min(win * 2, PROBE_MAX));
 				});
 			}
 		}).catch(function () { return null; });

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -51,9 +51,15 @@ window.MajesticMp4Index = (function () {
 	// a short read rather than guessing, so being wrong here is slow, not
 	// incorrect.
 	const STEP = 1024;
-	// Widest fragment seen on an av300 at 4K/20fps is ~730 KB; a probe window
-	// has to be wide enough that a moof is certain to fall inside it.
+	// A probe window only answers if a moof falls inside it, so it has to be
+	// wider than a fragment — and a fragment is not a fixed size. 730 KB was the
+	// widest on one av300 clip and 1.1 MB on the next from the same camera, so a
+	// constant picked from a sample is a bug waiting for a higher bitrate: the
+	// window silently contains no moof, and every lookup built on it fails.
+	// PROBE is therefore only where the search STARTS; widen() doubles it on a
+	// miss, up to a cap that no sane fragment reaches.
 	const PROBE = 768 * 1024;
+	const PROBE_MAX = 16 * 1024 * 1024;
 
 	function be32(u8, i) {
 		return (u8[i] << 24 | u8[i + 1] << 16 | u8[i + 2] << 8 | u8[i + 3]) >>> 0;
@@ -345,12 +351,19 @@ window.MajesticMp4Index = (function () {
 			return { sec: seq * per, exact: false };
 		}
 
-		function probeAt(pos) {
+		function probeAt(pos, win) {
+			const w = win || PROBE;
 			const start = Math.max(init.firstMoof, Math.min(pos, size - 1));
-			const want = Math.min(PROBE, size - start);
+			const want = Math.min(w, size - start);
 			return read(start, start + want - 1).then(function (buf) {
 				const i = findMoof(buf, 0);
-				if (i < 0) return null;
+				if (i < 0) {
+					// No fragment boundary in the window — it is narrower than a
+					// fragment. Widen rather than report "nothing here", which
+					// would walk the search off in the wrong direction.
+					if (w < PROBE_MAX && start + want < size) return probeAt(pos, w * 2);
+					return null;
+				}
 				const t = timeAt(buf, i);
 				return t === null ? null : { off: start + i, sec: t.sec, exact: t.exact };
 			});
@@ -370,10 +383,13 @@ window.MajesticMp4Index = (function () {
 		// enough to hold several — so finish by walking it. Without this the
 		// answer is only ever as precise as PROBE is wide, which is a couple of
 		// seconds on a real recording and much worse on small fragments.
-		function refine() {
+		function refine(win) {
+			const w = win || PROBE;
 			const start = Math.max(init.firstMoof, Math.min(lo, size - 1));
-			const want = Math.min(PROBE, size - start);
+			const want = Math.min(w, size - start);
 			return read(start, start + want - 1).then(function (buf) {
+				if (findMoof(buf, 0) < 0 && w < PROBE_MAX && start + want < size)
+					return refine(w * 2);
 				let at = findMoof(buf, 0);
 				while (at >= 0 && at + 16 <= buf.length) {
 					const t = timeAt(buf, at);
@@ -417,41 +433,51 @@ window.MajesticMp4Index = (function () {
 	// every fragment is as long as the first. Flagged `approximate` so a caller
 	// can say so rather than present a guess as a measurement.
 	function durationHint(read, size, init) {
-		const tailFrom = Math.max(init.firstMoof, size - PROBE);
-		return Promise.all([
-			read(init.firstMoof, init.firstMoof + STEP - 1),
-			read(tailFrom, size - 1),
-		]).then(function (r) {
-			const first = parseFragment(r[0]);
+		return read(init.firstMoof, init.firstMoof + STEP - 1).then(function (head) {
+			const first = parseFragment(head);
 			if (!first || first.short || !first.durTicks || !init.timescale) return null;
 			const per = first.durTicks / init.timescale;
+			// The first fragment is the best available guess at how wide the
+			// tail window must be, and it has already been read.
+			return tail(Math.max(PROBE, (first.total || 0) * 2)).then(function (buf) {
+				if (!buf) return null;
 
-			const tail = r[1];
-			let last = -1, at = 0;
-			for (;;) {
-				const i = findMoof(tail, at);
-				if (i < 0) break;
-				last = i;
-				// Past this box's type field. findMoof takes the offset to start
-				// looking for the *type* at, and this box's type sits at i + 4 —
-				// so anything less than i + 8 finds the same box forever.
-				at = i + 8;
+				// The LAST moof in the file: where it starts plus how long it
+				// runs is the clip's length, exactly.
+				let last = -1, at = 0;
+				for (;;) {
+					const i = findMoof(buf, at);
+					if (i < 0) break;
+					last = i;
+					// Past this box's type field: findMoof takes the offset to
+					// start looking for the *type* at, and this box's type sits
+					// at i + 4, so anything less than i + 8 finds it forever.
+					at = i + 8;
+				}
+				if (last < 0) return null;
+
+				const ticks = fragDecodeTicks(buf, last, buf.length);
+				if (ticks !== null) {
+					const dur = fragDurationTicks(buf, last, buf.length);
+					return {
+						seconds: (ticks + (dur || 0)) / init.timescale,
+						perFragment: per,
+						approximate: false,
+					};
+				}
+				const seq = moofSeq(buf, last);
+				if (seq === null) return null;
+				return { seconds: (seq + 1) * per, perFragment: per, approximate: true };
+			});
+
+			function tail(win) {
+				const from = Math.max(init.firstMoof, size - win);
+				return read(from, size - 1).then(function (buf) {
+					if (findMoof(buf, 0) >= 0) return buf;
+					if (win >= PROBE_MAX || from <= init.firstMoof) return buf;
+					return tail(win * 2);
+				});
 			}
-			if (last < 0) return null;
-
-			const ticks = fragDecodeTicks(tail, last, tail.length);
-			if (ticks !== null) {
-				const dur = fragDurationTicks(tail, last, tail.length);
-				return {
-					seconds: (ticks + (dur || 0)) / init.timescale,
-					perFragment: per,
-					approximate: false,
-				};
-			}
-
-			const seq = moofSeq(tail, last);
-			if (seq === null) return null;
-			return { seconds: (seq + 1) * per, perFragment: per, approximate: true };
 		}).catch(function () { return null; });
 	}
 

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -1,12 +1,15 @@
 // Byte<->time for the fragmented MP4s majestic records to the SD card.
 //
 // Why this file exists at all: the clips are fragmented MP4 — ftyp, moov, then
-// a moof+mdat pair per GOP — but majestic writes no random-access index. There
-// is no `sidx`, no `mfra`/`mfro` trailer, and no `tfdt` in any fragment (the
-// boxes present are mfhd, traf, tfhd, trun and nothing else). So nothing in the
-// file says which byte a given second starts at, and a browser told to seek has
-// to walk the fragment chain from the beginning. That is the whole reason
-// dragging the scrub bar on a 400 MB recording behaves the way it does.
+// a moof+mdat pair per GOP — with no random-access index over the file as a
+// whole. There is no `sidx` and no `mfra`/`mfro` trailer, so nothing says which
+// byte a given second starts at; that has to be recovered from outside.
+//
+// Each fragment does state its own start, in tfdt, and everything here is built
+// on that. Recordings written before majestic wrote tfdt have only
+// mfhd.sequence_number to go on, which counts writes rather than fragments —
+// it ran 71 ahead over 300 fragments on an av300 — so on those files a seek can
+// only be approximate, and says so.
 //
 // Everything here is therefore about recovering that index from outside the
 // file, over HTTP Range — which majestic does serve properly (206 with
@@ -20,7 +23,7 @@
 // Hence four routes, and the page uses the cheapest that answers its question:
 //
 //   durationHint()  how long is this clip?          2 requests
-//   locate()        which byte is second N at?      ~10 requests, approximate
+//   locate()        which byte is second N at?      ~10 requests
 //   spanFrom()      index just this selection       ~1 per second exported
 //   buildIndex()    index the whole clip, exactly   ~1 per second of clip
 //
@@ -34,11 +37,15 @@
 window.MajesticMp4Index = (function () {
 	'use strict';
 
-	// A fragment's moof is 160-240 bytes on everything majestic writes. 256
-	// covers the largest observed moof plus the 8-byte mdat header that follows
-	// it, which is all a walk step needs — so one read per fragment, not two.
-	// parseFragment() reports when it was not enough rather than guessing.
-	const STEP = 256;
+	// One walk step needs the whole moof plus the 8-byte mdat header behind it.
+	// A video-only moof is 260 bytes (240 before tfdt was added), and a second
+	// traf for audio roughly doubles it. 1 KiB covers both with room to spare,
+	// and costs nothing worth counting: a range request is 32-50 ms whether it
+	// asks for 256 bytes or 256 KiB, so the only thing to optimise is the
+	// number of requests — one per fragment, never two. parseFragment() reports
+	// a short read rather than guessing, so being wrong here is slow, not
+	// incorrect.
+	const STEP = 1024;
 	// Widest fragment seen on an av300 at 4K/20fps is ~730 KB; a probe window
 	// has to be wide enough that a moof is certain to fall inside it.
 	const PROBE = 768 * 1024;
@@ -128,6 +135,31 @@ window.MajesticMp4Index = (function () {
 		return be32(u8, at + 20);
 	}
 
+	// baseMediaDecodeTime — where this fragment starts, in timescale ticks.
+	//
+	// This is the only field in the file that maps a fragment to a time
+	// honestly, which makes it what every lookup here is built on. Recordings
+	// written before majestic wrote the box have to fall back on
+	// mfhd.sequence_number, and the difference is not subtle: seq counts
+	// writes rather than fragments, running 71 ahead over 300 fragments on an
+	// av300, so a seek aimed by it landed about six seconds out.
+	function fragDecodeTicks(u8, moofAt, moofEnd) {
+		const traf = findBox(u8, moofAt + 8, moofEnd, 'traf');
+		if (!traf) return null;
+		const tfdt = findBox(u8, traf[0] + 8, traf[1], 'tfdt');
+		if (!tfdt) return null;
+		const version = u8[tfdt[0] + 8];
+		const at = tfdt[0] + 12;
+		if (version === 1) {
+			if (at + 8 > tfdt[1]) return null;
+			// Safe as a Number: a microsecond timescale needs 2^53 ticks to
+			// overflow, which is a few hundred years of recording.
+			return be32(u8, at) * 4294967296 + be32(u8, at + 4);
+		}
+		if (at + 4 > tfdt[1]) return null;
+		return be32(u8, at);
+	}
+
 	// Sum the sample durations of a fragment, in timescale ticks.
 	//
 	// trun carries them per sample when flag 0x100 is set, which is what
@@ -189,6 +221,7 @@ window.MajesticMp4Index = (function () {
 			mdatSize: mdatSize,
 			total: moofSize + mdatSize,
 			seq: moofSeq(u8, 0),
+			decodeTicks: fragDecodeTicks(u8, 0, Math.min(moofSize, u8.length)),
 			durTicks: fragDurationTicks(u8, 0, Math.min(moofSize, u8.length)),
 		};
 	}
@@ -291,9 +324,21 @@ window.MajesticMp4Index = (function () {
 	// label a timeline with.
 	function locate(read, size, init, targetSec, secPerFrag) {
 		const per = secPerFrag > 0 ? secPerFrag : 1;
-		const target = Math.max(0, targetSec) / per;
+		const ts = init.timescale || 1;
+		const target = Math.max(0, targetSec);
 
 		let lo = init.firstMoof, hi = size, best = null;
+
+		// What a probe found: its byte offset and the time it starts at.
+		// Exact from tfdt; on a pre-tfdt recording, estimated from the write
+		// counter, which is the whole reason `exact` is reported back.
+		function timeAt(buf, i) {
+			const ticks = fragDecodeTicks(buf, i, buf.length);
+			if (ticks !== null) return { sec: ticks / ts, exact: true };
+			const seq = moofSeq(buf, i);
+			if (seq === null) return null;
+			return { sec: seq * per, exact: false };
+		}
 
 		function probeAt(pos) {
 			const start = Math.max(init.firstMoof, Math.min(pos, size - 1));
@@ -301,25 +346,48 @@ window.MajesticMp4Index = (function () {
 			return read(start, start + want - 1).then(function (buf) {
 				const i = findMoof(buf, 0);
 				if (i < 0) return null;
-				return { off: start + i, seq: moofSeq(buf, i) };
+				const t = timeAt(buf, i);
+				return t === null ? null : { off: start + i, sec: t.sec, exact: t.exact };
 			});
 		}
 
 		function loop() {
-			if (hi - lo <= PROBE) return probeAt(lo).then(settle);
+			if (hi - lo <= PROBE) return refine();
 			const mid = lo + Math.floor((hi - lo) / 2);
 			return probeAt(mid).then(function (p) {
-				if (!p || p.seq === null) { hi = mid; return loop(); }
-				if (p.seq > target) { hi = mid; } else { lo = p.off; best = p; }
-				if (p.seq === target) return settle(p);
+				if (!p) { hi = mid; return loop(); }
+				if (p.sec > target) { hi = mid; } else { lo = p.off; best = p; }
 				return loop();
 			});
 		}
 
-		function settle(p) {
-			const hit = p || best;
-			if (!hit) return { off: init.firstMoof, approxSec: 0 };
-			return { off: hit.off, approxSec: (hit.seq || 0) * per };
+		// The search narrows to a window, not to a fragment — a window is wide
+		// enough to hold several — so finish by walking it. Without this the
+		// answer is only ever as precise as PROBE is wide, which is a couple of
+		// seconds on a real recording and much worse on small fragments.
+		function refine() {
+			const start = Math.max(init.firstMoof, Math.min(lo, size - 1));
+			const want = Math.min(PROBE, size - start);
+			return read(start, start + want - 1).then(function (buf) {
+				let at = findMoof(buf, 0);
+				while (at >= 0 && at + 16 <= buf.length) {
+					const t = timeAt(buf, at);
+					if (t === null || t.sec > target) break;
+					best = { off: start + at, sec: t.sec, exact: t.exact };
+					const f = parseFragment(buf.subarray(at));
+					if (!f || f.short || !f.total) break;
+					at += f.total;
+				}
+				return settle();
+			}).catch(settle);
+		}
+
+		function settle() {
+			// Land at or before the moment asked for, never after it: starting
+			// late reads as the seek having been ignored, where starting a
+			// fragment early is just a moment of lead-in.
+			if (!best) return { off: init.firstMoof, approxSec: 0, exact: false };
+			return { off: best.off, approxSec: best.sec, exact: best.exact };
 		}
 
 		return Promise.resolve().then(loop);
@@ -332,14 +400,17 @@ window.MajesticMp4Index = (function () {
 	// 1100 requests. Far too much to spend on opening a clip. These two give
 	// the page what it actually needs for a fraction of that.
 
-	// Roughly how long the clip runs, in two reads.
+	// How long the clip runs, in two reads.
 	//
-	// The last moof in the file carries a sequence_number that is very nearly
-	// the fragment ordinal, and the first fragment says how long a fragment
-	// lasts — so duration is (lastSeq + 1) x fragmentDuration. It is a hint,
-	// not a measurement: sequence_number plateaus (see moofSeq) so this reads a
-	// little short, and it assumes fragments are of equal length, which is true
-	// for a fixed GOP and not guaranteed in general.
+	// The last fragment in the file states where it begins (tfdt) and how long
+	// it lasts (trun), so the two together are the clip's length exactly — no
+	// walk, no assumption that fragments are of equal size.
+	//
+	// Without tfdt there is nothing exact to read, and the answer degrades to
+	// (lastSeq + 1) x fragmentDuration: sequence_number is not a fragment
+	// ordinal, so that runs wrong by whatever it has drifted, and it assumes
+	// every fragment is as long as the first. Flagged `approximate` so a caller
+	// can say so rather than present a guess as a measurement.
 	function durationHint(read, size, init) {
 		const tailFrom = Math.max(init.firstMoof, size - PROBE);
 		return Promise.all([
@@ -362,6 +433,17 @@ window.MajesticMp4Index = (function () {
 				at = i + 8;
 			}
 			if (last < 0) return null;
+
+			const ticks = fragDecodeTicks(tail, last, tail.length);
+			if (ticks !== null) {
+				const dur = fragDurationTicks(tail, last, tail.length);
+				return {
+					seconds: (ticks + (dur || 0)) / init.timescale,
+					perFragment: per,
+					approximate: false,
+				};
+			}
+
 			const seq = moofSeq(tail, last);
 			if (seq === null) return null;
 			return { seconds: (seq + 1) * per, perFragment: per, approximate: true };

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -6,10 +6,15 @@
 // byte a given second starts at; that has to be recovered from outside.
 //
 // Each fragment does state its own start, in tfdt, and everything here is built
-// on that. Recordings written before majestic wrote tfdt have only
-// mfhd.sequence_number to go on, which counts writes rather than fragments —
-// it ran 71 ahead over 300 fragments on an av300 — so on those files a seek can
-// only be approximate, and says so.
+// on that.
+//
+// DEPRECATED FALLBACK, REMOVE AFTER 2029-01: recordings written before majestic
+// wrote tfdt have only mfhd.sequence_number to go on, which counts writes rather
+// than fragments — it ran 71 ahead over 300 fragments on an av300 — so on those
+// files a lookup can only be approximate, and says so through `approximate` on
+// durationHint and `exact` on locate. Cameras write tfdt now, so this is only
+// for clips already on cards when that shipped; once those have rotated away,
+// drop the seq branches and let both simply require tfdt.
 //
 // Everything here is therefore about recovering that index from outside the
 // file, over HTTP Range — which majestic does serve properly (206 with

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -36,8 +36,9 @@
 
 
 	// Bumped on every seek: a drag fires overlapping lookups and only the
-	// newest may move the picture.
+	// newest may move the picture. dayToken does the same for day switches.
 	let seekToken = 0;
+	let dayToken = 0;
 	let player = null;
 
 	const $id = function (s) { return document.getElementById(s); };
@@ -98,15 +99,27 @@
 
 	function loadDays() {
 		if (!state.prefix) return Promise.resolve();
-		return api('days=1&prefix=' + encodeURIComponent(state.prefix))
-			.then(function (j) { state.days = (j && j.days) || []; })
+		// The endpoint derives the recordings root itself; take its answer as
+		// authoritative so the path this page builds media URLs from cannot
+		// drift from the one the listing came out of.
+		return api('days=1')
+			.then(function (j) {
+				state.days = (j && j.days) || [];
+				if (j && j.prefix) state.prefix = j.prefix;
+			})
 			.catch(function () { state.days = []; });
 	}
 
 	function loadDay(name) {
 		state.dayName = name;
-		return api('day=' + encodeURIComponent(name) + '&prefix=' + encodeURIComponent(state.prefix))
+		// Switching days fast enough leaves two requests in flight, and they can
+		// land out of order: the slower one for the day nobody is looking at any
+		// more would overwrite the newer model, while clip paths keep being built
+		// from the newer dayName — a listing of one day fetched from another.
+		const token = ++dayToken;
+		return api('day=' + encodeURIComponent(name))
 			.then(function (j) {
+				if (token !== dayToken) return;
 				const isToday = (name === state.today) ||
 					(name === '.' && state.nowSec !== null);
 				state.day = TL.buildDay((j && j.clips) || [], {
@@ -114,7 +127,10 @@
 					nowSec: isToday ? state.nowSec : null,
 				});
 			})
-			.catch(function () { state.day = { clips: [], unplaced: [] }; });
+			.catch(function () {
+				if (token !== dayToken) return;
+				state.day = { clips: [], unplaced: [] };
+			});
 	}
 
 	// ---- the player ------------------------------------------------------
@@ -445,7 +461,10 @@
 		IDX.durationHint(IDX.reader(url), clip.size, init).then(function (h) {
 			if (!h || state.clip !== clip) return;
 			state.hint = h;
-			if (!TL.applyExactDuration(state.day, clip.name, h.seconds)) return;
+			// h.approximate is the whole point of the flag: a pre-tfdt recording
+			// can only be guessed at, and the clip list says so with "about"
+			// rather than presenting the guess as a measurement.
+			if (!TL.applyExactDuration(state.day, clip.name, h.seconds, !h.approximate)) return;
 			renderClips();
 			renderTimeline();
 
@@ -684,7 +703,12 @@
 		const per = state.hint ? state.hint.perFragment : 1;
 
 		IDX.locate(read, clip.size, init, s.from - clip.start, per).then(function (hit) {
-			return IDX.spanFrom(read, clip.size, init, hit.off, s.seconds, function (got, want) {
+			// locate lands at or BEFORE the requested second, so the span has to
+			// be measured from where it actually landed. Walking the selection's
+			// own length from an earlier boundary would add lead-in at the front
+			// and drop exactly as much off the end that was asked for.
+			const need = (s.to - clip.start) - hit.approxSec;
+			return IDX.spanFrom(read, clip.size, init, hit.off, need, function (got, want) {
 				if (noteEl) noteEl.textContent = 'Collecting ' + TL.duration(got) + ' of ' + TL.duration(want) + '…';
 			});
 		}).then(function (span) {

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -35,6 +35,11 @@
 	};
 
 
+	// Bumped on every seek: a drag fires overlapping lookups and only the
+	// newest may move the picture.
+	let seekToken = 0;
+	let player = null;
+
 	const $id = function (s) { return document.getElementById(s); };
 	function esc(s) {
 		return String(s).replace(/[&<>"]/g, function (c) {
@@ -114,21 +119,168 @@
 
 	// ---- the player ------------------------------------------------------
 	//
-	// A plain <video> element pointed at the clip's own URL, seeking on its own
-	// over the Range requests majestic serves.
+	// MSE fed from byte offsets the index works out, so a seek fetches the
+	// fragment holding that second instead of asking the browser to find it.
 	//
-	// An MSE path aimed by the fragment index would seek by byte offset rather
-	// than by asking the browser to find the moment, and it is a reasonable
-	// next step — but only reasonable, not necessary. A recording carries a
-	// tfdt in every fragment, so the element has the decode times it needs to
-	// seek without walking the file, and a plain element is a great deal less
-	// machinery to get wrong.
+	// Every fragment states its own start in tfdt, and that is what makes this
+	// simple rather than fiddly. SourceBuffer stays in its default 'segments'
+	// mode, where an appended fragment lands at the time it claims: append the
+	// fragments for 5s..9s and `buffered` reads 5.00-9.00, whatever was or was
+	// not appended before them. So there is no timestampOffset to maintain, no
+	// anchor to re-establish per seek, and the media timeline is clip time —
+	// video.currentTime is just the second being watched.
 	//
-	// What is worth remembering is why this is not MSE already: a SourceBuffer
-	// refuses a media segment that has no tfdt, outright and with an empty
-	// buffer. Recordings written before that box was added cannot be appended
-	// at all, however they are fed in — no mode, timestampOffset or codec
-	// string changes it — while the same files play in a plain element.
+	// ('sequence' mode is the wrong tool here for exactly that reason: it
+	// re-times each append to follow the last, so the same fragments land at
+	// 0.00-4.00 and every position on the timeline means something else.)
+	//
+	// DEPRECATED PATH, REMOVE AFTER 2029-01: recordings written before majestic
+	// emitted tfdt cannot be played this way at all — a SourceBuffer refuses a
+	// media segment without one, leaving `buffered` empty and no error worth
+	// reading. Cameras write tfdt now, so this only matters for clips already
+	// sitting on cards when that shipped. Once those have rotated away (a card
+	// fills and recycles in days; a few years is generous), delete plainFallback
+	// and the watchdog below with it, and let a clip that will not append fail
+	// honestly.
+	function mkPlayer(video, onFallback) {
+		let ms = null, sb = null, objUrl = null;
+		let read = null, size = 0, headerLen = 0;
+		let cursor = 0, dead = false, busy = false, reset = false;
+		let want = null, watchdog = null;
+		// A fragment is ~340 KB and at most ~730 KB on an av300 at 4K, so one
+		// read usually swallows a whole one; when it does not, the remainder
+		// costs one extra request rather than a wrong append.
+		const WINDOW = 1024 * 1024, AHEAD = 12, BEHIND = 30;
+
+		function bufferedAhead() {
+			try {
+				const t = video.currentTime;
+				for (let i = 0; i < sb.buffered.length; i++) {
+					if (t >= sb.buffered.start(i) - 0.25 && t <= sb.buffered.end(i))
+						return sb.buffered.end(i) - t;
+				}
+			} catch (e) { /* not ready */ }
+			return 0;
+		}
+
+		function covers(sec) {
+			try {
+				for (let i = 0; i < sb.buffered.length; i++)
+					if (sec >= sb.buffered.start(i) && sec < sb.buffered.end(i)) return true;
+			} catch (e) {}
+			return false;
+		}
+
+		function evict() {
+			try {
+				if (!sb.buffered.length) return;
+				const keep = video.currentTime - BEHIND;
+				if (keep > sb.buffered.start(0)) sb.remove(sb.buffered.start(0), keep);
+			} catch (e) { /* nothing to drop */ }
+		}
+
+		function fill() {
+			if (dead || !sb || sb.updating || busy) return;
+			if (reset) {
+				reset = false;
+				try { sb.remove(0, Infinity); return; } catch (e) { /* fall through */ }
+			}
+			if (want !== null && covers(want)) {
+				try { video.currentTime = want; } catch (e) {}
+				want = null;
+			}
+			if (cursor + 16 > size) {
+				// Every fragment is in. Say so, or the element treats the
+				// media as open-ended: currentTime runs on past the last
+				// buffered second, the page follows it out of the clip
+				// entirely, and a scrub back into the clip then looks like it
+				// was ignored.
+				try { if (ms && ms.readyState === 'open') ms.endOfStream(); } catch (e) {}
+				return;
+			}
+			if (bufferedAhead() > AHEAD) return;
+
+			busy = true;
+			const at = cursor;
+			read(at, Math.min(at + WINDOW, size) - 1).then(function (buf) {
+				if (dead || !sb) { busy = false; return; }
+				const f = IDX.parseFragment(buf);
+				// The tail of a clip still being recorded: headers on the card,
+				// payload not yet. Stop rather than append something partial.
+				if (!f || f.short || !f.total || at + f.total > size) { busy = false; return; }
+				const whole = f.total <= buf.length
+					? Promise.resolve(buf.subarray(0, f.total))
+					: read(at, at + f.total - 1);
+				return whole.then(function (bytes) {
+					if (dead || !sb) { busy = false; return; }
+					cursor = at + f.total;
+					try { sb.appendBuffer(bytes); } catch (e) { evict(); }
+					busy = false;
+				});
+			}).catch(function () { busy = false; });
+		}
+
+		return {
+			attach: function (url, initInfo, clipSize, mime) {
+				read = IDX.reader(url); size = clipSize;
+				headerLen = initInfo.headerLength; cursor = initInfo.firstMoof;
+				dead = false; busy = false; reset = false; want = null;
+				ms = new MediaSource();
+				objUrl = URL.createObjectURL(ms);
+				video.src = objUrl;
+				ms.addEventListener('sourceopen', function () {
+					try { sb = ms.addSourceBuffer(mime); } catch (e) { return onFallback(); }
+					sb.addEventListener('updateend', function () { evict(); fill(); });
+					read(0, headerLen - 1).then(function (head) {
+						if (dead || !sb) return;
+						try { sb.appendBuffer(head); } catch (e) { onFallback(); }
+					});
+				}, { once: true });
+
+				// A pre-tfdt recording buffers nothing and says almost nothing
+				// about why. What it does NOT do is fail the append: appendBuffer
+				// returns fine and the parse gives up afterwards, so "did we
+				// append" is not the question — "is there anything in the
+				// buffer" is. Give it a moment, then hand the clip to a plain
+				// element rather than leave a black frame and no explanation.
+				watchdog = setTimeout(function () {
+					if (dead) return;
+					let has = 0;
+					try { has = sb ? sb.buffered.length : 0; } catch (e) {}
+					if (!has) onFallback();
+				}, 5000);
+			},
+			// Whether the SourceBuffer ever accepted anything. The difference
+			// between "this media is not appendable" and "something went wrong
+			// just now" — only the first is worth abandoning MSE over.
+			hasData: function () {
+				try { return sb ? sb.buffered.length > 0 : false; } catch (e) { return false; }
+			},
+			seekTo: function (off, sec) {
+				want = sec;
+				if (covers(sec)) {
+					try { video.currentTime = sec; } catch (e) {}
+					want = null;
+					return;
+				}
+				cursor = off;
+				reset = true;
+				fill();
+			},
+			destroy: function () {
+				dead = true;
+				clearTimeout(watchdog);
+				try { if (sb && ms && ms.readyState === 'open') ms.removeSourceBuffer(sb); } catch (e) {}
+				try { if (ms && ms.readyState === 'open') ms.endOfStream(); } catch (e) {}
+				if (objUrl) { try { URL.revokeObjectURL(objUrl); } catch (e) {} }
+				sb = null; ms = null; objUrl = null;
+				// Let go of the revoked blob too, or the element raises an
+				// error for a source that no longer exists — which the page
+				// would otherwise read as the clip being unplayable.
+				try { video.removeAttribute('src'); video.load(); } catch (e) {}
+			},
+		};
+	}
 
 	// ---- opening a clip --------------------------------------------------
 
@@ -140,6 +292,7 @@
 		state.hint = null;
 		const url = fileUrl(clipPath(clip.name));
 
+		if (player) { player.destroy(); player = null; }
 		setStatus('Reading clip header…');
 
 		const read = IDX.reader(url);
@@ -169,7 +322,12 @@
 			state.mime = mime;
 			setStatus('');
 
-			video.src = url;
+			if ('MediaSource' in window && MediaSource.isTypeSupported(mime)) {
+				player = mkPlayer(video, function () { plainFallback(clip, url); });
+				player.attach(url, init, clip.size, mime);
+			} else {
+				video.src = url;
+			}
 			positionAt(atSec || 0);
 			video.play().catch(function () { /* autoplay policy; controls remain */ });
 
@@ -182,13 +340,45 @@
 		});
 	}
 
-	// Move to a moment inside the clip that is already open. The element does
-	// its own seeking over Range; the clips carry no index, so how quickly it
-	// gets there is the browser's business and not something the page can aim.
+	// Move to a moment inside the clip that is already open.
+	//
+	// With a player attached this is a lookup, not a request to search: locate()
+	// reads tfdt to find the byte the fragment starts at, in about ten range
+	// reads, and the player appends from there. Without one — no MSE, or a
+	// pre-tfdt recording that fell back — the element seeks for itself.
 	function positionAt(sec) {
 		const video = $id('rec-video');
 		if (!video) return;
-		try { video.currentTime = Math.max(0, sec); } catch (e) { /* not ready yet */ }
+		if (!player || !state.init) {
+			try { video.currentTime = Math.max(0, sec); } catch (e) { /* not ready */ }
+			return;
+		}
+		const clip = state.clip, init = state.init;
+		const per = state.hint ? state.hint.perFragment : 1;
+		const token = ++seekToken;
+		IDX.locate(IDX.reader(fileUrl(clipPath(clip.name))), clip.size, init, sec, per)
+			.then(function (hit) {
+				// A drag fires many of these; only the newest may move the
+				// picture, or it lands wherever the slowest lookup finished.
+				if (token !== seekToken || state.clip !== clip || !player) return;
+				player.seekTo(hit.off, Math.max(sec, hit.approxSec));
+			}).catch(function () { /* stay where we are */ });
+	}
+
+	// DEPRECATED, REMOVE AFTER 2029-01 — see the note above mkPlayer.
+	//
+	// A recording with no tfdt cannot go through a SourceBuffer at all. Hand it
+	// to the element instead of leaving a black frame: it plays these fine, it
+	// just has to find its own way to a seek.
+	function plainFallback(clip, url) {
+		if (!player || state.clip !== clip) return;
+		player.destroy();
+		player = null;
+		const video = $id('rec-video');
+		if (!video) return;
+		const at = video.currentTime || 0;
+		video.src = url + (at > 0.5 ? '#t=' + at.toFixed(2) : '');
+		video.play().catch(function () {});
 	}
 
 	// ---- storage ---------------------------------------------------------
@@ -255,9 +445,19 @@
 		IDX.durationHint(IDX.reader(url), clip.size, init).then(function (h) {
 			if (!h || state.clip !== clip) return;
 			state.hint = h;
-			if (TL.applyExactDuration(state.day, clip.name, h.seconds)) {
-				renderClips();
-				renderTimeline();
+			if (!TL.applyExactDuration(state.day, clip.name, h.seconds)) return;
+			renderClips();
+			renderTimeline();
+
+			// Until this landed the clip's length was a guess — the configured
+			// split, or the gap to the next clip. A clip cut short by a reboot
+			// is much shorter than that guess, so the playhead can be sitting
+			// past the end of footage that does not exist. Pull it back to the
+			// last moment there is, and re-aim the player at it.
+			if (state.playhead > clip.end - 0.5) {
+				state.playhead = Math.max(clip.start, clip.end - 0.5);
+				centreView(state.playhead);
+				positionAt(state.playhead - clip.start);
 			}
 		});
 	}
@@ -631,8 +831,15 @@
 		});
 		v.addEventListener('error', function () {
 			if (!state.clip) return;
+			const url = fileUrl(clipPath(state.clip.name));
+			// While MSE is driving and nothing has ever buffered, the
+			// SourceBuffer could not make sense of the media — a pre-tfdt
+			// recording, most likely — and the plain element has no such
+			// trouble. If data HAS buffered, the error is something else and
+			// throwing away a working player would only make it worse.
+			if (player && !player.hasData()) { plainFallback(state.clip, url); return; }
 			note('Playback stopped on <code>' + esc(state.clip.name) + '</code>. ' +
-				'<a href="' + esc(fileUrl(clipPath(state.clip.name))) + '" download>Save the clip</a> instead.', 'danger');
+				'<a href="' + esc(url) + '" download>Save the clip</a> instead.', 'danger');
 		});
 
 		const dl = $id('rec-dl');

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -1,0 +1,695 @@
+// Recordings browser: a day of footage as one scrubbable timeline.
+//
+// The page it replaces was "SD Card -> Browse files", which drops you in a
+// whole-device file manager holding a folder of 400 MB clips named 12-04.mp4.
+// Everything here exists to answer the question people actually arrive with —
+// what happened around half past twelve — rather than which file to open.
+//
+// Three modules, split by what can be silently wrong:
+//   timeline.js   places clips on the day and works out coverage and gaps
+//   mp4index.js   recovers byte<->time from clips that carry no seek index
+//   this file     the DOM, the player and the export
+//
+// Nothing here streams media through a CGI. Clips are fetched from their own
+// filesystem path, where majestic answers with sendfile and honours Range for
+// the browser's authenticated session; j/download.cgi would cat a whole
+// recording into the connection buffer and take the camera's RAM with it.
+(function () {
+	'use strict';
+
+	const IDX = window.MajesticMp4Index;
+	const TL = window.MajesticTimeline;
+	const DAY = TL.DAY;
+
+	// How much of the day the detail band shows, and the steps the zoom takes.
+	const ZOOMS = [15 * 60, 30 * 60, 3600, 3 * 3600, 6 * 3600, DAY];
+	let zoom = 2;                     // index into ZOOMS -> one hour
+
+	const state = {
+		cfg: {}, prefix: '', split: 1200, enabled: false,
+		offsetMs: 0, nowSec: null, today: '',
+		days: [], dayName: '', day: { clips: [], unplaced: [] },
+		view: { from: 0, to: 3600, width: 3600 },
+		playhead: 0, sel: null,
+		clip: null, mime: null, init: null, hint: null,
+	};
+
+
+	const $id = function (s) { return document.getElementById(s); };
+	function esc(s) {
+		return String(s).replace(/[&<>"]/g, function (c) {
+			return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+		});
+	}
+	// Same reasoning as files.js: majestic serves the absolute path, so the
+	// URL is the path with each component encoded.
+	function fileUrl(p) { return p.split('/').map(encodeURIComponent).join('/'); }
+	function clipPath(name) {
+		const d = state.dayName === '.' ? state.prefix : state.prefix + '/' + state.dayName;
+		return (d + '/' + name).replace(/\/{2,}/g, '/');
+	}
+
+	function note(html, kind) {
+		const n = $id('rec-note');
+		if (!n) return;
+		n.className = html ? 'alert alert-' + (kind || 'secondary') : 'd-none';
+		n.innerHTML = html || '';
+	}
+
+	// ---- loading ---------------------------------------------------------
+
+	function loadPulse() {
+		return apiFetch('/cgi-bin/j/pulse.cgi', { credentials: 'same-origin' })
+			.then(function (r) { return r.json(); })
+			.then(function (j) {
+				const off = parseTzOffsetMs(j.utc_offset);   // main.js; null if unusable
+				state.offsetMs = off === null ? 0 : off;
+				const nowMs = (+j.time_now || 0) * 1000 + state.offsetMs;
+				const d = new Date(nowMs);
+				// Read the shifted instant as if it were UTC — the camera's wall
+				// clock, which is what records.path %F and %H-%M are stamped in.
+				state.today = d.toISOString().slice(0, 10);
+				state.nowSec = d.getUTCHours() * 3600 + d.getUTCMinutes() * 60 + d.getUTCSeconds();
+			})
+			.catch(function () { /* the page still works without a clock */ });
+	}
+
+	function loadConfig() {
+		return apiFetch('/api/v1/config.json', { credentials: 'same-origin' })
+			.then(function (r) { return r.ok ? r.json() : {}; }).catch(function () { return {}; })
+			.then(function (c) {
+				state.cfg = c;
+				state.enabled = mjGet(c, 'records.enabled') === true;
+				state.prefix = (mjGet(c, 'records.path') || '').split('%')[0].replace(/\/+$/, '');
+				const sp = +mjGet(c, 'records.split');
+				state.split = sp > 0 ? sp * 60 : 1200;
+			});
+	}
+
+	function api(qs) {
+		return apiFetch('/cgi-bin/j/recordings.cgi?' + qs, { credentials: 'same-origin' })
+			.then(function (r) { return r.json(); });
+	}
+
+	function loadDays() {
+		if (!state.prefix) return Promise.resolve();
+		return api('days=1&prefix=' + encodeURIComponent(state.prefix))
+			.then(function (j) { state.days = (j && j.days) || []; })
+			.catch(function () { state.days = []; });
+	}
+
+	function loadDay(name) {
+		state.dayName = name;
+		return api('day=' + encodeURIComponent(name) + '&prefix=' + encodeURIComponent(state.prefix))
+			.then(function (j) {
+				const isToday = (name === state.today) ||
+					(name === '.' && state.nowSec !== null);
+				state.day = TL.buildDay((j && j.clips) || [], {
+					splitSec: state.split,
+					nowSec: isToday ? state.nowSec : null,
+				});
+			})
+			.catch(function () { state.day = { clips: [], unplaced: [] }; });
+	}
+
+	// ---- the player ------------------------------------------------------
+	//
+	// A plain <video> element pointed at the clip's own URL, and that is
+	// deliberate. The obvious ambition was MSE fed from the fragment index —
+	// jump the byte cursor, append from there, seek instantly. It does not work
+	// on these files: appending majestic's fragments to a SourceBuffer leaves
+	// `buffered` empty and raises an error on the SourceBuffer, in every
+	// combination of segments/sequence mode and timestampOffset tried, while an
+	// ffmpeg-authored fragmented MP4 appends to the same SourceBuffer fine. The
+	// same camera clips play perfectly in a plain element (3840x2160 decoded),
+	// and majestic serves Range properly, so the element can seek on its own.
+	//
+	// Shipping the MSE path would have meant shipping a black player — precisely
+	// the failure this page exists to remove. The index is still what makes the
+	// page work; it just serves the timeline and the export rather than playback.
+	// See docs in mp4index.js for what each lookup costs.
+
+	// ---- opening a clip --------------------------------------------------
+
+	function openClip(clip, atSec) {
+		const video = $id('rec-video');
+		if (!video || !clip) return;
+		state.clip = clip;
+		state.init = null;
+		state.hint = null;
+		const url = fileUrl(clipPath(clip.name));
+
+		setStatus('Reading clip header…');
+
+		const read = IDX.reader(url);
+		// 64 KiB is generous for ftyp + moov, so the codec probe and the init
+		// parse share one request.
+		read(0, 65535).then(function (head) {
+			if (state.clip !== clip) return;          // switched away mid-flight
+			const init = IDX.parseInit(head);
+			if (!init) throw new Error('not a fragmented MP4');
+			state.init = init;
+
+			const codec = codecFromHeader(head);
+			const mime = 'video/mp4; codecs="' + (codec || 'avc1.42E01E') + '"';
+
+			// An unplayable codec does not raise `error` on a <video>: H.265
+			// parses, reports a duration and then sits at videoWidth 0 forever.
+			// So ask before committing anything to the screen.
+			if (codec && !video.canPlayType(mime)) {
+				const family = /^(hvc1|hev1)/.test(codec) ? 'H.265 (HEVC)' : codec.split('.')[0];
+				setStatus('');
+				note('<strong>' + family + ' — this browser cannot decode it.</strong> ' +
+					'Save the clip and play it in VLC, or record the main stream as H.264. ' +
+					'<a href="mj-settings.cgi?tab=video0">Stream settings</a>', 'warning');
+				return;
+			}
+			note('');
+			state.mime = mime;
+			setStatus('');
+
+			video.src = url;
+			positionAt(atSec || 0);
+			video.play().catch(function () { /* autoplay policy; controls remain */ });
+
+			// Two reads to turn the clip list's estimate into a real length.
+			hintDuration(url, clip, init);
+		}).catch(function (e) {
+			setStatus('');
+			note('Could not open <code>' + esc(clip.name) + '</code> — ' + esc(e.message || 'unreadable') +
+				'. <a href="' + esc(url) + '" download>Save the clip</a> and play it locally.', 'danger');
+		});
+	}
+
+	// Move to a moment inside the clip that is already open. The element does
+	// its own seeking over Range; the clips carry no index, so how quickly it
+	// gets there is the browser's business and not something the page can aim.
+	function positionAt(sec) {
+		const video = $id('rec-video');
+		if (!video) return;
+		try { video.currentTime = Math.max(0, sec); } catch (e) { /* not ready yet */ }
+	}
+
+	// ---- storage ---------------------------------------------------------
+
+	// Same numbers and the same bar as the SD card page, because it is the same
+	// question asked from the other side: how much footage is there, and how
+	// much room is left before the oldest of it is deleted.
+	function loadStorage() {
+		if (!state.prefix) return;
+		apiFetch('/cgi-bin/j/sdcard.cgi?rec=' + encodeURIComponent(state.prefix),
+			{ credentials: 'same-origin' })
+			.then(function (r) { return r.json(); })
+			.then(function (d) {
+				if (!d || !d.mounted || !d.totalKb) return;
+				const card = $id('rec-storage-card'), el = $id('rec-storage');
+				if (!card || !el) return;
+				const total = d.totalKb * 1024, used = d.usedKb * 1024;
+				const rec = Math.min(d.recBytes || 0, used);
+				const other = Math.max(0, used - rec), free = Math.max(0, total - used);
+				const seg = function (b, c) {
+					return b > 0 ? '<div class="seg" style="width:' + (b / total * 100).toFixed(2) +
+						'%;background:' + c + '"></div>' : '';
+				};
+				const dot = function (c) {
+					return '<span class="dot" style="background:' + c + '"></span>';
+				};
+				// How much longer the card can record, from what this day's
+				// footage actually costs per second.
+				const day = state.day.clips.reduce(function (a, c) { return a + c.dur; }, 0);
+				const bytes = state.day.clips.reduce(function (a, c) { return a + c.size; }, 0);
+				const left = (day > 0 && bytes > 0)
+					? ' · about ' + TL.duration(free / (bytes / day)) + ' of footage left' : '';
+
+				card.hidden = false;
+				el.innerHTML =
+					'<div class="d-flex justify-content-between x-small mb-1">' +
+					'<span class="fw-semibold">Storage</span>' +
+					'<span class="text-secondary">' + TL.bytes(used) + ' of ' + TL.bytes(total) + ' used' +
+					esc(left) + '</span></div>' +
+					'<div class="storage-bar mb-2">' + seg(rec, '#4c60d8') + seg(other, '#e08a3c') + '</div>' +
+					'<div class="storage-legend x-small">' +
+					'<span>' + dot('#4c60d8') + 'Recordings <span class="text-secondary">' + TL.bytes(rec) + '</span></span>' +
+					'<span>' + dot('#e08a3c') + 'Other <span class="text-secondary">' + TL.bytes(other) + '</span></span>' +
+					'<span><span class="dot dot-free"></span>Free <span class="text-secondary">' + TL.bytes(free) + '</span></span>' +
+					(mjGet(state.cfg, 'records.maxUsage')
+						? '<span class="text-secondary">oldest clips deleted at ' +
+						esc(String(mjGet(state.cfg, 'records.maxUsage'))) + ' %</span>' : '') +
+					'</div>';
+			}).catch(function () { /* the page is useful without it */ });
+	}
+
+	// Where a day should open: the freshest footage in it, not the oldest.
+	// Landing on 06:00 when the camera has been running all day means watching
+	// the wrong end of the archive.
+	function freshest() {
+		const list = state.day.clips;
+		if (!list.length) return 0;
+		const last = list[list.length - 1];
+		return Math.max(last.start, last.end - 60);
+	}
+
+	// Turn the clip list's estimate into a measured length, in two reads.
+	function hintDuration(url, clip, init) {
+		IDX.durationHint(IDX.reader(url), clip.size, init).then(function (h) {
+			if (!h || state.clip !== clip) return;
+			state.hint = h;
+			if (TL.applyExactDuration(state.day, clip.name, h.seconds)) {
+				renderClips();
+				renderTimeline();
+			}
+		});
+	}
+
+	function setStatus(t) {
+		const s = $id('rec-status');
+		if (s) s.textContent = t || '';
+	}
+
+	// ---- codec probe (shared shape with files.js) ------------------------
+
+	function fourcc(u8, i) { return String.fromCharCode(u8[i], u8[i + 1], u8[i + 2], u8[i + 3]); }
+	function codecFromHeader(u8) {
+		const moov = IDX.findBox(u8, 0, u8.length, 'moov');
+		if (!moov) return null;
+		const hex = function (n) { return n.toString(16).padStart(2, '0'); };
+		for (let i = moov[0] + 8; i < moov[1] - 4; i++) {
+			const t = fourcc(u8, i);
+			if (t === 'hvc1' || t === 'hev1') return t + '.1.6.L93.B0';
+			if (t === 'av01') return 'av01.0.05M.08';
+			if (t === 'avc1' || t === 'avc3') {
+				// the avcC that follows carries profile/compat/level verbatim
+				for (let j = i; j < moov[1] - 8; j++) {
+					if (fourcc(u8, j) === 'avcC') return t + '.' + hex(u8[j + 5]) + hex(u8[j + 6]) + hex(u8[j + 7]);
+				}
+				return t + '.42E01E';
+			}
+		}
+		return null;
+	}
+
+	// ---- rendering -------------------------------------------------------
+
+	function pct(sec, view) { return ((sec - view.from) / view.width * 100); }
+
+	function renderTimeline() {
+		const strip = $id('rec-strip'), band = $id('rec-band');
+		if (!strip || !band) return;
+		const cov = TL.coverage(state.day);
+		const view = state.view;
+
+		// whole day
+		let h = '';
+		cov.forEach(function (c) {
+			h += '<div class="seg" style="left:' + (c.from / DAY * 100).toFixed(3) + '%;width:' +
+				((c.to - c.from) / DAY * 100).toFixed(3) + '%"></div>';
+		});
+		h += '<div class="rec-win" style="left:' + (view.from / DAY * 100).toFixed(3) + '%;width:' +
+			(view.width / DAY * 100).toFixed(3) + '%"></div>';
+		strip.innerHTML = h;
+
+		// detail band
+		let b = '';
+		cov.forEach(function (c) {
+			if (c.to <= view.from || c.from >= view.to) return;
+			const a = Math.max(c.from, view.from), z = Math.min(c.to, view.to);
+			b += '<div class="seg" style="left:' + pct(a, view).toFixed(3) + '%;width:' +
+				((z - a) / view.width * 100).toFixed(3) + '%"></div>';
+		});
+		// clip boundaries, so it is clear where one file ends and the next starts
+		state.day.clips.forEach(function (c) {
+			if (c.start <= view.from || c.start >= view.to) return;
+			b += '<div class="rec-edge" style="left:' + pct(c.start, view).toFixed(3) + '%"></div>';
+		});
+		if (state.sel) {
+			const a = Math.max(state.sel.from, view.from), z = Math.min(state.sel.to, view.to);
+			if (z > a) {
+				b += '<div class="rec-sel" style="left:' + pct(a, view).toFixed(3) + '%;width:' +
+					((z - a) / view.width * 100).toFixed(3) + '%"></div>';
+			}
+		}
+		if (state.playhead >= view.from && state.playhead <= view.to) {
+			b += '<div class="rec-head" style="left:' + pct(state.playhead, view).toFixed(3) + '%">' +
+				'<span class="rec-head-t">' + TL.hhmm(state.playhead) + '</span></div>';
+		}
+		band.innerHTML = b;
+
+		renderTicks();
+		renderSelection();
+		const lbl = $id('rec-view-label');
+		if (lbl) lbl.textContent = TL.hhmm(view.from) + ' – ' + TL.hhmm(view.to);
+	}
+
+	function renderTicks() {
+		const el = $id('rec-ticks');
+		if (!el) return;
+		const view = state.view, out = [];
+		for (let i = 0; i <= 4; i++) out.push(TL.hhmm(view.from + view.width * i / 4));
+		el.innerHTML = out.map(function (t) { return '<span>' + t + '</span>'; }).join('');
+	}
+
+	// The part of a selection that can actually be saved. An export is whole
+	// fragments out of ONE clip, so a drag running past the open clip saves
+	// less than it covers — report the trimmed range, or the bar promises
+	// footage the file does not contain.
+	function selectionSpan() {
+		if (!state.sel || !state.clip) return null;
+		const clip = state.clip;
+		const a = Math.max(state.sel.from, clip.start);
+		const b = Math.min(state.sel.to, clip.end);
+		if (b - a < 0.5) return null;                 // no overlap with this clip
+		return {
+			from: a, to: b, seconds: b - a,
+			// Size is estimated from the clip's own average bitrate. Knowing it
+			// exactly would mean indexing the span first, which is the work the
+			// Save button is for — a number is more use here than a spinner.
+			bytes: clip.dur > 0 ? Math.round(clip.size / clip.dur * (b - a)) : 0,
+			clipped: state.sel.from < clip.start - 0.5 || state.sel.to > clip.end + 0.5,
+		};
+	}
+
+	function renderSelection() {
+		const bar = $id('rec-export');
+		if (!bar) return;
+		if (!state.sel || state.sel.to - state.sel.from < 1) { bar.className = 'd-none'; return; }
+		const s = selectionSpan();
+		bar.className = 'rec-export';
+		if (!s) {
+			bar.innerHTML = '<div class="x-small text-secondary">' +
+				'Selection is outside the clip being played — pick a moment inside it first.</div>';
+			return;
+		}
+		bar.innerHTML =
+			'<div><div class="font-monospace fw-semibold">' + TL.clock(s.from) + ' – ' + TL.clock(s.to) + '</div>' +
+			'<div class="x-small text-secondary" id="rec-sel-note">' + TL.duration(s.seconds) +
+			' · about ' + TL.bytes(s.bytes) + ' · saved without re-encoding' +
+			(s.clipped ? ' · trimmed to this clip' : '') + '</div></div>' +
+			'<div class="mj-push-end d-flex gap-2">' +
+			'<button class="btn btn-sm btn-outline-secondary" id="rec-sel-clear" type="button">Clear</button>' +
+			'<button class="btn btn-sm btn-primary" id="rec-sel-save" type="button">Save clip</button></div>';
+		$id('rec-sel-clear').addEventListener('click', function () { state.sel = null; renderTimeline(); });
+		$id('rec-sel-save').addEventListener('click', saveSelection);
+	}
+
+	function renderClips() {
+		const el = $id('rec-clips');
+		if (!el) return;
+		const list = state.day.clips;
+		if (!list.length) {
+			el.innerHTML = '<div class="text-secondary small">No clips in this day.</div>';
+			return;
+		}
+		let h = '';
+		// newest first: that is the one people want
+		list.slice().reverse().forEach(function (c, i, arr) {
+			const prev = arr[i + 1];
+			if (prev && c.start - prev.end > TL.JOIN_TOLERANCE) {
+				h += '<div class="rec-gap"><span>not recording · ' +
+					TL.hhmm(prev.end) + ' – ' + TL.hhmm(c.start) + '</span></div>';
+			}
+			const on = state.clip && state.clip.name === c.name;
+			h += '<button type="button" class="rec-clip' + (on ? ' active' : '') + '" data-clip="' + esc(c.name) + '">' +
+				'<span class="rec-poster"' + (c.recording ? ' data-live="1"' : '') + '>' +
+				'<span class="rec-poster-t">' + TL.hhmm(c.start) + '</span></span>' +
+				'<span class="rec-clip-m"><span class="font-monospace fw-semibold">' + TL.hhmm(c.start) + '</span>' +
+				'<span class="x-small text-secondary">' +
+				(c.recording ? 'recording' : (c.estimated ? '≈ ' : '') + TL.duration(c.dur)) +
+				' · ' + TL.bytes(c.size) + '</span></span></button>';
+		});
+		if (state.day.unplaced.length) {
+			h += '<div class="rec-gap"><span>' + state.day.unplaced.length +
+				' clip(s) whose name has no time</span></div>';
+			state.day.unplaced.forEach(function (c) {
+				h += '<button type="button" class="rec-clip" data-clip="' + esc(c.name) + '">' +
+					'<span class="rec-poster"><span class="rec-poster-t">?</span></span>' +
+					'<span class="rec-clip-m"><span class="font-monospace fw-semibold">' + esc(c.name) + '</span>' +
+					'<span class="x-small text-secondary">' + TL.bytes(c.size) + '</span></span></button>';
+			});
+		}
+		el.innerHTML = h;
+	}
+
+	function renderDayNav() {
+		const el = $id('rec-daynav');
+		if (!el) return;
+		const i = state.days.map(function (d) { return d.name; }).indexOf(state.dayName);
+		const prev = i > 0 ? state.days[i - 1].name : '';
+		const next = i >= 0 && i < state.days.length - 1 ? state.days[i + 1].name : '';
+		const label = state.dayName === '.' ? 'All recordings' : state.dayName;
+		const total = state.day.clips.reduce(function (a, c) { return a + c.dur; }, 0);
+
+		el.innerHTML =
+			'<button class="btn btn-sm btn-outline-secondary" id="rec-prev" type="button"' +
+			(prev ? '' : ' disabled') + ' aria-label="Previous day">&lsaquo;</button>' +
+			'<select class="form-select form-select-sm rec-daypick" id="rec-daysel">' +
+			state.days.map(function (d) {
+				return '<option value="' + esc(d.name) + '"' + (d.name === state.dayName ? ' selected' : '') + '>' +
+					esc(d.name === '.' ? 'All recordings' : d.name) + ' — ' + d.clips + ' clip' + (d.clips === 1 ? '' : 's') +
+					'</option>';
+			}).join('') + '</select>' +
+			'<button class="btn btn-sm btn-outline-secondary" id="rec-next" type="button"' +
+			(next ? '' : ' disabled') + ' aria-label="Next day">&rsaquo;</button>' +
+			'<span class="small text-secondary">' + state.day.clips.length + ' clips · ' + TL.duration(total) + '</span>' +
+			(state.enabled
+				? '<span class="mj-push-end badge text-bg-success">Recording</span>'
+				: '<span class="mj-push-end badge text-bg-secondary">Recording off</span>') +
+			'<span class="small text-secondary">' + esc(label) + '</span>';
+
+		if (prev) $id('rec-prev').addEventListener('click', function () { goDay(prev); });
+		if (next) $id('rec-next').addEventListener('click', function () { goDay(next); });
+		$id('rec-daysel').addEventListener('change', function (e) { goDay(e.target.value); });
+	}
+
+	// ---- export ----------------------------------------------------------
+
+	// A clip is the init segment followed by whole fragments, so an export is a
+	// byte concatenation — no transcoding, and the camera only ever sendfiles
+	// the ranges it is asked for.
+	// Assemble the selection as a real file, without re-encoding it.
+	//
+	// Fragments are self-contained, so the clip is the init segment followed by
+	// whole fragments — a byte concatenation. Only the selected span is indexed
+	// (spanFrom), so a one-minute cut costs about sixty small reads instead of
+	// the eleven hundred a whole-clip index would.
+	function saveSelection() {
+		const btn = $id('rec-sel-save'), noteEl = $id('rec-sel-note');
+		const clip = state.clip, init = state.init;
+		const s = selectionSpan();
+		if (!s || !btn || !init) return;
+
+		btn.disabled = true;
+		btn.textContent = 'Saving…';
+		const read = IDX.reader(fileUrl(clipPath(clip.name)));
+		const per = state.hint ? state.hint.perFragment : 1;
+
+		IDX.locate(read, clip.size, init, s.from - clip.start, per).then(function (hit) {
+			return IDX.spanFrom(read, clip.size, init, hit.off, s.seconds, function (got, want) {
+				if (noteEl) noteEl.textContent = 'Collecting ' + TL.duration(got) + ' of ' + TL.duration(want) + '…';
+			});
+		}).then(function (span) {
+			if (!span.fragments.length) throw new Error('no fragments in range');
+			const r = IDX.exportRanges(span, 0, span.duration);
+			if (noteEl) noteEl.textContent = 'Fetching ' + TL.bytes(r.bytes) + '…';
+			return Promise.all([
+				read(r.header.start, r.header.end - 1),
+				read(r.body.start, r.body.end - 1),
+			]).then(function (parts) { return { parts: parts, span: span, r: r }; });
+		}).then(function (o) {
+			const blob = new Blob(o.parts, { type: 'video/mp4' });
+			const a = document.createElement('a');
+			a.href = URL.createObjectURL(blob);
+			a.download = (state.dayName === '.' ? '' : state.dayName + '_') +
+				TL.hhmm(s.from).replace(':', '-') + '_' +
+				TL.hhmm(s.from + o.span.duration).replace(':', '-') + '.mp4';
+			document.body.appendChild(a);
+			a.click();
+			a.remove();
+			setTimeout(function () { URL.revokeObjectURL(a.href); }, 30000);
+			btn.disabled = false;
+			btn.textContent = 'Save clip';
+			if (noteEl) {
+				noteEl.textContent = 'Saved ' + TL.duration(o.span.duration) + ' · ' +
+					TL.bytes(blob.size) + ' · ' + o.span.fragments.length + ' fragments, not re-encoded';
+			}
+		}).catch(function () {
+			btn.disabled = false;
+			btn.textContent = 'Save clip';
+			note('Could not assemble the clip — the card may be busy. Try a shorter range.', 'danger');
+		});
+	}
+
+	// ---- interaction -----------------------------------------------------
+
+	function secAtEvent(el, e) {
+		const r = el.getBoundingClientRect();
+		const x = (e.touches ? e.touches[0].clientX : e.clientX) - r.left;
+		return Math.max(0, Math.min(1, x / r.width));
+	}
+
+	function goTo(sec) {
+		state.playhead = Math.max(0, Math.min(sec, DAY));
+		let hit = TL.at(state.day, state.playhead);
+		if (!hit) {
+			// Scrubbing over a hole: skip to the next footage rather than
+			// snapping to a neighbour, which would jump in time without saying
+			// so. One hop only — nextCovered lands on a covered instant, so a
+			// second miss means there is nothing to play and we just move the
+			// playhead.
+			const nxt = TL.nextCovered(state.day, state.playhead);
+			if (nxt === null) { renderTimeline(); return; }
+			state.playhead = nxt;
+			hit = TL.at(state.day, nxt);
+			if (!hit) { renderTimeline(); return; }
+		}
+		if (!state.clip || state.clip.name !== hit.clip.name) {
+			openClip(hit.clip, hit.offset);
+			renderClips();
+		} else {
+			positionAt(hit.offset);
+		}
+		renderTimeline();
+	}
+
+	function centreView(sec) {
+		state.view = TL.window(sec, ZOOMS[zoom]);
+		renderTimeline();
+	}
+
+	function wire() {
+		const strip = $id('rec-strip'), band = $id('rec-band');
+
+		// day strip: click or drag the window
+		let stripDrag = false;
+		const stripMove = function (e) {
+			centreView(secAtEvent(strip, e) * DAY);
+			e.preventDefault();
+		};
+		strip.addEventListener('mousedown', function (e) { stripDrag = true; stripMove(e); });
+		strip.addEventListener('touchstart', function (e) { stripDrag = true; stripMove(e); }, { passive: false });
+		document.addEventListener('mousemove', function (e) { if (stripDrag) stripMove(e); });
+		document.addEventListener('touchmove', function (e) { if (stripDrag) stripMove(e); }, { passive: false });
+		document.addEventListener('mouseup', function () { stripDrag = false; });
+		document.addEventListener('touchend', function () { stripDrag = false; });
+
+		// detail band: drag scrubs, shift-drag selects a range to export
+		let mode = null, anchorSec = 0;
+		const bandSec = function (e) { return state.view.from + secAtEvent(band, e) * state.view.width; };
+		const bandDown = function (e) {
+			const s = bandSec(e);
+			if (e.shiftKey || e.altKey) { mode = 'sel'; anchorSec = s; state.sel = { from: s, to: s }; renderTimeline(); }
+			else { mode = 'scrub'; goTo(s); }
+			e.preventDefault();
+		};
+		const bandMove = function (e) {
+			if (!mode) return;
+			const s = bandSec(e);
+			if (mode === 'sel') {
+				state.sel = { from: Math.min(anchorSec, s), to: Math.max(anchorSec, s) };
+				renderTimeline();
+			} else { goTo(s); }
+			e.preventDefault();
+		};
+		band.addEventListener('mousedown', bandDown);
+		band.addEventListener('touchstart', bandDown, { passive: false });
+		document.addEventListener('mousemove', bandMove);
+		document.addEventListener('touchmove', bandMove, { passive: false });
+		document.addEventListener('mouseup', function () { mode = null; });
+		document.addEventListener('touchend', function () { mode = null; });
+
+		// wheel zooms the detail band around the pointer
+		band.addEventListener('wheel', function (e) {
+			const at = bandSec(e);
+			const was = zoom;
+			zoom = Math.max(0, Math.min(ZOOMS.length - 1, zoom + (e.deltaY > 0 ? 1 : -1)));
+			if (zoom !== was) { centreView(at); e.preventDefault(); }
+		}, { passive: false });
+
+		$id('rec-clips').addEventListener('click', function (e) {
+			const b = e.target.closest('[data-clip]');
+			if (!b) return;
+			const name = b.dataset.clip;
+			const c = state.day.clips.filter(function (x) { return x.name === name; })[0] ||
+				state.day.unplaced.filter(function (x) { return x.name === name; })[0];
+			if (!c) return;
+			if (c.start !== null && c.start !== undefined) {
+				state.playhead = c.start;
+				centreView(c.start);
+			}
+			openClip(c, 0);
+			renderClips();
+		});
+
+		const v = $id('rec-video');
+		v.addEventListener('timeupdate', function () {
+			if (!state.clip || state.clip.start === null) return;
+			const t = state.clip.start + v.currentTime;
+			// Only repaint when the playhead has actually moved a pixel's worth.
+			if (Math.abs(t - state.playhead) < state.view.width / 800) return;
+			state.playhead = t;
+			renderTimeline();
+		});
+		v.addEventListener('error', function () {
+			if (!state.clip) return;
+			note('Playback stopped on <code>' + esc(state.clip.name) + '</code>. ' +
+				'<a href="' + esc(fileUrl(clipPath(state.clip.name))) + '" download>Save the clip</a> instead.', 'danger');
+		});
+
+		const dl = $id('rec-dl');
+		if (dl) dl.addEventListener('click', function () {
+			if (!state.clip) return;
+			const a = document.createElement('a');
+			a.href = fileUrl(clipPath(state.clip.name));
+			a.download = state.clip.name;
+			document.body.appendChild(a); a.click(); a.remove();
+		});
+	}
+
+	function goDay(name) {
+		if (!name || name === state.dayName) return;
+		state.clip = null; state.init = null; state.hint = null; state.sel = null;
+		const v = $id('rec-video');
+		if (v) { try { v.removeAttribute('src'); v.load(); } catch (e) {} }
+		history.replaceState(null, '', location.pathname + '?day=' + encodeURIComponent(name));
+		loadDay(name).then(function () {
+			renderDayNav(); renderClips();
+			note('');
+			centreView(freshest());
+			goTo(freshest());
+		});
+	}
+
+	// ---- boot ------------------------------------------------------------
+
+	function empty(msg, cta) {
+		$id('rec-main').className = 'd-none';
+		note(msg + (cta || ''), 'secondary');
+	}
+
+	Promise.all([loadConfig(), loadPulse()]).then(function () {
+		if (!state.prefix) {
+			return empty('<strong>Recording is not configured.</strong> No recording path is set, so there is nothing to browse. ',
+				'<a href="tool-sdcard.cgi">Set up the SD card</a>.');
+		}
+		return loadDays().then(function () {
+			if (!state.days.length) {
+				return empty(state.enabled
+					? '<strong>Nothing recorded yet.</strong> Recording is on, but no clips have been written to <code>' + esc(state.prefix) + '</code> yet. '
+					: '<strong>Recording is off.</strong> The camera is not writing to the card, so there is nothing to browse. ',
+					'<a href="tool-sdcard.cgi">SD card</a>');
+			}
+			const want = (/[?&]day=([^&]*)/.exec(location.search) || [])[1];
+			const asked = want ? decodeURIComponent(want) : '';
+			const names = state.days.map(function (d) { return d.name; });
+			const pick = names.indexOf(asked) >= 0 ? asked : names[names.length - 1];
+
+			return loadDay(pick).then(function () {
+				wire();
+				renderDayNav();
+				renderClips();
+				loadStorage();
+				centreView(freshest());
+				goTo(freshest());     // opens the clip, so the page is not a black box
+			});
+		});
+	});
+})();

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -114,20 +114,21 @@
 
 	// ---- the player ------------------------------------------------------
 	//
-	// A plain <video> element pointed at the clip's own URL, and that is
-	// deliberate. The obvious ambition was MSE fed from the fragment index —
-	// jump the byte cursor, append from there, seek instantly. It does not work
-	// on these files: appending majestic's fragments to a SourceBuffer leaves
-	// `buffered` empty and raises an error on the SourceBuffer, in every
-	// combination of segments/sequence mode and timestampOffset tried, while an
-	// ffmpeg-authored fragmented MP4 appends to the same SourceBuffer fine. The
-	// same camera clips play perfectly in a plain element (3840x2160 decoded),
-	// and majestic serves Range properly, so the element can seek on its own.
+	// A plain <video> element pointed at the clip's own URL, seeking on its own
+	// over the Range requests majestic serves.
 	//
-	// Shipping the MSE path would have meant shipping a black player — precisely
-	// the failure this page exists to remove. The index is still what makes the
-	// page work; it just serves the timeline and the export rather than playback.
-	// See docs in mp4index.js for what each lookup costs.
+	// An MSE path aimed by the fragment index would seek by byte offset rather
+	// than by asking the browser to find the moment, and it is a reasonable
+	// next step — but only reasonable, not necessary. A recording carries a
+	// tfdt in every fragment, so the element has the decode times it needs to
+	// seek without walking the file, and a plain element is a great deal less
+	// machinery to get wrong.
+	//
+	// What is worth remembering is why this is not MSE already: a SourceBuffer
+	// refuses a media segment that has no tfdt, outright and with an empty
+	// buffer. Recordings written before that box was added cannot be appended
+	// at all, however they are fed in — no mode, timestampOffset or codec
+	// string changes it — while the same files play in a plain element.
 
 	// ---- opening a clip --------------------------------------------------
 

--- a/www/a/timeline.js
+++ b/www/a/timeline.js
@@ -1,0 +1,194 @@
+// The day model behind the recordings timeline: turning a directory listing
+// into placed clips, coverage segments and gaps.
+//
+// Kept apart from the DOM (recordings.js) because this is the part that can be
+// quietly wrong. A clip placed a minute out still draws a perfectly convincing
+// ribbon, and a gap that fails to appear looks exactly like a camera that was
+// recording. tests/timeline.test.js pins the cases that bite: an unparseable
+// filename, a clip still being written, a day that ends mid-recording, and the
+// difference between "no footage" and "not looked yet".
+window.MajesticTimeline = (function () {
+	'use strict';
+
+	const DAY = 86400;
+	// Clips that abut within this much are one stretch of footage, not two.
+	// Majestic closes one file and opens the next in the same second, but the
+	// names only carry minutes, so anything under a minute is the same run.
+	const JOIN_TOLERANCE = 61;
+
+	// records.filename defaults to "%H-%M"; "%H-%M-%S" is the other spelling
+	// people set. Anything else we decline to place rather than guess, because
+	// a clip drawn at the wrong time is worse than a clip listed without one.
+	function startOfName(name) {
+		const m = /^(\d{2})-(\d{2})(?:-(\d{2}))?\./.exec(name);
+		if (!m) return null;
+		const h = +m[1], mi = +m[2], s = m[3] ? +m[3] : 0;
+		if (h > 23 || mi > 59 || s > 59) return null;
+		return h * 3600 + mi * 60 + s;
+	}
+
+	// Place a day's clips on a 0..86400 line.
+	//
+	// opts: { splitSec, nowSec }  — nowSec is seconds into THIS day, or null
+	// when the day being shown is not today. The last clip of today is still
+	// being written, so its end is now, not a full split.
+	function buildDay(clips, opts) {
+		const o = opts || {};
+		const split = o.splitSec > 0 ? o.splitSec : 1200;
+		const now = (typeof o.nowSec === 'number') ? o.nowSec : null;
+
+		const placed = [];
+		const unplaced = [];
+		(clips || []).forEach(function (c) {
+			const start = startOfName(c.name);
+			if (start === null) unplaced.push(Object.assign({}, c, { start: null }));
+			else placed.push(Object.assign({}, c, { start: start }));
+		});
+		placed.sort(function (a, b) { return a.start - b.start; });
+
+		placed.forEach(function (c, i) {
+			const next = placed[i + 1];
+			let end;
+			if (next && next.start - c.start <= split * 1.5) {
+				// Back-to-back: the next file opening IS this one closing. This
+				// is the only exact duration available before the clip is
+				// indexed, so prefer it over the configured split.
+				end = next.start;
+				c.estimated = false;
+			} else if (!next && now !== null) {
+				// The newest clip of today is still growing.
+				end = Math.min(c.start + split, Math.max(c.start, now));
+				c.estimated = true;
+				c.recording = end >= now - JOIN_TOLERANCE;
+			} else {
+				end = c.start + split;
+				c.estimated = true;
+			}
+			// A recording that runs past midnight is split by majestic at the
+			// date change, so nothing on this day may extend beyond it.
+			c.end = Math.min(end, DAY);
+			c.dur = Math.max(0, c.end - c.start);
+		});
+
+		return { clips: placed, unplaced: unplaced };
+	}
+
+	// Replace a clip's estimated duration with the exact one, once its index
+	// has been walked. Does not move anything else: clip starts come from
+	// filenames and are already exact.
+	function applyExactDuration(day, name, seconds) {
+		const c = day.clips.filter(function (x) { return x.name === name; })[0];
+		if (!c || !(seconds > 0)) return false;
+		c.dur = seconds;
+		c.end = Math.min(c.start + seconds, DAY);
+		c.estimated = false;
+		return true;
+	}
+
+	// Merge placed clips into the stretches of footage the ribbon draws.
+	function coverage(day) {
+		const out = [];
+		day.clips.forEach(function (c) {
+			if (c.dur <= 0) return;
+			const last = out[out.length - 1];
+			if (last && c.start - last.to <= JOIN_TOLERANCE) {
+				last.to = Math.max(last.to, c.end);
+				last.clips.push(c.name);
+			} else {
+				out.push({ from: c.start, to: c.end, clips: [c.name] });
+			}
+		});
+		return out;
+	}
+
+	// The holes between them — what the camera did not record. Only the holes
+	// *between* footage: before the first clip and after the last is "not
+	// recording yet", which is not the same thing and is not drawn as a gap.
+	function gaps(day) {
+		const cov = coverage(day);
+		const out = [];
+		for (let i = 1; i < cov.length; i++) {
+			out.push({ from: cov[i - 1].to, to: cov[i].from });
+		}
+		return out;
+	}
+
+	// Which clip covers a moment, and how far into it. Null outside footage —
+	// the caller shows that as a gap rather than snapping to a neighbour,
+	// because snapping makes a scrub over a hole silently jump in time.
+	function at(day, sec) {
+		const list = day.clips;
+		for (let i = 0; i < list.length; i++) {
+			if (sec >= list[i].start && sec < list[i].end) {
+				return { clip: list[i], offset: sec - list[i].start };
+			}
+		}
+		return null;
+	}
+
+	// The next moment that has footage at or after `sec`, for skipping a gap.
+	function nextCovered(day, sec) {
+		const cov = coverage(day);
+		for (let i = 0; i < cov.length; i++) {
+			if (sec < cov[i].from) return cov[i].from;
+			if (sec < cov[i].to) return sec;
+		}
+		return null;
+	}
+
+	// ---- the detail window ----------------------------------------------
+
+	// The zoomed span, clamped so it can never leave the day. Returned as
+	// [from, to] in seconds; `width` is its length.
+	function window_(centerSec, widthSec) {
+		const w = Math.max(60, Math.min(widthSec, DAY));
+		let from = centerSec - w / 2;
+		if (from < 0) from = 0;
+		if (from + w > DAY) from = DAY - w;
+		return { from: from, to: from + w, width: w };
+	}
+
+	// ---- formatting ------------------------------------------------------
+
+	function clock(sec) {
+		const s = Math.max(0, Math.min(Math.round(sec), DAY));
+		const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), ss = s % 60;
+		return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0') +
+			':' + String(ss).padStart(2, '0');
+	}
+	function hhmm(sec) { return clock(sec).slice(0, 5); }
+
+	function duration(sec) {
+		const s = Math.max(0, Math.round(sec));
+		if (s < 60) return s + ' s';
+		const m = Math.floor(s / 60), ss = s % 60;
+		if (m < 60) return ss ? m + ' min ' + ss + ' s' : m + ' min';
+		const h = Math.floor(m / 60), mm = m % 60;
+		return mm ? h + ' h ' + mm + ' min' : h + ' h';
+	}
+
+	function bytes(n) {
+		n = +n || 0;
+		if (n >= 1073741824) return (n / 1073741824).toFixed(1) + ' GB';
+		if (n >= 1048576) return (n / 1048576).toFixed(0) + ' MB';
+		if (n >= 1024) return (n / 1024).toFixed(0) + ' KB';
+		return n + ' B';
+	}
+
+	return {
+		DAY: DAY,
+		JOIN_TOLERANCE: JOIN_TOLERANCE,
+		startOfName: startOfName,
+		buildDay: buildDay,
+		applyExactDuration: applyExactDuration,
+		coverage: coverage,
+		gaps: gaps,
+		at: at,
+		nextCovered: nextCovered,
+		window: window_,
+		clock: clock,
+		hhmm: hhmm,
+		duration: duration,
+		bytes: bytes,
+	};
+})();

--- a/www/a/timeline.js
+++ b/www/a/timeline.js
@@ -73,15 +73,19 @@ window.MajesticTimeline = (function () {
 		return { clips: placed, unplaced: unplaced };
 	}
 
-	// Replace a clip's estimated duration with the exact one, once its index
-	// has been walked. Does not move anything else: clip starts come from
-	// filenames and are already exact.
-	function applyExactDuration(day, name, seconds) {
+	// Replace a clip's guessed duration with a measured one. Does not move
+	// anything else: clip starts come from filenames and are already exact.
+	//
+	// `exact` defaults to true but must be passed honestly. A recording with no
+	// tfdt can only be guessed at, and a guess that arrives here unlabelled
+	// silently loses the marker the clip list uses to say so — the number
+	// changes and the "about" qualifier disappears with it.
+	function applyExactDuration(day, name, seconds, exact) {
 		const c = day.clips.filter(function (x) { return x.name === name; })[0];
 		if (!c || !(seconds > 0)) return false;
 		c.dur = seconds;
 		c.end = Math.min(c.start + seconds, DAY);
-		c.estimated = false;
+		c.estimated = (exact === false);
 		return true;
 	}
 

--- a/www/cgi-bin/j/recordings.cgi
+++ b/www/cgi-bin/j/recordings.cgi
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Recordings browser backend: which days hold footage, and what is in one day.
+# GET ?days=1&prefix=<dir>      -> {"prefix":"…","days":[{name,clips,mtime}]}
+# GET ?day=<name>&prefix=<dir>  -> {"path":"…","clips":[{name,size,mtime}]}
+#
+# It never serves media, and must never be made to. The browser fetches a clip
+# straight off its filesystem path, where majestic answers with sendfile and
+# honours Range; routing a 400 MB recording through a CGI would cat it into the
+# connection buffer and take the camera's RAM with it. Everything here is
+# metadata only — names, sizes, mtimes.
+#
+# <prefix> comes from the client, which reads records.path out of
+# /api/v1/config.json and splits it at the first strftime %. Same arrangement as
+# j/sdcard.cgi's ?rec=, and for the same reason: no shell here has to parse YAML
+# or JSON to find out where recordings live.
+
+json_hdr() { printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Control: no-store\n\n'; }
+
+# Escape a string for embedding inside JSON quotes (drop control chars).
+json_str() { printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+
+json_hdr
+
+prefix=$(printf '%s' "${GET_prefix:-}" | sed 's#/*$##')
+if [ -z "$prefix" ] || [ ! -d "$prefix" ]; then
+	printf '{"error":"no recordings directory"}'
+	exit 0
+fi
+
+# Count the clips in a directory without stat-ing each one, and without a
+# subprocess: the day list is drawn for a whole card at once, and a month of
+# footage is a lot of files. `set --` does the glob, so $# is already the count.
+# An unmatched glob stays literal, which is what -e rules out.
+count_clips() {
+	set -- "$1"/*.mp4
+	[ -e "$1" ] || { echo 0; return; }
+	echo $#
+}
+
+if [ -n "$GET_days" ]; then
+	printf '{"prefix":"%s","days":[' "$(json_str "$prefix")"
+	first=1
+	# Day folders are records.path's %F, so their names sort chronologically.
+	# A prefix with no % in it records straight into the prefix instead; that
+	# shows up as the "." day so the page has something to select.
+	n=$(count_clips "$prefix")
+	if [ -n "$n" ] && [ "$n" -gt 0 ] 2>/dev/null; then
+		mt=$(stat -c '%Y' "$prefix" 2>/dev/null || echo 0)
+		printf '{"name":".","clips":%s,"mtime":%s}' "$n" "$mt"
+		first=0
+	fi
+	for d in "$prefix"/*/; do
+		[ -d "$d" ] || continue
+		name=$(basename "$d")
+		n=$(count_clips "$prefix/$name")
+		[ -n "$n" ] || continue
+		[ "$n" -gt 0 ] 2>/dev/null || continue
+		mt=$(stat -c '%Y' "$prefix/$name" 2>/dev/null || echo 0)
+		[ "$first" = 1 ] || printf ','
+		first=0
+		printf '{"name":"%s","clips":%s,"mtime":%s}' "$(json_str "$name")" "$n" "$mt"
+	done
+	printf ']}'
+	exit 0
+fi
+
+# One day. The name is a single path component under the prefix — never a path,
+# so a caller cannot walk out of the recordings directory with it.
+day="$GET_day"
+case "$day" in
+	.)         dir="$prefix" ;;
+	''|*/*|.*) printf '{"error":"bad day"}'; exit 0 ;;
+	*)         dir="$prefix/$day" ;;
+esac
+
+if [ ! -d "$dir" ]; then
+	printf '{"error":"no such day"}'
+	exit 0
+fi
+
+printf '{"path":"%s","clips":[' "$(json_str "$dir")"
+first=1
+for f in "$dir"/*.mp4; do
+	[ -f "$f" ] || continue
+	info=$(stat -c '%s|%Y' "$f" 2>/dev/null) || continue
+	sz=${info%%|*}; mt=${info#*|}
+	[ "$first" = 1 ] || printf ','
+	first=0
+	printf '{"name":"%s","size":%s,"mtime":%s}' "$(json_str "$(basename "$f")")" "$sz" "$mt"
+done
+printf ']}'

--- a/www/cgi-bin/j/recordings.cgi
+++ b/www/cgi-bin/j/recordings.cgi
@@ -21,7 +21,14 @@ json_str() { printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"
 
 json_hdr
 
-prefix=$(printf '%s' "${GET_prefix:-}" | sed 's#/*$##')
+# Where recordings live is majestic's business, not the caller's. This used to
+# take the directory from ?prefix=, which made an authenticated request able to
+# enumerate MP4 names, sizes and mtimes anywhere the web process can read —
+# never mind that the page only ever sent the configured path. A filesystem
+# path arriving from a client is not a permission, so derive it here and ignore
+# what was sent. Same value the page computes for itself: records.path up to the
+# first strftime %.
+prefix=$(yaml-cli -g .records.path 2>/dev/null | sed 's/%.*//; s#/*$##')
 if [ -z "$prefix" ] || [ ! -d "$prefix" ]; then
 	printf '{"error":"no recordings directory"}'
 	exit 0

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -84,6 +84,15 @@ Pragma: no-cache
 						</ul>
 					</li>	
 					<li class="nav-item"><a class="nav-link" href="preview.cgi">Preview</a></li>
+					<!-- Top level rather than under Tools: browsing an archive is a
+					     viewing job like Preview, not a maintenance one, and the
+					     File Manager route it replaces was the thing nobody found.
+					     Same card guard as the SDcard entry below — a camera with
+					     no card cannot record, so the page would only ever show its
+					     empty state. -->
+					<% if [ -e /dev/mmcblk0 ]; then %>
+						<li class="nav-item"><a class="nav-link" href="tool-recordings.cgi">Recordings</a></li>
+					<% fi %>
 					<!-- Other OpenIPC cameras on this link. Hidden until
 					     /a/cameras-switch.js confirms there are peers; inert
 					     markup, filled by JS with textContent (peer names are

--- a/www/cgi-bin/tool-recordings.cgi
+++ b/www/cgi-bin/tool-recordings.cgi
@@ -1,0 +1,71 @@
+#!/usr/bin/haserl
+<%in p/common.cgi %>
+<% page_title="Recordings" %>
+<%in p/header.cgi %>
+
+<div id="rec-note" class="d-none"></div>
+
+<div id="rec-main">
+
+	<div id="rec-daynav" class="d-flex flex-wrap align-items-center gap-2 mb-3"></div>
+
+	<div class="row g-4">
+		<div class="col-12 col-lg-8">
+			<div class="card"><div class="card-body">
+
+				<div class="rec-stage">
+					<video id="rec-video" class="rec-video" controls playsinline preload="metadata"></video>
+				</div>
+
+				<div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+					<span class="small text-secondary" id="rec-status"></span>
+					<button class="btn btn-sm btn-outline-secondary mj-push-end" id="rec-dl" type="button">Save whole clip</button>
+				</div>
+
+				<div class="rec-lbl mt-3">Whole day</div>
+				<div class="rec-strip" id="rec-strip"></div>
+				<div class="rec-hours">
+					<span>00</span><span>02</span><span>04</span><span>06</span><span>08</span><span>10</span>
+					<span>12</span><span>14</span><span>16</span><span>18</span><span>20</span><span>22</span><span>24</span>
+				</div>
+
+				<div class="d-flex justify-content-between align-items-center mt-3">
+					<span class="rec-lbl" id="rec-view-label"></span>
+					<span class="x-small text-secondary">drag to scrub · shift-drag to select · scroll to zoom</span>
+				</div>
+				<div class="rec-band" id="rec-band"></div>
+
+				<!-- Reserved, and deliberately empty. Majestic's motion detection is
+				     hardware-assisted but is never written to the card, so there is no
+				     event data to draw here yet. -->
+				<div class="rec-motion"></div>
+				<div class="rec-ticks" id="rec-ticks"></div>
+				<div class="x-small text-secondary mt-1">Motion — lights up once the camera records detection events</div>
+
+				<div id="rec-export" class="d-none"></div>
+
+			</div></div>
+		</div>
+
+		<div class="col-12 col-lg-4">
+			<div class="card h-100"><div class="card-body">
+				<div class="d-flex justify-content-between align-items-center">
+					<h3 class="m-0">Clips</h3>
+					<span class="x-small text-secondary">newest first</span>
+				</div>
+				<div id="rec-clips" class="mt-3"><div class="text-secondary small">loading…</div></div>
+			</div></div>
+		</div>
+	</div>
+
+	<div class="card mt-4" id="rec-storage-card" hidden><div class="card-body">
+		<div id="rec-storage"></div>
+	</div></div>
+
+</div>
+
+<script src="/a/timeline.js"></script>
+<script src="/a/mp4index.js"></script>
+<script src="/a/recordings.js" defer></script>
+
+<%in p/footer.cgi %>


### PR DESCRIPTION
Turning recording on led to **SD Card → Browse files**, which is the generic whole-device file manager showing a list of 400 MB clips named `12-04.mp4` — no durations, no coverage, no way to tell which one holds the minute you want. This adds a Recordings page that treats the card as a day you scrub.

| file | role |
|---|---|
| `tool-recordings.cgi` | page shell, guarded on `/dev/mmcblk0` like SDcard |
| `j/recordings.cgi` | day and clip metadata as JSON — names, sizes, mtimes, and never a byte of media |
| `timeline.js` | places clips on the day from their `%H-%M` names, merges them into coverage, finds the gaps |
| `mp4index.js` | byte↔time for clips with no index over the file as a whole |
| `recordings.js` | the DOM, the player and the export |

## What it costs decides what it does

Measured against an hi3516av300: a range request costs **32–50 ms whatever it asks for**, and a bulk read runs at ~10 MiB/s. So the price of an answer is the number of **requests**, not the bytes — and a full walk of a 20-minute clip's ~1100 fragments is ~55 s, far too much to spend opening one.

So `mp4index` offers four routes and the page takes the cheapest that answers its question:

```
durationHint()  how long is this clip?      2 requests
locate()        which byte is second N at?  ~10 requests
spanFrom()      index just this selection   ~1 per second exported
buildIndex()    the whole clip, exactly     ~1 per second of clip
```

`buildIndex` is the reference the other three are measured against — the tests assert `spanFrom` agrees with it **byte-for-byte** — but nothing on the hot path calls it.

## Export is what the format gives away

Fragments are self-contained, so saving 12:31–12:41 is the init segment followed by whole fragments: a byte concatenation, no transcoding. Verified end to end against the lab camera — a 10 s cut assembled from ranges decodes clean in ffmpeg at 3840×2160, exactly 10.000009 s.

## Playback

MSE fed from byte offsets `locate()` works out, so a scrub fetches the fragment holding that second instead of asking the browser to find it. The SourceBuffer stays in its **default `segments` mode**: with `tfdt` present each fragment lands at the time it claims, so appending the 5s–9s fragments gives `buffered` 5.00–9.00 whatever came before. No `timestampOffset`, no per-seek anchor, and `currentTime` is simply the second being watched.

Verified by driving this page against real camera fragments in Chromium: MSE attaches, buffers the clip end to end, clicking a clip restarts it at 0, and a scrub to 12:04:07 lands at 6.57 s.

Recordings written before majestic emitted `tfdt` cannot go through a SourceBuffer at all, so a watchdog hands those to a plain `<video>`. That path and the `sequence_number` branches in `mp4index` are marked **REMOVE AFTER 2029-01** — they exist only for clips already on cards when `tfdt` shipped.

## Notes for review

- **Nothing goes through `j/download.cgi`.** It `cat`s a whole file into the connection buffer and takes the camera's RAM with it. Clips are fetched from their own path, where majestic sendfiles and honours Range.
- **The motion lane is drawn, labelled and empty on purpose** — majestic's detection is hardware-assisted but never written to the card, so there is no event data to draw yet.
- **New CSS is `.rec-*`** rather than Bootstrap utilities, because `position-relative`, `overflow-hidden` and `w-100` are not in the PurgeCSS subset this tree ships and would silently do nothing.
- Two new suites: `tests/mp4index.test.js` and `tests/timeline.test.js`. Both cover things that fail silently — a wrong offset seeks to the wrong moment, a mis-summed duration makes a timeline that lies.

Fixes #207.

Depends on majestic writing `tfdt` in every fragment for the exact paths; without it the page falls back and says so.