### PR TITLE
Live View: when WebRTC serves the other channel, the chip says so

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -319,9 +319,12 @@ const tick = (n) => new Promise((r) => setTimeout(r, n || 60));
 	{
 		// WebRTC takes ?stream= as a preference, and majestic#299 arrived as
 		// "Main selected, Sub displayed" with nothing on the page admitting
-		// it. With no remembered choice the page opens on Sub.
+		// it. With no remembered choice the page opens on Sub. Main's size is
+		// deliberately non-canonical: the settings page accepts and persists
+		// this form, and a size the preview refused to read would silence
+		// the note exactly when it was needed.
 		const env = load({
-			main: '1920x1080', sub: '800x600', transport: 'webrtc',
+			main: '1920 X 1080', sub: '800x600', transport: 'webrtc',
 		});
 		await tick();
 		const live = env.made[0];

--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -93,7 +93,7 @@ function load(cfg) {
 		MajesticVideo: impls.mse,
 		MajesticWebRTC: impls.webrtc,
 		MajesticTransport: {
-			available: () => true, preferred: () => 'mse',
+			available: () => true, preferred: () => cfg.transport || 'mse',
 			choose() {}, demote() {},
 			impl: (k) => (k === 'webrtc' ? impls.webrtc : impls.mse),
 			iceServers: () => [],
@@ -313,6 +313,34 @@ const tick = (n) => new Promise((r) => setTimeout(r, n || 60));
 		await tick();
 		env.el('mj-stream-auto').fire('click');
 		check('stored as auto', env.stored === 'auto', String(env.stored));
+	}
+
+	group('the chip names the channel WebRTC actually served');
+	{
+		// WebRTC takes ?stream= as a preference, and majestic#299 arrived as
+		// "Main selected, Sub displayed" with nothing on the page admitting
+		// it. With no remembered choice the page opens on Sub.
+		const env = load({
+			main: '1920x1080', sub: '800x600', transport: 'webrtc',
+		});
+		await tick();
+		const live = env.made[0];
+		live.say('playing');
+		// The camera serves the channel that was asked for: no note.
+		live.opts.onCodec('h264', 'h264', 800, 600);
+		check('the served channel is not named when it matches',
+			env.el('mj-badge').textContent.indexOf('stream') === -1,
+			env.el('mj-badge').textContent);
+		// The camera serves Main against a Sub request: the chip says so.
+		live.opts.onCodec('h264', 'h264', 1920, 1080);
+		check('a mismatch names what arrived',
+			/ · Main stream$/.test(env.el('mj-badge').textContent),
+			env.el('mj-badge').textContent);
+		// A frame matching neither configured size claims nothing.
+		live.opts.onCodec('h264', 'h264', 1280, 720);
+		check('an unrecognised size claims nothing',
+			env.el('mj-badge').textContent.indexOf('stream') === -1,
+			env.el('mj-badge').textContent);
 	}
 
 	done();

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -78,10 +78,13 @@
 				stream = 0;
 			}
 		}
-		// "WxH" per channel. Auto compares areas, so parse once.
+		// "WxH" per channel. Auto compares areas, so parse once. The same
+		// tolerant grammar as mj-settings' parseWH — that page accepts and
+		// persists "1920 X 1080", and a size the preview refused to read
+		// would silence both Auto and the served-channel note for it.
 		sizeOf = [0, 1].map(n => {
 			const v = mjGet(cfg, 'video' + n + '.size');
-			const m = /^(\d+)x(\d+)$/.exec(String(v || ''));
+			const m = /^\s*(\d+)\s*x\s*(\d+)\s*$/i.exec(String(v || ''));
 			return m ? { w: +m[1], h: +m[2] } : null;
 		});
 		autoApply();

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -225,12 +225,31 @@
 	// reported about its own picture.
 	let chipMedia = null, chipFps = 0;
 	let cfgFps = [0, 0];
+	// WebRTC takes ?stream= as a preference, not an order: the camera can
+	// serve the other channel — a codec its negotiation can give this
+	// browser, or a daemon fault (majestic#299 arrived as "Main selected,
+	// Sub displayed" with nothing on the page admitting it). The radios say
+	// what was asked; when the picture is recognisably the other channel's,
+	// the chip says what actually arrived. Only when both sizes are known
+	// and the frame matches the other channel exactly — a camera with unset
+	// (sensor-native) sizes claims nothing rather than guessing. MSE needs
+	// none of this: /ws/video serves the number it is given or nothing.
+	function servedNote() {
+		if (!usingWebRTC || !chipMedia) return '';
+		const want = sizeOf[stream ? 1 : 0], other = sizeOf[stream ? 0 : 1];
+		if (!want || !other) return '';
+		const is = d => d.w === chipMedia.w && d.h === chipMedia.h;
+		if (is(want) || !is(other)) return '';
+		return stream ? ' · Main stream' : ' · Sub stream';
+	}
+
 	function setChip() {
 		if (!badge || !chipMedia) return;
 		const fps = usingWebRTC ? chipFps : cfgFps[stream ? 1 : 0];
 		badge.textContent = (chipMedia.codec || '').toUpperCase() + ' ' +
 			chipMedia.w + '×' + chipMedia.h +
-			(fps ? ' · ' + Math.round(fps) + ' fps' : '');
+			(fps ? ' · ' + Math.round(fps) + ' fps' : '') +
+			servedNote();
 	}
 	// Talkback is deliberately NOT carried across a transport switch or a
 	// reattach. Everything else here is a preference; this one holds a live


### PR DESCRIPTION
Follow-up to the report in #184 (and majestic#299): with WebRTC enabled, the reporter selected **Main** and got the **Sub** stream — and nothing on the page admitted it.

The stream request itself is correct and was verified on hardware (CDP WebSocket capture: `?stream=0`/`?stream=1` follow the radios, and the av300 serves the requested channel both ways — the wrong-channel behaviour is daemon-side, tracked in majestic#299). But WebRTC's `?stream=` is a preference, not an order, and the UI should not pretend otherwise: the chip now appends the served channel's name — `H264 800×600 · 15 fps · Sub stream` — whenever the frame recognisably belongs to the channel that was *not* selected.

Deliberately conservative: only when both channels' configured sizes are known and the frame matches the other one exactly; a camera with unset (sensor-native) sizes claims nothing, and MSE is exempt because `/ws/video` serves the number it is given or nothing. Covered in the vm suite (which gains a `transport` knob); verified live that an honestly-serving camera gets no note in either direction.