### PR TITLE
Recordings: convert each timestamp on its own instant, not the day's

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,8 +217,12 @@ Small `#!/bin/sh` scripts that emit JSON for the front-end. `pulse.cgi` is polle
   everything the page says out loud about zones is gated on `tzUsable()`, so a
   failed or malformed pulse offers no toggle and claims no zone.
 
-  The toggle appears only when the two zones actually differ, but the day nav's
-  trailing note names the zone either way — not knowing which clock you were
+  The toggle appears only when the two zones actually differ somewhere in the
+  day — sampled hourly by `refreshTz()`, which is a sample and not a proof, and
+  costs at worst a toggle that was not offered rather than a time printed
+  wrong. The same samples give the note its zone labels, which show both ends
+  (`UTC+01:00→+02:00`) on a day a clock changed rather than naming one offset
+  the day did not keep. The day nav's trailing note names the zone either way — not knowing which clock you were
   reading was the original bug. Read on another clock a camera day no longer
   starts at midnight, so the whole-day axis is relabelled (`renderHours`, which
   wraps and falls back to `hh:mm` for zones offset by minutes) rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,20 +200,36 @@ Small `#!/bin/sh` scripts that emit JSON for the front-end. `pulse.cgi` is polle
   the clip list are all read out of filenames. That is what is on the card and
   what VLC and the File Manager agree with. On a camera whose timezone was
   never set it is also the time somewhere the viewer is not — `Etc/GMT` — so
-  `state.shift` (seconds to add to a camera-local second to read it on the
-  viewer's clock) moves the **printing** only, via the local `hhmm`/`clock`
-  wrappers. Nothing in the model, the playhead, the selection or the export
-  arithmetic ever leaves camera time. The `mj-rec-tz` toggle in the day nav
-  picks the mode and is only offered when the two zones actually differ; the
-  trailing note in the day nav names the zone either way, because not knowing
-  which clock you were reading was the original bug. Shifted, a camera day runs
-  03:00 to 03:00, so `wrapSec` wraps where `TL.clock` clamps, and the whole-day
-  axis is relabelled (`renderHours`) instead of using the static `00…24` the
-  page ships. An exported cut is named after what was displayed, date included
-  (`stampDate`), or the filename would pair the camera's date with the viewer's
-  time. The header's clock is a different question and is answered differently:
-  it is the **browser's**, because nothing there is stamped by the camera —
-  device time survives only as `#clock-drift`.
+  the `mj-rec-tz` toggle in the day nav moves the **printing** only, through
+  the local `hhmm`/`clock` wrappers. Nothing in the model, the playhead, the
+  selection or the export arithmetic ever leaves camera time.
+
+  Conversion is **per timestamp, not per day**: `instantOf(sec)` resolves a
+  camera-local second to the instant it happened (solving the offset/instant
+  circularity in one correction) and `viewerAt()` reads that instant on the
+  browser's clock. A single offset for the whole day is wrong on the two days a
+  year either zone changes and states an hour that never existed. The camera's
+  offset comes from `/etc/timezone` via `Intl` — `ianaZone()` puts back the
+  underscores `fw-time.cgi` strips — so it is right for the date being browsed,
+  not just today; `pulse.cgi`'s `%z` is the fallback when the name is not one
+  the browser knows, and is right except across a change in the camera's own
+  zone. **`state.offsetMs` defaulting to 0 is not a camera that reported UTC**:
+  everything the page says out loud about zones is gated on `tzUsable()`, so a
+  failed or malformed pulse offers no toggle and claims no zone.
+
+  The toggle appears only when the two zones actually differ, but the day nav's
+  trailing note names the zone either way — not knowing which clock you were
+  reading was the original bug. Read on another clock a camera day no longer
+  starts at midnight, so the whole-day axis is relabelled (`renderHours`, which
+  wraps and falls back to `hh:mm` for zones offset by minutes) rather than
+  using the static `00…24` the page ships, and an exported cut is named after
+  what was displayed, date included (`stampDate`). The mode itself lives in a
+  module variable, not in `localStorage` — storage is where it is *remembered*,
+  and it throws outright in some privacy configurations.
+
+  The header's clock is a different question and is answered differently: it is
+  the **browser's**, because nothing there is stamped by the camera — device
+  time survives only as `#clock-drift`.
 
 ### FPV variant
 

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -28,7 +28,7 @@
 	const state = {
 		cfg: {}, prefix: '', split: 1200, enabled: false, card: null,
 		offsetMs: 0, offsetKnown: false, zone: null, nowSec: null, today: '',
-		tzAt: 0, tzCamOff: 0, tzMyOff: 0, tzDiffers: false, tzOn: false,
+		tzSamples: [], tzDiffers: false, tzOn: false,
 		days: [], dayName: '', day: { clips: [], unplaced: [] },
 		view: { from: 0, to: 3600, width: 3600 },
 		playhead: 0, sel: null,
@@ -96,7 +96,11 @@
 	// reach and the only thing that can answer for a date that is not today —
 	// the camera ships a POSIX TZ string ("EST5EDT,M3.2.0,M11.1.0") that nothing
 	// in a browser will evaluate, and pulse.cgi's %z is one number for now.
-	const dtfCache = {};
+	// A bare object, not {}: the key is /etc/timezone, which fw-time.cgi writes
+	// from a POST, and on a plain object `'constructor' in cache` is true. That
+	// hands back Object as though it were a cached formatter, which ianaZone
+	// then accepts and zoneOffsetMs calls formatToParts on.
+	const dtfCache = Object.create(null);
 	function zoneFmt(zone) {
 		if (!(zone in dtfCache)) {
 			try {
@@ -178,22 +182,49 @@
 	}
 	function hhmm(sec) { return clock(sec).slice(0, 5); }
 
-	// What the two clocks were doing in the middle of the day being read — the
-	// only honest place to sample them for a label, since either may change
-	// during it. Recomputed per day, not per timestamp, because it answers
-	// "is there a choice here", not "what time is this".
+	// What the two clocks were doing across the day being read. Sampled hourly
+	// rather than once, because one reading cannot answer for a day on which
+	// either zone changed — and that is exactly the day whose ribbon most needs
+	// explaining. Hourly is a sample and not a proof: two zones that diverge for
+	// less than an hour can slip between the marks. Missing one costs a toggle
+	// that was not offered, never a time printed wrong, because the conversion
+	// itself never consults this.
 	function refreshTz() {
-		const at = instantOf(DAY / 2);
-		state.tzAt = at === null ? Date.now() : at;
-		state.tzCamOff = camOffsetAt(state.tzAt);
-		state.tzMyOff = -new Date(state.tzAt).getTimezoneOffset() * 60000;
+		const out = [];
+		for (let h = 0; h <= 24; h++) {
+			const ms = instantOf(h * 3600);
+			if (ms === null) { out.length = 0; break; }
+			out.push({ cam: camOffsetAt(ms), me: -new Date(ms).getTimezoneOffset() * 60000 });
+		}
+		state.tzSamples = out;
 		// A camera we were never told the zone of cannot be compared. With pulse
 		// unread or malformed, offsetMs is a default of zero, and treating that
 		// as a verified UTC would have the page both claim a zone nobody reported
-		// and offer a conversion computed from the claim. `at` being null is the
-		// flat records.path with no %F: no date, so nothing to convert against.
-		state.tzDiffers = tzUsable() && at !== null && state.tzCamOff !== state.tzMyOff;
+		// and offer a conversion computed from the claim. An empty sample list is
+		// the flat records.path with no %F: no date, so nothing to convert.
+		state.tzDiffers = tzUsable() && out.length > 0 &&
+			out.some(function (x) { return x.cam !== x.me; });
 		state.tzOn = tzWanted === 'local' && state.tzDiffers;
+	}
+
+	// One offset if the zone held all day, both ends if it changed. Naming a
+	// single offset for a day that had two is the same overclaim as converting
+	// the day by a single shift.
+	function zoneSpan(which) {
+		const s = state.tzSamples || [];
+		if (!s.length) return '';
+		let lo = s[0][which], hi = s[0][which];
+		s.forEach(function (x) { if (x[which] < lo) lo = x[which]; if (x[which] > hi) hi = x[which]; });
+		return lo === hi ? offsetLabel(lo)
+			: offsetLabel(lo) + '→' + offsetLabel(hi).slice(3);
+	}
+	// Whether the gap between the two held all day, and what it was. A day with
+	// a changeover in it has no single answer, and says so instead.
+	function zoneGap() {
+		const s = state.tzSamples || [];
+		if (!s.length) return null;
+		const d = s[0].me - s[0].cam;
+		return s.every(function (x) { return x.me - x.cam === d; }) ? d : null;
 	}
 
 	// The date an exported cut is stamped with. It follows what was on screen,
@@ -960,8 +991,8 @@
 		// a switch between two identical readings would be inventing a question.
 		const differs = state.tzDiffers;
 		const local = state.tzOn;
-		const camZone = offsetLabel(state.tzCamOff);
-		const myZone = offsetLabel(state.tzMyOff);
+		const camZone = zoneSpan('cam');
+		const myZone = zoneSpan('me');
 		const tz = !differs ? '' :
 			'<span class="btn-group" role="group" aria-label="Which clock times are shown in">' +
 			'<button type="button" class="btn btn-sm ' +
@@ -975,14 +1006,17 @@
 		// always was. With them apart it is the one line that explains why the
 		// ribbon reads the way it does — including, in the viewer's own clock,
 		// that a camera day no longer starts at midnight.
-		const deltaMs = state.tzMyOff - state.tzCamOff;
+		const gap = zoneGap();
 		const zoneNote = !differs ? esc(label)
 			: local
 				? 'your time (' + esc(myZone) + ') · camera day ' + esc(label) +
 					' starts ' + hhmm(0) + ' here'
-				: 'camera time (' + esc(camZone) + '), ' +
-					(deltaMs > 0 ? 'behind' : 'ahead of') + ' yours by ' +
-					TL.duration(Math.abs(deltaMs) / 1000);
+				: 'camera time (' + esc(camZone) + ')' + (gap === null
+					// A day with a changeover in it has no single gap, so it is
+					// not given one — the ribbon is relabelled either way.
+					? ' · clocks change during this day'
+					: ', ' + (gap > 0 ? 'behind' : 'ahead of') + ' yours by ' +
+						TL.duration(Math.abs(gap) / 1000));
 
 		el.innerHTML =
 			'<button class="btn btn-sm btn-outline-secondary" id="rec-prev" type="button"' +

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -27,7 +27,8 @@
 
 	const state = {
 		cfg: {}, prefix: '', split: 1200, enabled: false, card: null,
-		offsetMs: 0, nowSec: null, today: '', shift: 0,
+		offsetMs: 0, offsetKnown: false, zone: null, nowSec: null, today: '',
+		tzAt: 0, tzCamOff: 0, tzMyOff: 0, tzDiffers: false, tzOn: false,
 		days: [], dayName: '', day: { clips: [], unplaced: [] },
 		view: { from: 0, to: 3600, width: 3600 },
 		playhead: 0, sel: null,
@@ -72,63 +73,141 @@
 	// somewhere the viewer is not — which is how you end up looking at footage
 	// you shot at twenty to nine and being told it is quarter to six.
 	//
-	// So the model stays camera-local end to end and only the printing moves.
-	// state.shift is the seconds to add to a camera-local second to read it on
-	// the viewer's clock, and it is 0 unless the viewer asked for their own
-	// clock AND the two zones actually differ.
+	// So the model stays camera-local end to end and only the printing moves:
+	// a camera-local second is resolved to the instant it happened, and that
+	// instant is read on the viewer's clock. Per second, not per day — a single
+	// offset for the whole day is wrong on the two days a year one of the two
+	// zones changes, and states an hour that never existed.
 	const TZ_KEY = 'mj-rec-tz';
 
-	function tzMode() {
-		// Storage throws outright in some privacy modes, so this can never be
-		// the thing that stops the page rendering.
-		try { return localStorage.getItem(TZ_KEY) === 'local' ? 'local' : 'camera'; }
-		catch (e) { return 'camera'; }
-	}
+	// Held here rather than read back out of storage on every call. Storage
+	// throws outright in some privacy configurations, and a setter that failed
+	// silently would leave the button snapping back to camera on every click:
+	// storage is where the choice is remembered, not where it lives.
+	let tzWanted = 'camera';
+	try { if (localStorage.getItem(TZ_KEY) === 'local') tzWanted = 'local'; } catch (e) {}
+
 	function setTzMode(m) {
-		try { localStorage.setItem(TZ_KEY, m); } catch (e) { /* remembered for this visit only */ }
+		tzWanted = m === 'local' ? 'local' : 'camera';
+		try { localStorage.setItem(TZ_KEY, tzWanted); } catch (e) { /* this visit only */ }
 	}
 
-	// The viewer's offset on the day being read rather than today's: browsing
-	// last week's footage across a daylight-saving change would otherwise be an
-	// hour out. The camera's offset can only ever be today's — pulse.cgi reports
-	// a number, not a zone, so there is no asking it what it was in March.
-	function viewerOffsetMs(dayName) {
-		const d = /^\d{4}-\d{2}-\d{2}$/.test(dayName)
-			? new Date(dayName + 'T12:00:00') : new Date();
-		return isNaN(d.getTime()) ? 0 : -d.getTimezoneOffset() * 60000;
+	// A zone's offset at a given instant. Intl is the only timezone database in
+	// reach and the only thing that can answer for a date that is not today —
+	// the camera ships a POSIX TZ string ("EST5EDT,M3.2.0,M11.1.0") that nothing
+	// in a browser will evaluate, and pulse.cgi's %z is one number for now.
+	const dtfCache = {};
+	function zoneFmt(zone) {
+		if (!(zone in dtfCache)) {
+			try {
+				dtfCache[zone] = new Intl.DateTimeFormat('en-US', {
+					timeZone: zone, hourCycle: 'h23',
+					year: 'numeric', month: '2-digit', day: '2-digit',
+					hour: '2-digit', minute: '2-digit', second: '2-digit',
+				});
+			} catch (e) { dtfCache[zone] = null; }   // not a name this browser knows
+		}
+		return dtfCache[zone];
 	}
-	function tzDeltaSec() {
-		return Math.round((viewerOffsetMs(state.dayName) - state.offsetMs) / 1000);
+	function zoneOffsetMs(zone, ms) {
+		const f = zoneFmt(zone);
+		if (!f) return null;
+		const p = {};
+		f.formatToParts(new Date(ms)).forEach(function (x) { p[x.type] = x.value; });
+		// The wall clock read back as if it were UTC. Its distance from the
+		// instant is the offset — the only way to get a number out of Intl
+		// without parsing a localised "GMT+3".
+		return Date.UTC(+p.year, +p.month - 1, +p.day, +p.hour % 24, +p.minute, +p.second) - ms;
 	}
-	function updateShift() {
-		state.shift = tzMode() === 'local' ? tzDeltaSec() : 0;
+
+	// /etc/timezone as a name the browser's database will accept. fw-time.cgi
+	// writes it de-underscored out of the bundled table ("America/New York"),
+	// which Intl rejects; no zone name contains a space, so putting them back is
+	// exact. Without it the camera side falls back to pulse.cgi's single number,
+	// which is right except across a change in the camera's own zone.
+	function ianaZone(s) {
+		const z = String(s || '').trim().replace(/ /g, '_');
+		return z && zoneFmt(z) ? z : null;
 	}
+	function camOffsetAt(ms) {
+		if (state.zone) {
+			const o = zoneOffsetMs(state.zone, ms);
+			if (o !== null) return o;
+		}
+		return state.offsetMs;
+	}
+	function tzUsable() { return !!state.zone || state.offsetKnown; }
+
 	function offsetLabel(ms) {
 		const m = Math.round(ms / 60000), a = Math.abs(m);
 		return 'UTC' + (m < 0 ? '-' : '+') + String(Math.floor(a / 60)).padStart(2, '0') +
 			':' + String(a % 60).padStart(2, '0');
 	}
 
-	// The wrap is why these exist instead of calling timeline.js directly:
-	// shifted, a camera day runs 03:00 to 03:00, and TL.clock clamps to the day
-	// rather than wrapping — it would flatten both ends onto midnight.
-	function wrapSec(sec) { return ((sec + state.shift) % DAY + DAY) % DAY; }
-	function hhmm(sec) { return TL.hhmm(wrapSec(sec)); }
-	function clock(sec) { return TL.clock(wrapSec(sec)); }
+	// The instant a camera-local second on the day being browsed happened.
+	// Solved rather than computed: the offset depends on the instant and the
+	// instant depends on the offset. One correction settles it everywhere except
+	// inside the hour a spring-forward skips, which no wall clock names anyway.
+	function dayBaseUtc() {
+		if (!/^\d{4}-\d{2}-\d{2}$/.test(state.dayName)) return null;
+		const t = Date.parse(state.dayName + 'T00:00:00Z');
+		return isNaN(t) ? null : t;
+	}
+	function instantOf(sec) {
+		const base = dayBaseUtc();
+		if (base === null) return null;
+		const naive = base + sec * 1000;
+		return naive - camOffsetAt(naive - camOffsetAt(naive));
+	}
+	// That instant read on the viewer's clock. Date's local getters are the
+	// browser's own timezone database, so this is exact through a change in the
+	// viewer's zone as well — including the two days a year it happens mid-day.
+	function viewerAt(sec) {
+		const ms = instantOf(sec);
+		if (ms === null) return null;
+		const d = new Date(ms);
+		return { ms: ms, sec: d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds() };
+	}
+
+	// Camera mode leaves timeline.js to print, exactly as before this existed.
+	// Its clamp is what gives the last tick of the day "24" rather than "00".
+	function clock(sec) {
+		if (!state.tzOn) return TL.clock(sec);
+		const v = viewerAt(sec);
+		return TL.clock(v === null ? sec : v.sec);
+	}
+	function hhmm(sec) { return clock(sec).slice(0, 5); }
+
+	// What the two clocks were doing in the middle of the day being read — the
+	// only honest place to sample them for a label, since either may change
+	// during it. Recomputed per day, not per timestamp, because it answers
+	// "is there a choice here", not "what time is this".
+	function refreshTz() {
+		const at = instantOf(DAY / 2);
+		state.tzAt = at === null ? Date.now() : at;
+		state.tzCamOff = camOffsetAt(state.tzAt);
+		state.tzMyOff = -new Date(state.tzAt).getTimezoneOffset() * 60000;
+		// A camera we were never told the zone of cannot be compared. With pulse
+		// unread or malformed, offsetMs is a default of zero, and treating that
+		// as a verified UTC would have the page both claim a zone nobody reported
+		// and offer a conversion computed from the claim. `at` being null is the
+		// flat records.path with no %F: no date, so nothing to convert against.
+		state.tzDiffers = tzUsable() && at !== null && state.tzCamOff !== state.tzMyOff;
+		state.tzOn = tzWanted === 'local' && state.tzDiffers;
+	}
 
 	// The date an exported cut is stamped with. It follows what was on screen,
 	// or the file would carry neither reading: a cut labelled 20:47 saved as
-	// 2026-08-29_17-47 is the camera's date beside the viewer's time. Where the
-	// shift carries the selection past midnight the date goes with it — noon UTC
-	// is only a handle to add whole days to, so no zone or DST rule touches it.
+	// 2026-08-29_17-47 is the camera's date beside the viewer's time. Read off
+	// the instant itself, so a selection the shift carries over midnight lands
+	// on the date the viewer would call it.
 	function stampDate(sec) {
 		if (state.dayName === '.') return '';
 		if (!/^\d{4}-\d{2}-\d{2}$/.test(state.dayName)) return state.dayName + '_';
-		const roll = Math.floor((sec + state.shift) / DAY);
-		if (!roll) return state.dayName + '_';
-		const d = new Date(state.dayName + 'T12:00:00Z');
-		d.setUTCDate(d.getUTCDate() + roll);
-		return d.toISOString().slice(0, 10) + '_';
+		const v = state.tzOn ? viewerAt(sec) : null;
+		if (!v) return state.dayName + '_';
+		const d = new Date(v.ms), p = function (n) { return String(n).padStart(2, '0'); };
+		return d.getFullYear() + '-' + p(d.getMonth() + 1) + '-' + p(d.getDate()) + '_';
 	}
 
 	// ---- loading ---------------------------------------------------------
@@ -138,7 +217,12 @@
 			.then(function (r) { return r.json(); })
 			.then(function (j) {
 				const off = parseTzOffsetMs(j.utc_offset);   // main.js; null if unusable
+				// Zero is the fallback the day arithmetic below has always used,
+				// but it must not be mistaken for a camera that reported UTC:
+				// everything the page says out loud about zones is gated on this.
+				state.offsetKnown = off !== null;
 				state.offsetMs = off === null ? 0 : off;
+				state.zone = ianaZone(j.timezone);
 				const nowMs = (+j.time_now || 0) * 1000 + state.offsetMs;
 				const d = new Date(nowMs);
 				// Read the shifted instant as if it were UTC — the camera's wall
@@ -760,14 +844,16 @@
 	function renderHours() {
 		const el = $id('rec-hours');
 		if (!el) return;
-		const fine = (state.shift % 3600) !== 0;
+		// Labelled first, thinned second: whether two digits can say anything
+		// true is a property of the labels, not of a number this can assume.
+		// In camera mode the last one is "24" by TL.clock's clamp, which reads
+		// as the end of this day rather than the start of the next.
+		const all = [];
+		for (let i = 0; i <= 24; i++) all.push(hhmm(i * 3600));
+		const fine = all.some(function (t) { return t.slice(3) !== '00'; });
 		const out = [];
 		for (let i = 0; i <= 24; i += (fine ? 4 : 2)) {
-			// The last tick is midnight either way; unshifted the axis has always
-			// called it 24, which reads as "the end of this day" rather than as
-			// the start of the next one.
-			out.push(i === 24 && !state.shift ? '24'
-				: fine ? hhmm(i * 3600) : hhmm(i * 3600).slice(0, 2));
+			out.push(fine ? all[i] : all[i].slice(0, 2));
 		}
 		el.innerHTML = out.map(function (t) { return '<span>' + t + '</span>'; }).join('');
 	}
@@ -862,7 +948,7 @@
 	function renderDayNav() {
 		const el = $id('rec-daynav');
 		if (!el) return;
-		updateShift();
+		refreshTz();
 		const i = state.days.map(function (d) { return d.name; }).indexOf(state.dayName);
 		const prev = i > 0 ? state.days[i - 1].name : '';
 		const next = i >= 0 && i < state.days.length - 1 ? state.days[i + 1].name : '';
@@ -872,11 +958,11 @@
 		// The choice only exists when there is something to choose: a camera set
 		// to the viewer's own zone prints the same times either way, and offering
 		// a switch between two identical readings would be inventing a question.
-		const delta = tzDeltaSec();
-		const local = state.shift !== 0;
-		const camZone = offsetLabel(state.offsetMs);
-		const myZone = offsetLabel(viewerOffsetMs(state.dayName));
-		const tz = !delta ? '' :
+		const differs = state.tzDiffers;
+		const local = state.tzOn;
+		const camZone = offsetLabel(state.tzCamOff);
+		const myZone = offsetLabel(state.tzMyOff);
+		const tz = !differs ? '' :
 			'<span class="btn-group" role="group" aria-label="Which clock times are shown in">' +
 			'<button type="button" class="btn btn-sm ' +
 			(local ? 'btn-outline-secondary' : 'btn-primary') + '" id="rec-tz-cam"' +
@@ -889,12 +975,14 @@
 		// always was. With them apart it is the one line that explains why the
 		// ribbon reads the way it does — including, in the viewer's own clock,
 		// that a camera day no longer starts at midnight.
-		const zoneNote = !delta ? esc(label)
+		const deltaMs = state.tzMyOff - state.tzCamOff;
+		const zoneNote = !differs ? esc(label)
 			: local
 				? 'your time (' + esc(myZone) + ') · camera day ' + esc(label) +
 					' starts ' + hhmm(0) + ' here'
 				: 'camera time (' + esc(camZone) + '), ' +
-					(delta > 0 ? 'behind' : 'ahead of') + ' yours by ' + TL.duration(Math.abs(delta));
+					(deltaMs > 0 ? 'behind' : 'ahead of') + ' yours by ' +
+					TL.duration(Math.abs(deltaMs) / 1000);
 
 		el.innerHTML =
 			'<button class="btn btn-sm btn-outline-secondary" id="rec-prev" type="button"' +
@@ -927,7 +1015,7 @@
 		if (prev) $id('rec-prev').addEventListener('click', function () { goDay(prev); });
 		if (next) $id('rec-next').addEventListener('click', function () { goDay(next); });
 		$id('rec-daysel').addEventListener('change', function (e) { goDay(e.target.value); });
-		if (delta) {
+		if (differs) {
 			$id('rec-tz-cam').addEventListener('click', function () { setTz('camera'); });
 			$id('rec-tz-loc').addEventListener('click', function () { setTz('local'); });
 		}


### PR DESCRIPTION
Follow-up to #213. Review found four faults in how the viewer-clock reading was worked out; three share a root — the conversion was **one offset sampled once per day**, which cannot describe a day on which either clock changed.

| Fault | Effect |
|---|---|
| Viewer offset read at noon, applied to every second | a day holding a DST change was an hour out on the side noon wasn't on |
| Camera offset was `pulse.cgi`'s `%z` — the offset *now* | browse January footage in August and every time is an hour out. Ordinary browsing, not an edge case |
| Absent/malformed offset left `state.offsetMs` at its default `0` | the page labelled that `UTC+00:00` and offered a conversion computed from the claim. A default is not a measurement |
| `setTzMode` wrote only to `localStorage` | where storage throws — which the getter's own `catch` admits happens — the button set nothing and snapped back. The comment promised a visit-only fallback that didn't exist |

### What it does now

A camera-local second is resolved to **the instant it happened**, and that instant is read on the viewer's clock — per timestamp. `instantOf()` *solves* rather than computes (the offset depends on the instant and the instant on the offset; one correction settles it everywhere except inside the hour a spring-forward skips, which no wall clock names).

- **Viewer side**: `Date`'s local getters — the browser's own tz database, exact by construction.
- **Camera side**: `/etc/timezone` through `Intl`. The name is stored de-underscored and `Intl` rejects that spelling, so `ianaZone()` puts them back. This answers for *the date being browsed*. `pulse.cgi`'s number remains the fallback for a name the browser doesn't know.
- **Nothing claimed that wasn't reported**: `tzUsable()` gates the toggle *and* every zone label.
- **Mode lives in a module variable**, with storage as the place it's remembered.

The axis is labelled before it's thinned, so whether two digits can say something true is read off the labels rather than assumed; the last tick still reads `24` via `TL.clock`'s clamp.

### Verified in a browser against real transitions

| Case | Result |
|---|---|
| Camera `Etc/GMT`, viewer `Europe/Berlin`, 2026-03-29 | axis `01 04 06 …` — the missing hour is missing. Old code printed `02` |
| Camera `America/New York`, viewer UTC, 2026-01-15 | day starts **05:00** (EST) |
| same camera, 2026-08-29 | day starts **04:00** (EDT) — one camera, one page load |
| Pulse returns neither zone nor offset | no toggle, no zone claim, camera axis unchanged |
| `localStorage` throws on every access | toggle still switches both ways; only the remembering is lost |