### PR TITLE
SD card: land a blank card in the archive, in one press

### DIFF
--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -1362,15 +1362,34 @@
 	// still reads /mnt/mmcblk0p1, so setting `enabled` alone would arm a
 	// recorder aimed at a directory on the overlay — which majestic refuses
 	// outright — leaving recording on and nothing written.
+	//
+	// Which is why the mountpoint is demanded rather than used if present.
+	// loadCard() swallows its own failure and resolves with state.card null, so
+	// "no mountpoint" here means the card was not asked about successfully — and
+	// enabling anyway would leave records.path at whatever it was, recreating
+	// precisely the state this exists to prevent.
+	//
+	// Resolves to '' when recording is really on, and to a reason when it is
+	// not; a write that was refused must never be reported as one that landed.
 	function useCardForRecording() {
 		return loadCard().then(function () {
-			const mp = state.card && state.card.mountpoint;
-			const rec = { enabled: 'true' };
-			if (mp) rec.path = mp + '/%F';
+			const d = state.card;
+			if (!d || !d.mounted || !d.mountpoint)
+				return 'The card was prepared, but the camera did not report where it ' +
+					'mounted, so recording was left off.';
 			return apiFetch('/api/v1/config', {
 				method: 'POST', credentials: 'same-origin',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ records: rec }),
+				body: JSON.stringify({
+					records: { enabled: 'true', path: d.mountpoint + '/%F' },
+				}),
+			}).then(function (r) {
+				if (r.ok) return '';
+				// Plain text, not markup: this is read out through alert().
+				return r.text().then(function (t) {
+					return 'The card is ready, but the camera refused to start recording' +
+						(t ? ': ' + t.slice(0, 160) : ' (HTTP ' + r.status + ').');
+				});
 			});
 		});
 	}
@@ -1398,10 +1417,19 @@
 						return;
 					}
 					say('<span class="text-secondary">Starting recording…</span>');
-					return useCardForRecording().then(function () {
+					return useCardForRecording().then(function (why) {
+						// The card really was prepared, so the page has to re-read
+						// itself either way: everything it currently says about the
+						// card is now out of date. Which is also why the failure
+						// cannot be reported in place — the re-read owns #rec-note
+						// and watchCard() refreshes it every few seconds, so a line
+						// written there is wiped almost immediately. alert() is
+						// what sdcard.js already uses to report a failed op, and it
+						// is the one surface a re-render cannot take away.
+						if (why) alert(why);
 						waitStep = 0;
 						stalled = false;
-						boot();
+						return boot();
 					});
 				})
 				.catch(function () {

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -1296,6 +1296,121 @@
 	// and an archive is a setting. Sending someone to another page to flip it,
 	// and back here to find out whether it took, is a lot of ceremony for a
 	// checkbox — so the checkbox is here.
+	// Getting from a just-inserted blank card to a recording camera is one
+	// decision — use this card — but it read as four pages: here to be told the
+	// card is not formatted, the SD card page to format it, back here to find
+	// the switch, and the settings page if the recording path did not match
+	// where the card actually mounted. None of those steps is a choice the
+	// person makes; they are all bookkeeping the page can do itself. So the
+	// whole sequence sits behind one button, on the page where the wish was
+	// expressed.
+	//
+	// Offered only for the states this page can actually cure. A read-only card
+	// is a hardware verdict and an absent one is a missing card: neither is
+	// mended by pressing anything here, and offering a button that cannot work
+	// is worse than offering none.
+	function cardFix() {
+		const d = state.card;
+		if (!d || !d.present) return null;
+		switch (d.health) {
+		case 'unformatted':
+		case 'unreadable':
+			// "unreadable" may be a filesystem this camera cannot read rather
+			// than an empty card, so the warning is as blunt for it as for a
+			// blank one — in both cases what is on the card does not survive.
+			return { op: 'format', cls: 'btn-danger',
+				label: 'Format the card and start recording',
+				ask: 'Erase everything on the SD card, format it, and start recording to it?',
+				doing: 'Formatting the card…' };
+		case 'unmounted':
+			// Nothing is lost by mounting, so nothing is asked.
+			return { op: 'mount', cls: 'btn-primary',
+				label: 'Mount the card and start recording', ask: '',
+				doing: 'Mounting the card…' };
+		default:
+			return null;
+		}
+	}
+
+	// Choosing between one option is not a choice, and on every build seen so
+	// far `mkfs` is exactly ["vfat"]. Where a firmware really does ship more,
+	// vfat stays the pick: it is the one every card reader, phone and laptop
+	// can read, which is what someone pulling the card out actually needs.
+	function fixFs() {
+		const l = (state.card && state.card.mkfs) || [];
+		return l.indexOf('vfat') >= 0 ? 'vfat' : (l[0] || 'vfat');
+	}
+
+	function fixButton(fix) {
+		return '<div class="mt-3">' +
+			'<button type="button" class="btn btn-sm ' + fix.cls + '" id="rec-fix">' +
+			esc(fix.label) + '</button>' +
+			'<span class="small ms-2" id="rec-fix-msg"></span></div>';
+	}
+
+	function sdOp(p) {
+		return apiFetch('/cgi-bin/j/sdcard.cgi', {
+			method: 'POST', credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams(p).toString(),
+		}).then(function (r) { return r.json(); });
+	}
+
+	// Point recording at where the card actually mounted rather than where the
+	// config guessed it would. The two differ exactly when it matters most: a
+	// card with no partition table mounts at /mnt/mmcblk0 while records.path
+	// still reads /mnt/mmcblk0p1, so setting `enabled` alone would arm a
+	// recorder aimed at a directory on the overlay — which majestic refuses
+	// outright — leaving recording on and nothing written.
+	function useCardForRecording() {
+		return loadCard().then(function () {
+			const mp = state.card && state.card.mountpoint;
+			const rec = { enabled: 'true' };
+			if (mp) rec.path = mp + '/%F';
+			return apiFetch('/api/v1/config', {
+				method: 'POST', credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ records: rec }),
+			});
+		});
+	}
+
+	function wireFix(fix) {
+		const btn = $id('rec-fix');
+		if (!btn) return;
+		btn.addEventListener('click', function () {
+			if (fix.ask && !confirm(fix.ask)) return;
+			btn.disabled = true;
+			const msg = $id('rec-fix-msg');
+			const say = function (h) { if (msg) msg.innerHTML = h; };
+			say('<span class="text-secondary">' + esc(fix.doing) + '</span>');
+			sdOp(fix.op === 'format' ? { op: 'format', fs: fixFs() } : { op: fix.op })
+				.then(function (r) {
+					// The endpoint's own words: it is the only thing that knows
+					// whether this was a stale partition table, a card that has
+					// stopped taking writes, or a filesystem this build cannot
+					// create.
+					if (!r || r.ok === false) {
+						btn.disabled = false;
+						say('<span class="text-danger">' +
+							esc((r && r.error) || 'The camera could not prepare the card.') +
+							'</span>');
+						return;
+					}
+					say('<span class="text-secondary">Starting recording…</span>');
+					return useCardForRecording().then(function () {
+						waitStep = 0;
+						stalled = false;
+						boot();
+					});
+				})
+				.catch(function () {
+					btn.disabled = false;
+					say('<span class="text-danger">The camera did not answer — check that it is still reachable.</span>');
+				});
+		});
+	}
+
 	function enableSwitch() {
 		return '<div class="form-check form-switch mt-3 mb-0">' +
 			'<input class="form-check-input" type="checkbox" role="switch" id="rec-enable">' +
@@ -1304,10 +1419,12 @@
 	}
 
 	// One POST, which is what majestic's write-back API is for: it walks the
-	// tree, reloads the pipeline and saves the file in a single round trip. The
-	// value goes as a string like every other write from this WebUI — the C side
-	// coerces it — and a non-200 means nothing persisted. Resolves to '' when it
-	// worked and to a reason when it did not.
+	// tree, applies the change and saves the file in a single round trip —
+	// records.enabled starts the recorder there and then, with no reload and
+	// nothing for this page to follow up with. The value goes as a string like
+	// every other write from this WebUI — the C side coerces it — and a non-200
+	// means nothing persisted. Resolves to '' when it worked and to a reason
+	// when it did not.
 	function setRecording() {
 		return apiFetch('/api/v1/config', {
 			method: 'POST', credentials: 'same-origin',
@@ -1353,7 +1470,7 @@
 	// it?". Backs off rather than hammering, stops as soon as there is a day,
 	// and does not poll a tab nobody is looking at.
 	const WAITS = [4000, 4000, 8000, 16000, 30000];
-	let waitTimer = null, waitStep = 0;
+	let waitTimer = null, waitStep = 0, stalled = false;
 	function waitForFirstClip() {
 		clearTimeout(waitTimer);
 		const ms = WAITS[Math.min(waitStep, WAITS.length - 1)];
@@ -1361,11 +1478,38 @@
 		waitTimer = setTimeout(function () {
 			if (document.hidden) { waitForFirstClip(); return; }
 			loadDays().then(function () {
-				if (!state.days.length) { waitForFirstClip(); return; }
+				if (!state.days.length) {
+					// Once the backoff has run its course the wait has stopped
+					// being a wait, and saying "not yet" again would be a guess
+					// the evidence no longer supports.
+					if (waitStep > WAITS.length && !stalled) { stalled = true; stalledNote(); }
+					waitForFirstClip();
+					return;
+				}
 				waitStep = 0;
+				stalled = false;
 				boot();
 			});
 		}, ms);
+	}
+
+	// The wait above assumes the recorder is coming. When it is not, nothing
+	// about this page ever changes and "no clips yet" becomes a claim it repeats
+	// for as long as the tab is open. What it cannot do is say why: from here a
+	// recorder that never started and one that started and cannot write look
+	// identical, and the card has already been asked and answered healthy. So
+	// the note reports the fact and names the two things that produce it,
+	// without picking one. Polling carries on underneath, so a recorder that was
+	// merely slow still lands its clip and the page moves on by itself.
+	function stalledNote() {
+		empty('<strong>Recording is on, but nothing has been written.</strong> ' +
+			'No clip has reached <code>' + esc(state.prefix) + '</code>, and the card ' +
+			'reports no fault. Either the camera cannot write there, or it is running ' +
+			'a firmware that only starts recording when it starts — old enough that ' +
+			'switching records on does not take effect until it is restarted.',
+			' <a href="tool-sdcard.cgi">Check the SD card</a> or ' +
+			'<a href="fw-restart.cgi">restart the camera</a>.',
+			'warning');
 	}
 
 	// wire() binds to document, so it must run once however many times the page
@@ -1386,6 +1530,11 @@
 					// Only when the card is fine is an empty archive really about
 					// whether recording is switched on.
 					const bad = cardTrouble();
+					// A card that only needs preparing is not really an error —
+					// it is step one of setting recording up, and all of it fits
+					// here. Where that is the case the alert carries the button
+					// that does it rather than a signpost to another page.
+					const fix = bad ? cardFix() : null;
 					// A switch is only worth offering where flipping it would
 					// actually produce recordings: a card that cannot be written
 					// to would take the setting and still record nothing.
@@ -1395,8 +1544,9 @@
 							? '<strong>Nothing recorded yet.</strong> Recording is on, but no clips have been written to <code>' + esc(state.prefix) + '</code> yet.'
 							: '<strong>Recording is off.</strong> The camera is not writing to the card, so there is nothing to browse.'),
 						' <a href="tool-sdcard.cgi">SD card</a>' + (bad ? cardKernelLines() : '') +
-						(canStart ? enableSwitch() : ''),
+						(fix ? fixButton(fix) : '') + (canStart ? enableSwitch() : ''),
 						bad ? 'danger' : 'secondary');
+					if (fix) wireFix(fix);
 					if (canStart) wireEnable();
 					else if (!bad && state.enabled) waitForFirstClip();
 					return;

--- a/www/cgi-bin/j/sdcard.cgi
+++ b/www/cgi-bin/j/sdcard.cgi
@@ -98,6 +98,53 @@ probe_new() {
 probe_write() { printf '%s' "$PROBE" | dd of="$1" bs=512 count=1 2>/dev/null; }
 probe_seen() { [ "$(dd if="$1" bs=1 count=${#PROBE} 2>/dev/null)" = "$PROBE" ]; }
 
+# Stamp the partition and read it back, with the same three outcomes mbr_ok
+# has and for the same reason: "could not look" is not "looked and found the
+# wrong thing", and only the second is evidence against the card.
+#
+# A read that comes back EMPTY means the device node went away again under the
+# mdev churn that dogs every step of a format, not that the card refused the
+# write. Convicting on that put the harshest message this endpoint owns — your
+# card is failing, replace it — in front of someone holding a perfectly good
+# card, on roughly one format in five. So absence is retried, and a write that
+# fails outright is retried too rather than being read back and blamed.
+#
+# A single mismatch is not enough to convict either, and this is the subtle
+# half. Mid-churn the stamp can be written to one node and read back from
+# another after the kernel has re-created the partition, so what returns is the
+# sector that was already on the card — non-empty, and nothing like the stamp.
+# On a freshly wiped card that is random bytes, which reads exactly like a card
+# refusing writes. A card that has genuinely stopped taking them fails EVERY
+# attempt, so requiring the mismatch to repeat separates the two at no cost to
+# the diagnosis.
+#
+# 0 the stamp came back, 1 it repeatedly did not, 2 could not get a clean look.
+probe_card() {
+	i=0
+	miss=0
+	while [ "$i" -lt 6 ]; do
+		if ensure_node; then
+			probe_new
+			if probe_write "$1"; then
+				uncache
+				got=$(dd if="$1" bs=1 count=${#PROBE} 2>/dev/null)
+				[ "$got" = "$PROBE" ] && return 0
+				# Only count it against the card if the partition is still there
+				# and full length now: a mismatch read across a node swap says
+				# nothing about whether the card kept the write.
+				if [ -n "$got" ] && node_ready; then
+					miss=$((miss + 1))
+					[ "$miss" -ge 3 ] && return 1
+				fi
+			fi
+		fi
+		sleep 1
+		i=$((i + 1))
+	done
+	[ "$miss" -ge 3 ] && return 1
+	return 2
+}
+
 # Kernel complaints about this card, newest last. Corroborating detail only:
 # the ring buffer is small and chatty (on hi3516av300 the CMA allocator alone
 # pushes a card error out of it within minutes), so finding nothing here proves
@@ -187,18 +234,62 @@ get_info() {
 	printf '"health":"%s","fsErrors":[%s],"mkfs":[%s]}' "$health" "$errs" "$(mkfs_list)"
 }
 
-# Ensure the /dev/mmcblk0p1 node exists: the kernel may know the partition
-# (in /proc/partitions) before mdev has created the device node. mdev -s makes
-# it (and fires the OpenIPC SD automount rule).
+# The node existing is not the same as the partition being usable, and waiting
+# only for `-b` is what made formatting a blank card fail about one run in
+# four. Writing a partition table makes the kernel drop and re-add the
+# partition, and around that pair mdev can leave a node behind whose partition
+# the kernel no longer has: it opens fine and every size query answers zero.
+# That is what reaches mkfs as "image is too small" — a complaint it makes
+# about a 59 GB card — and what reaches mount as a bare ENOENT on the device.
+#
+# So measure the partition instead of asking whether a filename exists: read
+# its far end. A sector that comes back from the last block of the partition is
+# proof the kernel has it at the size /sys claims, which is the thing mkfs and
+# mount are each about to rely on.
+node_ready() {
+	[ -b "${DEV}p1" ] || return 1
+	sz=$(cat "$SYS/mmcblk0p1/size" 2>/dev/null)
+	case "$sz" in ''|*[!0-9]*) return 1;; esac
+	[ "$sz" -gt 0 ] || return 1
+	[ "$(dd if="${DEV}p1" bs=512 skip=$((sz - 1)) count=1 2>/dev/null | wc -c)" = 512 ]
+}
+
+# Ensure /dev/mmcblk0p1 is there and usable: the kernel knows the partition
+# (it is in /proc/partitions and /sys) before the node exists in /dev.
+#
+# Make the node here, from the major:minor the kernel already publishes, rather
+# than asking mdev for it. `mdev -s` was what stood here, and it is a rescan of
+# every device in /sys that re-runs the hotplug rules for each — which for this
+# partition means /lib/mdev/automount.sh, the script whose umount pass unmounts
+# the card and rmdir's /mnt/mmcblk0p1. So the call made to recover from node
+# churn was itself a generator of it, and every retry made the next step more
+# likely to fail. mknod asks the kernel for nothing and disturbs nothing.
 ensure_node() {
-	[ -b "${DEV}p1" ] && return 0
+	node_ready && return 0
 	i=0
-	while [ ! -b "${DEV}p1" ] && [ "$i" -lt 10 ]; do
-		mdev -s 2>/dev/null
-		[ -b "${DEV}p1" ] && break
+	while [ "$i" -lt 10 ]; do
+		mm=$(cat "$SYS/mmcblk0p1/dev" 2>/dev/null)   # e.g. "179:1"
+		case "$mm" in
+			[0-9]*:[0-9]*)
+				[ -b "${DEV}p1" ] ||
+					mknod "${DEV}p1" b "${mm%%:*}" "${mm##*:}" 2>/dev/null
+				;;
+			*)
+				# The kernel has no partition at all, not merely no node for
+				# one: there is nothing in /sys to make a node from. It re-reads
+				# the table only while nothing holds the disk open, and the
+				# automount is exactly such a holder, so partprobe here can have
+				# failed with EBUSY and left the kernel on its old idea of the
+				# layout. Let go of the card and ask again.
+				umount /mnt/mmcblk0p1 2>/dev/null
+				umount "$DEV" 2>/dev/null
+				partprobe "$DEV" 2>/dev/null
+				;;
+		esac
+		node_ready && return 0
 		sleep 1; i=$((i + 1))
 	done
-	[ -b "${DEV}p1" ]
+	node_ready
 }
 
 do_format() {
@@ -206,54 +297,137 @@ do_format() {
 	case "$fs" in vfat|ext4|exfat) ;; *) err="unsupported filesystem"; return;; esac
 	command -v "mkfs.$fs" >/dev/null 2>&1 || { err="mkfs.$fs not installed"; return; }
 	umount /mnt/mmcblk0p1 2>/dev/null; umount "${DEV}p1" 2>/dev/null; umount "$DEV" 2>/dev/null
-	# Look before writing, and look on every format rather than only the ones
-	# that write: the kernel can be holding an mmcblk0p1 from an earlier boot
-	# over a card whose sector 0 no longer has the table it came from, and it
-	# was skipping the check on exactly that reading that let a card storing
-	# nothing format "successfully" in the lab.
+	# Always write the table. Format means erase, so there is no state of the
+	# card that makes writing one wrong — and deciding *not* to write it was a
+	# way to get this wrong. The test that guarded it read sector 0, and that
+	# read can come back from the page cache rather than the card (uncache is
+	# defence in depth, not a guarantee, once something holds the device open).
+	# A stale-but-valid-looking table then skipped the partitioning entirely and
+	# mkfs ran against whatever the kernel still believed the layout to be,
+	# which is a format that "succeeds" onto a partition that is not there.
+	#
+	# Writing unconditionally also subsumes the case the guard was added for —
+	# a kernel holding an mmcblk0p1 from an earlier boot over a card whose
+	# sector 0 no longer has the table it came from — without having to
+	# recognise it first.
+	logln "# partition ${DEV}"
+	logln "$(printf 'o\nn\np\n1\n\n\nw\n' | fdisk "$DEV" 2>&1)"
+	partprobe "$DEV" 2>/dev/null
 	uncache
 	mbr_ok "$DEV"; st=$?
-	# A table is written when the card has none, and also when the one the
-	# kernel is holding is not on the card any more. That second case says
-	# nothing about the card until something has been written to it — a healthy
-	# card whose table was wiped out from under a mounted kernel needs its table
-	# put back, not condemning.
-	if [ "$st" != 0 ] || ! grep -q 'mmcblk0p1$' /proc/partitions; then
-		logln "# partition ${DEV}"
-		logln "$(printf 'o\nn\np\n1\n\n\nw\n' | fdisk "$DEV" 2>&1)"
-		partprobe "$DEV" 2>/dev/null
-		uncache
-		mbr_ok "$DEV"; st=$?
-	fi
-	# Only now can a missing table mean something about the card: one was
-	# written to it on this run and did not come back.
+	# Now a missing table means something about the card: one was written to it
+	# on this run and did not come back. Before the write it would have meant
+	# only that the card had never been partitioned, which is why someone is
+	# here in the first place.
 	case "$st" in
 		1) err="$UNSTORED"; return;;
 		2) logln "# note: could not read the partition table back to check it";;
 	esac
 	ensure_node || { err="the partition table was written but the kernel never created ${DEV}p1 — rebooting the camera will pick it up"; return; }
 	umount "${DEV}p1" 2>/dev/null   # automount may have grabbed it
-	probe_new
-	probe_write "${DEV}p1"
-	uncache
-	probe_seen "${DEV}p1" || { err="$UNSTORED"; return; }
+	probe_card "${DEV}p1"; ps=$?
+	case "$ps" in
+		1) err="$UNSTORED"; return;;
+		2) logln "# note: could not read the write probe back to check it";;
+	esac
 	logln "# mkfs.$fs ${DEV}p1"
-	o=$(mkfs.$fs "${DEV}p1" 2>&1); rc=$?
+	mkfs_settled
 	[ -n "$o" ] && logln "$o"
 	[ "$rc" -eq 0 ] || { err="$(first_line "${o:-mkfs.$fs failed}")"; return; }
+	# Mounting IS the proof that a filesystem was written, and it is what the
+	# caller wanted anyway — so ask that question first and ask no other.
+	#
+	# What stood here instead was a pair of cold reads of the raw partition
+	# (probe_seen, then blkid) run immediately after mkfs. Every one of those
+	# races the mdev remove/add pair that writing the filesystem sets off, and a
+	# read landing in the gap reports a device that is briefly absent — which
+	# this then announced as "mkfs reported success but no filesystem was
+	# written", about a card carrying a perfectly good one. Between that and the
+	# mount below, a blank card failed to format on roughly one attempt in four.
+	logln "# mount ${DEV}p1 /mnt/mmcblk0p1"
+	if mount_after_format; then
+		[ -n "$o" ] && logln "$o"
+		return
+	fi
+	[ -n "$o" ] && logln "$o"
+	# It did not mount. Only now is it worth asking what mkfs actually left
+	# behind, and only now is the answer worth trusting: mount_after_format has
+	# spent its retries, so the node has stopped moving under us.
+	#
+	# blkid is judged on its *output*, never its exit status: busybox blkid
+	# exits 0 for a blank partition and for a device that does not exist at all,
+	# so `blkid || fail` — which this once was — could never fire. Nothing down
+	# here blames the card: a card that failed the write probe was reported as
+	# such above, and one that could not be probed at all was never convicted in
+	# the first place.
 	uncache
-	# Past the probe the card is known to be keeping writes, so nothing below
-	# blames it. mkfs writes its superblock over the stamp, and blkid is judged
-	# on its *output*, never its exit status: busybox blkid exits 0 for a blank
-	# partition and for a device that does not exist at all, so `blkid || fail`
-	# — which is what stood here — could never fail.
 	if probe_seen "${DEV}p1" || [ -z "$(blkid "${DEV}p1" 2>/dev/null)" ]; then
 		err="mkfs.$fs reported success but no filesystem was written"
 		return
 	fi
-	mkdir -p /mnt/mmcblk0p1
-	mount "${DEV}p1" /mnt/mmcblk0p1 2>/dev/null
-	mountpoint -q /mnt/mmcblk0p1 || err="mount after format failed"
+	err="$(first_line "${o:-mount after format failed}")"
+}
+
+# mkfs gets the same settle treatment as the probe above and the mount below,
+# because it fails the same way for the same reason: "image is too small" is
+# what mkfs.vfat says when the kernel hands it a partition that has momentarily
+# gone to zero length, and it says it about a 59 GB card. node_ready() makes
+# that rare rather than impossible — it proves the partition is there and full
+# length, but cannot hold it that way across the exec that follows.
+#
+# Only the transient complaints are retried. Matching them by message is crude,
+# and deliberately narrow for that reason: anything else mkfs says is a real
+# refusal and is reported the first time, unretried. Sets `o` and `rc` for the
+# caller, as the inline call it replaced did.
+mkfs_settled() {
+	i=0
+	while [ "$i" -lt 5 ]; do
+		if ensure_node; then
+			o=$(mkfs.$fs "${DEV}p1" 2>&1); rc=$?
+			[ "$rc" -eq 0 ] && return 0
+			case "$o" in
+				*"too small"*|*[Nn]"o such file"*|*"Invalid argument"*) ;;
+				*) return 1;;
+			esac
+		else
+			# Say what actually went wrong. Reporting this as "mkfs failed"
+			# blames the one step that never got to run.
+			o="the kernel did not settle on a partition to format — the table was written, so try the format once more"
+		fi
+		sleep 1
+		i=$((i + 1))
+	done
+	rc=${rc:-1}
+	return 1
+}
+
+# Mount the card we have just formatted, against a hotplug helper that is
+# actively fighting us. Every partition re-read fires mdev, and the remove half
+# of the pair runs /lib/mdev/automount.sh, whose my_umount both unmounts the
+# card AND rmdir's /mnt/mmcblk0p1 — so a mount can fail with ENOENT on the
+# directory created two statements earlier, or on a node mdev has dropped and
+# not yet remade. Neither is a fault of the card, and reporting either to
+# somebody who asked for a format is reporting the wrong thing: this was ~1 run
+# in 4 on a perfectly good card.
+#
+# There is no lock to take against an asynchronous helper, so the honest
+# approach is to keep asking until the kernel and mdev have settled and only
+# then believe a failure. The add half of the same pair also mounts the card
+# itself, which is why an already-mounted card counts as success here rather
+# than as a competing attempt.
+mount_after_format() {
+	i=0
+	while [ "$i" -lt 8 ]; do
+		mountpoint -q /mnt/mmcblk0p1 && return 0
+		if ensure_node; then
+			mkdir -p /mnt/mmcblk0p1 2>/dev/null
+			o=$(mount "${DEV}p1" /mnt/mmcblk0p1 2>&1)
+			mountpoint -q /mnt/mmcblk0p1 && return 0
+		fi
+		sleep 1
+		i=$((i + 1))
+	done
+	return 1
 }
 
 # What mount and umount say when they refuse is the whole diagnosis — a card

--- a/www/cgi-bin/j/sdcard.cgi
+++ b/www/cgi-bin/j/sdcard.cgi
@@ -120,9 +120,9 @@ probe_seen() { [ "$(dd if="$1" bs=1 count=${#PROBE} 2>/dev/null)" = "$PROBE" ]; 
 #
 # 0 the stamp came back, 1 it repeatedly did not, 2 could not get a clean look.
 probe_card() {
-	i=0
-	miss=0
-	while [ "$i" -lt 6 ]; do
+	pc_i=0
+	pc_miss=0
+	while [ "$pc_i" -lt 6 ]; do
 		if ensure_node; then
 			probe_new
 			if probe_write "$1"; then
@@ -133,15 +133,15 @@ probe_card() {
 				# and full length now: a mismatch read across a node swap says
 				# nothing about whether the card kept the write.
 				if [ -n "$got" ] && node_ready; then
-					miss=$((miss + 1))
-					[ "$miss" -ge 3 ] && return 1
+					pc_miss=$((pc_miss + 1))
+					[ "$pc_miss" -ge 3 ] && return 1
 				fi
 			fi
 		fi
 		sleep 1
-		i=$((i + 1))
+		pc_i=$((pc_i + 1))
 	done
-	[ "$miss" -ge 3 ] && return 1
+	[ "$pc_miss" -ge 3 ] && return 1
 	return 2
 }
 
@@ -264,10 +264,15 @@ node_ready() {
 # the card and rmdir's /mnt/mmcblk0p1. So the call made to recover from node
 # churn was itself a generator of it, and every retry made the next step more
 # likely to fail. mknod asks the kernel for nothing and disturbs nothing.
+# Every loop here carries its own counter. `i` was shared, and ensure_node —
+# which each of the retry helpers calls inside its own loop — resets it to 0 and
+# counts it up again, so an outer loop's remaining attempts were whatever the
+# inner one happened to leave behind. The retries added to ride out the hotplug
+# churn could therefore be skipped by the settling they were waiting on.
 ensure_node() {
 	node_ready && return 0
-	i=0
-	while [ "$i" -lt 10 ]; do
+	en_i=0
+	while [ "$en_i" -lt 10 ]; do
 		mm=$(cat "$SYS/mmcblk0p1/dev" 2>/dev/null)   # e.g. "179:1"
 		case "$mm" in
 			[0-9]*:[0-9]*)
@@ -287,7 +292,7 @@ ensure_node() {
 				;;
 		esac
 		node_ready && return 0
-		sleep 1; i=$((i + 1))
+		sleep 1; en_i=$((en_i + 1))
 	done
 	node_ready
 }
@@ -380,8 +385,8 @@ do_format() {
 # refusal and is reported the first time, unretried. Sets `o` and `rc` for the
 # caller, as the inline call it replaced did.
 mkfs_settled() {
-	i=0
-	while [ "$i" -lt 5 ]; do
+	mk_i=0
+	while [ "$mk_i" -lt 5 ]; do
 		if ensure_node; then
 			o=$(mkfs.$fs "${DEV}p1" 2>&1); rc=$?
 			[ "$rc" -eq 0 ] && return 0
@@ -395,7 +400,7 @@ mkfs_settled() {
 			o="the kernel did not settle on a partition to format — the table was written, so try the format once more"
 		fi
 		sleep 1
-		i=$((i + 1))
+		mk_i=$((mk_i + 1))
 	done
 	rc=${rc:-1}
 	return 1
@@ -416,8 +421,8 @@ mkfs_settled() {
 # itself, which is why an already-mounted card counts as success here rather
 # than as a competing attempt.
 mount_after_format() {
-	i=0
-	while [ "$i" -lt 8 ]; do
+	mt_i=0
+	while [ "$mt_i" -lt 8 ]; do
 		mountpoint -q /mnt/mmcblk0p1 && return 0
 		if ensure_node; then
 			mkdir -p /mnt/mmcblk0p1 2>/dev/null
@@ -425,7 +430,7 @@ mount_after_format() {
 			mountpoint -q /mnt/mmcblk0p1 && return 0
 		fi
 		sleep 1
-		i=$((i + 1))
+		mt_i=$((mt_i + 1))
 	done
 	return 1
 }


### PR DESCRIPTION
Walking the "insert an empty SD card, get recordings" journey on a t31 nightly found two separate things wrong. Both are fixed here, and both were reproduced and verified on that camera.

## The format did not survive a blank card

#220 made the format verify itself; it did not make it survive the hotplug path. On a genuinely blank card the format failed on roughly **one attempt in four**, with a different message each time and every one of them wrong about the cause.

One cause underneath all of them: `/proc/sys/kernel/hotplug` is `/sbin/mdev`, and `mdev.conf` runs `/lib/mdev/automount.sh` for `mmcblk[0-9]p[0-9]`. That script's `my_umount` unmounts the card **and `rmdir`s the mountpoint**. Every partition-table re-read — `fdisk`'s, and again when `mkfs` closes the device — emits a remove/add pair, so throughout a format both `/dev/mmcblk0p1` and `/mnt/mmcblk0p1` blink out and back. `dmesg` shows the tell: `mmcblk0: p1` twice, 23 ms apart.

Each step failed in its own voice, and each blamed the card:

| what the user saw | what was actually happening |
|---|---|
| `mkfs.vfat: image is too small` | about a 59 GB card — mkfs opened a partition momentarily at length 0 |
| `mount … failed: No such file or directory` | ENOENT on the mountpoint automount had just removed |
| `mkfs reported success but no filesystem was written` | the post-mkfs `blkid` landed in the gap; busybox blkid prints nothing for an absent device |
| **"the card did not keep what was written to it … needs replacing"** | the write probe reading back empty, or reading the card's own pre-existing random bytes after a node swap |

That last one is the harshest thing this endpoint can say, and it was saying it to people holding good cards.

Worst of all, `ensure_node` — the function meant to recover from this — called `mdev -s`, which rescans every device in `/sys` and re-runs the hotplug rules, i.e. re-runs `automount.sh`. **The recovery was a generator of the churn**, and each retry made the next step likelier to fail.

The fixes, in one sentence each:

- `ensure_node` makes the node itself with `mknod` from the major:minor already in `/sys`, never `mdev -s`; when `/sys` has no partition at all it lets go of the card and re-runs `partprobe`, which can have failed with EBUSY while the automount held the disk.
- `node_ready` replaces `[ -b … ]` — a filename existing is not a partition being usable, so it reads the partition's **last sector** to prove the kernel has it at full length (no `blockdev` on OpenIPC).
- `probe_card` gets `mbr_ok`'s three outcomes and needs **three** mismatches before convicting: an empty read is never evidence, and one mismatch can be a read across a node swap, while a card that truly refuses writes fails every attempt.
- `mkfs` and `mount` retry, matching only transient complaints; anything else is a real refusal reported first time.
- the partition table is written **unconditionally** — format means erase, and the guard that skipped it read sector 0, which can come from the page cache.
- **mounting is the proof** a filesystem was written; the raw-device checks are demoted to diagnosing a mount that failed, once the retries have spent themselves.

## Four pages and six clicks to switch recording on

Inserting an empty card and wanting recordings meant: Recordings (told the card is not formatted) → SD card page → Format → back to Recordings for the switch → settings if the path did not match where the card mounted. None of those steps is a choice the person makes.

The empty state now carries the action:

> The SD card is not formatted — nothing is being recorded.
> **[ Format the card and start recording ]**

One press does the lot: format, mount, point `records.path` at **where the card actually mounted**, switch recording on. That last part is easy to miss — a card with no partition table mounts at `/mnt/mmcblk0` while `records.path` still reads `/mnt/mmcblk0p1`, so setting `enabled` alone arms a recorder aimed at the overlay, which majestic refuses outright, leaving recording "on" and nothing written.

Offered only where pressing it can work: `unformatted`/`unreadable` get the destructive version behind a confirm, `unmounted` gets a plain Mount with no confirm, and `readonly`/`absent` get no button at all — neither is mended by pressing anything here. The filesystem is not asked for either, since `mkfs` is `["vfat"]` on every build seen and choosing between one option is not a choice.

Also: the wait for the first clip now admits when it has stopped being a wait. "Nothing recorded yet" was repeated for as long as the tab stayed open. Once the backoff is spent it says so and names the two things that produce it, without picking one — from the page they look identical, and the card has already answered healthy. Polling continues underneath, so a merely-slow recorder still lands its clip and the page moves on.

## Verification

All on the reported t31 (`nightly-20260830-2b619b9`), card filled with 32 MiB of `/dev/urandom` and rebooted, so the kernel reports `unknown partition table`, no `mmcblk0p1`, nothing mounted.

- **Format: 15/15 clean**, against 11/15 before, and no run reaches the failing-card verdict. Each of the four messages above was reproduced first and is gone.
- **Journey**: one press, one confirm, page showing clips **25 seconds later**, majestic's pid unchanged from boot.
- `npm test` passes; `tools/lint-templates.sh` clean; `bootstrap.min.css` regenerated and unchanged (every class used is already in the purged set).

## Note

The final step — the clip actually appearing — also needs the runtime `records.enabled` fix on the majestic side, without which enabling recording via the API writes the config and starts no recorder on Ingenic. That is a separate change in the daemon; this PR stands on its own for the format and the journey, and the "stopped being a wait" note above is what an older daemon looks like from here.