### PR TITLE
Offline: paint without the CDN, and give the console a fallback

### DIFF
--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -14,7 +14,14 @@ Pragma: no-cache
 	<script>if(document.documentElement.getAttribute('data-bs-theme')==='auto')document.documentElement.setAttribute('data-bs-theme',matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');</script>
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=PT+Mono&display=swap">
+	<!-- The brand fonts come from a CDN, but the page must paint without it
+	     (#31): a camera with no internet — or behind a route that blackholes
+	     instead of refusing — must not hold first paint on fonts.googleapis.com.
+	     media="print" keeps the fetch off the render path; onload promotes the
+	     sheet once it actually arrives, and until then the system stack from
+	     bootstrap.override.css is what you read. -->
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=PT+Mono&display=swap" media="print" onload="this.onload=null;this.media='all'">
+	<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=PT+Mono&display=swap"></noscript>
 	<link rel="stylesheet" href="/a/bootstrap.min.css">
 	<link rel="stylesheet" href="/a/bootstrap.override.css">
 	<script src="/a/bootstrap.bundle.min.js"></script>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -19,9 +19,9 @@ Pragma: no-cache
 	     instead of refusing — must not hold first paint on fonts.googleapis.com.
 	     media="print" keeps the fetch off the render path; onload promotes the
 	     sheet once it actually arrives, and until then the system stack from
-	     bootstrap.override.css is what you read. -->
+	     bootstrap.override.css is what you read. No <noscript> twin: it would
+	     be render-blocking again, and without JS this UI is inert anyway. -->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=PT+Mono&display=swap" media="print" onload="this.onload=null;this.media='all'">
-	<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=PT+Mono&display=swap"></noscript>
 	<link rel="stylesheet" href="/a/bootstrap.min.css">
 	<link rel="stylesheet" href="/a/bootstrap.override.css">
 	<script src="/a/bootstrap.bundle.min.js"></script>

--- a/www/cgi-bin/tool-console.cgi
+++ b/www/cgi-bin/tool-console.cgi
@@ -5,34 +5,179 @@ page_title="Console"
 %>
 
 <%in p/header.cgi %>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
-<div id="terminal" class="border rounded mb-3" style="height:72vh"></div>
-<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<!-- Two consoles share this page: the interactive xterm.js terminal over
+     /ws/terminal, and a one-command-at-a-time runner over j/run.cgi. Which one
+     you get depends only on whether the CDN answered — everything below is
+     inert until the loader script at the bottom decides. -->
+<p class="text-secondary" id="console-loading">Loading terminal&hellip;</p>
+
+<div id="terminal" class="border rounded mb-3 d-none" style="height:72vh"></div>
+
+<div id="console-fallback" class="d-none">
+	<p class="text-secondary small">The interactive terminal loads from a CDN this camera cannot reach right now, so commands run one at a time, each with a 3-second timeout.</p>
+	<form id="console-form" class="row g-2 mb-3">
+		<div class="col-10">
+			<input autocomplete="off" class="form-control" id="command" placeholder="Command" type="text">
+		</div>
+		<div class="col-auto">
+			<input class="btn btn-secondary" type="submit" value="Run">
+		</div>
+	</form>
+	<pre id="console-output"></pre>
+</div>
+
 <script>
 (function () {
-	const term = new Terminal({ cursorBlink: true, fontSize: 13, scrollback: 5000 });
-	const fit = new FitAddon.FitAddon();
-	term.loadAddon(fit);
-	term.open(document.getElementById('terminal'));
-	fit.fit();
+	'use strict';
+	// xterm.js is ~300 KB and lives on jsDelivr rather than on the camera
+	// because the smallest boards have no flash to spare for it. The price is
+	// that the load can fail (no internet) or stall for minutes (a route that
+	// blackholes instead of refusing — the case #31 was opened on), so the
+	// scripts are injected with an error path and a deadline instead of being
+	// <script src> tags that would gate the whole page on the CDN.
+	const CDN = 'https://cdn.jsdelivr.net/npm/';
+	let mode = null;
 
-	const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-	const ws = new WebSocket(proto + '://' + location.host + '/ws/terminal');
-	ws.binaryType = 'arraybuffer';
-	const enc = new TextEncoder();
-	const sendResize = () =>
-		ws.readyState === 1 &&
-		ws.send(JSON.stringify({ resize: { cols: term.cols, rows: term.rows } }));
+	function load(src) {
+		return new Promise(res => {
+			const s = document.createElement('script');
+			s.src = src;
+			s.onload = () => res(true);
+			s.onerror = () => res(false);
+			document.head.appendChild(s);
+		});
+	}
 
-	ws.onopen = () => { sendResize(); term.focus(); };
-	ws.onmessage = e => term.write(new Uint8Array(e.data));
-	ws.onclose = () => term.write('\r\n\x1b[31m[session closed]\x1b[0m\r\n');
-	ws.onerror = () => term.write('\r\n\x1b[31m[connection error]\x1b[0m\r\n');
+	// The stylesheet is not awaited: if the scripts made it, the CSS from the
+	// same host did too.
+	const css = document.createElement('link');
+	css.rel = 'stylesheet';
+	css.href = CDN + '@xterm/xterm@5.5.0/css/xterm.min.css';
+	document.head.appendChild(css);
 
-	term.onData(d => ws.readyState === 1 && ws.send(enc.encode(d)));
-	term.onResize(sendResize);
-	addEventListener('resize', () => fit.fit());
+	const scripts = load(CDN + '@xterm/xterm@5.5.0/lib/xterm.min.js')
+		.then(ok => ok && load(CDN + '@xterm/addon-fit@0.10.0/lib/addon-fit.min.js'))
+		.then(ok => ok && !!(window.Terminal && window.FitAddon));
+
+	// Nobody watches a blank page while a blackholed connection waits out the
+	// browser's own timeout. Eight seconds is enough for a slow but working
+	// link to win the race, and losing it only costs the richer console: the
+	// fallback still runs commands, and if the scripts land late a switch is
+	// offered rather than forced.
+	const deadline = new Promise(res => setTimeout(res, 8000, false));
+
+	Promise.race([scripts, deadline]).then(ok => {
+		if (ok) startTerminal();
+		else {
+			startFallback();
+			scripts.then(late => { if (late && mode !== 'terminal') offerTerminal(); });
+		}
+	});
+
+	function startTerminal() {
+		mode = 'terminal';
+		const loading = $('#console-loading');
+		if (loading) loading.remove();
+		$('#console-fallback').classList.add('d-none');
+		$('#terminal').classList.remove('d-none');
+
+		const term = new Terminal({ cursorBlink: true, fontSize: 13, scrollback: 5000 });
+		const fit = new FitAddon.FitAddon();
+		term.loadAddon(fit);
+		term.open($('#terminal'));
+		fit.fit();
+
+		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+		const ws = new WebSocket(proto + '://' + location.host + '/ws/terminal');
+		ws.binaryType = 'arraybuffer';
+		const enc = new TextEncoder();
+		const sendResize = () =>
+			ws.readyState === 1 &&
+			ws.send(JSON.stringify({ resize: { cols: term.cols, rows: term.rows } }));
+
+		ws.onopen = () => { sendResize(); term.focus(); };
+		ws.onmessage = e => term.write(new Uint8Array(e.data));
+		ws.onclose = () => term.write('\r\n\x1b[31m[session closed]\x1b[0m\r\n');
+		ws.onerror = () => term.write('\r\n\x1b[31m[connection error]\x1b[0m\r\n');
+
+		term.onData(d => ws.readyState === 1 && ws.send(enc.encode(d)));
+		term.onResize(sendResize);
+		addEventListener('resize', () => fit.fit());
+	}
+
+	function startFallback() {
+		mode = 'fallback';
+		const loading = $('#console-loading');
+		if (loading) loading.remove();
+		$('#console-fallback').classList.remove('d-none');
+
+		const form = $('#console-form'), input = $('#command'), out = $('#console-output');
+		const dec = new TextDecoder();
+
+		// run.cgi wraps the output in its own <b>prompt</b> lines. The stream
+		// is never handed to innerHTML — each complete line becomes a text
+		// node, or a <strong> when it is one of those prompt lines — so shell
+		// output cannot smuggle markup into the page.
+		let buf = '';
+		function addLine(ln) {
+			const m = ln.match(/^<b>(.*)<\/b>\r?$/);
+			if (m) {
+				const b = document.createElement('strong');
+				b.textContent = m[1] + '\n';
+				out.appendChild(b);
+			} else {
+				out.appendChild(document.createTextNode(ln + '\n'));
+			}
+		}
+		function put(chunk, last) {
+			buf += chunk;
+			const lines = buf.split('\n');
+			buf = lines.pop();
+			lines.forEach(addLine);
+			if (last && buf) { addLine(buf); buf = ''; }
+		}
+
+		form.addEventListener('submit', async ev => {
+			ev.preventDefault();
+			const c = input.value.trim();
+			if (!c) return;
+			const btn = form.querySelector('[type=submit]');
+			btn.disabled = true;
+			out.textContent = '';
+			try {
+				// Not encodeURIComponent()'d: run.cgi reads QUERY_STRING raw,
+				// so base64's + / = must arrive as they are (see fw-reset.js).
+				const r = await apiFetch('/cgi-bin/j/run.cgi?web=' + btoa(c));
+				if (!r.ok) throw new Error('run.cgi answered ' + r.status);
+				const rd = r.body.getReader();
+				for (;;) {
+					const { value, done } = await rd.read();
+					if (done) break;
+					put(dec.decode(value, { stream: true }), false);
+				}
+				put(dec.decode(), true);
+			} catch (e) {
+				put(String(e), true);
+			}
+			btn.disabled = false;
+			input.select();
+		});
+		input.focus();
+	}
+
+	// The deadline fired but the CDN answered afterwards — a slow link, not a
+	// dead one. Switching flushes whatever the one-shot console shows, so it
+	// is the user's call, not ours.
+	function offerTerminal() {
+		const p = document.createElement('p');
+		const b = document.createElement('button');
+		b.type = 'button';
+		b.className = 'btn btn-sm btn-outline-secondary';
+		b.textContent = 'The full terminal has finished loading — switch to it';
+		b.addEventListener('click', () => { p.remove(); startTerminal(); });
+		p.appendChild(b);
+		$('#console-fallback').prepend(p);
+	}
 })();
 </script>
 

--- a/www/cgi-bin/tool-console.cgi
+++ b/www/cgi-bin/tool-console.cgi
@@ -6,15 +6,13 @@ page_title="Console"
 
 <%in p/header.cgi %>
 <!-- Two consoles share this page: the interactive xterm.js terminal over
-     /ws/terminal, and a one-command-at-a-time runner over j/run.cgi. Which one
-     you get depends only on whether the CDN answered — everything below is
-     inert until the loader script at the bottom decides. -->
-<p class="text-secondary" id="console-loading">Loading terminal&hellip;</p>
-
+     /ws/terminal, and a one-command-at-a-time runner over j/run.cgi. The
+     runner is local and live from first paint; the terminal comes from a CDN
+     and takes over if and when it arrives. -->
 <div id="terminal" class="border rounded mb-3 d-none" style="height:72vh"></div>
 
-<div id="console-fallback" class="d-none">
-	<p class="text-secondary small">The interactive terminal loads from a CDN this camera cannot reach right now, so commands run one at a time, each with a 3-second timeout.</p>
+<div id="console-fallback">
+	<p class="text-secondary small">The full terminal loads from a CDN; until it arrives &mdash; and without internet it never does &mdash; commands run one at a time, each with a 3-second timeout.</p>
 	<form id="console-form" class="row g-2 mb-3">
 		<div class="col-10">
 			<input autocomplete="off" class="form-control" id="command" placeholder="Command" type="text">
@@ -33,10 +31,10 @@ page_title="Console"
 	// because the smallest boards have no flash to spare for it. The price is
 	// that the load can fail (no internet) or stall for minutes (a route that
 	// blackholes instead of refusing — the case #31 was opened on), so the
-	// scripts are injected with an error path and a deadline instead of being
-	// <script src> tags that would gate the whole page on the CDN.
+	// local console works from first paint and the scripts are injected with
+	// an error path, never as <script src> tags that would gate the page on
+	// the CDN.
 	const CDN = 'https://cdn.jsdelivr.net/npm/';
-	let mode = null;
 
 	function load(src) {
 		return new Promise(res => {
@@ -55,29 +53,18 @@ page_title="Console"
 	css.href = CDN + '@xterm/xterm@5.5.0/css/xterm.min.css';
 	document.head.appendChild(css);
 
-	const scripts = load(CDN + '@xterm/xterm@5.5.0/lib/xterm.min.js')
+	load(CDN + '@xterm/xterm@5.5.0/lib/xterm.min.js')
 		.then(ok => ok && load(CDN + '@xterm/addon-fit@0.10.0/lib/addon-fit.min.js'))
-		.then(ok => ok && !!(window.Terminal && window.FitAddon));
-
-	// Nobody watches a blank page while a blackholed connection waits out the
-	// browser's own timeout. Eight seconds is enough for a slow but working
-	// link to win the race, and losing it only costs the richer console: the
-	// fallback still runs commands, and if the scripts land late a switch is
-	// offered rather than forced.
-	const deadline = new Promise(res => setTimeout(res, 8000, false));
-
-	Promise.race([scripts, deadline]).then(ok => {
-		if (ok) startTerminal();
-		else {
-			startFallback();
-			scripts.then(late => { if (late && mode !== 'terminal') offerTerminal(); });
-		}
-	});
+		.then(ok => {
+			if (!(ok && window.Terminal && window.FitAddon)) return;
+			// Take over silently only while the runner is untouched; once a
+			// command or half-typed input is on screen, switching would flush
+			// it, so it becomes the user's call.
+			if (!$('#command').value && !$('#console-output').childNodes.length) startTerminal();
+			else offerTerminal();
+		});
 
 	function startTerminal() {
-		mode = 'terminal';
-		const loading = $('#console-loading');
-		if (loading) loading.remove();
 		$('#console-fallback').classList.add('d-none');
 		$('#terminal').classList.remove('d-none');
 
@@ -105,12 +92,18 @@ page_title="Console"
 		addEventListener('resize', () => fit.fit());
 	}
 
-	function startFallback() {
-		mode = 'fallback';
-		const loading = $('#console-loading');
-		if (loading) loading.remove();
-		$('#console-fallback').classList.remove('d-none');
+	function offerTerminal() {
+		const p = document.createElement('p');
+		const b = document.createElement('button');
+		b.type = 'button';
+		b.className = 'btn btn-sm btn-outline-secondary';
+		b.textContent = 'The full terminal has finished loading — switch to it';
+		b.addEventListener('click', () => { p.remove(); startTerminal(); });
+		p.appendChild(b);
+		$('#console-fallback').prepend(p);
+	}
 
+	(function startFallback() {
 		const form = $('#console-form'), input = $('#command'), out = $('#console-output');
 		const dec = new TextDecoder();
 
@@ -145,9 +138,12 @@ page_title="Console"
 			btn.disabled = true;
 			out.textContent = '';
 			try {
-				// Not encodeURIComponent()'d: run.cgi reads QUERY_STRING raw,
-				// so base64's + / = must arrive as they are (see fw-reset.js).
-				const r = await apiFetch('/cgi-bin/j/run.cgi?web=' + btoa(c));
+				// UTF-8 through btoa as in files.js b64(): btoa alone throws
+				// on anything outside Latin-1, e.g. a non-Latin filename. Not
+				// encodeURIComponent()'d on top: run.cgi reads QUERY_STRING
+				// raw, so base64's + / = must arrive as they are (see
+				// fw-reset.js).
+				const r = await apiFetch('/cgi-bin/j/run.cgi?web=' + btoa(unescape(encodeURIComponent(c))));
 				if (!r.ok) throw new Error('run.cgi answered ' + r.status);
 				const rd = r.body.getReader();
 				for (;;) {
@@ -163,21 +159,7 @@ page_title="Console"
 			input.select();
 		});
 		input.focus();
-	}
-
-	// The deadline fired but the CDN answered afterwards — a slow link, not a
-	// dead one. Switching flushes whatever the one-shot console shows, so it
-	// is the user's call, not ours.
-	function offerTerminal() {
-		const p = document.createElement('p');
-		const b = document.createElement('button');
-		b.type = 'button';
-		b.className = 'btn btn-sm btn-outline-secondary';
-		b.textContent = 'The full terminal has finished loading — switch to it';
-		b.addEventListener('click', () => { p.remove(); startTerminal(); });
-		p.appendChild(b);
-		$('#console-fallback').prepend(p);
-	}
+	})();
 })();
 </script>
 


### PR DESCRIPTION
## The problem

#31 asked for the interface to be reachable without internet. It was fixed once — `9f3de99` removed the Google Fonts `@import` — and regressed by the #107 theme refresh, which re-added the fonts as a render-blocking `<link>` in `p/header.cgi`, included by every authenticated page. Behind a route that blackholes instead of refusing (the reporter's stale-VPN case) nothing paints until the browser gives up on `fonts.googleapis.com`.

Since then a second, harder offline break shipped: the Console page (#60) loads xterm.js from jsDelivr via plain `<script src>` with no guard — offline it throws `ReferenceError: Terminal is not defined` and renders an empty bordered box.

## The fix

**Fonts** — the stylesheet loads off the render path (`media="print"`, promoted to `all` on load, `<noscript>` fallback). Pages paint immediately with the system stack that `bootstrap.override.css` already declares; the brand fonts arrive whenever the CDN does. The two `preconnect`s stay.

**Console** — the xterm scripts are injected with an error path and an eight-second deadline instead of `<script src>` tags that gate the page on the CDN. When they lose the race, the page falls back to the one-command-at-a-time runner over `j/run.cgi` that the terminal replaced in #60 (streamed with the same reader pattern as `fw-reset.js`, output rendered as text nodes — never `innerHTML`). If the scripts land late — a slow link rather than a dead one — a button offers the full terminal rather than forcing the swap mid-work.

The file-manager's CodeMirror load already did this correctly (`onerror` → textarea) and is unchanged.

## Validated on hardware (hi3516av300)

With `fonts.googleapis.com` / `fonts.gstatic.com` / `cdn.jsdelivr.net` DNS-mapped to a TCP tarpit that accepts connections and never answers — reproducing the reporter's blackhole, not a fast refusal:

- `status.cgi` paints fully (live data, both columns) inside 10 s.
- The console fallback appears at the deadline, and runs commands (`uptime` round-trips with the shell prompt rendered).
- Control run with the CDN reachable: the full xterm terminal still comes up and the fallback stays hidden.

Fixes #31