### PR TITLE
Live View: settings-free — every setting moves to mj-settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /node_modules/
 /majestic-webui-dist.tar.gz
 *.sqsh
+
+# session verification scratch — lab-camera screenshots must never be committed
+.verify-tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,13 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   built client-side by `renderLive()` in `mj-settings.js` (`.mj-live-video`
   elements), though it loads all four preview player scripts. `preview()`
   (in `p/common.cgi`) has exactly one caller: `preview.cgi`.
+- **The Live page is settings-free by design.** It is the page every user of
+  the future multi-user system gets, read-only, so nothing on it changes the
+  camera: no night/IR/light toggles (those live in mj-settings' Live section,
+  `wireNightToggles` in `mj-settings.js`), no custom control panels. The one
+  exception is the PTZ pad — steering, not configuration — kept on the video
+  until the multi-user split decides who may steer. Every setting belongs
+  under `mj-settings.cgi` only.
 - **The Live page is a hero stage.** `preview()` emits `#mj-stage` — a
   `position:relative` box that reserves the stream's aspect ratio (16:9 until
   `onCodec` reports the real one), with everything overlaid on the video so

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -849,6 +849,50 @@
 		});
 	}
 
+	// The night/IR/light runtime toggles under the live preview. Moved here from
+	// the Live page, which is deliberately settings-free. Gating mirrors what
+	// that page did: the light monitor owns all three while it is active, and
+	// IR cut / light need their pins configured. State comes from the metrics
+	// endpoint because these are runtime facts, not config values.
+	function wireNightToggles(pv) {
+		const byId = id => pv.querySelector('#' + id);
+		const night = byId('toggle-night'), ircut = byId('toggle-ircut');
+		const light = byId('toggle-light'), lightmon = byId('mj-lightmon');
+		if (!night) return;
+		const active = v => v !== false && v != null;
+		const lm = active(getDotted(state.config, 'nightMode.lightMonitor'));
+		night.disabled = lm;
+		ircut.disabled = lm || !active(getDotted(state.config, 'nightMode.irCutPin1'));
+		light.disabled = lm || !active(getDotted(state.config, 'nightMode.backlightPin'));
+		if (lm) lightmon.hidden = false;
+
+		[['night', night], ['ircut', ircut], ['light', light]].forEach(([n, el2]) =>
+			apiFetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
+				.then(r => r.text()).then(v => { el2.checked = +v > 0; })
+				.catch(() => {}));
+
+		night.addEventListener('click', () => {
+			apiFetch('/night/toggle', { credentials: 'same-origin' })
+				.then(r => r.json()).then(data => {
+					night.checked = data;
+					// Night mode drives the filter and the light where they are
+					// not independently pinned, so the controls follow it.
+					if (!ircut.disabled) ircut.checked = data;
+					if (!light.disabled) light.checked = data;
+				}).catch(() => {});
+		});
+		ircut.addEventListener('click', () => {
+			apiFetch('/night/ircut', { credentials: 'same-origin' })
+				.then(r => r.json()).then(data => { ircut.checked = data; })
+				.catch(() => {});
+		});
+		light.addEventListener('click', () => {
+			apiFetch('/night/light', { credentials: 'same-origin' })
+				.then(r => r.json()).then(data => { light.checked = data; })
+				.catch(() => {});
+		});
+	}
+
 	// The Live adjustments leaf: the preview and the x-live knobs side by side, so
 	// dragging one shows its effect without scrolling. One "Reset all" rather than
 	// a per-knob reset. The knobs register in state.fields, so the page Save and
@@ -878,9 +922,23 @@
 				'</div></div>' +
 				'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
 				'<video id="mj-live-video-b" autoplay muted playsinline class="mj-live-video" style="display:none"></video>' +
+				// The night/IR/light toggles live HERE, not on the Live page:
+				// that page is deliberately settings-free (the future
+				// multi-user read-only view), and these change the camera for
+				// everyone. Same ids and wiring the Live page used to carry.
+				'<div class="d-flex flex-wrap align-items-center gap-2 mt-2">' +
+				'<input type="checkbox" class="btn-check" id="toggle-night">' +
+				'<label class="btn btn-sm btn-outline-primary" for="toggle-night">🌙 Night mode</label>' +
+				'<input type="checkbox" class="btn-check" id="toggle-ircut">' +
+				'<label class="btn btn-sm btn-outline-primary" for="toggle-ircut">👁 IR filter</label>' +
+				'<input type="checkbox" class="btn-check" id="toggle-light">' +
+				'<label class="btn btn-sm btn-outline-primary" for="toggle-light">💡 Light</label>' +
+				'<span class="small" id="mj-lightmon" hidden><a href="mj-settings.cgi?tab=nightMode">Light monitor active</a></span>' +
+				'</div>' +
 				'</div></div>';
 			row.appendChild(pv);
 			attachLivePreview(pv.querySelector('#mj-live-video'));
+			wireNightToggles(pv);
 		}
 
 		const col = el('div', withVideo ? 'col-12 col-lg-5' : 'col-12 col-lg-6');

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -1,7 +1,9 @@
-// Camera Preview page glue: night/IRcut/light toggles (via the /night and
-// /metrics/night APIs) and the live player attach, with an MJPEG/no-signal
-// fallback. `$`, mjConfig and mjGet are globals from main.js; this file loads
-// after preview.js and preview-webrtc.js.
+// Live View page glue: the player attach with its MJPEG/no-signal fallback.
+// Nothing here changes the camera — the page is deliberately settings-free
+// (it is the future multi-user system's read-only view), and the night/IR/
+// light toggles that used to live here moved to mj-settings' Live section
+// (mj-settings.js). `$`, mjConfig and mjGet are globals from main.js; this
+// file loads after preview.js and preview-webrtc.js.
 //
 // TWO TRANSPORTS, ONE FAÇADE. MajesticVideo (MSE) and MajesticWebRTC return
 // the same object, so everything below is written once and the choice is made
@@ -23,35 +25,6 @@
 // choice beats both. Otherwise the first bad afternoon would quietly park a
 // browser on the slower transport for good.
 (function () {
-	// --- Night / IRcut / Light toggles ---
-	mjConfig().then(cfg => {
-		const active = v => v !== false && v != null;
-		const lm = active(mjGet(cfg, 'nightMode.lightMonitor'));
-		$('#toggle-night').disabled = lm;
-		$('#toggle-ircut').disabled = lm || !active(mjGet(cfg, 'nightMode.irCutPin1'));
-		$('#toggle-light').disabled = lm || !active(mjGet(cfg, 'nightMode.backlightPin'));
-		if (lm) $('#mj-lightmon').hidden = false;
-	});
-
-	['night', 'ircut', 'light'].forEach(n =>
-		apiFetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
-			.then(r => r.text()).then(v => { $('#toggle-' + n).checked = +v > 0; })
-			.catch(() => {}));
-
-	$('#toggle-night').addEventListener('click', () => {
-		apiFetch('/night/toggle', { credentials: 'same-origin' }).then(api => api.json()).then(data => {
-			$('#toggle-night').checked = data;
-			if (!$('#toggle-ircut').disabled) $('#toggle-ircut').checked = data;
-			if (!$('#toggle-light').disabled) $('#toggle-light').checked = data;
-		});
-	});
-	$('#toggle-ircut').addEventListener('click', () => {
-		apiFetch('/night/ircut', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-ircut').checked = data; });
-	});
-	$('#toggle-light').addEventListener('click', () => {
-		apiFetch('/night/light', { credentials: 'same-origin' }).then(api => api.json()).then(data => { $('#toggle-light').checked = data; });
-	});
-
 	// --- Live player (WebRTC or MSE, with MJPEG / no-signal fallback) ---
 	const initial = $('#live-video');
 	if (!initial || !window.MajesticVideo) return;

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -5,7 +5,15 @@
 <%in p/header.cgi %>
 <!-- No page heading: the nav underlines "Live", and the row the <h2> occupied
      is exactly the row the player needs to fit a laptop viewport without
-     scrolling. -->
+     scrolling.
+
+     This page is deliberately settings-free: it is the page every user of a
+     future multi-user system gets, read-only, so nothing on it changes the
+     camera. Every setting — including the night/IR/light toggles that used
+     to sit here — lives in mj-settings.cgi, whose Live section pairs the
+     same preview with the real-time adjustments. The one exception is the
+     PTZ pad, which steers rather than configures; it stays on the video
+     until the multi-user split decides who may steer. -->
 
 
 <div class="row g-4">
@@ -15,23 +23,7 @@
 			<% if [ -n "$ptz_support" ]; then %>
 				<%in p/motor.cgi %>
 			<% fi %>
-			<!-- Device controls, not view controls: what they switch is the
-			     camera itself, for every viewer, so they live on the page
-			     rather than in the player's bar. Same ids the wiring in
-			     preview-page.js has always used. -->
-			<div class="d-flex flex-wrap align-items-center gap-2 mt-2">
-				<input type="checkbox" class="btn-check" id="toggle-night">
-				<label class="btn btn-sm btn-outline-primary" for="toggle-night">🌙 Night mode</label>
-
-				<input type="checkbox" class="btn-check" id="toggle-ircut">
-				<label class="btn btn-sm btn-outline-primary" for="toggle-ircut">👁 IR filter</label>
-
-				<input type="checkbox" class="btn-check" id="toggle-light">
-				<label class="btn btn-sm btn-outline-primary" for="toggle-light">💡 Light</label>
-
-				<span class="small" id="mj-lightmon" hidden><a href="mj-settings.cgi?tab=nightMode">Light monitor active</a></span>
-				<a class="small ms-auto" href="mj-endpoints.cgi">Stream URLs</a>
-			</div>
+			<p class="small mb-0 mt-2"><a href="mj-endpoints.cgi">Stream URLs</a></p>
 		</div></div>
 	</div>
 </div>


### PR DESCRIPTION
Design decision (maintainer): the Live page is what every user of the coming multi-user system will see — read-only included — so nothing on it may change the camera.

- **Night mode / IR filter / Light leave the Live page** and land in mj-settings' Live section, directly under the preview they affect, beside the real-time adjustment knobs. Same ids and wiring (`wireNightToggles` in `mj-settings.js`): gating from the already-loaded config, runtime state from `/metrics/night`, the light-monitor notice included.
- **The PTZ pad stays on the video** — steering, not configuration, and explicitly "for now": the multi-user split will decide who may steer.
- **`preview-page.js` loses its toggle block whole** — against the stripped page its unguarded lookups would have thrown before the player attached.
- This also settles that custom `p/motor.cgi` settings panels have no home on the Live page in any arrangement; that ecosystem continues in the upcoming customization-API discussion.

Verified on the hi3516av300 (and eyeballed by the maintainer on the live camera): the Live page carries nothing but the player, the PTZ pad and a Stream URLs link, zero console errors; the settings Live tab shows the toggles with correct gating (IR filter disabled where no `irCutPin1` is configured), states loaded from metrics, preview decoding beside them. Tests and template lint green; purged CSS regenerated.