### PR TITLE
Header: show the reader's clock, not the time in London

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1076,6 +1076,20 @@ mark {
 	color: rgba(255, 255, 255, 0.9);
 }
 
+/* The camera-clock drift warning in the signature bar. Bootstrap's .text-danger
+   would be the obvious class and is the wrong one: it is #dc3545 in both themes,
+   which is 4.2:1 on the light page ground and 4.0:1 on the dark one — under the
+   4.5:1 this text needs at normal size and weight, and failing it on the one
+   line that exists to be noticed. So each theme gets a red that clears it on the
+   ground it is actually drawn on. */
+#clock-drift {
+	color: #ea868f;   /* 7.2:1 on #14161c */
+}
+
+[data-bs-theme=light] #clock-drift {
+	color: #b02a37;   /* 6.0:1 on #f4f5f9 */
+}
+
 /* Links never wrap. With a peer camera on the link the expanded row is tight
    between the breakpoint and about 1300px, and letting "Sign out" break onto a
    second line does not make the bar narrower — it makes it taller, which is the

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -277,20 +277,36 @@ function heartbeat() {
 				const skew = json.time_now * 1000 - Date.now();
 				const mins = Math.round(skew / 60000);
 				const el = $('#clock-drift');
-				if (Math.abs(skew) > 60000) {
+				// Cleared when the clocks agree, not left standing: the camera's
+				// clock can be corrected while the page is open, and a stale warning
+				// would outlive the fault it describes.
+				const text = Math.abs(skew) > 60000
+					? '⚠ camera ' + (mins > 0 ? '+' : '') + mins + 'm' : '';
+				// Written only when it actually changes. The element is a live
+				// region, and re-setting textContent to the same string still
+				// replaces the text node — a screen reader would hear the same
+				// warning read out afresh every two seconds for as long as the page
+				// stayed open. (A plain `return` here would be worse than the noise
+				// it saves: this runs inside the heartbeat's one handler, so it
+				// would take memory, overlay and uptime down with it.)
+				if (el.textContent !== text) {
+					el.textContent = text;
 					// Colour comes from #clock-drift in bootstrap.override.css, which
-					// is theme-aware; .text-danger is one red for both and fails
-					// contrast on each. Only the spacing is a utility.
-					el.className = 'ms-1';
-					el.textContent = '⚠ camera ' + (mins > 0 ? '+' : '') + mins + 'm';
-					el.title = 'Camera clock is ' + Math.abs(mins) + ' minutes ' +
-						(mins > 0 ? 'ahead of' : 'behind') + ' this browser. Check Time Settings.';
-				} else {
-					// Cleared, not left standing: the camera's clock can be corrected
-					// while the page is open, and a stale warning would outlive the fault.
-					el.className = '';
-					el.textContent = '';
-					el.title = '';
+					// is theme-aware; .text-danger is one red for both themes and
+					// fails contrast on each. Only the spacing is a utility.
+					el.className = text ? 'ms-1' : '';
+					if (text) {
+						// The glyph and "+12m" are a shorthand that only reads next to
+						// the clock beside it, and title is not exposed on a span nobody
+						// can focus — so the sentence is what is announced.
+						const why = 'Camera clock is ' + Math.abs(mins) + ' minutes ' +
+							(mins > 0 ? 'ahead of' : 'behind') + ' this browser. Check Time Settings.';
+						el.title = why;
+						el.setAttribute('aria-label', why);
+					} else {
+						el.title = '';
+						el.removeAttribute('aria-label');
+					}
 				}
 			}
 

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -105,6 +105,29 @@ function fmtDeviceTime(epochMs, offsetMs) {
 	return new Date(epochMs + offsetMs).toLocaleString(undefined, { timeZone: 'UTC' });
 }
 
+// ...and the reader's own clock, which is the one the signature bar shows. Not
+// polled: the browser already knows the time, and it knows it in the zone the
+// person is actually in, which is more than the camera can say. Time only —
+// today's date is in the tooltip, because the bar is glanced at rather than
+// read and the full "8/29/2026, 5:47:07 PM" it used to carry crowded the row.
+function localClock() {
+	const el = $('#time-local');
+	if (!el) return;
+	const tick = () => {
+		const d = new Date();
+		el.textContent = d.toLocaleTimeString();
+		el.dateTime = d.toISOString();
+		el.title = d.toLocaleDateString(undefined, {
+			weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+		});
+		// Re-armed on the next second boundary rather than every 1000 ms: a fixed
+		// interval started mid-second slides against the wall clock and makes the
+		// display visibly skip a second every minute or so.
+		setTimeout(tick, 1000 - (Date.now() % 1000));
+	};
+	tick();
+}
+
 function setProgressBar(id, value, name) {
 	$(id).setAttribute('aria-valuenow', value);
 	$(id).title = name + ': ' + value + '%'
@@ -241,26 +264,32 @@ function heartbeat() {
 				st.title = 'SoC temperature ' + json.soc_temp;
 			}
 
-			// Device time, deliberately -- log rows render in the viewer's zone
-			// (logs.js), so these two disagree by design. This bar is the one
-			// place a camera whose clock is actually wrong must look wrong, so
-			// flag real drift rather than hiding it behind the browser's clock.
-			// (Skew is zone-independent: a correct camera reads 0 whatever the
-			// timezones are, so anything here is a genuine clock problem.)
+			// The camera's clock is worth a line only when it is wrong. It used to
+			// be printed in full on every page, in the camera's own zone, which is
+			// the one zone nobody reading the page is in — and on a camera whose
+			// timezone was never set that reads "Etc/GMT", i.e. the time in
+			// London. What device time is genuinely good for is catching a camera
+			// that has drifted, because recordings and log rows are stamped by it
+			// and nothing else on the page would show it. So only the drift is
+			// left. (Skew is zone-independent: a correct camera reads 0 whatever
+			// either timezone is, so anything here is a real clock problem.)
 			if (json.time_now !== '') {
-				const epochMs = json.time_now * 1000;
-				// Unlike the log rows there is no raw form to fall back to here, so
-				// an unknown offset renders as UTC rather than blanking the bar.
-				const text = fmtDeviceTime(epochMs, parseTzOffsetMs(json.utc_offset) || 0) + ' ' + json.timezone;
-				const skew = epochMs - Date.now();
-				const el = $('#time-now');
+				const skew = json.time_now * 1000 - Date.now();
+				const mins = Math.round(skew / 60000);
+				const el = $('#clock-drift');
 				if (Math.abs(skew) > 60000) {
-					const mins = Math.round(skew / 60000);
-					el.textContent = text + ' ⚠ ' + (mins > 0 ? '+' : '') + mins + 'm';
+					// Colour comes from #clock-drift in bootstrap.override.css, which
+					// is theme-aware; .text-danger is one red for both and fails
+					// contrast on each. Only the spacing is a utility.
+					el.className = 'ms-1';
+					el.textContent = '⚠ camera ' + (mins > 0 ? '+' : '') + mins + 'm';
 					el.title = 'Camera clock is ' + Math.abs(mins) + ' minutes ' +
 						(mins > 0 ? 'ahead of' : 'behind') + ' this browser. Check Time Settings.';
 				} else {
-					el.textContent = text;
+					// Cleared, not left standing: the camera's clock can be corrected
+					// while the page is open, and a stale warning would outlive the fault.
+					el.className = '';
+					el.textContent = '';
 					el.title = '';
 				}
 			}
@@ -448,6 +477,7 @@ function initAll() {
 		});
 	});
 
+	localClock();
 	heartbeat();
 }
 

--- a/www/cgi-bin/j/pulse.cgi
+++ b/www/cgi-bin/j/pulse.cgi
@@ -61,10 +61,15 @@ if [ -n "$mjpid" ] && [ -r "/proc/$mjpid/stat" ]; then
 fi
 
 # Epoch and UTC offset in one date(1), split with parameter expansion, so the
-# 2s heartbeat gains no extra fork. The header needs both: /etc/timezone is only
-# a display label (fw-time.js writes it de-underscored, e.g. "America/New York",
-# which Intl.DateTimeFormat rejects), so the numeric offset is what actually
-# renders the camera's wall clock.
+# 2s heartbeat gains no extra fork. The header uses only the epoch now, and only
+# to notice a camera whose clock has drifted — it shows the reader's own clock,
+# not this one. The offset and the label are for the pages that must speak the
+# camera's wall clock because the filesystem does: fw-time.cgi, the File Manager
+# (mtimes) and Recordings (clips are named by the camera's strftime). Those
+# fetch this once on load rather than on the heartbeat. /etc/timezone is a
+# display label only — fw-time.js writes it de-underscored, e.g. "America/New
+# York", which Intl.DateTimeFormat rejects — so the numeric offset is what
+# actually renders a wall clock.
 now=$(date '+%s %z')
 
 payload=$(printf '{"soc_temp":"%s","time_now":"%s","timezone":"%s","utc_offset":"%s","mem_used":"%d","overlay_used":"%d","daynight_value":"%d","uptime":"%s","uptime_s":%d,"mj_uptime":"%s"}' \

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -136,7 +136,14 @@ Pragma: no-cache
 
 				<div class="col-1" id="daynight_value"></div>
 				<div class="col-md-4 col-lg-3 mb-2 text-end">
-					<div id="time-now"></div>
+					<!-- The reader's clock, not the camera's. This bar used to print
+					     the camera's wall time and its timezone label — "8/29/2026,
+					     5:47:07 PM Etc/GMT" — which is a time nobody looking at the
+					     page is in: a camera whose zone was never set says GMT, and
+					     the reader is wherever they are. Both spans are filled by
+					     main.js; the camera's clock survives only as the drift
+					     warning, which appears when it is actually wrong. -->
+					<div id="time-now"><time id="time-local"></time><span id="clock-drift"></span></div>
 					<div class="text-secondary" id="soc-temp"></div>
 				</div>
 			</div>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -143,7 +143,7 @@ Pragma: no-cache
 					     the reader is wherever they are. Both spans are filled by
 					     main.js; the camera's clock survives only as the drift
 					     warning, which appears when it is actually wrong. -->
-					<div id="time-now"><time id="time-local"></time><span id="clock-drift"></span></div>
+					<div id="time-now"><time id="time-local"></time><span id="clock-drift" role="status" aria-live="polite"></span></div>
 					<div class="text-secondary" id="soc-temp"></div>
 				</div>
 			</div>


### PR DESCRIPTION
The signature bar printed the camera's wall clock and timezone label on every page — `8/29/2026, 5:47:07 PM Etc/GMT`. That's the one zone nobody reading the page is in: a camera whose timezone was never set reports `Etc/GMT`, so the bar reported the time in London to a reader three hours east of it, in the widest and most persistent text on the row.

**Now:** the browser's clock, client-side, no camera round-trip, in the reader's own zone. Time only — the date is in the tooltip. At 390px the old string wrapped to two lines; this one doesn't.

**Kept:** the camera's clock still matters when it's *wrong* — recordings and log rows are stamped by it and nothing else on the page would show it. So device time survives as a drift warning that appears only when the camera disagrees with the browser by over a minute, and clears again if the clock is corrected while the page is open. Skew is zone-independent, so this is orthogonal to the zone complaint: a correct camera shows nothing here whatever the two zones are.

**Contrast:** the warning deliberately avoids `.text-danger` — it's `#dc3545` in both themes, 4.2:1 on the light ground and 4.0:1 on the dark, under the 4.5:1 normal-weight text needs on the one line meant to be noticed. Each theme gets a red that clears it (6.0:1 / 7.2:1), read back from `getComputedStyle`, not judged by eye.

`pulse.cgi` still reports `timezone`/`utc_offset`: fw-time.cgi, the File Manager and Recordings must speak the camera's wall clock because the filesystem does. They fetch it once on load, not on the heartbeat.

Verified on the lab camera, both themes, 1400px and 390px, with the camera clock correct, ahead and behind.