### PR TITLE
Live View: the toast says when the shared encoder moved, and for whom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,14 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   nothing ever displaces the picture: the status chip `#mj-badge` top-right
   (`CODEC W×H · fps`; fps is live WebRTC stats via a loosened `onStats` gate,
   or the configured `videoN.fps` on MSE, which measures nothing), the stats
-  panel top-left as translucent glass, the adaptation note (dismissible)
-  above the bar, and the auto-hiding control bar (`.mj-bar`: shown on hover /
+  panel top-left as translucent glass, the adaptation toast `#mj-adapt`
+  under the chip (`preview-adapt.js` — event-driven off the camera's `enc=`
+  stats counter, it reports the moment the shared encoder's bitrate moved,
+  in which direction, and whose connection moved it; it replaced a standing
+  "the camera is adapting" disclosure note that fired whether or not
+  anything was happening and could not name the responsible link; on a
+  majestic without the counter it stays dormant), and the auto-hiding
+  control bar (`.mj-bar`: shown on hover /
   `:focus-within` / a JS `.mj-show` tap-toggle). `preview-hero.js` owns the
   stage chrome — bar visibility, fullscreen (on the stage; hidden on iOS
   Safari which lacks the API), snapshot (`/image.jpg` → blob download, shown

--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -21,7 +21,7 @@ const IDS = [
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
 	'mj-stream-auto', 'mj-auto', 'mj-sub', 'mj-talk', 'mj-talk-ctl',
 	'mj-talk-lbl', 'mj-transport-w', 'mj-transport-m', 'mj-transport-ctl',
-	'mj-transport-lbl', 'mj-transport-note', 'mj-note-close', 'mj-vol',
+	'mj-transport-lbl', 'mj-vol',
 	'mj-player', 'mj-stage', 'toggle-ircut', 'toggle-light', 'toggle-night',
 ];
 

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -26,7 +26,7 @@ const IDS = [
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-transport-w',
 	'mj-transport-m', 'mj-transport-ctl', 'mj-transport-lbl',
-	'mj-transport-note', 'mj-note-close', 'mj-vol', 'mj-player', 'mj-stage',
+	'mj-vol', 'mj-player', 'mj-stage',
 	'toggle-ircut', 'toggle-light', 'toggle-night',
 ];
 

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -749,7 +749,8 @@ mark {
 	right: 0.5rem;
 	z-index: 5;
 	margin: 0;
-	padding: 0.3rem 0.6rem;
+	/* Room on the right for the corner-anchored ×. */
+	padding: 0.3rem 1.5rem 0.3rem 0.6rem;
 	max-width: min(75%, 22rem);
 	background: rgba(0, 0, 0, 0.65);
 	color: rgba(255, 255, 255, 0.9);
@@ -757,6 +758,18 @@ mark {
 	backdrop-filter: blur(4px);
 	cursor: pointer;
 	animation: mj-adapt-in 0.2s ease;
+}
+
+/* Corner-anchored rather than flowed after the text: inline, it would wrap
+   to a line of its own whenever the last text line runs long. */
+.mj-adapt-close {
+	position: absolute;
+	top: 0.1rem;
+	right: 0.25rem;
+	border: 0;
+	background: none;
+	color: inherit;
+	padding: 0 0.25rem;
 }
 
 .mj-adapt-rates {

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -741,25 +741,37 @@ mark {
 	color: rgba(255, 255, 255, 0.7);
 }
 
-.mj-adapt-note {
+/* The adaptation toast: under the chip, same glass. Hover pins it and click
+   dismisses (preview-adapt.js), so unlike the chip it takes the pointer. */
+.mj-adapt-toast {
 	position: absolute;
-	left: 0.5rem;
-	bottom: 3.25rem;
+	top: 2.4rem;
+	right: 0.5rem;
 	z-index: 5;
 	margin: 0;
-	padding: 0.25rem 0.5rem;
-	background: rgba(0, 0, 0, 0.55);
-	color: rgba(255, 255, 255, 0.85);
+	padding: 0.3rem 0.6rem;
+	max-width: min(75%, 22rem);
+	background: rgba(0, 0, 0, 0.65);
+	color: rgba(255, 255, 255, 0.9);
 	border-radius: 0.4rem;
-	max-width: 75%;
+	backdrop-filter: blur(4px);
+	cursor: pointer;
+	animation: mj-adapt-in 0.2s ease;
 }
 
-.mj-adapt-close {
-	border: 0;
-	background: none;
-	color: inherit;
-	padding: 0 0.25rem;
-	pointer-events: auto;
+.mj-adapt-rates {
+	display: block;
+	font-variant-numeric: tabular-nums;
+	font-weight: 600;
+}
+
+/* Green up, amber down — the direction at a glance, the sentence for why. */
+.mj-adapt-up { color: #4ade80; }
+.mj-adapt-down { color: #fbbf24; }
+
+@keyframes mj-adapt-in {
+	from { opacity: 0; transform: translateX(0.5rem); }
+	to { opacity: 1; transform: none; }
 }
 
 /* The bar: invisible until pointed at, focused into (keyboard users keep it

--- a/www/a/preview-adapt.js
+++ b/www/a/preview-adapt.js
@@ -28,10 +28,14 @@ window.MajesticAdapt = (function () {
 	const SHOW_MS = 6000;
 
 	let el = null, ratesEl = null, whyEl = null;
-	// Last applied rate seen, in kbps, 0 = configured; null = no tick yet.
-	// Kept per channel is not needed: reset() is called on a channel switch,
-	// because the two channels' encoders move independently.
-	let last = null;
+	// The baseline: last applied rate seen (kbps, 0 = configured) and which
+	// channel it belongs to. Keyed on the channel because the two channels
+	// are two encoders: whenever ticks start describing the other one — a
+	// stream switch, or a reconnect whose negotiation landed on the other
+	// channel — the old number is the wrong encoder's and comparing across
+	// would announce a step nobody's encoder took. chan starts null, which
+	// no real channel equals, so the first tick always adopts silently.
+	let last = 0, chan = null;
 	let hideTimer = null, pinned = false, wired = false;
 
 	function fmt(kbps) {
@@ -43,23 +47,38 @@ window.MajesticAdapt = (function () {
 	function wire() {
 		if (wired || !el) return;
 		wired = true;
-		// Hover pins — someone reading it should not have it vanish mid-
-		// sentence. Click dismisses; stopPropagation keeps the tap from also
-		// toggling the control bar underneath (the stage owns that tap).
-		el.addEventListener('mouseenter', function () {
-			pinned = true;
-			clearTimeout(hideTimer);
-		});
+		// Hover or focus pins — someone reading it should not have it vanish
+		// mid-sentence, and a keyboard reaching the × deserves the same
+		// stay as a pointer resting on the text. Click anywhere dismisses;
+		// stopPropagation keeps the tap from also toggling the control bar
+		// underneath (the stage owns that tap). The × is the same dismissal
+		// for those who cannot click a paragraph: a real button, so Enter
+		// and Space work without any handler here.
+		el.addEventListener('mouseenter', pin);
+		el.addEventListener('focusin', pin);
 		el.addEventListener('click', function (ev) {
 			ev.stopPropagation();
 			hide();
 		});
 	}
 
+	function pin() {
+		pinned = true;
+		clearTimeout(hideTimer);
+	}
+
 	function hide() {
 		clearTimeout(hideTimer);
 		pinned = false;
-		if (el) el.hidden = true;
+		if (!el) return;
+		// If the keyboard was on the × when the toast went, the focus would
+		// otherwise fall to the body; the stage is where it came from and is
+		// itself focusable.
+		if (el.contains(document.activeElement)) {
+			const stage = document.getElementById('mj-stage');
+			if (stage && stage.focus) stage.focus();
+		}
+		el.hidden = true;
 	}
 
 	function show(fromK, toK, why, up) {
@@ -84,8 +103,8 @@ window.MajesticAdapt = (function () {
 	// One reading of the camera's stats line, once a second while WebRTC is
 	// the live transport. All rates in kbps; enc 0 means "at the configured
 	// rate", configured 0 means the config has not landed (or names no sane
-	// rate), and a step whose either end is unknowable is skipped rather
-	// than guessed at.
+	// rate). t.channel is the channel the picture actually belongs to, as
+	// the page best knows it.
 	function tick(t) {
 		if (!el) {
 			el = document.getElementById('mj-adapt');
@@ -94,18 +113,32 @@ window.MajesticAdapt = (function () {
 			wire();
 		}
 		const cur = t.enc | 0;
-		if (last === null) {
-			// First reading of this session or channel: adopt, don't
-			// announce. Joining a stream that is already adapted is a state,
-			// not an event — the disclosure note covers states.
+		const ch = t.channel === undefined ? -1 : t.channel | 0;
+		if (ch !== chan) {
+			// First reading, or the ticks now describe the other channel's
+			// encoder: adopt, don't announce. A state you arrive into is not
+			// an event you witnessed, and a step measured across two
+			// encoders is not a step either of them took. Any toast still
+			// standing is about the encoder being left.
+			chan = ch;
 			last = cur;
+			hide();
 			return;
 		}
 		if (cur === last) return;
-		const from = last || (t.configured | 0);
-		const to = cur || (t.configured | 0);
+		const cfg = t.configured | 0;
+		// A step to or from 0 reads "the configured rate" for that end, so
+		// without the config it cannot be described yet — the page attaches
+		// on a deadline and the stats can outrun the config fetch. Hold the
+		// baseline rather than advancing it: held, the step is still pending
+		// on the next tick and is announced once the config lands; advanced,
+		// it would be consumed silently and the return-to-configured event
+		// lost for good.
+		if ((cur === 0 || last === 0) && !cfg) return;
+		const from = last || cfg;
+		const to = cur || cfg;
 		last = cur;
-		if (!from || !to || from === to) return;
+		if (from === to) return;
 
 		const up = to > from;
 		let why;
@@ -130,9 +163,12 @@ window.MajesticAdapt = (function () {
 	}
 
 	// The channel changed, or the transport did: whatever enc we knew was
-	// the other encoder's, and the toast on screen is about it too.
+	// the other encoder's, and the toast on screen is about it too. Clearing
+	// chan (which no real channel equals) makes the next tick adopt
+	// silently, whichever channel it turns out to describe.
 	function reset() {
-		last = null;
+		chan = null;
+		last = 0;
 		hide();
 	}
 

--- a/www/a/preview-adapt.js
+++ b/www/a/preview-adapt.js
@@ -1,0 +1,140 @@
+// The adaptation toast: says so, at the moment the shared encoder moves.
+//
+// The transport note discloses that WebRTC *may* adapt the stream's bitrate;
+// this is the other half — that it just *did*, in which direction, and whose
+// connection did it. The distinction matters because the encoder is shared:
+// rate changes reach every viewer of the channel and whatever is recording
+// it, so a drop on your screen is not necessarily your link, and a drop you
+// caused is not only your problem. That attribution is the whole reason this
+// exists; a plain bitrate readout already lives in the stats panel.
+//
+// Fed from the camera's own per-second stats line rather than inferred from
+// received throughput: enc= is where the bitrate arbitration actually holds
+// the encoder (0 = untouched, at the configured rate), remb= this session's
+// own estimate. Measured receive rate breathes with scene complexity, so a
+// toast built on it would cry wolf on every busy frame; enc= only moves when
+// the camera really moved the encoder. On a majestic without the counter the
+// tick never sees one and nothing here ever shows.
+//
+// Attribution is a comparison, not a message from the camera: the encoder
+// follows the lowest live estimate, so if our own estimate sits at (or near)
+// the new rate we are the floor — "your connection"; if ours is well above
+// it, somebody else's is — "another viewer". Near, not equal, because the
+// camera clamps and quantises what it applies.
+window.MajesticAdapt = (function () {
+	// How long a toast stands once shown. No confirmation phase, unlike a
+	// buffered player's toast: WebRTC has no buffer to drain, so the rate on
+	// screen is the new rate within a round trip of the decision.
+	const SHOW_MS = 6000;
+
+	let el = null, ratesEl = null, whyEl = null;
+	// Last applied rate seen, in kbps, 0 = configured; null = no tick yet.
+	// Kept per channel is not needed: reset() is called on a channel switch,
+	// because the two channels' encoders move independently.
+	let last = null;
+	let hideTimer = null, pinned = false, wired = false;
+
+	function fmt(kbps) {
+		return kbps >= 1000
+			? (kbps / 1000).toFixed(1).replace(/\.0$/, '') + ' Mbit/s'
+			: kbps + ' kbit/s';
+	}
+
+	function wire() {
+		if (wired || !el) return;
+		wired = true;
+		// Hover pins — someone reading it should not have it vanish mid-
+		// sentence. Click dismisses; stopPropagation keeps the tap from also
+		// toggling the control bar underneath (the stage owns that tap).
+		el.addEventListener('mouseenter', function () {
+			pinned = true;
+			clearTimeout(hideTimer);
+		});
+		el.addEventListener('click', function (ev) {
+			ev.stopPropagation();
+			hide();
+		});
+	}
+
+	function hide() {
+		clearTimeout(hideTimer);
+		pinned = false;
+		if (el) el.hidden = true;
+	}
+
+	function show(fromK, toK, why, up) {
+		if (!el || !ratesEl || !whyEl) return;
+		ratesEl.innerHTML = '';
+		ratesEl.appendChild(document.createTextNode(fmt(fromK) + ' '));
+		const arrow = document.createElement('span');
+		arrow.className = up ? 'mj-adapt-up' : 'mj-adapt-down';
+		arrow.textContent = (up ? '↗ ' : '↘ ') + fmt(toK);
+		ratesEl.appendChild(arrow);
+		whyEl.textContent = why;
+		// A new step replaces whatever was showing, pin included: the pin
+		// held the old news, and this is news.
+		pinned = false;
+		el.hidden = false;
+		clearTimeout(hideTimer);
+		hideTimer = setTimeout(function () {
+			if (!pinned) hide();
+		}, SHOW_MS);
+	}
+
+	// One reading of the camera's stats line, once a second while WebRTC is
+	// the live transport. All rates in kbps; enc 0 means "at the configured
+	// rate", configured 0 means the config has not landed (or names no sane
+	// rate), and a step whose either end is unknowable is skipped rather
+	// than guessed at.
+	function tick(t) {
+		if (!el) {
+			el = document.getElementById('mj-adapt');
+			ratesEl = document.getElementById('mj-adapt-rates');
+			whyEl = document.getElementById('mj-adapt-why');
+			wire();
+		}
+		const cur = t.enc | 0;
+		if (last === null) {
+			// First reading of this session or channel: adopt, don't
+			// announce. Joining a stream that is already adapted is a state,
+			// not an event — the disclosure note covers states.
+			last = cur;
+			return;
+		}
+		if (cur === last) return;
+		const from = last || (t.configured | 0);
+		const to = cur || (t.configured | 0);
+		last = cur;
+		if (!from || !to || from === to) return;
+
+		const up = to > from;
+		let why;
+		if (!up) {
+			// The encoder follows the lowest estimate. Ours at or near the
+			// new rate means the floor is us; well above it means another
+			// viewer's link. The margin absorbs the camera's clamping.
+			const ours = t.remb > 0 &&
+				t.remb <= to + Math.max(100, to * 0.15);
+			why = ours
+				? 'Matched to your connection — every viewer of this ' +
+					'stream now receives this rate.'
+				: 'Another viewer’s connection can’t keep up — ' +
+					'the stream follows the slowest link watching it.';
+		} else {
+			why = cur === 0
+				? 'Back at the configured rate — no connection is ' +
+					'holding it down.'
+				: 'Raised — the slowest connection watching improved.';
+		}
+		show(from, to, why, up);
+	}
+
+	// The channel changed, or the transport did: whatever enc we knew was
+	// the other encoder's, and the toast on screen is about it too.
+	function reset() {
+		last = null;
+		hide();
+	}
+
+	return { tick: tick, reset: reset };
+})();

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -25,7 +25,7 @@
 	});
 	stage.addEventListener('pointerdown', e => {
 		if (e.pointerType !== 'touch') return;
-		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, .mj-adapt-note')) return;
+		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-adapt')) return;
 		if (stage.classList.contains('mj-show')) {
 			stage.classList.remove('mj-show');
 			clearTimeout(hideTimer);

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -180,13 +180,25 @@
 	// and the frame matches the other channel exactly — a camera with unset
 	// (sensor-native) sizes claims nothing rather than guessing. MSE needs
 	// none of this: /ws/video serves the number it is given or nothing.
-	function servedNote() {
-		if (!usingWebRTC || !chipMedia) return '';
-		const want = sizeOf[stream ? 1 : 0], other = sizeOf[stream ? 0 : 1];
-		if (!want || !other) return '';
+	// Which channel the picture actually belongs to: the requested one, unless
+	// the frame provably matches the other channel exactly. The adaptation
+	// toast reads this too — enc= describes the encoder of the channel being
+	// SERVED, so on a served-channel mismatch the requested channel's
+	// configured bitrate would be the wrong endpoint for its steps.
+	function servedStream() {
+		const asked = stream ? 1 : 0;
+		if (!usingWebRTC || !chipMedia) return asked;
+		const want = sizeOf[asked], other = sizeOf[asked ? 0 : 1];
+		if (!want || !other) return asked;
 		const is = d => d.w === chipMedia.w && d.h === chipMedia.h;
-		if (is(want) || !is(other)) return '';
-		return stream ? ' · Main stream' : ' · Sub stream';
+		if (is(want) || !is(other)) return asked;
+		return asked ? 0 : 1;
+	}
+
+	function servedNote() {
+		const served = servedStream();
+		if (served === (stream ? 1 : 0)) return '';
+		return served === 0 ? ' · Main stream' : ' · Sub stream';
 	}
 
 	function setChip() {
@@ -533,12 +545,19 @@
 				// The adaptation toast, fed the camera's own view of the
 				// shared encoder. Guarded: preview-adapt.js is its own file,
 				// and an older majestic sends no enc= at all — either way
-				// nothing here should ever invent a rate change.
+				// nothing here should ever invent a rate change. The channel
+				// is the SERVED one, not the requested one: enc= describes
+				// the encoder actually feeding this picture, and the module
+				// re-adopts its baseline whenever the channel changes under
+				// it — a stream switch, or a reconnect that negotiated the
+				// other channel.
 				if (window.MajesticAdapt && s.cam && s.cam.enc !== undefined) {
+					const ch = servedStream();
 					window.MajesticAdapt.tick({
 						enc: parseInt(s.cam.enc, 10) || 0,
 						remb: parseInt(s.cam.remb, 10) || 0,
-						configured: cfgKbps[stream ? 1 : 0],
+						configured: cfgKbps[ch],
+						channel: ch,
 					});
 				}
 			},

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -65,18 +65,13 @@
 		// the radio behind it stays in the tab order, so without this the
 		// keyboard can pick a stream the camera does not have.
 		if (s1) s1.disabled = !subOk;
-		// Whether each channel will actually be adapted. Absent means an older
-		// camera that has no such setting and always adapted, so only an
-		// explicit false counts as pinned.
-		adapts = [
-			mjGet(cfg, 'video0.adjustBitrate') !== false,
-			mjGet(cfg, 'video1.adjustBitrate') !== false,
-		];
 		// The configured frame rates, which are what the chip shows on MSE —
 		// that player measures nothing.
 		cfgFps = [+mjGet(cfg, 'video0.fps') || 0, +mjGet(cfg, 'video1.fps') || 0];
+		// The configured bitrates, which are what the adaptation toast names
+		// as the rate the encoder returns to when nothing is holding it down.
+		cfgKbps = [+mjGet(cfg, 'video0.bitrate') || 0, +mjGet(cfg, 'video1.bitrate') || 0];
 		setChip();
-		syncTransportNote();
 		ice = MajesticTransport.iceServers(
 			mjGet(cfg, 'webrtc.iceServers'),
 			mjGet(cfg, 'webrtc.turnUsername'),
@@ -120,7 +115,7 @@
 	// which is where "why am I not on WebRTC?" gets asked.
 	const transportW = $('#mj-transport-w'), transportM = $('#mj-transport-m');
 	const transportGrp = $('#mj-transport-ctl');
-	const transportLbl = $('#mj-transport-lbl'), transportNote = $('#mj-transport-note');
+	const transportLbl = $('#mj-transport-lbl');
 	function reflectTransport(kind) {
 		if (transportW) transportW.checked = kind === 'webrtc';
 		if (transportM) transportM.checked = kind === 'mse';
@@ -132,30 +127,6 @@
 	// session that is long over.
 	const TRANSPORT_TITLE = transportLbl ? transportLbl.title : '';
 
-	// The bitrate adaptation is the thing worth disclosing. It is what makes
-	// WebRTC work on a thin link, and it reaches past the person who switched it
-	// on: the encoder is shared with everyone else watching that stream, and
-	// with whatever is recording it. So say it where it cannot be missed, and
-	// only while it is actually happening — a tooltip needs a pointer to find,
-	// and this is not a detail for people who happen to own a mouse.
-	// Dismissed is for this page view: the note is a disclosure, and a person
-	// who has read it should not have it back over the picture on every
-	// channel change. A fresh load discloses again.
-	let noteDismissed = false;
-	function syncTransportNote() {
-		// Only while it is true. The note is a disclosure, and a disclosure that
-		// fires when nothing is happening teaches people to ignore it — the
-		// camera does not touch a channel whose adjustBitrate is off, so saying
-		// it is adapting that stream is simply wrong. Per channel, because the
-		// two settings are independent and Main/Sub is one click apart.
-		if (transportNote) {
-			transportNote.hidden =
-				noteDismissed || !(usingWebRTC && adapts[stream ? 1 : 0]);
-		}
-		if (transportLbl && usingWebRTC) {
-			transportLbl.title = TRANSPORT_TITLE;
-		}
-	}
 	const s0 = $('#mj-stream-0'), s1 = $('#mj-stream-1');
 	const autoCtl = $('#mj-stream-auto'), autoLbl = $('#mj-auto');
 
@@ -190,9 +161,6 @@
 	// boundary would otherwise cut the session on every frame of the resize.
 	const AUTO_MIN_GAP_MS = 1000;
 	let lastAutoAt = 0, autoTimer = null;
-	// Per channel, filled when the config lands; true until then, which is what
-	// a camera without the setting does.
-	let adapts = [true, true];
 	// The chip: what is playing, in one line — "H264 3840×2160 · 25 fps". The
 	// transport is not named here; the picker names it, once. fps has two
 	// sources that cannot be merged: WebRTC measures it every second
@@ -201,6 +169,8 @@
 	// reported about its own picture.
 	let chipMedia = null, chipFps = 0;
 	let cfgFps = [0, 0];
+	// Per channel too: videoN.bitrate, for the toast's "back to configured".
+	let cfgKbps = [0, 0];
 	// WebRTC takes ?stream= as a preference, not an order: the camera can
 	// serve the other channel — a codec its negotiation can give this
 	// browser, or a daemon fault (majestic#299 arrived as "Main selected,
@@ -314,6 +284,12 @@
 		// The camera's own estimate of what this link will carry, which is what
 		// it sets the encoder from — not a measurement of what arrived.
 		set('#mj-st-remb', cam.remb || '-');
+		// Where the shared encoder actually is. enc=0 means WebRTC has not
+		// moved it — it runs at the operator's configured rate. Absent means
+		// a majestic build without the counter, and the row claims nothing.
+		set('#mj-st-enc', cam.enc === undefined ? '-'
+			: (parseInt(cam.enc, 10) || 0) === 0 ? 'configured rate'
+			: parseInt(cam.enc, 10) + ' kbit/s · adapted');
 		set('#mj-st-pli', cam.pli || '-');
 		set('#mj-st-ain', cam['audio-in'] || '-');
 		// Both halves, because they answer different questions: the browser
@@ -338,12 +314,20 @@
 		// stats tick refills it, and until then the chip claims nothing.
 		chipFps = 0;
 		player.setVolume(vol);
+		// The toast's baseline belongs to a WebRTC session; MSE feeds it
+		// nothing, so a stale baseline (and a toast still standing) would
+		// describe a session that is gone. Back on WebRTC it re-adopts from
+		// the first tick rather than announcing whatever moved while away.
+		if (window.MajesticAdapt && !usingWebRTC) window.MajesticAdapt.reset();
 		syncAudioCtl();
 		// The outgoing player's destroy() released the microphone, so talkback
 		// comes back up off whatever the new one is doing.
 		syncTalkCtl();
 		syncStatsCtl();
-		syncTransportNote();
+		// Back on WebRTC, the toggle's tooltip goes back to the standing
+		// explanation: a failure wrote its reason there, and leaving it would
+		// keep complaining about a session that is long over.
+		if (transportLbl && usingWebRTC) transportLbl.title = TRANSPORT_TITLE;
 	}
 
 	// The swap itself lives in preview-swap.js — two elements, a trial that
@@ -546,6 +530,17 @@
 					setChip();
 				}
 				if (statsBox && !statsBox.hidden) showStats(s);
+				// The adaptation toast, fed the camera's own view of the
+				// shared encoder. Guarded: preview-adapt.js is its own file,
+				// and an older majestic sends no enc= at all — either way
+				// nothing here should ever invent a rate change.
+				if (window.MajesticAdapt && s.cam && s.cam.enc !== undefined) {
+					window.MajesticAdapt.tick({
+						enc: parseInt(s.cam.enc, 10) || 0,
+						remb: parseInt(s.cam.remb, 10) || 0,
+						configured: cfgKbps[stream ? 1 : 0],
+					});
+				}
 			},
 		};
 	}
@@ -701,11 +696,6 @@
 		// correcting a default is helpful, overriding a decision is not.
 		const moved = !userPickedStream && chooseSub(cfg);
 		if (moved && player) player.setStream(stream);
-		// The note follows the channel, and this is the one path that changes
-		// the channel without going through attachPlayer(). A camera whose two
-		// channels differ would otherwise disclose Main's setting while playing
-		// Sub, until something else happened to re-sync it.
-		syncTransportNote();
 
 		// The ICE list, unconditionally. A blind attach opened with an empty
 		// one, and the getter is only read when a session opens — so without
@@ -757,13 +747,15 @@
 	// Everything a channel change has to reach: the player on screen, any trial
 	// being judged — a trial keeps the stream it was opened with, so otherwise
 	// it would be promoted onto the channel the viewer had already left — and
-	// the adaptation notice, which is per channel.
+	// the adaptation toast's baseline, which belongs to the channel being left.
 	function goToStream(n) {
 		stream = n;
+		// The two channels are two encoders; the baseline and any toast on
+		// screen describe the one being left.
+		if (window.MajesticAdapt) window.MajesticAdapt.reset();
 		if (player) player.setStream(n);
 		const t = swap.trial();
 		if (t) t.setStream(n);
-		syncTransportNote();
 		// On MSE the chip's fps is the configured rate, which is per channel.
 		setChip();
 	}
@@ -867,13 +859,4 @@
 		// showing" has one answer and not two that have to agree.
 		statsBtn.addEventListener('change', syncStatsCtl);
 	}
-
-	// The adaptation note's dismissal. State lives beside its reader
-	// (syncTransportNote), which would otherwise re-show the note on the next
-	// channel or transport change.
-	const noteClose = $('#mj-note-close');
-	if (noteClose) noteClose.addEventListener('click', () => {
-		noteDismissed = true;
-		syncTransportNote();
-	});
 })();

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -503,6 +503,7 @@ preview() {
 						<tbody>
 							<tr><td class="pe-3 mj-stat-key">session</td><td id="mj-st-cam">-</td></tr>
 							<tr><td class="pe-3 mj-stat-key">estimate</td><td id="mj-st-remb">-</td></tr>
+						<tr><td class="pe-3 mj-stat-key">encoder</td><td id="mj-st-enc">-</td></tr>
 							<tr><td class="pe-3 mj-stat-key">keyframes</td><td id="mj-st-pli">-</td></tr>
 							<tr><td class="pe-3 mj-stat-key">audio in</td><td id="mj-st-ain">-</td></tr>
 							<tr><td class="pe-3 mj-stat-key">talkback</td><td id="mj-st-talk">-</td></tr>
@@ -511,14 +512,17 @@ preview() {
 				</div>
 			</div>
 		</div>
-		<!-- Shown only while WebRTC is the live transport. A sentence rather
-		     than a control, and dismissible: the tooltip on the picker cannot
-		     be the whole disclosure, because the thing being disclosed reaches
-		     past the person reading it. -->
-		<p id="mj-transport-note" class="mj-adapt-note small" hidden>
-			The camera is adapting this stream's bitrate to your connection.
-			Anyone else watching the same stream sees that too.
-			<button type="button" class="mj-adapt-close" id="mj-note-close" aria-label="Dismiss">×</button>
+		<!-- The adaptation toast (preview-adapt.js): the whole disclosure of
+		     WebRTC's shared-encoder bitrate adaptation, made at the moment it
+		     acts rather than as a standing sentence (the always-on note this
+		     replaces taught people to ignore it, and could not tell whose
+		     connection was responsible). Names the direction and says whose
+		     link moved the encoder — a change caused by another viewer is the
+		     case nothing else on the page would explain. Below the chip so
+		     the two can show together. -->
+		<p id="mj-adapt" class="mj-adapt-toast small" hidden>
+			<span id="mj-adapt-rates" class="mj-adapt-rates"></span>
+			<span id="mj-adapt-why" class="mj-adapt-why"></span>
 		</p>
 		<!-- PTZ mount. Empty and hidden on every camera; p/motor.cgi (included
 		     by preview.cgi only when the hardware exists) emits the pad after

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -520,9 +520,14 @@ preview() {
 		     link moved the encoder — a change caused by another viewer is the
 		     case nothing else on the page would explain. Below the chip so
 		     the two can show together. -->
-		<p id="mj-adapt" class="mj-adapt-toast small" hidden>
+		<!-- role=status so the announcement reaches a screen reader when the
+		     text lands; the × is the keyboard's dismissal (click-anywhere
+		     only serves a pointer) and focusing it pins the toast the same
+		     way hovering does. -->
+		<p id="mj-adapt" class="mj-adapt-toast small" role="status" hidden>
 			<span id="mj-adapt-rates" class="mj-adapt-rates"></span>
 			<span id="mj-adapt-why" class="mj-adapt-why"></span>
+			<button type="button" class="mj-adapt-close" aria-label="Dismiss">×</button>
 		</p>
 		<!-- PTZ mount. Empty and hidden on every camera; p/motor.cgi (included
 		     by preview.cgi only when the hardware exists) emits the pad after

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -32,6 +32,7 @@
 <script src="/a/preview-webrtc.js"></script>
 <script src="/a/preview-swap.js"></script>
 <script src="/a/preview-transport.js"></script>
+<script src="/a/preview-adapt.js"></script>
 <script src="/a/preview-page.js"></script>
 <script src="/a/preview-hero.js"></script>
 


### PR DESCRIPTION
WebRTC's bitrate adaptation drives one encoder per channel, and majestic moves it to the lowest estimate among that channel's viewers — so a drop on your screen is not necessarily your link, and a drop you caused is not only your problem. Until now nothing on the page could tell those apart: a standing note disclosed that adaptation happens, always, in the same words, whether or not anything was happening.

**The toast replaces the note with the event itself.** `preview-adapt.js` keys off the `enc=` counter majestic now sends in the per-second `/ws/webrtc` stats line — where the arbitration actually holds the encoder, `0` meaning "at the configured rate" — rather than inferring from received throughput, which breathes with scene complexity and would cry wolf on every busy frame. When `enc=` steps, the toast names both rates, the direction (green up, amber down), and whose connection did it:

- our own `remb=` at or near the new rate → *"Matched to your connection — every viewer of this stream now receives this rate."*
- our estimate well above it → *"Another viewer's connection can't keep up — the stream follows the slowest link watching it."*
- up-steps → *"Raised — the slowest connection watching improved."* / *"Back at the configured rate."*

The baseline is adopted silently on join, channel change and transport return — a state you arrive into is not an event you witnessed. Hover pins the toast, click dismisses it, a new step replaces it. The stats panel gains an **encoder** row from the same counter. On a majestic without `enc=` the toast stays dormant and the row shows `-`: nothing here guesses.

**The standing disclosure note goes** (`#mj-transport-note`, its dismissal wiring, the `adapts[]` config read): it fired whether or not anything was adapting — the kind of disclosure people learn to ignore — and said "your connection" even when the encoder was following someone else's. The one thing it did besides disclose, restoring the transport toggle's tooltip after a failure, moves to `settle()`.

Verified on a hi3516av300 against two live Chromium viewers, one behind a 600 kbit/s policed link. The clean viewer's timeline:

```
TOAST: 4 Mbit/s ↘ 1 Mbit/s    Another viewer's connection can't keep up —
                              the stream follows the slowest link watching it.
  (throttled viewer leaves)
TOAST: 1 Mbit/s ↗ 4.1 Mbit/s  Raised — the slowest connection watching improved.
```

while the throttled viewer itself saw its own arrival as *"Matched to your connection"*. `npm test` passes; the vm-driven page tests needed no new stubs (the module is its own file, every hook in `preview-page.js` is guarded), and the retired note's ids left the `IDS` lists.
