### PR TITLE
PTZ: ptz_control names the method, ptz_speed sets the rate (#227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,15 +234,22 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   while the stage itself has focus (the bar's slider and radios own them
   otherwise), `apiFetch` to `j/ptz.cgi`. **Three PTZ backends**, detected in
   `common.cgi:update_caminfo` into `ptz_backend` (cached in sysinfo like
-  `ptz_support`): `gpio` (U-Boot `gpio_motors` + `gpio-motors` binary) and
-  `motor` (`ptz` + `/usr/bin/motor`) are stepped eight-way pads speaking
-  `j/ptz.cgi?h=&v=` (validated as small signed ints); `pelco` (`ptz` +
-  `/usr/bin/btzoom`) is the community Pelco-D serial mod — four directions,
-  zoom and focus, each a fixed timed pulse — speaking `j/ptz.cgi?act=<verb>`
-  against a closed whitelist (btzoom execs `pelcoD_$1`, so the verb must
-  never pass through raw). `bin/btzoom` ships in this repo (adopted from
-  OpenIPC/sandbox `scripts/pelcoD`, port from U-Boot `ptz_port`, default
-  `/dev/ttyAMA0`) so a Pelco camera needs only `fw_setenv ptz true`. A held
+  `ptz_support`). The switch is U-Boot `ptz_control` (#227): `gpio`
+  (`gpio-motors` binary; pins in `ptz_gpio` — though the binary itself still
+  reads legacy `gpio_motors`, so set that one until the firmware utility
+  learns the new name), `pelco-d` (`/usr/bin/btzoom`; `ptz_port` default
+  `/dev/ttyAMA0`, `ptz_speed` default 115200 from a whitelist of standard
+  rates), `motor` (`/usr/bin/motor`; profile in `ptz_profile`, legacy `ptz`
+  value as fallback), or `none`. With `ptz_control` unset the pre-#227
+  detection stands (legacy `gpio_motors`/`ptz` vars), so field cameras keep
+  their pads; `j/ptz.cgi` honours the same switch. `gpio` and `motor` are
+  stepped eight-way pads speaking `j/ptz.cgi?h=&v=` (validated as small
+  signed ints); `pelco` is the community Pelco-D serial mod — four
+  directions, zoom and focus, each a fixed timed pulse — speaking
+  `j/ptz.cgi?act=<verb>` against a closed whitelist (btzoom execs
+  `pelcoD_$1`, so the verb must never pass through raw). `bin/btzoom` ships
+  in this repo (adopted from OpenIPC/sandbox `scripts/pelcoD`) so a Pelco
+  camera needs only `fw_setenv ptz_control pelco-d`. A held
   Pelco button strings pulses end-to-end via the one-request-in-flight
   guard — btzoom answers only after its pulse ends. To render either pad on
   a camera without hardware: set the env vars, `touch`+`chmod +x` fake

--- a/bin/btzoom
+++ b/bin/btzoom
@@ -13,6 +13,13 @@
 
 PORT=$(fw_printenv -n ptz_port 2>/dev/null)
 [ -n "$PORT" ] || PORT=/dev/ttyAMA0
+SPEED=$(fw_printenv -n ptz_speed 2>/dev/null)
+case "$SPEED" in
+	# A rate stty would refuse must not kill the command whole; the popular
+	# rates are plenty, and anything else falls back to the old default.
+	1200|2400|4800|9600|19200|38400|57600|115200) ;;
+	*) SPEED=115200 ;;
+esac
 DELAY='sleep .5'
 LOCK=/tmp/btzoom.lock
 
@@ -48,7 +55,7 @@ trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
 # runs for every command rather than trusting that `start` — the long lens
 # wakeup and ICR exercise, a maintenance action nobody is required to run —
 # happened first.
-stty -F "$PORT" 115200 raw -echo -onlcr 2>/dev/null
+stty -F "$PORT" "$SPEED" raw -echo -onlcr 2>/dev/null
 
 pelcoD_night() {
 	printf '\xFF\x01\x00\x09\x00\x01\x0B' > "$PORT"
@@ -59,7 +66,7 @@ pelcoD_day() {
 }
 
 pelcoD_start() {
-	stty -F "$PORT" 115200 raw -echo -onlcr
+	stty -F "$PORT" "$SPEED" raw -echo -onlcr
 	$DELAY
 	# Lens wakeup.
 	printf '\x51\x01\x04\x79\x01\x0D\x0A\x2E\x02\x7E\x00\x00\x00\x95' > "$PORT"

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -47,7 +47,14 @@ motor_ok=0
 profile=""
 case "$ptz_control" in
 	pelco-d) [ -x /usr/bin/btzoom ] && pelco_ok=1 ;;
-	gpio) command -v gpio-motors >/dev/null 2>&1 && gpio_ok=1 ;;
+	gpio)
+		# Binary AND a pin list (either name — the binary itself still reads
+		# the legacy one), mirroring update_caminfo.
+		if command -v gpio-motors >/dev/null 2>&1 &&
+			{ [ -n "$(fw_printenv -n ptz_gpio 2>/dev/null)" ] || [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; }; then
+			gpio_ok=1
+		fi
+		;;
 	motor)
 		profile=$(fw_printenv -n ptz_profile 2>/dev/null)
 		[ -n "$profile" ] || profile="$ptz"

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -35,14 +35,39 @@ done
 echo "$HORIZONTAL" | grep -qE '^-?[0-9]{1,2}$' || HORIZONTAL=0
 echo "$VERTICAL" | grep -qE '^-?[0-9]{1,2}$' || VERTICAL=0
 
+# The same switch update_caminfo honours (#227): ptz_control names the
+# method outright; unset falls back to the pre-#227 detection so nothing in
+# the field breaks; "none" (or an unknown method) serves nobody.
+ptz_control=$(fw_printenv -n ptz_control 2>/dev/null)
 ptz=$(fw_printenv -n ptz 2>/dev/null)
+
+pelco_ok=0
+gpio_ok=0
+motor_ok=0
+profile=""
+case "$ptz_control" in
+	pelco-d) [ -x /usr/bin/btzoom ] && pelco_ok=1 ;;
+	gpio) command -v gpio-motors >/dev/null 2>&1 && gpio_ok=1 ;;
+	motor)
+		profile=$(fw_printenv -n ptz_profile 2>/dev/null)
+		[ -n "$profile" ] || profile="$ptz"
+		[ -x /usr/bin/motor ] && [ -n "$profile" ] && motor_ok=1
+		;;
+	none) ;;
+	"")
+		[ -x /usr/bin/btzoom ] && [ -n "$ptz" ] && pelco_ok=1
+		command -v gpio-motors >/dev/null 2>&1 && [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && gpio_ok=1
+		profile="$ptz"
+		[ -x /usr/bin/motor ] && [ -n "$profile" ] && motor_ok=1
+		;;
+esac
 
 # The verb is matched against the closed list, never passed through: btzoom
 # execs "pelcoD_$1", so an unlisted word would call whatever function the
 # query string names. (start/day/night exist in btzoom but are lens
 # maintenance, not viewing controls — not reachable from here.)
 if [ -n "$ACTION" ]; then
-	if [ -x /usr/bin/btzoom ] && [ -n "$ptz" ]; then
+	if [ "$pelco_ok" = 1 ]; then
 		case "$ACTION" in
 			up|down|left|right|stop|wide|tele|near|far)
 				/usr/bin/btzoom "$ACTION"
@@ -56,13 +81,13 @@ if [ -n "$ACTION" ]; then
 	exit 1
 fi
 
-if command -v gpio-motors >/dev/null 2>&1 && [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; then
+if [ "$gpio_ok" = 1 ]; then
 	gpio-motors "$HORIZONTAL" "$VERTICAL" 10
 	exit $?
 fi
 
-if [ -x /usr/bin/motor ] && [ -n "$ptz" ]; then
-	/usr/bin/motor "$ptz" "$HORIZONTAL" "$VERTICAL"
+if [ "$motor_ok" = 1 ]; then
+	/usr/bin/motor "$profile" "$HORIZONTAL" "$VERTICAL"
 	exit $?
 fi
 

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -687,7 +687,11 @@ update_caminfo() {
 	ptz_control=$(fw_printenv -n ptz_control 2>/dev/null)
 	case "$ptz_control" in
 		gpio)
-			if command -v gpio-motors >/dev/null 2>&1; then
+			# The binary AND a pin list: gpio-motors without pins errors on
+			# every press, and the pad must not render what cannot work. The
+			# binary itself still reads the legacy name, so either satisfies.
+			if command -v gpio-motors >/dev/null 2>&1 &&
+				{ [ -n "$(fw_printenv -n ptz_gpio 2>/dev/null)" ] || [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; }; then
 				ptz_support="1"; ptz_backend="gpio"
 			fi
 			;;
@@ -697,7 +701,10 @@ update_caminfo() {
 			fi
 			;;
 		motor)
-			if [ -x /usr/bin/motor ]; then
+			# Same rule: the profile is what the binary is called with, so a
+			# pad without one would render presses the endpoint refuses.
+			if [ -x /usr/bin/motor ] &&
+				{ [ -n "$(fw_printenv -n ptz_profile 2>/dev/null)" ] || [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; }; then
 				ptz_support="1"; ptz_backend="motor"
 			fi
 			;;

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -670,23 +670,48 @@ update_caminfo() {
 
 	# WebUI
 	ui_password=$(grep root /etc/shadow | cut -d: -f2)
-	# PTZ preview controls. Three backends, each needing both its switch and
-	# its binary: GPIO motors (gpio_motors + gpio-motors), a motor profile
-	# (ptz + /usr/bin/motor), or Pelco-D over serial (ptz + /usr/bin/btzoom).
-	# The backend decides which pad p/motor.cgi draws — the first two are
-	# stepped pan/tilt with diagonals, Pelco-D is four directions in timed
-	# pulses plus zoom and focus. Order matters only when a camera has
-	# several installed; the stepped backends win because their protocol
-	# carries magnitudes the Pelco pulses cannot.
-	if [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && command -v gpio-motors >/dev/null 2>&1; then
-		ptz_support="1"; ptz_backend="gpio"
-	elif [ -x /usr/bin/motor ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
-		ptz_support="1"; ptz_backend="motor"
-	elif [ -x /usr/bin/btzoom ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
-		ptz_support="1"; ptz_backend="pelco"
-	else
-		ptz_support=""; ptz_backend=""
-	fi
+	# PTZ preview controls. The switch is the U-Boot ptz_control variable
+	# (#227): it names the method — "gpio" (gpio-motors, pins in ptz_gpio or
+	# the legacy gpio_motors, which the gpio-motors binary itself still
+	# reads), "pelco-d" (btzoom over serial, port/rate in ptz_port and
+	# ptz_speed), "motor" (a motor profile in ptz_profile or the legacy ptz
+	# value), or "none". An explicit method is trusted but still needs its
+	# binary — a pad whose every press fails is worse than no pad. With
+	# ptz_control unset, the pre-#227 detection stands so no camera in the
+	# field loses its pad: gpio wins over a profile wins over Pelco, because
+	# the stepped protocols carry magnitudes the Pelco pulses cannot.
+	# The backend decides which pad p/motor.cgi draws — gpio and motor are
+	# stepped eight-way pan/tilt, Pelco-D is four directions in timed pulses
+	# plus zoom and focus.
+	ptz_support=""; ptz_backend=""
+	ptz_control=$(fw_printenv -n ptz_control 2>/dev/null)
+	case "$ptz_control" in
+		gpio)
+			if command -v gpio-motors >/dev/null 2>&1; then
+				ptz_support="1"; ptz_backend="gpio"
+			fi
+			;;
+		pelco-d)
+			if [ -x /usr/bin/btzoom ]; then
+				ptz_support="1"; ptz_backend="pelco"
+			fi
+			;;
+		motor)
+			if [ -x /usr/bin/motor ]; then
+				ptz_support="1"; ptz_backend="motor"
+			fi
+			;;
+		none) ;;
+		"")
+			if [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && command -v gpio-motors >/dev/null 2>&1; then
+				ptz_support="1"; ptz_backend="gpio"
+			elif [ -x /usr/bin/motor ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
+				ptz_support="1"; ptz_backend="motor"
+			elif [ -x /usr/bin/btzoom ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
+				ptz_support="1"; ptz_backend="pelco"
+			fi
+			;;
+	esac
 
 	# Network
 	network_interface=$(ip route | awk '/default/ {print $5}' | head -n1)


### PR DESCRIPTION
Implements all three points of #227:

1. **`ptz_speed`** — feeds both `stty` calls in `btzoom`, validated against the standard rates (1200–115200), defaulting to the old 115200; a bogus value falls back rather than killing the command.
2. **`ptz_control`** — the explicit method switch: `gpio`, `pelco-d`, `motor`, `none`. An explicit method is trusted but still requires its binary; `none` disables PTZ regardless of any legacy configuration; **unset falls back to the pre-#227 detection unchanged**, so no field camera loses its pad. `j/ptz.cgi` honours the same switch, so pad and endpoint cannot disagree.
3. **`ptz_gpio`** — accepted as the tidier name, with one caveat the WebUI cannot fix alone: `gpio-motors.c:120` runs `fw_printenv -n gpio_motors` itself for the pin list, so that variable still has to be set until the firmware utility learns the new name (one-hunk patch proposed in the issue).

Also: the motor-profile backend (not covered in the issue) slots in as `ptz_control=motor` with the profile in `ptz_profile`, falling back to the legacy `ptz` value where it doubled as the profile name.

Verified on the hi3516av300: `pelco-d` enabled by `ptz_control` alone (no legacy `ptz`); `stty` observed at `ptz_speed=9600` and back at 115200 for a bogus rate; `gpio` enabled by `ptz_control` alone (no legacy `gpio_motors`); `ptz_control=none` showing no pad and refusing the API with every legacy variable and binary present; legacy-only configuration untouched. Tests and template lint green.