### PR TITLE
Settings: decide the heading's focus ring ourselves, not by engine heuristic

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -974,11 +974,16 @@ mark {
    pointer user has no reason to see a focus ring on it — it read as the title
    having been selected, or as a stray border round the card (#184).
 
-   So the ring goes for pointer focus and stays for keyboard focus, which is the
-   one case where it is doing its job: :focus-visible is exactly that
-   distinction, and the heading is only ever focused programmatically, so
-   nothing else can put a ring here. */
-#mj-settings-form h3[tabindex]:focus:not(:focus-visible) {
+   So the ring goes for pointer focus and stays for keyboard focus. The
+   :focus-visible rule below expresses that, but only where the engine agrees
+   that a script-set focus after a pointer pick is not "visible" — Chrome and
+   Firefox do, Safari answers :focus-visible for any focus() it did not watch
+   the mouse cause, and drew its default ring round every section title (#222).
+   So revealSection() also states the modality outright: a pointer pick tags
+   the heading .mj-focus-quiet (dropped again on blur), and that rule needs no
+   guessing from the engine. Keyboard picks get neither and keep the ring. */
+#mj-settings-form h3[tabindex]:focus:not(:focus-visible),
+#mj-settings-form h3.mj-focus-quiet:focus {
 	outline: none;
 }
 

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -359,16 +359,20 @@
 				const newTab = u.searchParams.get('tab');
 				if (!newTab) return;
 				ev.preventDefault();
+				// A keyboard-activated link fires its click with detail 0, a
+				// pointer with the tap count — decided here, where the event is,
+				// because revealSection() runs after an await and cannot ask.
+				const byPointer = ev.detail > 0;
 				// Picking the section that is already open is still a deliberate
 				// pick: below md it means "take me back down to it", and a control
 				// that does nothing at all reads as a dead one.
-				if (newTab === state.sec) { revealSection(); return; }
+				if (newTab === state.sec) { revealSection(byPointer); return; }
 				// Answering "no" to the prompt is choosing to stay, so nothing moves.
 				if (hasDirty() && !confirm('You have unsaved changes. Discard and switch sections?')) return;
 				// After load(), never inside it: the section has to be in the document
 				// first, and buildNav() — which load() re-runs while a search is
 				// active, resizing the rail *above* the form — has to have finished.
-				load(newTab, /*push*/ true).then(revealSection);
+				load(newTab, /*push*/ true).then(() => revealSection(byPointer));
 			});
 		});
 	}
@@ -384,7 +388,7 @@
 	// — and the column's top edge is what should end up near the top of the
 	// screen anyway. How far below the edge it lands is scroll-margin-top, in the
 	// stylesheet beside the rest of the below-md rail rules.
-	function revealSection() {
+	function revealSection(byPointer) {
 		const form = document.getElementById('mj-settings-form');
 		const col = document.getElementById('mj-settings-form-col');
 		if (!form || !col) return;
@@ -393,9 +397,19 @@
 		// reader, so the section's own heading takes it and announces the name.
 		// preventScroll because the scroll below is ours: focusing the live
 		// panel's heading would otherwise skip the preview sitting above it.
+		//
+		// Whether a script-set focus draws the browser's ring is a per-engine
+		// guess — Safari answers :focus-visible for it where Chrome and Firefox
+		// do not, and painted its default ring round every section title a
+		// pointer picked (#222). So the pick's own modality decides, not the
+		// heuristic: a pointer pick mutes the ring, a keyboard pick keeps it.
 		const h = form.querySelector('h3');
 		if (h) {
 			h.tabIndex = -1;
+			if (byPointer) {
+				h.classList.add('mj-focus-quiet');
+				h.addEventListener('blur', () => h.classList.remove('mj-focus-quiet'), { once: true });
+			}
 			h.focus({ preventScroll: true });
 		}
 


### PR DESCRIPTION
Fixes #222.

**What the reporter saw.** Opening Camera → Settings and picking a section drew the browser's default focus ring as a blue box around the section's title, with no interaction on the title itself.

**Why.** `revealSection()` moves focus to the section's `<h3>` so that a pick which neither navigates nor opens anything still announces the section to a screen reader (#199). The ring was meant to be suppressed for pointer picks by `#mj-settings-form h3[tabindex]:focus:not(:focus-visible)` — but whether a *script-set* focus matches `:focus-visible` is a per-engine heuristic. Chromium 131/151, Firefox 132 and Playwright's WebKit all answer "not visible" after a pointer click (verified against the lab camera with real input events — no ring in any of them), while Safari answers `:focus-visible` for any `focus()` the mouse did not directly cause, and paints its default ring. The screenshot's ring is exactly the shape the suppressed rule produces when it fails to apply: force the keyboard path in Chromium and the same full-width box appears around the title.

**Fix.** Stop asking the engine to guess a modality the click event already states: a keyboard-activated click carries `detail === 0`, a pointer click a positive tap count. The nav handler passes that down, and a pointer pick tags the heading `.mj-focus-quiet` (removed again on blur); the author rule `h3.mj-focus-quiet:focus { outline: none }` outranks the UA ring regardless of what the engine decided `:focus-visible` means. Keyboard picks carry no tag and keep the ring where their engine draws one — Chromium still shows `outline: auto` on a keyboard pick, unchanged.

**Verified on the lab hi3516av300** through Playwright (Chromium, Firefox, WebKit) with real input dispatch: pointer picks are quiet in all three; the class-forced case (the Safari condition) computes `outline: none`; keyboard picks keep the Chromium ring; the tag sheds on blur. Firefox reports `detail 1` even for keyboard-activated link clicks so its keyboard picks are tagged quiet too — no regression, since Firefox's heuristic already drew no ring on this focus before the change.

No `bootstrap.min.css` regeneration needed: the new rule lives in `bootstrap.override.css`, which is not purged.