### PR TITLE
SD card: say when the card cannot be recorded to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,10 @@ When you'd touch this code:
 
 Small `#!/bin/sh` scripts that emit JSON for the front-end. `pulse.cgi` is polled every 2s by `main.js:heartbeat` and fills the top bar (SoC temp, memory, overlay, uptime, day/night). `run.cgi` streams the output of a base64-encoded shell command (`cmd=` for trusted local, `web=` adds `timeout 3` for the console page).
 
+`sdcard.cgi` reports the card and runs its management ops, and it is read by two pages — `a/sdcard.js` and `a/recordings.js`. The judgement of whether a card is usable is made **once, server-side**, in its `health` field (`ok`, `readonly`, `unmounted`, `unreadable`, `unformatted`, `absent`); the pages only choose wording. `readonly` is the one that matters and the one nothing else can show: a card the kernel dropped to read-only (`errors=remount-ro`) still reports its old free space through `df`, so capacity, the storage bar and the clip list all read exactly as they did before recording stopped. `fsErrors` carries up to three matching `dmesg` lines and is gathered only in the unhealthy states — the endpoint is polled every 5 s and `dmesg` is ~80 KB on a running camera. It is corroboration only: the ring buffer is small and chatty enough that an error that stopped recording hours ago has usually scrolled out of it, so an empty list must never be rendered as a clean bill of health.
+
+`canFsck` exists because busybox ships the generic `fsck` wrapper on every build but it only execs `fsck.<fs>`, and a build without dosfstools has no `fsck.vfat` for it to find. The pages hide the Check action and say "reformat" instead when it is false, rather than offering a repair the firmware cannot perform.
+
 ### Front-end — `www/a/`
 
 - Pure JS, no framework. `$`/`$$` are `querySelector` wrappers. Don't introduce jQuery or any bundler — the README is explicit about keeping this small.

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -405,14 +405,34 @@
 	// The second is why this is loaded before the page decides it has nothing
 	// to show: "nothing recorded yet" and "the card went read-only at 12:04"
 	// look identical from the clip list alone.
-	function loadCard() {
+	// `rec` asks the endpoint to du(1) the whole archive for the storage bar,
+	// which is not free on a card holding a month of clips — so the periodic
+	// refresh, which only needs the health verdict and df's numbers, leaves it
+	// off and carries the measured recBytes forward.
+	function loadCard(withRec) {
 		if (!state.prefix) return Promise.resolve();
-		return apiFetch('/cgi-bin/j/sdcard.cgi?rec=' + encodeURIComponent(state.prefix),
-			{ credentials: 'same-origin' })
+		const q = withRec === false ? '' : '?rec=' + encodeURIComponent(state.prefix);
+		return apiFetch('/cgi-bin/j/sdcard.cgi' + q, { credentials: 'same-origin' })
 			.then(function (r) { return r.json(); })
-			.then(function (d) { state.card = d; })
-			.catch(function () { /* the page is useful without it */ });
+			.then(function (d) {
+				// Asked without ?rec= the endpoint reports recBytes as 0 rather
+				// than leaving it out, so the carry-forward has to key off the
+				// question asked, not the answer given, or the storage bar's
+				// Recordings segment collapses on the first refresh.
+				if (d && withRec === false && state.card) d.recBytes = state.card.recBytes;
+				state.card = d;
+			})
+			// The page still browses the archive without this, but it must not
+			// go on claiming the camera is recording — see cardWritable().
+			.catch(function () { state.card = null; });
 	}
+
+	// Positive claims need positive evidence. A card is only known writable
+	// when the endpoint said so; a request that failed, or an answer this
+	// release does not understand, is an unknown card, and an unknown card
+	// must not be painted green — that false reassurance is the whole bug
+	// this page is here to stop telling.
+	function cardWritable() { return !!state.card && state.card.health === 'ok'; }
 
 	// Why there is no new footage, said on the page people actually arrive at.
 	// Returns '' while the card is fine — including while it is merely full,
@@ -467,9 +487,11 @@
 	// much room is left before the oldest of it is deleted.
 	function renderStorage() {
 		const d = state.card;
-		if (!d || !d.mounted || !d.totalKb) return;
 		const card = $id('rec-storage-card'), el = $id('rec-storage');
 		if (!card || !el) return;
+		// Hidden rather than left standing: a card unmounted while the page is
+		// open would otherwise keep showing the space it had when it left.
+		if (!d || !d.mounted || !d.totalKb) { card.hidden = true; return; }
 		const total = d.totalKb * 1024, used = d.usedKb * 1024;
 		const rec = Math.min(d.recBytes || 0, used);
 		const other = Math.max(0, used - rec), free = Math.max(0, total - used);
@@ -504,6 +526,33 @@
 				? '<span class="text-secondary">oldest clips deleted at ' +
 				esc(String(mjGet(state.cfg, 'records.maxUsage'))) + ' %</span>' : '') +
 			'</div>';
+	}
+
+	// The card is the one thing on this page that changes underneath it. Days
+	// and clips are history and a reload is the natural way to get more of
+	// them, but a card goes read-only mid-session — which is exactly the
+	// failure this page exists to report, and reporting it only to whoever
+	// happens to load the page afterwards would miss the person already
+	// watching. Slow on purpose: this is a viewer, sometimes left open on a
+	// wall display, not a dashboard.
+	const CARD_POLL_MS = 30000;
+
+	function watchCard() {
+		setInterval(function () {
+			if (document.hidden) return;
+			const before = state.card ? state.card.health : null;
+			loadCard(false).then(function () {
+				const after = state.card ? state.card.health : null;
+				renderStorage();
+				// Everything else only moves when the verdict itself moves —
+				// no reason to rebuild the day picker and the clip list every
+				// thirty seconds for numbers that did not change.
+				if (after === before) return;
+				renderHealth();
+				renderDayNav();
+				renderClips();
+			});
+		}, CARD_POLL_MS);
 	}
 
 	// Where a day should open: the freshest footage in it, not the oldest.
@@ -684,7 +733,7 @@
 		// which is a statement about the clock and cannot know the card stopped
 		// accepting writes. On a card that cannot be written the last clip is
 		// not growing — it is the truncated one the failure interrupted.
-		const writable = !cardTrouble();
+		const writable = cardWritable();
 		// newest first: that is the one people want
 		list.slice().reverse().forEach(function (c, i, arr) {
 			const prev = arr[i + 1];
@@ -736,14 +785,19 @@
 			'<button class="btn btn-sm btn-outline-secondary" id="rec-next" type="button"' +
 			(next ? '' : ' disabled') + ' aria-label="Next day">&rsaquo;</button>' +
 			'<span class="small text-secondary">' + state.day.clips.length + ' clips · ' + TL.duration(total) + '</span>' +
-			// Three states, not two: the switch being on is a setting, and a
-			// card that cannot be written to makes a green "Recording" badge
-			// the loudest wrong thing on the page.
+			// Four states, not two: the switch being on is a setting, and a card
+			// that cannot be written to makes a green "Recording" badge the
+			// loudest wrong thing on the page. The fourth is the card we could
+			// not ask — still not green, because green is a claim.
 			(!state.enabled
 				? '<span class="mj-push-end badge text-bg-secondary">Recording off</span>'
 				: cardTrouble()
 					? '<span class="mj-push-end badge text-bg-danger">Cannot record</span>'
-					: '<span class="mj-push-end badge text-bg-success">Recording</span>') +
+					: cardWritable()
+						? '<span class="mj-push-end badge text-bg-success">Recording</span>'
+						: '<span class="mj-push-end badge text-bg-secondary" ' +
+							'title="Recording is switched on, but the SD card\'s state could not be read">' +
+							'Recording — card unknown</span>') +
 			'<span class="small text-secondary">' + esc(label) + '</span>';
 
 		if (prev) $id('rec-prev').addEventListener('click', function () { goDay(prev); });
@@ -998,6 +1052,7 @@
 				renderClips();
 				renderHealth();
 				renderStorage();
+				watchCard();
 				centreView(freshest());
 				goTo(freshest());     // opens the clip, so the page is not a black box
 			});

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -26,7 +26,7 @@
 	let zoom = 2;                     // index into ZOOMS -> one hour
 
 	const state = {
-		cfg: {}, prefix: '', split: 1200, enabled: false,
+		cfg: {}, prefix: '', split: 1200, enabled: false, card: null,
 		offsetMs: 0, nowSec: null, today: '',
 		days: [], dayName: '', day: { clips: [], unplaced: [] },
 		view: { from: 0, to: 3600, width: 3600 },
@@ -399,51 +399,111 @@
 
 	// ---- storage ---------------------------------------------------------
 
+	// The card behind the archive, fetched once. It answers two questions on
+	// this page: how much room is left (the storage bar at the bottom), and
+	// whether anything can still be written at all (the banner at the top).
+	// The second is why this is loaded before the page decides it has nothing
+	// to show: "nothing recorded yet" and "the card went read-only at 12:04"
+	// look identical from the clip list alone.
+	function loadCard() {
+		if (!state.prefix) return Promise.resolve();
+		return apiFetch('/cgi-bin/j/sdcard.cgi?rec=' + encodeURIComponent(state.prefix),
+			{ credentials: 'same-origin' })
+			.then(function (r) { return r.json(); })
+			.then(function (d) { state.card = d; })
+			.catch(function () { /* the page is useful without it */ });
+	}
+
+	// Why there is no new footage, said on the page people actually arrive at.
+	// Returns '' while the card is fine — including while it is merely full,
+	// which is normal operation: majestic deletes the oldest clips at
+	// records.maxUsage and carries on.
+	function cardTrouble() {
+		const d = state.card;
+		if (!d) return '';
+		switch (d.health) {
+		case 'readonly':
+			return '<strong>The SD card is mounted read-only — nothing is being recorded.</strong> ' +
+				'It reports free space and its older clips still play, but the camera cannot write to it. ' +
+				'The kernel drops a card to read-only as soon as its filesystem stops making sense, ' +
+				'so expect a damaged filesystem rather than a full one.';
+		case 'unreadable':
+			return '<strong>The SD card has no readable filesystem — nothing is being recorded.</strong> ' +
+				'A partition is there but nothing on the camera can read it, so it is either damaged or was never formatted.';
+		case 'unformatted':
+			return '<strong>The SD card is not formatted — nothing is being recorded.</strong>';
+		case 'unmounted':
+			return '<strong>The SD card is not mounted — nothing is being recorded.</strong> ' +
+				'The filesystem is intact; it just is not attached to <code>' + esc(d.mountpoint || '') + '</code>.';
+		case 'absent':
+			return '<strong>There is no SD card in the camera — nothing is being recorded.</strong>';
+		default:
+			return '';
+		}
+	}
+
+	// Kernel complaints about the card, when the endpoint found any. Never
+	// rendered as reassurance: the ring buffer is small, so an error that
+	// stopped recording this morning has usually scrolled out of it by now.
+	function cardKernelLines() {
+		const d = state.card;
+		if (!d || !d.fsErrors || !d.fsErrors.length) return '';
+		return '<div class="mt-2"><div class="x-small text-secondary mb-1">Recent kernel messages about this card:</div>' +
+			'<pre class="x-small mb-0" style="white-space:pre-wrap">' + esc(d.fsErrors.join('\n')) + '</pre></div>';
+	}
+
+	function renderHealth() {
+		const el = $id('rec-health');
+		if (!el) return;
+		const msg = cardTrouble();
+		if (!msg) { el.className = 'd-none'; el.innerHTML = ''; return; }
+		el.className = 'alert alert-danger';
+		el.innerHTML = msg + cardKernelLines() +
+			'<div class="mt-2"><a class="btn btn-sm btn-danger" href="tool-sdcard.cgi">Open the SD card page</a></div>';
+	}
+
 	// Same numbers and the same bar as the SD card page, because it is the same
 	// question asked from the other side: how much footage is there, and how
 	// much room is left before the oldest of it is deleted.
-	function loadStorage() {
-		if (!state.prefix) return;
-		apiFetch('/cgi-bin/j/sdcard.cgi?rec=' + encodeURIComponent(state.prefix),
-			{ credentials: 'same-origin' })
-			.then(function (r) { return r.json(); })
-			.then(function (d) {
-				if (!d || !d.mounted || !d.totalKb) return;
-				const card = $id('rec-storage-card'), el = $id('rec-storage');
-				if (!card || !el) return;
-				const total = d.totalKb * 1024, used = d.usedKb * 1024;
-				const rec = Math.min(d.recBytes || 0, used);
-				const other = Math.max(0, used - rec), free = Math.max(0, total - used);
-				const seg = function (b, c) {
-					return b > 0 ? '<div class="seg" style="width:' + (b / total * 100).toFixed(2) +
-						'%;background:' + c + '"></div>' : '';
-				};
-				const dot = function (c) {
-					return '<span class="dot" style="background:' + c + '"></span>';
-				};
-				// How much longer the card can record, from what this day's
-				// footage actually costs per second.
-				const day = state.day.clips.reduce(function (a, c) { return a + c.dur; }, 0);
-				const bytes = state.day.clips.reduce(function (a, c) { return a + c.size; }, 0);
-				const left = (day > 0 && bytes > 0)
-					? ' · about ' + TL.duration(free / (bytes / day)) + ' of footage left' : '';
+	function renderStorage() {
+		const d = state.card;
+		if (!d || !d.mounted || !d.totalKb) return;
+		const card = $id('rec-storage-card'), el = $id('rec-storage');
+		if (!card || !el) return;
+		const total = d.totalKb * 1024, used = d.usedKb * 1024;
+		const rec = Math.min(d.recBytes || 0, used);
+		const other = Math.max(0, used - rec), free = Math.max(0, total - used);
+		const seg = function (b, c) {
+			return b > 0 ? '<div class="seg" style="width:' + (b / total * 100).toFixed(2) +
+				'%;background:' + c + '"></div>' : '';
+		};
+		const dot = function (c) {
+			return '<span class="dot" style="background:' + c + '"></span>';
+		};
+		// How much longer the card can record, from what this day's
+		// footage actually costs per second.
+		const day = state.day.clips.reduce(function (a, c) { return a + c.dur; }, 0);
+		const bytes = state.day.clips.reduce(function (a, c) { return a + c.size; }, 0);
+		// A projection of how long the card will last is a promise about future
+		// writes, so it is only offered while future writes are possible.
+		const left = (d.health === 'ok' && day > 0 && bytes > 0)
+			? ' · about ' + TL.duration(free / (bytes / day)) + ' of footage left' : '';
 
-				card.hidden = false;
-				el.innerHTML =
-					'<div class="d-flex justify-content-between x-small mb-1">' +
-					'<span class="fw-semibold">Storage</span>' +
-					'<span class="text-secondary">' + TL.bytes(used) + ' of ' + TL.bytes(total) + ' used' +
-					esc(left) + '</span></div>' +
-					'<div class="storage-bar mb-2">' + seg(rec, '#4c60d8') + seg(other, '#e08a3c') + '</div>' +
-					'<div class="storage-legend x-small">' +
-					'<span>' + dot('#4c60d8') + 'Recordings <span class="text-secondary">' + TL.bytes(rec) + '</span></span>' +
-					'<span>' + dot('#e08a3c') + 'Other <span class="text-secondary">' + TL.bytes(other) + '</span></span>' +
-					'<span><span class="dot dot-free"></span>Free <span class="text-secondary">' + TL.bytes(free) + '</span></span>' +
-					(mjGet(state.cfg, 'records.maxUsage')
-						? '<span class="text-secondary">oldest clips deleted at ' +
-						esc(String(mjGet(state.cfg, 'records.maxUsage'))) + ' %</span>' : '') +
-					'</div>';
-			}).catch(function () { /* the page is useful without it */ });
+		card.hidden = false;
+		el.innerHTML =
+			'<div class="d-flex justify-content-between x-small mb-1">' +
+			'<span class="fw-semibold">Storage</span>' +
+			'<span class="text-secondary">' + TL.bytes(used) + ' of ' + TL.bytes(total) + ' used' +
+			esc(left) + '</span></div>' +
+			'<div class="storage-bar mb-2">' + seg(rec, '#4c60d8') + seg(other, '#e08a3c') + '</div>' +
+			'<div class="storage-legend x-small">' +
+			'<span>' + dot('#4c60d8') + 'Recordings <span class="text-secondary">' + TL.bytes(rec) + '</span></span>' +
+			'<span>' + dot('#e08a3c') + 'Other <span class="text-secondary">' + TL.bytes(other) + '</span></span>' +
+			'<span><span class="dot dot-free"></span>Free <span class="text-secondary">' + TL.bytes(free) + '</span></span>' +
+			(mjGet(state.cfg, 'records.maxUsage')
+				? '<span class="text-secondary">oldest clips deleted at ' +
+				esc(String(mjGet(state.cfg, 'records.maxUsage'))) + ' %</span>' : '') +
+			'</div>';
 	}
 
 	// Where a day should open: the freshest footage in it, not the oldest.
@@ -620,6 +680,11 @@
 			return;
 		}
 		let h = '';
+		// timeline.js calls the newest clip "recording" when it ends about now,
+		// which is a statement about the clock and cannot know the card stopped
+		// accepting writes. On a card that cannot be written the last clip is
+		// not growing — it is the truncated one the failure interrupted.
+		const writable = !cardTrouble();
 		// newest first: that is the one people want
 		list.slice().reverse().forEach(function (c, i, arr) {
 			const prev = arr[i + 1];
@@ -629,11 +694,12 @@
 			}
 			const on = state.clip && state.clip.name === c.name;
 			h += '<button type="button" class="rec-clip' + (on ? ' active' : '') + '" data-clip="' + esc(c.name) + '">' +
-				'<span class="rec-poster"' + (c.recording ? ' data-live="1"' : '') + '>' +
+				'<span class="rec-poster"' + (c.recording && writable ? ' data-live="1"' : '') + '>' +
 				'<span class="rec-poster-t">' + TL.hhmm(c.start) + '</span></span>' +
 				'<span class="rec-clip-m"><span class="font-monospace fw-semibold">' + TL.hhmm(c.start) + '</span>' +
 				'<span class="x-small text-secondary">' +
-				(c.recording ? 'recording' : (c.estimated ? '≈ ' : '') + TL.duration(c.dur)) +
+				(c.recording && writable ? 'recording'
+					: (c.estimated ? '≈ ' : '') + TL.duration(c.dur)) +
 				' · ' + TL.bytes(c.size) + '</span></span></button>';
 		});
 		if (state.day.unplaced.length) {
@@ -670,9 +736,14 @@
 			'<button class="btn btn-sm btn-outline-secondary" id="rec-next" type="button"' +
 			(next ? '' : ' disabled') + ' aria-label="Next day">&rsaquo;</button>' +
 			'<span class="small text-secondary">' + state.day.clips.length + ' clips · ' + TL.duration(total) + '</span>' +
-			(state.enabled
-				? '<span class="mj-push-end badge text-bg-success">Recording</span>'
-				: '<span class="mj-push-end badge text-bg-secondary">Recording off</span>') +
+			// Three states, not two: the switch being on is a setting, and a
+			// card that cannot be written to makes a green "Recording" badge
+			// the loudest wrong thing on the page.
+			(!state.enabled
+				? '<span class="mj-push-end badge text-bg-secondary">Recording off</span>'
+				: cardTrouble()
+					? '<span class="mj-push-end badge text-bg-danger">Cannot record</span>'
+					: '<span class="mj-push-end badge text-bg-success">Recording</span>') +
 			'<span class="small text-secondary">' + esc(label) + '</span>';
 
 		if (prev) $id('rec-prev').addEventListener('click', function () { goDay(prev); });
@@ -892,9 +963,9 @@
 
 	// ---- boot ------------------------------------------------------------
 
-	function empty(msg, cta) {
+	function empty(msg, cta, kind) {
 		$id('rec-main').className = 'd-none';
-		note(msg + (cta || ''), 'secondary');
+		note(msg + (cta || ''), kind || 'secondary');
 	}
 
 	Promise.all([loadConfig(), loadPulse()]).then(function () {
@@ -902,12 +973,19 @@
 			return empty('<strong>Recording is not configured.</strong> No recording path is set, so there is nothing to browse. ',
 				'<a href="tool-sdcard.cgi">Set up the SD card</a>.');
 		}
-		return loadDays().then(function () {
+		return Promise.all([loadDays(), loadCard()]).then(function () {
 			if (!state.days.length) {
-				return empty(state.enabled
-					? '<strong>Nothing recorded yet.</strong> Recording is on, but no clips have been written to <code>' + esc(state.prefix) + '</code> yet. '
-					: '<strong>Recording is off.</strong> The camera is not writing to the card, so there is nothing to browse. ',
-					'<a href="tool-sdcard.cgi">SD card</a>');
+				// The card gets the first word: "nothing recorded yet" is a
+				// guess, and a read-only or unreadable card is the answer.
+				// Only when the card is fine is an empty archive really about
+				// whether recording is switched on.
+				const bad = cardTrouble();
+				return empty(bad ||
+					(state.enabled
+						? '<strong>Nothing recorded yet.</strong> Recording is on, but no clips have been written to <code>' + esc(state.prefix) + '</code> yet.'
+						: '<strong>Recording is off.</strong> The camera is not writing to the card, so there is nothing to browse.'),
+					' <a href="tool-sdcard.cgi">SD card</a>' + (bad ? cardKernelLines() : ''),
+					bad ? 'danger' : 'secondary');
 			}
 			const want = (/[?&]day=([^&]*)/.exec(location.search) || [])[1];
 			const asked = want ? decodeURIComponent(want) : '';
@@ -918,7 +996,8 @@
 				wire();
 				renderDayNav();
 				renderClips();
-				loadStorage();
+				renderHealth();
+				renderStorage();
 				centreView(freshest());
 				goTo(freshest());     // opens the clip, so the page is not a black box
 			});

--- a/www/a/sdcard.js
+++ b/www/a/sdcard.js
@@ -38,11 +38,74 @@
 			.catch(() => { SD.innerHTML = '<div class="alert alert-danger">Failed to read SD-card status.</div>'; });
 	}
 
+	// `ok` is spelled out rather than left as the default: render() calls this
+	// with {} before the first fetch lands and after a failed one, and an
+	// unknown card must not be badged as a healthy one.
 	function badge(d) {
-		if (!d.present) return '<span class="badge text-bg-secondary">No card</span>';
-		if (d.mounted) return '<span class="badge text-bg-success">Mounted</span>';
-		if (d.fs) return '<span class="badge text-bg-warning">Not mounted</span>';
-		return '<span class="badge text-bg-danger">Unformatted</span>';
+		switch (d.health) {
+		case 'ok': return '<span class="badge text-bg-success">Mounted</span>';
+		case 'readonly': return '<span class="badge text-bg-danger">Read-only</span>';
+		case 'unreadable': return '<span class="badge text-bg-danger">No filesystem</span>';
+		case 'unformatted': return '<span class="badge text-bg-danger">Unformatted</span>';
+		case 'unmounted': return '<span class="badge text-bg-warning">Not mounted</span>';
+		default: return '<span class="badge text-bg-secondary">No card</span>';
+		}
+	}
+
+	// What to do about a card that cannot be recorded to. `fsck` is the right
+	// answer where the firmware has the helper for this filesystem, and is not
+	// an answer at all where it does not: busybox ships the generic `fsck`
+	// wrapper on every build, but it only execs `fsck.<fs>`, and a build
+	// without dosfstools has no fsck.vfat for it to find. Saying "run Check"
+	// there would send people after a button the page has not drawn.
+	function remedy(d) {
+		if (d.canFsck) {
+			return {
+				text: 'Checking the filesystem is the next step: it unmounts the card, repairs what it can and mounts it back.',
+				btn: '<button class="btn btn-sm btn-danger" data-act="fsck">Check and repair</button>',
+			};
+		}
+		return {
+			text: (d.fs
+				? 'This firmware ships no <code>fsck.' + esc(d.fs) + '</code>, so there is no repair to offer: ' +
+					'copy off anything you still need, then reformat.'
+				: 'With no filesystem to read there is nothing a repair tool could work on — the card has to be reformatted.') +
+				' A card that goes bad again soon afterwards is worn out; replace it.',
+			btn: '<button class="btn btn-sm btn-danger" data-act="format">Format the card…</button>',
+		};
+	}
+
+	// Kernel messages, when there are any. Shown as corroboration and never as
+	// a verdict: the ring buffer is small and chatty, so the errors that
+	// stopped a recording hours ago have usually scrolled out of it. An empty
+	// list means nothing was found, not that nothing happened — which is why
+	// this renders nothing at all rather than "no errors".
+	function kernelLines(d) {
+		if (!d.fsErrors || !d.fsErrors.length) return '';
+		return '<div class="mt-2"><div class="x-small text-secondary mb-1">Recent kernel messages about this card:</div>' +
+			'<pre class="x-small mb-0" style="white-space:pre-wrap">' + esc(d.fsErrors.join('\n')) + '</pre></div>';
+	}
+
+	// The one thing the rest of the page cannot tell you. Everything else here
+	// — capacity, free space, the storage bar — reads exactly the same on a
+	// card that has been read-only since lunchtime as on a healthy one.
+	function health(d) {
+		let title, body;
+		if (d.health === 'readonly') {
+			title = 'This card is mounted read-only.';
+			body = 'Nothing can be written to it, so recording is not running — whatever the free space below says. ' +
+				'The kernel drops a card to read-only the moment its filesystem stops making sense ' +
+				'(<code>errors=remount-ro</code>), so treat this as a damaged filesystem. ';
+		} else if (d.health === 'unreadable') {
+			title = 'No filesystem can be read from this card.';
+			body = 'The partition is there, but nothing on the camera recognises what is inside it — ' +
+				'it was either never formatted, or the filesystem is damaged past recognition. ';
+		} else {
+			return '';
+		}
+		const fix = remedy(d);
+		return '<div class="alert alert-danger"><strong>' + title + '</strong> ' + body + fix.text +
+			kernelLines(d) + '<div class="mt-2">' + fix.btn + '</div></div>';
 	}
 
 	function storageBar(d) {
@@ -55,7 +118,14 @@
 		const bar = segs.map(s => '<div class="seg" style="width:' + (s.b / total * 100).toFixed(2) + '%;background:' + s.c + '" title="' + s.name + ' ' + humanBytes(s.b) + '"></div>').join('');
 		const leg = segs.map(s => '<span><i class="dot" style="background:' + s.c + '"></i>' + s.name + ' <span class="text-secondary">' + humanBytes(s.b) + '</span></span>').join('')
 			+ '<span><i class="dot dot-free"></i>Free <span class="text-secondary">' + humanBytes(free) + '</span></span>';
-		return '<div class="d-flex justify-content-between x-small mb-1"><span class="fw-semibold">Storage</span><span class="text-secondary">' + humanBytes(used) + ' of ' + humanBytes(total) + ' used</span></div>'
+		// The free figure is what df reports, and df keeps reporting the space
+		// that was free at the moment the kernel stopped letting anything use
+		// it. Left unqualified it is the single most misleading number on this
+		// page — the reason a dead card reads as healthy.
+		const cap = d.health === 'readonly'
+			? '<span class="text-danger">' + humanBytes(free) + ' free, but nothing can be written</span>'
+			: '<span class="text-secondary">' + humanBytes(used) + ' of ' + humanBytes(total) + ' used</span>';
+		return '<div class="d-flex justify-content-between x-small mb-1"><span class="fw-semibold">Storage</span>' + cap + '</div>'
 			+ '<div class="storage-bar mb-2">' + bar + '</div><div class="storage-legend x-small mb-2">' + leg + '</div>';
 	}
 
@@ -75,13 +145,16 @@
 		if (d.canFsck) acts += '<button class="btn btn-sm btn-outline-secondary" data-act="fsck">Check</button>';
 		acts += '<button class="btn btn-sm btn-outline-danger" data-act="format">Format…</button>';
 
-		SD.innerHTML = head + '<div class="row g-4">'
+		SD.innerHTML = head + health(d) + '<div class="row g-4">'
 			+ '<div class="col-12 col-lg-7"><div class="card h-100"><div class="card-body">'
 			+ '<dl class="small list mb-3">'
 			+ '<dt>Model</dt><dd>' + esc(d.model || '—') + ' <span class="text-secondary">(' + esc(d.cardtype || 'SD') + ')</span></dd>'
 			+ '<dt>Capacity</dt><dd>' + humanBytes(d.sizeBytes) + '</dd>'
-			+ '<dt>Filesystem</dt><dd>' + (d.fs ? esc(d.fs) : '<span class="text-danger">unformatted</span>') + '</dd>'
-			+ '<dt>Mount</dt><dd>' + (d.mounted ? esc(d.mountpoint) : 'not mounted') + '</dd>'
+			+ '<dt>Filesystem</dt><dd>' + (d.fs ? esc(d.fs)
+				: '<span class="text-danger">' + (d.health === 'unreadable' ? 'none readable' : 'unformatted') + '</span>') + '</dd>'
+			+ '<dt>Mount</dt><dd>' + (d.mounted
+				? esc(d.mountpoint) + (d.health === 'readonly' ? ' <span class="text-danger">— read-only</span>' : '')
+				: 'not mounted') + '</dd>'
 			+ '<dt>Manufactured</dt><dd class="text-secondary">' + esc(d.date || '—') + '</dd>'
 			+ '</dl>'
 			+ storageBar(d)
@@ -96,20 +169,29 @@
 			+ '<dt>Split</dt><dd>' + (mjGet(cfg, 'records.split') || '—') + ' min</dd>'
 			+ '<dt>Max usage</dt><dd>' + (mjGet(cfg, 'records.maxUsage') || '—') + ' %</dd>'
 			+ '</dl>'
-			+ (d.mounted && !onThisCard ? '<button class="btn btn-sm btn-primary mb-3" id="sd-use">Use this card for recording</button>'
-				: (onThisCard ? '<div class="x-small text-success mb-3">✓ Recording to this card</div>' : ''))
+			+ (onThisCard
+				// "Recording to this card" is a claim about what is happening,
+				// not about what is configured, so it has to know the card is
+				// writable before it makes it.
+				? (d.health === 'readonly'
+					? '<div class="x-small text-danger mb-3">Configured to record here, but the card is read-only — nothing is being written.</div>'
+					: '<div class="x-small text-success mb-3">✓ Recording to this card</div>')
+				: (d.mounted && d.health !== 'readonly'
+					? '<button class="btn btn-sm btn-primary mb-3" id="sd-use">Use this card for recording</button>' : ''))
 			+ '<div><a class="small" href="mj-settings.cgi?tab=records">Recording settings →</a></div>'
 			+ '</div></div></div></div>';
-
-		wire();
 	}
 
 	function busy(btn) { if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>'; } }
 	function after(r) { if (r && r.ok === false) alert('Failed: ' + (r.error || '')); load(); }
 
+	// Bound once, to the container the page never replaces. It used to be bound
+	// per render to #sd-actions, which was safe only because that element was
+	// thrown away each time; #sd is not, and this page re-renders every five
+	// seconds. Delegating from here also lets the health alert offer the same
+	// data-act buttons as the actions row.
 	function wire() {
-		const acts = $('#sd-actions');
-		if (acts) acts.addEventListener('click', e => {
+		SD.addEventListener('click', e => {
 			const b = e.target.closest('[data-act]'); if (!b) return;
 			const act = b.dataset.act;
 			if (act === 'browse') { location = 'tool-files.cgi?cd=' + encodeURIComponent(state.mountpoint); return; }
@@ -117,10 +199,14 @@
 			if (act === 'fsck' && !confirm('Unmount and check the filesystem?')) return;
 			busy(b); op({ op: act }).then(after);
 		});
-		const tog = $('#sd-rec-toggle');
-		if (tog) tog.addEventListener('change', () => { tog.disabled = true; setConfig({ records: { enabled: tog.checked } }).then(load); });
-		const use = $('#sd-use');
-		if (use) use.addEventListener('click', () => { busy(use); setConfig({ records: { path: state.mountpoint + '/%F', enabled: true } }).then(load); });
+		SD.addEventListener('click', e => {
+			const use = e.target.closest('#sd-use'); if (!use) return;
+			busy(use); setConfig({ records: { path: state.mountpoint + '/%F', enabled: true } }).then(load);
+		});
+		SD.addEventListener('change', e => {
+			const tog = e.target.closest('#sd-rec-toggle'); if (!tog) return;
+			tog.disabled = true; setConfig({ records: { enabled: tog.checked } }).then(load);
+		});
 	}
 
 	function openFormat() {
@@ -142,5 +228,6 @@
 		modal.show();
 	}
 
+	wire();
 	load().then(() => { clearInterval(timer); timer = setInterval(() => { if (!document.hidden) load(); }, 5000); });
 })();

--- a/www/cgi-bin/j/sdcard.cgi
+++ b/www/cgi-bin/j/sdcard.cgi
@@ -1,8 +1,25 @@
 #!/bin/sh
 # SD-card backend: JSON status (GET) + management ops (POST).
 # GET  ?rec=<dir>  -> {present,device,target,model,...,sizeBytes,fs,mounted,
-#                      mountpoint,totalKb,usedKb,availKb,recBytes,mkfs:[...]}
+#                      mountpoint,totalKb,usedKb,availKb,recBytes,mkfs:[...],
+#                      health,fsErrors:[...]}
 # POST op=format|mount|unmount|fsck [fs=vfat] -> {ok,error,log}
+#
+# `health` is the one judgement this endpoint makes, and it is made here rather
+# than in each page because two pages ask the same question from different
+# sides. One of:
+#
+#   absent       no card in the slot
+#   unformatted  a card with no partition table and nothing readable on it
+#   unreadable   a partition is there but no filesystem can be read off it —
+#                either never formatted, or damaged past recognition
+#   unmounted    a filesystem is there, nothing has mounted it
+#   readonly     mounted read-only: the card CANNOT be recorded to, whatever
+#                the free space says. Usually the kernel's own doing —
+#                `errors=remount-ro` drops a vfat card to read-only the moment
+#                the FAT stops making sense, and df keeps reporting the space
+#                that was free when it happened.
+#   ok           mounted read-write
 
 DEV=/dev/mmcblk0
 SYS=/sys/block/mmcblk0
@@ -11,6 +28,35 @@ json_hdr() { printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Cont
 json_str() { printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
 json_log() { printf '%s' "$1" | tr -d '\000-\010\013-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | awk 'BEGIN{ORS=""}{print (NR>1?"\\n":"") $0}'; }
 sysf() { cat "$SYS/device/$1" 2>/dev/null; }
+
+# Append one line to the op log shown in the browser. `L="${L}x\n"` does not
+# interpret the escape in POSIX sh, so what reached the page was a literal
+# backslash-n between every line; the newline has to be a real one for
+# json_log's awk to turn it into a JSON escape.
+logln() { L="$L$1
+"; }
+
+# Kernel complaints about this card, newest last. Corroborating detail only:
+# the ring buffer is small and chatty (on hi3516av300 the CMA allocator alone
+# pushes a card error out of it within minutes), so finding nothing here proves
+# nothing and must never be rendered as a clean bill of health. Two greps
+# rather than one so a timeout on some other block device cannot be reported as
+# an SD-card fault.
+fs_errors() {
+	dmesg 2>/dev/null | grep -E 'mmcblk|mmc[0-9]' |
+		grep -iE 'error|fail|timeout|corrupt|read-only|remount' | tail -n 3
+}
+
+# fs_errors as a JSON array body. The while loop is the right-hand side of a
+# pipe, so `i` lives in that one subshell and survives across iterations.
+json_errs() {
+	i=0
+	fs_errors | while IFS= read -r ln; do
+		[ "$i" = 0 ] || printf ','
+		i=1
+		printf '"%s"' "$(json_str "$ln")"
+	done
+}
 
 # the active target partition/device and its conventional mount point
 target() { if [ -b "${DEV}p1" ]; then printf '%sp1' "$DEV"; else printf '%s' "$DEV"; fi; }
@@ -24,7 +70,7 @@ mkfs_list() {
 }
 
 get_info() {
-	if [ ! -b "$DEV" ]; then printf '{"present":false,"mkfs":[%s]}' "$(mkfs_list)"; return; fi
+	if [ ! -b "$DEV" ]; then printf '{"present":false,"health":"absent","fsErrors":[],"mkfs":[%s]}' "$(mkfs_list)"; return; fi
 	t=$(target); base=${t##*/}
 	[ -b "${DEV}p1" ] && partd=true || partd=false
 	size=$(( $(cat "$SYS/size" 2>/dev/null || echo 0) * 512 ))
@@ -37,6 +83,16 @@ get_info() {
 		bt=$(blkid "$t" 2>/dev/null)
 		fs=$(printf '%s' "$bt" | sed -n 's/.*TYPE="\([^"]*\)".*/\1/p')
 		[ -z "$fs" ] && [ -n "$bt" ] && fs="formatted"
+	fi
+	# A card mounted read-only cannot be recorded to, and nothing else on this
+	# page can tell you that: df still reports the space that was free when the
+	# kernel gave up on it. The mount options are field 4 and the flag is a
+	# whole comma-separated word — matching a bare substring would find the
+	# "ro" in `errors=remount-ro` on every healthy vfat mount.
+	ro=false
+	if [ -n "$mp" ]; then
+		opts=$(awk -v d="$t" '$1==d{print $4; exit}' /proc/mounts)
+		case ",$opts," in *,ro,*) ro=true;; esac
 	fi
 	mounted=false; total=0; used=0; avail=0; rec=0
 	if [ -n "$mp" ]; then
@@ -53,8 +109,20 @@ get_info() {
 		"$(json_str "$(sysf name)")" "$(json_str "$(sysf type)")" "$(json_str "$(sysf manfid)")" \
 		"$(json_str "$(sysf oemid)")" "$(json_str "$(sysf date)")" "$(json_str "$(sysf serial)")"
 	canfsck=false; command -v "fsck.$fs" >/dev/null 2>&1 && canfsck=true
-	printf '"sizeBytes":%s,"fs":"%s","totalKb":%s,"usedKb":%s,"availKb":%s,"recBytes":%s,"canFsck":%s,"mkfs":[%s]}' \
-		"$size" "$(json_str "$fs")" "$total" "$used" "$avail" "$rec" "$canfsck" "$(mkfs_list)"
+	if [ "$ro" = true ]; then health=readonly
+	elif [ "$mounted" = true ]; then health=ok
+	elif [ -n "$fs" ]; then health=unmounted
+	elif [ "$partd" = true ]; then health=unreadable
+	else health=unformatted
+	fi
+	# Only scraped when something is wrong with the card. This endpoint is
+	# polled every 5 s by the SD-card page, and dmesg is 80 KB on a running
+	# camera — no reason to walk it while the card is healthy.
+	errs=""
+	case "$health" in readonly|unreadable) errs=$(json_errs);; esac
+	printf '"sizeBytes":%s,"fs":"%s","totalKb":%s,"usedKb":%s,"availKb":%s,"recBytes":%s,"canFsck":%s,' \
+		"$size" "$(json_str "$fs")" "$total" "$used" "$avail" "$rec" "$canfsck"
+	printf '"health":"%s","fsErrors":[%s],"mkfs":[%s]}' "$health" "$errs" "$(mkfs_list)"
 }
 
 # Ensure the /dev/mmcblk0p1 node exists: the kernel may know the partition
@@ -77,41 +145,66 @@ do_format() {
 	command -v "mkfs.$fs" >/dev/null 2>&1 || { err="mkfs.$fs not installed"; return; }
 	umount /mnt/mmcblk0p1 2>/dev/null; umount "${DEV}p1" 2>/dev/null; umount "$DEV" 2>/dev/null
 	if ! grep -q 'mmcblk0p1$' /proc/partitions; then
-		L="${L}# partition ${DEV}\n"
-		L="${L}$(printf 'o\nn\np\n1\n\n\nw\n' | fdisk "$DEV" 2>&1)\n"
+		logln "# partition ${DEV}"
+		logln "$(printf 'o\nn\np\n1\n\n\nw\n' | fdisk "$DEV" 2>&1)"
 		partprobe "$DEV" 2>/dev/null
 	fi
 	ensure_node || { err="partition node mmcblk0p1 was not created"; return; }
 	umount "${DEV}p1" 2>/dev/null   # automount may have grabbed it
-	L="${L}# mkfs.$fs ${DEV}p1\n"
-	L="${L}$(mkfs.$fs "${DEV}p1" 2>&1)\n"
+	logln "# mkfs.$fs ${DEV}p1"
+	logln "$(mkfs.$fs "${DEV}p1" 2>&1)"
 	blkid "${DEV}p1" >/dev/null 2>&1 || { err="format failed"; return; }
 	mkdir -p /mnt/mmcblk0p1
 	mount "${DEV}p1" /mnt/mmcblk0p1 2>/dev/null
 	mountpoint -q /mnt/mmcblk0p1 || err="mount after format failed"
 }
 
+# What mount and umount say when they refuse is the whole diagnosis — a card
+# whose filesystem has been destroyed fails with "Invalid argument", which is
+# worth reporting verbatim rather than flattening to "mount failed".
+first_line() { printf '%s' "$1" | sed -n '1p'; }
+
 do_mount() {
 	ensure_node
 	t=$(target); base=${t##*/}; mkdir -p "/mnt/$base"
-	mount "$t" "/mnt/$base" 2>/dev/null
-	mountpoint -q "/mnt/$base" || err="mount failed"
+	logln "# mount $t /mnt/$base"
+	o=$(mount "$t" "/mnt/$base" 2>&1)
+	[ -n "$o" ] && logln "$o"
+	mountpoint -q "/mnt/$base" || err="$(first_line "${o:-mount failed}")"
 }
 
 do_unmount() {
 	t=$(target)
-	umount "$t" 2>/dev/null || err="unmount failed (in use?)"
+	logln "# umount $t"
+	o=$(umount "$t" 2>&1) || err="$(first_line "${o:-unmount failed (in use?)}")"
+	[ -n "$o" ] && logln "$o"
 }
 
 do_fsck() {
 	t=$(target)
 	fs=$(awk -v d="$t" '$1==d{print $3; exit}' /proc/mounts)
 	[ -z "$fs" ] && fs=$(blkid "$t" 2>/dev/null | sed -n 's/.*TYPE="\([^"]*\)".*/\1/p')
-	command -v "fsck.$fs" >/dev/null 2>&1 || { err="no fsck tool for ${fs:-this filesystem}"; return; }
+	# busybox ships the generic `fsck` wrapper, which only execs a per-filesystem
+	# helper; on a build without dosfstools there is no fsck.vfat for it to find.
+	# The page hides the button in that case (canFsck), so this is the backstop.
+	[ -n "$fs" ] || { err="no filesystem could be identified on the card — there is nothing to repair"; return; }
+	command -v "fsck.$fs" >/dev/null 2>&1 || {
+		err="this firmware has no fsck.$fs — the card cannot be repaired here"; return; }
+	# The check needs the card offline, but leaving it that way turns a repair
+	# into a second outage — a camera that was recording would go on not
+	# recording until somebody noticed the Mount button. So put it back exactly
+	# where it was, and only if it was mounted to begin with.
+	was=$(awk -v d="$t" '$1==d{print $2; exit}' /proc/mounts)
 	umount "$t" 2>/dev/null
-	L="${L}# fsck.$fs $t\n"
+	logln "# fsck.$fs $t"
 	o=$(fsck -t "$fs" -y "$t" 2>&1); rc=$?
-	L="${L}${o}\n"
+	logln "$o"
+	if [ -n "$was" ]; then
+		logln "# mount $t $was"
+		m=$(mount "$t" "$was" 2>&1)
+		[ -n "$m" ] && logln "$m"
+		mountpoint -q "$was" || { err="checked, but the card would not mount again"; return; }
+	fi
 	[ "$rc" -le 1 ] || err="fsck reported errors"
 }
 

--- a/www/cgi-bin/tool-recordings.cgi
+++ b/www/cgi-bin/tool-recordings.cgi
@@ -3,6 +3,11 @@
 <% page_title="Recordings" %>
 <%in p/header.cgi %>
 
+<!-- Two banners, and they are not interchangeable. #rec-health is about the
+     card and stays put for as long as the card is in trouble; #rec-note is the
+     transient one the player writes to and clears on every clip and day change,
+     so a card warning parked in it would be wiped by the first seek. -->
+<div id="rec-health" class="d-none"></div>
 <div id="rec-note" class="d-none"></div>
 
 <div id="rec-main">


### PR DESCRIPTION
Fixes #208.

## The problem

A card whose filesystem has gone bad reads as perfectly healthy in this UI right up until you notice nothing has been recorded for hours. The kernel mounts a vfat card with `errors=remount-ro` and drops it to read-only the moment the FAT stops making sense; `df` then goes on reporting the space that was free *at that instant*, so capacity, the storage bar and the clip list all look exactly as they did before recording stopped.

The only place the truth was written down was `/proc/mounts` — which `j/sdcard.cgi` already reads, for the mountpoint and the filesystem type, three fields away from the answer.

## What changed

**One judgement, made server-side.** `j/sdcard.cgi` gains a `health` field — `ok`, `readonly`, `unmounted`, `unreadable`, `unformatted`, `absent` — decided once and worded by whichever page is asking, rather than each page re-deriving it from `mounted`/`fs`/`partitioned` and drifting apart. `ro` is matched as a whole comma-separated word; a substring test finds the `ro` in `errors=remount-ro` on every healthy mount.

**The SD card page** badges the state, says plainly that nothing can be written however much space is free, marks the mount read-only, and stops claiming "✓ Recording to this card" when nothing is being written to it.

**The Recordings page** — the page people actually open when they wonder where the footage went — carries the same warning above the timeline in its own banner (`#rec-health`, separate from the transient per-clip `#rec-note`, which the player clears on every seek), folds the card's condition into the empty state so "Nothing recorded yet" is replaced by the real reason, stops labelling the truncated last clip as still "recording", and no longer paints a green **Recording** badge next to an archive that stopped growing hours ago.

**The repair is offered, and only when it exists.** busybox ships the generic `fsck` wrapper on every build, but it only execs `fsck.<fs>` — and a build without dosfstools has no `fsck.vfat` for it to find, which is the case on the lab hi3516av300 the issue was reported from. Where the helper exists the alert offers **Check and repair**; where it does not it says so and offers **Format**. `do_fsck` now remounts the card where it found it: taking a recording camera offline to repair it and then leaving it offline is a second outage.

**`fsErrors`** carries up to three matching `dmesg` lines as corroboration, gathered only in the unhealthy states — the endpoint is polled every 5 s and `dmesg` is 80 KB on a running camera. It is never presented as reassurance: on hi3516av300 the CMA allocator alone pushes a card error out of the ring buffer within minutes, so an empty list means nothing was found, not that nothing happened. The UI renders nothing rather than "no errors".

**Incidentally**, since these paths were being touched: `mount`, `unmount` and `fsck` now report what the tool actually said (`mount: mounting /dev/mmcblk0p1 on /mnt/mmcblk0p1 failed: Invalid argument` is the diagnosis; "mount failed" is not), and the op log renders with real newlines instead of a literal `\n` between every line (`L="${L}x\n"` does not interpret the escape in POSIX sh). The SD page's event handlers now delegate once from the container the page never replaces, instead of being re-bound on every 5-second render.

## Verified on hardware

An hi3516av300 with a 32 GB card, over every state the code distinguishes:

| state | result |
|---|---|
| healthy `rw` mount, options containing `errors=remount-ro` | `health:"ok"` — the substring trap avoided |
| remounted `ro` with footage already on the card | `health:"readonly"`, `availKb` still 30 GB — the misleading number the issue is about |
| superblock wiped, nothing will mount | `health:"unreadable"` |
| unmounted with an intact filesystem | `health:"unmounted"` |
| kernel messages injected via `/dev/kmsg` | both FAT-fs lines and the I/O error picked up |
| stand-in `fsck.vfat` installed | Check offered, runs, and the card comes back mounted **rw** |
| `POST op=mount` on a card with no superblock | error is `mount: … failed: Invalid argument` |
| SD page, 12 s of re-renders then one toggle | exactly one `POST /api/v1/config` — handlers bound once |

`npm test` passes. The camera was returned to its starting configuration afterwards (the stub removed from the overlay's upper dir, not through the merged path).

### What the read-only card looks like

**SD Card page** — badge reads **Read-only**; a danger alert states that nothing can be written, names `errors=remount-ro` as the cause, quotes the kernel lines it found, and offers Format (this build has no `fsck.vfat`); the Mount row reads `/mnt/mmcblk0p1 — read-only`; the storage line reads *29.1 GB free, but nothing can be written*; the Recording card reads *Configured to record here, but the card is read-only — nothing is being written.*

**Recordings page** — the same warning above the day picker with an **Open the SD card page** button, and the day badge reads **Cannot record** in red instead of a green **Recording**. Clips written before the failure still play.

Screenshots of all four states are attached in the issue thread.
