### PR TITLE
PTZ: one pad, three backends — and Pelco-D works out of the box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,11 +222,24 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   `preview-page.js` in a bare `vm` with a stubbed `$` over an `IDS` list: any
   new element preview-page.js touches must be `$`-guarded and, for coverage,
   added to both `IDS` lists. PTZ is `p/motor.cgi` (markup only, hidden) +
-  `preview-ptz.js`, which relocates the pad into the stage's `#mj-ptz` mount:
-  Pointer Events with capture for press-and-hold, arrow keys only while the
-  stage itself has focus (the bar's slider and radios own them otherwise),
-  `apiFetch` to `j/ptz.cgi?h=&v=` (which validates both as small signed
-  integers before they reach the motor binary's argv).
+  `preview-ptz.js`, which relocates the pad(s) into the stage's `#mj-ptz`
+  mount: Pointer Events with capture for press-and-hold, arrow keys only
+  while the stage itself has focus (the bar's slider and radios own them
+  otherwise), `apiFetch` to `j/ptz.cgi`. **Three PTZ backends**, detected in
+  `common.cgi:update_caminfo` into `ptz_backend` (cached in sysinfo like
+  `ptz_support`): `gpio` (U-Boot `gpio_motors` + `gpio-motors` binary) and
+  `motor` (`ptz` + `/usr/bin/motor`) are stepped eight-way pads speaking
+  `j/ptz.cgi?h=&v=` (validated as small signed ints); `pelco` (`ptz` +
+  `/usr/bin/btzoom`) is the community Pelco-D serial mod — four directions,
+  zoom and focus, each a fixed timed pulse — speaking `j/ptz.cgi?act=<verb>`
+  against a closed whitelist (btzoom execs `pelcoD_$1`, so the verb must
+  never pass through raw). `bin/btzoom` ships in this repo (adopted from
+  OpenIPC/sandbox `scripts/pelcoD`, port from U-Boot `ptz_port`, default
+  `/dev/ttyAMA0`) so a Pelco camera needs only `fw_setenv ptz true`. A held
+  Pelco button strings pulses end-to-end via the one-request-in-flight
+  guard — btzoom answers only after its pulse ends. To render either pad on
+  a camera without hardware: set the env vars, `touch`+`chmod +x` fake
+  binaries, and remove `/tmp/webui/sysinfo.txt` (no reboot needed).
 - **Two clocks, and the page says which one it is printing.** Every second in
   `recordings.js` and `timeline.js` is **camera-local** and must stay that way:
   clips are named by the camera's own strftime, so day folders, the ribbon and

--- a/bin/btzoom
+++ b/bin/btzoom
@@ -14,11 +14,41 @@
 PORT=$(fw_printenv -n ptz_port 2>/dev/null)
 [ -n "$PORT" ] || PORT=/dev/ttyAMA0
 DELAY='sleep .5'
+LOCK=/tmp/btzoom.lock
 
 if [ -z "$1" ]; then
 	echo "Usage: $0 [start], [stop], [day], [night], [wide], [tele], [far], [near], [up], [down], [left], [right]"
 	exit 0
 fi
+
+# One invocation on the wire at a time. Every movement is command + delay +
+# stop, and two of those interleaved from separate callers (two tabs, a
+# webhook) corrupt each other's frames and let one caller's delayed stop
+# truncate the other's move. mkdir is the portable atomic; a holder that died
+# without cleaning up must not wedge the camera, so a lock older than a
+# minute is broken open. Waiting is bounded — a caller that cannot have the
+# port within ~2s reports that rather than hanging the UI.
+i=0
+until mkdir "$LOCK" 2>/dev/null; do
+	if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+		rmdir "$LOCK" 2>/dev/null
+		continue
+	fi
+	i=$((i + 1))
+	if [ "$i" -ge 40 ]; then
+		echo "PTZ port is busy."
+		exit 1
+	fi
+	sleep .05
+done
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+
+# The port must be raw at the right rate before any frame goes out, and a
+# freshly booted camera has had nobody set it. Cheap and idempotent, so it
+# runs for every command rather than trusting that `start` — the long lens
+# wakeup and ICR exercise, a maintenance action nobody is required to run —
+# happened first.
+stty -F "$PORT" 115200 raw -echo -onlcr 2>/dev/null
 
 pelcoD_night() {
 	printf '\xFF\x01\x00\x09\x00\x01\x0B' > "$PORT"

--- a/bin/btzoom
+++ b/bin/btzoom
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Pelco-D lens/pan control over a serial port. Origin: the community pelcoD
+# mod from OpenIPC/sandbox (scripts/pelcoD) by @sansarus, adopted here so a
+# Pelco camera works with `fw_setenv ptz true` alone instead of hand-installed
+# scripts. Changes from the original: POSIX function syntax (busybox ash does
+# not promise the `function` keyword), and the port comes from the U-Boot
+# `ptz_port` variable so non-SigmaStar boards can point it at their UART —
+# the original hardcoded /dev/ttyAMA0, including inside start's stty call.
+#
+# Every movement is a timed pulse: command, half a second, stop. The camera
+# ends its own move, which is why the WebUI paces a held button by waiting
+# for each request to answer rather than counting ticks.
+
+PORT=$(fw_printenv -n ptz_port 2>/dev/null)
+[ -n "$PORT" ] || PORT=/dev/ttyAMA0
+DELAY='sleep .5'
+
+if [ -z "$1" ]; then
+	echo "Usage: $0 [start], [stop], [day], [night], [wide], [tele], [far], [near], [up], [down], [left], [right]"
+	exit 0
+fi
+
+pelcoD_night() {
+	printf '\xFF\x01\x00\x09\x00\x01\x0B' > "$PORT"
+}
+
+pelcoD_day() {
+	printf '\xFF\x01\x00\x0B\x00\x01\x0D' > "$PORT"
+}
+
+pelcoD_start() {
+	stty -F "$PORT" 115200 raw -echo -onlcr
+	$DELAY
+	# Lens wakeup.
+	printf '\x51\x01\x04\x79\x01\x0D\x0A\x2E\x02\x7E\x00\x00\x00\x95' > "$PORT"
+	$DELAY
+	printf '\xFF\x01\x00\x07\x00\x53\x5B' > "$PORT"
+	$DELAY
+	printf '\xFF\x01\x00\x07\x00\x52\x5A' > "$PORT"
+	# Click-clack the ICR.
+	sleep 3
+	pelcoD_night
+	sleep 3
+	pelcoD_day
+}
+
+pelcoD_stop() {
+	printf '\xFF\x01\x00\x00\x00\x00\x01' > "$PORT"
+}
+
+pelcoD_tele() {
+	printf '\xFF\x01\x00\x20\x00\x00\x21' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_wide() {
+	printf '\xFF\x01\x00\x40\x00\x00\x41' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_far() {
+	printf '\xFF\x01\x00\x80\x00\x00\x81' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_near() {
+	printf '\xFF\x01\x01\x00\x00\x00\x02' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_up() {
+	printf '\xFF\x01\x00\x08\x00\x00\x09' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_down() {
+	printf '\xFF\x01\x00\x10\x00\x00\x11' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_right() {
+	printf '\xFF\x01\x00\x02\x00\x00\x03' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+pelcoD_left() {
+	printf '\xFF\x01\x00\x04\x00\x00\x05' > "$PORT"
+	$DELAY
+	pelcoD_stop
+}
+
+case "$1" in
+	start|stop|day|night|wide|tele|far|near|up|down|left|right)
+		"pelcoD_$1"
+		;;
+	*)
+		echo "Unknown command: $1"
+		exit 1
+		;;
+esac

--- a/sbin/updatewebui
+++ b/sbin/updatewebui
@@ -382,6 +382,13 @@ do_install() {
 		die "the overlay did not end up as planned, so the manifest was left alone"
 	settle_view
 	write_manifest
+	# The per-boot sysinfo cache was written by the release this one just
+	# replaced, and everything derived at detection time — PTZ backend and
+	# support, most visibly — stays frozen at the old release's answers until
+	# something regenerates it. Drop it; the next request rebuilds it with
+	# the new code. (A camera that gained /usr/bin/btzoom from this very
+	# install would otherwise hide its pad until a reboot.)
+	rm -f /tmp/webui/sysinfo.txt
 	echo
 	echo "WebUI updated to $source_name."
 	verify_view "$tmp/want"

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -828,12 +828,29 @@ mark {
 	   gradient padding reaches up over the pad's lower row — at equal
 	   z-index it swallows the pointerdown that starts a hold. */
 	z-index: 7;
+	/* Pelco cameras stack a zoom/focus cluster above the direction pad. */
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 6px;
 }
 
 .mj-ptz-pad {
 	display: grid;
 	grid-template-columns: repeat(3, 2.4rem);
 	gap: 2px;
+}
+
+/* Zoom (−/+) over focus (near/far): two columns, reading left-to-right as
+   less/more like the old sandbox pad its users are coming from. */
+.mj-ptz-fn {
+	grid-template-columns: repeat(2, 2.4rem);
+}
+
+/* The empty corners of the Pelco plus-shape — grid cells, not buttons, so
+   the arrows land where the eight-way pad has its own. */
+.mj-ptz-void {
+	height: 2.4rem;
 }
 
 .mj-ptz-btn {

--- a/www/a/preview-ptz.js
+++ b/www/a/preview-ptz.js
@@ -1,17 +1,25 @@
-// The PTZ D-pad, on the video. Loaded only via p/motor.cgi, which preview.cgi
+// The PTZ pads, on the video. Loaded only via p/motor.cgi, which preview.cgi
 // includes only when the camera has motors. `$` and `apiFetch` are globals
 // from main.js.
 //
-// The pad is emitted after the player (the stage is already closed when the
-// include runs) and moved into the stage's #mj-ptz mount here. Press-and-hold
-// uses Pointer Events with capture: the old mouse handlers stopped the pan
-// the moment the pointer drifted off a 2.3rem glyph, which on a moving
-// picture is constantly. Arrow keys drive it too, but only while the stage
-// itself has focus — inside the bar the arrows belong to the volume slider
-// and the radio groups.
+// Two protocols behind one pad. Stepped backends (gpio-motors, the motor
+// profiles) take ?h=&v= magnitudes and buttons carry data-dir; the Pelco-D
+// backend (btzoom) takes ?act= verbs — four directions, zoom, focus — each a
+// fixed timed pulse the camera ends by itself, and buttons carry data-act.
+// The markup decides which kind this camera has; this file just reads what
+// the buttons say.
+//
+// The pads are emitted after the player (the stage is already closed when
+// the include runs) and moved into the stage's #mj-ptz mount here.
+// Press-and-hold uses Pointer Events with capture: drifting off a small
+// button mid-hold must not stop the pan. Arrow keys drive it too, but only
+// while the stage itself has focus — inside the bar the arrows belong to the
+// volume slider and the radio groups.
 (function () {
-	const pad = $('#mj-ptz-pad'), mount = $('#mj-ptz'), stage = $('#mj-stage');
+	const pad = $('#mj-ptz-pad'), fn = $('#mj-ptz-fn');
+	const mount = $('#mj-ptz'), stage = $('#mj-stage');
 	if (!pad || !mount) return;
+	if (fn) { mount.appendChild(fn); fn.hidden = false; }
 	mount.appendChild(pad);
 	pad.hidden = false;
 	mount.hidden = false;
@@ -25,33 +33,40 @@
 	let inflight = false, holdTimer = null;
 
 	// One request in flight at a time — a hold does not queue moves behind a
-	// slow camera, it just measures out what the camera keeps up with.
-	// apiFetch rather than fetch: a lapsed session redirects to the login page
-	// instead of 401ing invisibly at 4 Hz for ever.
-	function fire(dir) {
+	// slow camera, it just measures out what the camera keeps up with. For
+	// Pelco this is also the pulse pacing: btzoom answers only after its
+	// pulse has ended, so a hold strings pulses end to end rather than
+	// stacking them. apiFetch rather than fetch: a lapsed session redirects
+	// to the login page instead of 401ing invisibly at 4 Hz for ever.
+	function req(query) {
 		if (inflight) return;
-		const d = DIRS[dir];
-		if (!d) return;
 		inflight = true;
-		apiFetch('/cgi-bin/j/ptz.cgi?h=' + d[0] * STEP + '&v=' + d[1] * STEP,
-			{ credentials: 'same-origin' })
+		apiFetch('/cgi-bin/j/ptz.cgi?' + query, { credentials: 'same-origin' })
 			.catch(() => {})
 			.finally(() => { inflight = false; });
 	}
-	function startHold(dir) {
+	// What one press of this button means, from its own dataset.
+	function fire(btn) {
+		if (btn.dataset.act) { req('act=' + btn.dataset.act); return; }
+		const d = DIRS[btn.dataset.dir];
+		if (d) req('h=' + d[0] * STEP + '&v=' + d[1] * STEP);
+	}
+	function startHold(btn) {
 		stopHold();
-		fire(dir);
-		holdTimer = setInterval(() => fire(dir), TICK_MS);
+		fire(btn);
+		holdTimer = setInterval(() => fire(btn), TICK_MS);
 	}
 	function stopHold() {
 		if (holdTimer) { clearInterval(holdTimer); holdTimer = null; }
 	}
 
-	pad.querySelectorAll('button').forEach(btn => {
-		const dir = btn.dataset.dir;
-		// Board-defined home/park slot; a single step, not a hold.
-		if (dir === 'cc') {
-			btn.addEventListener('click', () => fire(dir));
+	// The centre is a single press on both pads: the stepped backends call it
+	// home/park (board-defined), Pelco calls it stop.
+	const isCentre = btn => btn.dataset.dir === 'cc' || btn.dataset.act === 'stop';
+
+	mount.querySelectorAll('button').forEach(btn => {
+		if (isCentre(btn)) {
+			btn.addEventListener('click', () => fire(btn));
 			return;
 		}
 		btn.addEventListener('pointerdown', e => {
@@ -59,23 +74,33 @@
 			// Capture keeps pointerup coming to this button however far the
 			// finger or cursor wanders mid-hold.
 			try { btn.setPointerCapture(e.pointerId); } catch (err) {}
-			startHold(dir);
+			startHold(btn);
 		});
 		btn.addEventListener('pointerup', stopHold);
 		btn.addEventListener('pointercancel', stopHold);
-		// Enter/Space on a focused button: a single step, so the keyboard can
-		// nudge precisely; sweeping is what the stage-level arrows are for.
-		btn.addEventListener('click', e => { if (e.detail === 0) fire(dir); });
+		// Enter/Space on a focused button: a single step or pulse, so the
+		// keyboard can nudge precisely; sweeping is what the stage-level
+		// arrows are for.
+		btn.addEventListener('click', e => { if (e.detail === 0) fire(btn); });
 	});
 
 	if (stage) {
-		const KEYS = { ArrowUp: 'uc', ArrowDown: 'dc', ArrowLeft: 'lc', ArrowRight: 'rc' };
+		// Arrows resolve to whatever button the pad actually has for that
+		// direction, so the same keys drive both protocols.
+		const KEYS = {
+			ArrowUp: '[data-dir="uc"],[data-act="up"]',
+			ArrowDown: '[data-dir="dc"],[data-act="down"]',
+			ArrowLeft: '[data-dir="lc"],[data-act="left"]',
+			ArrowRight: '[data-dir="rc"],[data-act="right"]',
+		};
 		stage.addEventListener('keydown', e => {
 			// Only when the stage ITSELF is focused — focus on any control in
 			// the bar means the arrows are that control's.
 			if (e.target !== stage || !KEYS[e.key]) return;
 			e.preventDefault();
-			if (!e.repeat) startHold(KEYS[e.key]);
+			if (e.repeat) return;
+			const btn = pad.querySelector(KEYS[e.key]);
+			if (btn) startHold(btn);
 		});
 		stage.addEventListener('keyup', e => { if (KEYS[e.key]) stopHold(); });
 	}

--- a/www/a/preview-ptz.js
+++ b/www/a/preview-ptz.js
@@ -30,24 +30,46 @@
 		lc: [-1, 0], cc: [0, 0], rc: [1, 0],
 		dl: [-1, -1], dc: [0, -1], dr: [1, -1],
 	};
-	let inflight = false, holdTimer = null;
+	let inflight = false, holdTimer = null, queuedStop = null;
 
 	// One request in flight at a time — a hold does not queue moves behind a
 	// slow camera, it just measures out what the camera keeps up with. For
 	// Pelco this is also the pulse pacing: btzoom answers only after its
 	// pulse has ended, so a hold strings pulses end to end rather than
-	// stacking them. apiFetch rather than fetch: a lapsed session redirects
-	// to the login page instead of 401ing invisibly at 4 Hz for ever.
-	function req(query) {
-		if (inflight) return;
+	// stacking them. The one press that must NOT be droppable is stop: a
+	// Pelco pulse is in flight half the time, and a stop that vanished into
+	// that window would let the hold's next pulse move a camera the user
+	// just told to stand still — so it queues, and goes out the moment the
+	// current request answers. apiFetch rather than fetch: a lapsed session
+	// redirects to the login page instead of 401ing invisibly at 4 Hz.
+	function req(query, isStop) {
+		if (inflight) {
+			if (isStop) queuedStop = query;
+			return;
+		}
 		inflight = true;
 		apiFetch('/cgi-bin/j/ptz.cgi?' + query, { credentials: 'same-origin' })
+			// The body, not just the headers: j/ptz.cgi answers 200 before it
+			// execs anything, so the headers arrive in milliseconds while the
+			// motor is still moving. The body closes when the CGI exits —
+			// that is the end of a Pelco pulse, and it is what makes a held
+			// button string pulses end to end instead of stacking requests
+			// four times a second behind the camera's port lock.
+			.then(r => r.text())
 			.catch(() => {})
-			.finally(() => { inflight = false; });
+			.finally(() => {
+				inflight = false;
+				const q = queuedStop;
+				queuedStop = null;
+				if (q) req(q, true);
+			});
 	}
 	// What one press of this button means, from its own dataset.
 	function fire(btn) {
-		if (btn.dataset.act) { req('act=' + btn.dataset.act); return; }
+		if (btn.dataset.act) {
+			req('act=' + btn.dataset.act, btn.dataset.act === 'stop');
+			return;
+		}
 		const d = DIRS[btn.dataset.dir];
 		if (d) req('h=' + d[0] * STEP + '&v=' + d[1] * STEP);
 	}
@@ -66,7 +88,10 @@
 
 	mount.querySelectorAll('button').forEach(btn => {
 		if (isCentre(btn)) {
-			btn.addEventListener('click', () => fire(btn));
+			// Stop first kills any hold still ticking (a keyboard hold can be
+			// live while the mouse presses Stop), then fires — and for Pelco
+			// the request itself is the un-droppable kind.
+			btn.addEventListener('click', () => { stopHold(); fire(btn); });
 			return;
 		}
 		btn.addEventListener('pointerdown', e => {

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -1,5 +1,14 @@
 #!/bin/sh
-# PTZ step handler: GPIO stepper (gpio-motors) or profile motor (/usr/bin/motor + U-Boot ptz=).
+# PTZ handler for all three backends. Two request shapes:
+#
+#   ?h=<±N>&v=<±N>   step move — GPIO stepper (gpio-motors) or profile motor
+#                    (/usr/bin/motor + U-Boot ptz=)
+#   ?act=<verb>      timed pulse — Pelco-D over serial (/usr/bin/btzoom +
+#                    U-Boot ptz=): up down left right stop wide tele near far
+#
+# Both shapes answer 200 first, like the rest of j/; the pad never reads the
+# body. act= wins when both are present — a caller that sends both knows the
+# camera better than this script does.
 
 echo "HTTP/1.1 200 OK
 Content-type: text/plain; charset=UTF-8
@@ -10,10 +19,12 @@ Pragma: no-cache
 
 HORIZONTAL=0
 VERTICAL=0
+ACTION=""
 for param in $(echo "$QUERY_STRING" | tr '&' ' '); do
 	case "$param" in
 		h=*) HORIZONTAL="${param#*=}" ;;
 		v=*) VERTICAL="${param#*=}" ;;
+		act=*) ACTION="${param#*=}" ;;
 	esac
 done
 
@@ -24,12 +35,32 @@ done
 echo "$HORIZONTAL" | grep -qE '^-?[0-9]{1,2}$' || HORIZONTAL=0
 echo "$VERTICAL" | grep -qE '^-?[0-9]{1,2}$' || VERTICAL=0
 
+ptz=$(fw_printenv -n ptz 2>/dev/null)
+
+# The verb is matched against the closed list, never passed through: btzoom
+# execs "pelcoD_$1", so an unlisted word would call whatever function the
+# query string names. (start/day/night exist in btzoom but are lens
+# maintenance, not viewing controls — not reachable from here.)
+if [ -n "$ACTION" ]; then
+	if [ -x /usr/bin/btzoom ] && [ -n "$ptz" ]; then
+		case "$ACTION" in
+			up|down|left|right|stop|wide|tele|near|far)
+				/usr/bin/btzoom "$ACTION"
+				exit $?
+				;;
+		esac
+		echo "Unknown PTZ action."
+		exit 1
+	fi
+	echo "Pelco-D PTZ not available on this device."
+	exit 1
+fi
+
 if command -v gpio-motors >/dev/null 2>&1 && [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; then
 	gpio-motors "$HORIZONTAL" "$VERTICAL" 10
 	exit $?
 fi
 
-ptz=$(fw_printenv -n ptz 2>/dev/null)
 if [ -x /usr/bin/motor ] && [ -n "$ptz" ]; then
 	/usr/bin/motor "$ptz" "$HORIZONTAL" "$VERTICAL"
 	exit $?

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -670,12 +670,22 @@ update_caminfo() {
 
 	# WebUI
 	ui_password=$(grep root /etc/shadow | cut -d: -f2)
-	# PTZ preview controls: GPIO motors (gpio_motors + gpio-motors) or motor profile (ptz + /usr/bin/motor).
-	if { [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && command -v gpio-motors >/dev/null 2>&1; } ||
-		{ [ -x /usr/bin/motor ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; }; then
-		ptz_support="1"
+	# PTZ preview controls. Three backends, each needing both its switch and
+	# its binary: GPIO motors (gpio_motors + gpio-motors), a motor profile
+	# (ptz + /usr/bin/motor), or Pelco-D over serial (ptz + /usr/bin/btzoom).
+	# The backend decides which pad p/motor.cgi draws — the first two are
+	# stepped pan/tilt with diagonals, Pelco-D is four directions in timed
+	# pulses plus zoom and focus. Order matters only when a camera has
+	# several installed; the stepped backends win because their protocol
+	# carries magnitudes the Pelco pulses cannot.
+	if [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && command -v gpio-motors >/dev/null 2>&1; then
+		ptz_support="1"; ptz_backend="gpio"
+	elif [ -x /usr/bin/motor ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
+		ptz_support="1"; ptz_backend="motor"
+	elif [ -x /usr/bin/btzoom ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
+		ptz_support="1"; ptz_backend="pelco"
 	else
-		ptz_support=""
+		ptz_support=""; ptz_backend=""
 	fi
 
 	# Network
@@ -698,7 +708,7 @@ update_caminfo() {
 
 	local variables="flash_size flash_type fw_build fw_variant fw_version mj_version network_address
 		network_gateway network_hostname network_interface network_macaddr overlay_root ptz_support
-		sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
+		ptz_backend sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
 	rm -f ${sysinfo_file}
 
 	local v

--- a/www/cgi-bin/p/motor.cgi
+++ b/www/cgi-bin/p/motor.cgi
@@ -1,9 +1,34 @@
-<!-- PTZ pad. Emitted after the player (preview() has already closed the
+<!-- PTZ pad(s). Emitted after the player (preview() has already closed the
      stage by the time this include runs) and hidden: preview-ptz.js relocates
-     it into the stage's #mj-ptz mount and unhides it, so a failed script
-     leaves no stray pad below the video. Real buttons with names — the emoji
-     pad before this read as glyph soup to a screen reader and took no
-     keyboard at all. -->
+     everything into the stage's #mj-ptz mount and unhides it, so a failed
+     script leaves no stray pad below the video. Real buttons with names — the
+     emoji pads before this read as glyph soup to a screen reader and took no
+     keyboard at all.
+
+     Which pad depends on the backend common.cgi detected. The stepped
+     backends (gpio-motors, motor) take eight directions with magnitudes; the
+     Pelco-D backend (btzoom) speaks four directions in fixed timed pulses and
+     adds what the old sandbox pad had: zoom (−/+) and focus (the orange and
+     blue diamonds its users already know). -->
+<% if [ "$ptz_backend" = "pelco" ]; then %>
+<div id="mj-ptz-fn" class="mj-ptz-pad mj-ptz-fn" role="group" aria-label="Zoom and focus" hidden>
+	<button type="button" class="mj-ptz-btn" data-act="wide" aria-label="Zoom out" title="Zoom out">−</button>
+	<button type="button" class="mj-ptz-btn" data-act="tele" aria-label="Zoom in" title="Zoom in">+</button>
+	<button type="button" class="mj-ptz-btn" data-act="near" aria-label="Focus near" title="Focus near">🔶</button>
+	<button type="button" class="mj-ptz-btn" data-act="far" aria-label="Focus far" title="Focus far">🔷</button>
+</div>
+<div id="mj-ptz-pad" class="mj-ptz-pad" role="group" aria-label="Pan and tilt" hidden>
+	<span class="mj-ptz-void"></span>
+	<button type="button" class="mj-ptz-btn" data-act="up" aria-label="Tilt up">▲</button>
+	<span class="mj-ptz-void"></span>
+	<button type="button" class="mj-ptz-btn" data-act="left" aria-label="Pan left">◀</button>
+	<button type="button" class="mj-ptz-btn" data-act="stop" aria-label="Stop" title="Stop">■</button>
+	<button type="button" class="mj-ptz-btn" data-act="right" aria-label="Pan right">▶</button>
+	<span class="mj-ptz-void"></span>
+	<button type="button" class="mj-ptz-btn" data-act="down" aria-label="Tilt down">▼</button>
+	<span class="mj-ptz-void"></span>
+</div>
+<% else %>
 <div id="mj-ptz-pad" class="mj-ptz-pad" role="group" aria-label="Pan and tilt" hidden>
 	<button type="button" class="mj-ptz-btn" data-dir="ul" aria-label="Pan up-left">◤</button>
 	<button type="button" class="mj-ptz-btn" data-dir="uc" aria-label="Tilt up">▲</button>
@@ -15,4 +40,5 @@
 	<button type="button" class="mj-ptz-btn" data-dir="dc" aria-label="Tilt down">▼</button>
 	<button type="button" class="mj-ptz-btn" data-dir="dr" aria-label="Pan down-right">◢</button>
 </div>
+<% fi %>
 <script src="/a/preview-ptz.js"></script>


### PR DESCRIPTION
Addresses maintainer feedback (@flyrouter): two PTZ implementations cover 70–80% of hardware in the field — GPIO steppers via `gpio-motors`, and the community **Pelco-D** serial mod — and they should both be usable without hand-installing scripts over the WebUI's files.

## What was wrong

The Pelco-D mod lived as a curl-installed replacement of `p/motor.cgi`, and on current master that arrangement was broken three ways: `fw_setenv ptz true` alone never set `ptz_support` (the detection also demands `/usr/bin/motor`), so the pad gated itself off; the replaced pad leaned on `.btn-motor` CSS this tree no longer ships; and the next `updatewebui` would archive the local edit and reinstall ours, which speaks a protocol (`?h=&v=`) the camera has no binary for.

## What changed

- **Detection** (`common.cgi`) now names the backend — `gpio`, `motor`, or `pelco` (`ptz=` + `/usr/bin/btzoom`) — cached in sysinfo as `ptz_backend`. The stepped backends win when several are installed, since their protocol carries magnitudes the Pelco pulses cannot.
- **`p/motor.cgi`** draws the pad the backend deserves. Stepped: the eight-way pad as before. Pelco: what its users already know from the sandbox pad — four directions in a plus shape, a stop, zoom −/+ and the orange/blue focus diamonds — as real labelled buttons on the video stage.
- **`j/ptz.cgi`** gains `?act=<verb>` for Pelco next to the existing `?h=&v=`, matched against a closed whitelist (`up down left right stop wide tele near far`) — `btzoom` execs `pelcoD_$1`, so the verb must never pass through raw; `start`/`day`/`night` (lens maintenance) stay unreachable from HTTP.
- **`bin/btzoom` ships in the tree** (installs to `/usr/bin` like `ntfy.sh`), adopted from OpenIPC/sandbox `scripts/pelcoD` by @sansarus — so a Pelco camera needs `fw_setenv ptz true` and nothing else. Two changes from the original: POSIX function syntax (busybox ash does not promise the `function` keyword), and the serial port comes from U-Boot `ptz_port` (default `/dev/ttyAMA0`, which the original hardcoded — including inside `start`'s `stty`).
- **`preview-ptz.js`** reads what each button says (`data-dir` steps vs `data-act` verbs). A held Pelco button strings pulses end-to-end through the existing one-request-in-flight guard — `btzoom` answers only after its pulse ends, so pacing comes free. Stage-focused arrow keys resolve to whichever button the pad has for that direction, driving both protocols with the same keys.

## Verified on hardware

On the hi3516av300, using the maintainer's own fake-enable recipes (env vars + stub binaries logging their argv; no reboot — dropping `/tmp/webui/sysinfo.txt` suffices):

- gpio variant: eight-way pad renders, 550 ms hold = exactly three paced `gpio-motors 0 5 10` calls;
- pelco variant: both clusters render in the stage mount, clicks land `tele` / `near` / `stop`, ArrowUp lands `up`, and `act=day` and `act=;reboot` both bounce off the whitelist;
- `bin/btzoom` passes `sh -n` and `busybox ash -n`; templates lint clean, all test suites green.