### PR TITLE
Header: menu beside the logo, Sign out alone on the right

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1031,3 +1031,28 @@ mark {
 	height: 1px;
 	background: var(--bs-border-color);
 }
+
+/* The navbar used to carry justify-content-end, which pushed the whole menu to
+   the right edge and left a long gap after the logo — the eye had to cross it
+   before finding anything, and "Sign out" sat in the middle of the run rather
+   than apart from it. The menu now starts beside the brand and only Sign out is
+   pushed away, so the destructive action is the one thing not in the reading
+   order of the rest.
+
+   Not Bootstrap's ms-auto: that class is not in the PurgeCSS subset this tree
+   ships, so it would silently do nothing (see .mj-push-end). Scoped to the
+   expanded breakpoint because navbar-expand-lg stacks the menu vertically below
+   it, where an auto left margin only shunts one item to the right of a column. */
+@media (min-width: 992px) {
+	/* The auto margin needs somewhere to push into: the ul is a flex item that
+	   otherwise shrinks to its own contents, leaving no free space inside it
+	   however wide the bar is. Letting it span the collapse is what turns the
+	   margin into a gap. */
+	#navbarNav .navbar-nav {
+		flex-grow: 1;
+	}
+
+	.navbar-nav .nav-push-end {
+		margin-left: auto;
+	}
+}

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1075,3 +1075,31 @@ mark {
 	/* 4.6:1 on rgb(76, 96, 216); 85% would still be 4.3:1. */
 	color: rgba(255, 255, 255, 0.9);
 }
+
+/* Links never wrap. With a peer camera on the link the expanded row is tight
+   between the breakpoint and about 1300px, and letting "Sign out" break onto a
+   second line does not make the bar narrower — it makes it taller, which is the
+   worse failure. The row overflows instead, which is what it already did.
+
+   A hostname is whatever someone typed, so it is capped and ellipsised rather
+   than allowed to push the row arbitrarily wide.
+
+   What is deliberately NOT done here: releasing min-width down the flex chain
+   so the row always fits. It does fit, by crushing the camera switcher to a
+   few pixels — measured at 5px wide against 226px of content — which is worse
+   than an honest overflow. Seven menus, a hostname and Sign out do not fit in
+   960px; that predates this change and wants solving by dropping something at
+   narrow widths, not by squeezing. */
+@media (min-width: 992px) {
+	.navbar-nav .nav-link {
+		white-space: nowrap;
+	}
+
+	#cam-switch-name {
+		display: inline-block;
+		max-width: 12rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		vertical-align: bottom;
+	}
+}

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1059,9 +1059,19 @@ mark {
 
 /* The peer count beside the camera name ("+5"), subordinate to it on either
    navbar. It carried text-body-secondary, which is not in the PurgeCSS subset
-   this tree ships — so it was never muted at all, in any theme. A translucent
-   white works against both bars: the dark grey one and the brand-coloured one
-   the light theme paints. */
+   this tree ships — so it was never muted at all, in any theme.
+
+   How far it can be muted depends on the bar underneath, and the two bars are
+   nothing alike. Against the dark one there is room to spare: 75% white is
+   9.0:1. Against the light one — which is the brand indigo, not a light
+   surface — the same 75% composites to #d2d7f5 and manages only 3.7:1, under
+   the 4.5:1 that small normal-weight text needs. So it is muted as far as each
+   bar allows rather than by one number that is wrong on one of them. */
 #cam-switch-count {
-	color: rgba(255, 255, 255, 0.7);
+	color: rgba(255, 255, 255, 0.75);
+}
+
+[data-bs-theme=light] #cam-switch-count {
+	/* 4.6:1 on rgb(76, 96, 216); 85% would still be 4.3:1. */
+	color: rgba(255, 255, 255, 0.9);
 }

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1056,3 +1056,12 @@ mark {
 		margin-left: auto;
 	}
 }
+
+/* The peer count beside the camera name ("+5"), subordinate to it on either
+   navbar. It carried text-body-secondary, which is not in the PurgeCSS subset
+   this tree ships — so it was never muted at all, in any theme. A translucent
+   white works against both bars: the dark grey one and the brand-coloured one
+   the light theme paints. */
+#cam-switch-count {
+	color: rgba(255, 255, 255, 0.7);
+}

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -29,7 +29,7 @@ Pragma: no-cache
 			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
 			</button>
-			<div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+			<div class="collapse navbar-collapse" id="navbarNav">
 				<ul class="navbar-nav">
 					<li class="nav-item dropdown">
 						<a aria-expanded="false" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" id="dropdownInformation" role="button">Information</a>
@@ -114,7 +114,7 @@ Pragma: no-cache
 						</a>
 						<ul aria-labelledby="cam-switch-toggle" class="dropdown-menu dropdown-menu-end" id="cam-switch-menu"></ul>
 					</li>
-					<li class="nav-item"><a class="nav-link" href="#" id="nav-logout" title="Sign out">Sign out</a></li>
+					<li class="nav-item nav-push-end"><a class="nav-link" href="#" id="nav-logout" title="Sign out">Sign out</a></li>
 				</ul>
 			</div>
 		</div>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -99,10 +99,12 @@ Pragma: no-cache
 					     untrusted), so nothing is interpolated server-side. -->
 					<li class="nav-item dropdown d-none" id="cam-switch">
 						<!-- The label is this camera's own hostname, which the user
-						     can set to anything, so it is coloured with the brand
-						     accent and given a camera glyph to read as "the device
-						     you are on" rather than another menu word. -->
-						<a aria-expanded="false" class="nav-link dropdown-toggle d-inline-flex align-items-center gap-1 text-primary" data-bs-toggle="dropdown" href="#" id="cam-switch-toggle" role="button">
+						     can set to anything, so it is given a camera glyph and
+						     extra weight to read as "the device you are on" rather
+						     than another menu word. Not the brand accent: in light
+						     theme the navbar IS the brand colour, and the accent
+						     vanished into it completely. -->
+						<a aria-expanded="false" class="nav-link dropdown-toggle d-inline-flex align-items-center gap-1" data-bs-toggle="dropdown" href="#" id="cam-switch-toggle" role="button">
 							<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
 								<path d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2z"/>
 							</svg>
@@ -110,7 +112,7 @@ Pragma: no-cache
 							<!-- "+N" for the other cameras: reads as "N more" rather
 							     than a bare count, and stays muted so it does not
 							     compete with the accented hostname. -->
-							<span class="small fw-normal text-body-secondary" id="cam-switch-count"></span>
+							<span class="small fw-normal" id="cam-switch-count"></span>
 						</a>
 						<ul aria-labelledby="cam-switch-toggle" class="dropdown-menu dropdown-menu-end" id="cam-switch-menu"></ul>
 					</li>


### PR DESCRIPTION
Maintainers asked why the header did not match the design page. It didn't because the Recordings PR only *added* a nav item — it never touched the layout, and the canvas had been drawing a header the page does not have. This makes the page match it.

```
before   [logo] .......................... Information … Recordings Sign out
after    [logo] Information … Recordings ..................... Sign out
```

The collapse carried `justify-content-end`, which pushed the **whole** menu to the right edge: a long empty run after the logo for the eye to cross before finding anything, and `Sign out` — the one destructive item in the bar — sitting mid-run between `Recordings` and the edge like another page link. Now the menu starts beside the brand and only `Sign out` is set apart.

## And a bug the change surfaced

The camera switcher was **invisible in the light theme**. The hostname carried `text-primary` so it would read as the brand accent rather than another menu word — but the light theme paints the navbar with that same brand colour, so it was indigo on indigo. It only ever appeared in the dark theme, and it is hidden until another camera answers discovery, so it had never been in frame in a design or a screenshot.

The glyph and the extra weight carry that distinction instead, which works against either bar. The `+5` peer count had the mirror-image problem: `text-body-secondary` is not in the PurgeCSS subset this tree ships, so it was never muted in any theme; it gets a translucent white that reads as subordinate on both bars.

## Two notes for review

**Not Bootstrap's `ms-auto`.** That class is not in the shipped subset either, so it would have silently done nothing — the same trap `.mj-push-end` exists to work around.

**The auto margin needs somewhere to push into.** `navbar-nav` is a flex item that otherwise shrinks to its own contents, so however wide the bar gets there is no free space *inside* the `ul` for a margin to consume. Letting it span the collapse is what turns the margin into a gap. Scoped to `#navbarNav` so it cannot surprise another navbar, and to the expanded breakpoint — `navbar-expand-lg` stacks the menu vertically below it, where an auto left margin would only shunt one item to the right of a column.

## Checked

Rendered against the live camera at 1400px and 390px, dark and light, with the switcher forced visible and populated the way `cameras-switch.js` fills it. Collapsed, the menu stacks and `Sign out` stays in line — the push is correctly confined above the breakpoint.