### PR TITLE
Live adjustments: a luma histogram and scene starting points

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js"
+    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/luma.test.js
+++ b/tests/luma.test.js
@@ -1,0 +1,133 @@
+// The luma histogram behind the Live adjustments panel.
+//
+// This exists because the subject fails silently. A histogram computed with
+// the wrong coefficients, the wrong bucket edges or the wrong denominator
+// still draws a plausible shape over a live picture, and nobody reviewing a
+// screenshot can tell that "2.1% blown" is off by a factor of three. The two
+// clipping fractions are the only numbers on the panel an installer acts on,
+// so they are the ones worth pinning to frames whose answer is known by
+// construction.
+//
+// It also cannot be reproduced on demand in a browser: it needs a camera, a
+// negotiated stream and a scene that clips. Here the frames are made up, which
+// is the point.
+'use strict';
+
+const path = require('path');
+const { check, group, done } = require('./assert');
+
+const luma = require(path.join(__dirname, '..', 'www', 'a', 'mj-luma.js'));
+
+// An RGBA buffer of w*h pixels, each filled by px(i) -> [r, g, b].
+function frame(w, h, px) {
+	const d = new Uint8ClampedArray(w * h * 4);
+	for (let i = 0; i < w * h; i++) {
+		const c = px(i);
+		d[i * 4] = c[0];
+		d[i * 4 + 1] = c[1];
+		d[i * 4 + 2] = c[2];
+		d[i * 4 + 3] = 255;
+	}
+	return d;
+}
+
+const grey = (v) => (w, h) => frame(w, h, () => [v, v, v]);
+const near = (a, b, eps) => Math.abs(a - b) <= eps;
+
+group('a flat frame lands in exactly one bucket');
+{
+	const black = luma.histogram(grey(0)(16, 16), 16, 16);
+	check('black is 100% in the first bucket', black.low === 1, black.low);
+	check('black clips nothing at the top', black.high === 0, black.high);
+	check('black means 0', black.mean === 0, black.mean);
+
+	const white = luma.histogram(grey(255)(16, 16), 16, 16);
+	// The off-by-one that a naive `y * BINS / 255` makes: 255 lands in bucket
+	// 64 of a 64-bucket array, so `high` reads 0 and a blown-out sky reports
+	// no clipping at all.
+	check('white is 100% in the last bucket', white.high === 1, white.high);
+	check('white clips nothing at the bottom', white.low === 0, white.low);
+	// Not ===: the 709 coefficients sum to a hair under 1 in binary, so a white
+	// frame means 254.99999999999997. That is fine for a mean; it is NOT fine
+	// for bucketing, which is why histogram() rounds before it buckets.
+	check('white means 255', near(white.mean, 255, 1e-6), white.mean);
+
+	const mid = luma.histogram(grey(128)(16, 16), 16, 16);
+	check('mid grey clips at neither end', mid.low === 0 && mid.high === 0,
+		mid.low + '/' + mid.high);
+	check('mid grey means 128', mid.mean === 128, mid.mean);
+	check('mid grey sits in the middle bucket',
+		mid.bins.indexOf(Math.max.apply(null, mid.bins)) === 32,
+		mid.bins.indexOf(Math.max.apply(null, mid.bins)));
+}
+
+group('clipping fractions are of the whole frame');
+{
+	// A quarter blown, a quarter crushed, half mid-grey.
+	const d = frame(20, 20, (i) => (i < 100 ? [0, 0, 0] : i < 200 ? [255, 255, 255] : [128, 128, 128]));
+	const r = luma.histogram(d, 20, 20);
+	check('a quarter crushed reads 0.25', near(r.low, 0.25, 1e-9), r.low);
+	check('a quarter blown reads 0.25', near(r.high, 0.25, 1e-9), r.high);
+	check('the buckets add up to the pixel count',
+		r.bins.reduce((a, b) => a + b, 0) === 400, r.bins.reduce((a, b) => a + b, 0));
+	check('total is the pixel count, not the byte count', r.total === 400, r.total);
+}
+
+group('luma is Rec.709, not 601 and not an average');
+{
+	// The three primaries at full strength. 709 weights them 0.2126 / 0.7152 /
+	// 0.0722; 601 weights them 0.299 / 0.587 / 0.114, and a plain average gives
+	// all three 85. Each of those three answers is a different bucket.
+	const one = (c) => luma.histogram(frame(4, 4, () => c), 4, 4).mean;
+	check('pure red means ~54', near(one([255, 0, 0]), 54.2, 0.5), one([255, 0, 0]));
+	check('pure green means ~182', near(one([0, 255, 0]), 182.4, 0.5), one([0, 255, 0]));
+	check('pure blue means ~18', near(one([0, 0, 255]), 18.4, 0.5), one([0, 0, 255]));
+	check('green is weighted far above red', one([0, 255, 0]) > one([255, 0, 0]) * 3);
+}
+
+group('a ramp fills every bucket evenly');
+{
+	// 256 columns, one per code value, so each of the 64 buckets should get
+	// exactly four of them — the check that the bucket edges are uniform and
+	// that nothing is being dropped or double-counted at a boundary.
+	const d = frame(256, 1, (i) => [i, i, i]);
+	const r = luma.histogram(d, 256, 1);
+	check('every bucket is occupied', r.bins.every((b) => b > 0), r.bins.filter((b) => !b).length);
+	check('every bucket holds exactly four values',
+		r.bins.every((b) => b === 4), r.bins.join(','));
+	check('a ramp means ~127.5', near(r.mean, 127.5, 0.6), r.mean);
+}
+
+group('the drawn path is a closed step function over the box');
+{
+	const r = luma.histogram(frame(64, 1, (i) => [i * 4, i * 4, i * 4]), 64, 1);
+	const d = luma.path(r.bins);
+	check('starts at the baseline', d.indexOf('M0,100') === 0, d.slice(0, 12));
+	check('closes back to the baseline', /L64,100 Z$/.test(d), d.slice(-14));
+	// Two points per bucket is what makes it steps rather than a curve.
+	check('two vertices per bucket', (d.match(/L/g) || []).length === 64 * 2 + 1,
+		(d.match(/L/g) || []).length);
+	const ys = (d.match(/L\d+,([\d.]+)/g) || []).map((s) => Number(s.split(',')[1]));
+	check('nothing escapes the box', ys.every((y) => y >= 0 && y <= 100));
+
+	// The log scale exists so the tail that matters is legible. The number the
+	// panel acts on is the 1%-clipped threshold, so that is the one to pin: a
+	// bucket holding 1% of the peak must draw as a bar somebody can see, not as
+	// a thickening of the axis. Linearly it would be 0.94% of the height.
+	const spiky = new Array(luma.BINS).fill(0);
+	spiky[0] = 10000;
+	spiky[63] = 100;                      // 1% of the peak
+	const h = luma.path(spiky).match(/L\d+,([\d.]+)/g).map((s) => Number(s.split(',')[1]));
+	// index 126/127 are the last bucket's two vertices; 100 is the baseline.
+	const tail = 100 - Math.min(h[126], h[127]);
+	check('a bucket at 1% of the peak draws as a visible bar', tail > 5,
+		tail.toFixed(2) + '%');
+	check('and well above what a linear scale would give', tail > 0.94 * 4,
+		tail.toFixed(2) + '% vs 0.94% linear');
+
+	const flat = luma.path(new Array(luma.BINS).fill(0));
+	check('an empty frame degrades to the baseline, not to NaN',
+		flat.indexOf('NaN') < 0 && /^M0,100/.test(flat), flat);
+}
+
+done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1096,6 +1096,137 @@ mark {
 	cursor: default;
 }
 
+/* ── scene presets ──────────────────────────────────────────────────────────
+   Coarse starting points, above the sliders that refine them. Which one is
+   lit is derived from the four values, never stored, so a preset the user has
+   since nudged reports itself as Custom on its own. */
+.mj-scene-row {
+	display: flex;
+	gap: 0.375rem;
+}
+
+.mj-scene-chip {
+	flex: 1 1 0;
+	padding: 0.5rem 0.25rem;
+	border: 1px solid var(--bs-border-color);
+	border-radius: var(--bs-border-radius);
+	background: var(--bs-tertiary-bg);
+	color: var(--bs-secondary-color);
+	font-size: 0.8125rem;
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.mj-scene-chip:hover {
+	border-color: var(--bs-tertiary-color);
+	color: var(--bs-body-color);
+}
+
+.mj-scene-chip-on {
+	background: var(--bs-primary);
+	border-color: var(--bs-primary);
+	color: #fff;
+}
+
+.mj-scene-status {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	margin-top: 0.55rem;
+	font-size: 0.75rem;
+	color: var(--bs-tertiary-color);
+}
+
+.mj-scene-status b {
+	font-weight: 600;
+	color: var(--bs-secondary-color);
+}
+
+.mj-pip {
+	flex: 0 0 auto;
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+	background: var(--bs-primary);
+}
+
+/* ── luma histogram ─────────────────────────────────────────────────────────
+   Drawn from the decoded picture in the browser, so it shows what actually
+   comes out of the camera — after the ISP knobs, after the encoder — and costs
+   the camera nothing. The two clipping bands are the point: a blown sky or
+   crushed shadows is the commonest install fault and the one thing a picture
+   at this size will not tell you by eye. */
+.mj-luma-plot {
+	position: relative;
+	height: 7.75rem;
+	background: var(--bs-tertiary-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: var(--bs-border-radius);
+	overflow: hidden;
+}
+
+.mj-luma-plot svg {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+/* Neutral, deliberately: the plot measures luma, and a coloured fill would be
+   claiming to say something about hue that it does not measure. */
+.mj-luma-path {
+	fill: rgba(var(--bs-body-color-rgb), 0.45);
+}
+
+.mj-luma-mid {
+	stroke: rgba(var(--bs-body-color-rgb), 0.16);
+	stroke-width: 0.35;
+	fill: none;
+}
+
+.mj-luma-clip {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 10px;
+}
+
+.mj-luma-clip-l {
+	left: 0;
+	background: linear-gradient(90deg, rgba(255, 193, 7, 0.32), transparent);
+}
+
+.mj-luma-clip-r {
+	right: 0;
+	background: linear-gradient(270deg, rgba(255, 193, 7, 0.32), transparent);
+}
+
+.mj-luma-read {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-top: 0.45rem;
+	font-family: var(--bs-font-monospace);
+	font-size: 0.6875rem;
+	color: var(--bs-tertiary-color);
+}
+
+.mj-luma-warn {
+	color: var(--bs-warning);
+}
+
+.mj-luma-ok {
+	color: #2fb673;
+}
+
+.mj-luma-scale {
+	margin-left: auto;
+}
+
+.mj-luma-mean {
+	font-family: var(--bs-font-monospace);
+	font-variant-numeric: tabular-nums;
+}
+
 /* ── orientation ─────────────────────────────────────────────────────────── */
 .mj-geo-row {
 	display: flex;

--- a/www/a/mj-luma.js
+++ b/www/a/mj-luma.js
@@ -1,0 +1,139 @@
+// Luma histogram for the Live adjustments preview.
+//
+// Why the browser and not the camera: the question an installer has while
+// tuning is "am I blowing the sky or crushing the shadows", and the honest
+// answer is about the picture that comes out — after the ISP knobs, after the
+// encoder. That picture is already decoded in the <video> element, so a canvas
+// readback answers it for free and costs the camera nothing. There is no
+// endpoint to add and no per-frame work on a 32 MB board.
+//
+// A separate file for two reasons. mj-settings.js is about the form, and the
+// arithmetic here fails SILENTLY — a histogram computed wrongly still draws a
+// plausible shape, and nobody notices that "2.1% blown" is off by a factor of
+// three by looking at it. tests/luma.test.js drives `histogram` directly.
+(function () {
+	'use strict';
+
+	// 64 buckets: enough that a clipped edge is a visible spike and few enough
+	// that the shape is readable in a 23rem panel.
+	const BINS = 64;
+	// The sample is a thumbnail, not the frame. A luma distribution is a
+	// statistic — 160x90 is 14,400 pixels, which is plenty for one, and small
+	// enough that the draw plus the readback stay far away from a frame budget.
+	const SW = 160, SH = 90;
+
+	// Rec.709, because that is what an H.264 HD stream is: using the 601
+	// coefficients on 709 content skews the mean by a couple of per cent and
+	// biases it differently in greens than in reds.
+	function luma(r, g, b) {
+		return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+	}
+
+	// Pure, so the test can hand it bytes it made up. `data` is RGBA, as
+	// getImageData gives it.
+	//
+	// `low`/`high` are the fraction of pixels in the first and last bucket.
+	// They are the point of the whole panel: everything else here is a shape,
+	// but those two numbers are the fault an installer is actually looking for.
+	function histogram(data, w, h) {
+		const bins = new Array(BINS).fill(0);
+		const n = w * h;
+		let sum = 0;
+		for (let i = 0; i < n; i++) {
+			const p = i * 4;
+			const y = luma(data[p], data[p + 1], data[p + 2]);
+			// Bucket the rounded 8-bit code value, not the raw float. The 709
+			// coefficients do not sum to exactly 1 in binary — 0.2126 + 0.7152
+			// + 0.0722 lands a hair under — so a grey pixel at 128 computes as
+			// 127.99999999999999 and truncates into the bucket below. On a
+			// greyscale ramp that shows up as buckets of 3 and 5 where every
+			// one should hold 4, which is the one case where a reader can check
+			// the answer by eye.
+			const c = Math.round(y);
+			// 255 must land in the last bucket, not one past it.
+			let b = (c * BINS) >> 8;
+			if (b >= BINS) b = BINS - 1;
+			bins[b]++;
+			sum += y;
+		}
+		return {
+			bins: bins,
+			total: n,
+			mean: n ? sum / n : 0,
+			low: n ? bins[0] / n : 0,
+			high: n ? bins[BINS - 1] / n : 0,
+		};
+	}
+
+	// An SVG path over a 0..BINS x 0..100 box, drawn as steps rather than a
+	// curve — a histogram is buckets, and a smoothed one invents detail between
+	// them that the data does not have.
+	//
+	// The vertical scale is logarithmic. A linear one is dominated by whatever
+	// the scene's most common tone is, which flattens the shadow and highlight
+	// tails into an invisible smear along the axis — and the tails are the part
+	// worth looking at.
+	function path(bins) {
+		let peak = 0;
+		for (let i = 0; i < bins.length; i++) if (bins[i] > peak) peak = bins[i];
+		if (!peak) return 'M0,100 L' + bins.length + ',100 Z';
+		const norm = (v) => Math.log1p((v / peak) * 24) / Math.log(25);
+		let d = 'M0,100';
+		for (let i = 0; i < bins.length; i++) {
+			const y = (100 - norm(bins[i]) * 94).toFixed(2);
+			d += ' L' + i + ',' + y + ' L' + (i + 1) + ',' + y;
+		}
+		return d + ' L' + bins.length + ',100 Z';
+	}
+
+	// opts.video  () => the <video> to sample. A getter, not a node: the MSE
+	//             player swaps its element on every reconnect, so a captured
+	//             one is detached within a session and samples nothing.
+	// opts.onData (result) — result is what histogram() returns, plus `path`.
+	// opts.hz     samples per second (default 4).
+	function start(opts) {
+		const canvas = document.createElement('canvas');
+		canvas.width = SW;
+		canvas.height = SH;
+		// willReadFrequently: this is a readback loop, and without it the
+		// browser keeps the surface on the GPU and pays a stall per getImageData.
+		const ctx = canvas.getContext('2d', { willReadFrequently: true });
+		let timer = null;
+		let stopped = false;
+
+		function tick() {
+			if (stopped) return;
+			const v = opts.video();
+			// Nothing to read: the tab is hidden, the player has not attached
+			// yet, or the stream dropped. Say nothing rather than draw a lie —
+			// an empty histogram would read as "the picture is black".
+			if (!document.hidden && v && v.readyState >= 2 && v.videoWidth > 0) {
+				try {
+					ctx.drawImage(v, 0, 0, SW, SH);
+					const d = ctx.getImageData(0, 0, SW, SH).data;
+					const r = histogram(d, SW, SH);
+					r.path = path(r.bins);
+					opts.onData(r);
+				} catch (e) {
+					// A frame that cannot be drawn (mid-teardown, or a tainted
+					// canvas on some future cross-origin source) is not worth
+					// killing the loop over; the next tick may well work.
+				}
+			}
+			timer = setTimeout(tick, 1000 / (opts.hz || 4));
+		}
+
+		tick();
+		return {
+			stop: function () {
+				stopped = true;
+				if (timer) clearTimeout(timer);
+				timer = null;
+			},
+		};
+	}
+
+	const api = { start: start, histogram: histogram, path: path, BINS: BINS };
+	if (typeof module === 'object' && module.exports) module.exports = api;
+	if (typeof window === 'object') window.MajesticLuma = api;
+})();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -45,6 +45,18 @@
 		fs: '<svg viewBox="0 0 20 20" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M3 7.4V3h4.4M16.9 7.4V3h-4.4M3 12.6V17h4.4M16.9 12.6V17h-4.4"></path></svg>',
 	};
 
+	// Scene starting points, keyed by the same dot tails as LIVE_META. They are
+	// exactly that — a place to start before you tune by eye — and the panel
+	// says so, because a preset presented as an answer is worse than no preset:
+	// every install has its own light. Tone only; a preset must never quietly
+	// change which way up the picture is.
+	const LIVE_PRESETS = [
+		{ id: 'neutral',  label: 'Neutral',   v: { luminance: 50, contrast: 50, saturation: 50, hue: 50 } },
+		{ id: 'indoor',   label: 'Indoor',    v: { luminance: 52, contrast: 46, saturation: 52, hue: 50 } },
+		{ id: 'outdoor',  label: 'Outdoor',   v: { luminance: 46, contrast: 58, saturation: 54, hue: 50 } },
+		{ id: 'lowlight', label: 'Low light', v: { luminance: 60, contrast: 42, saturation: 38, hue: 50 } },
+	];
+
 	// The orientation pad's four states. mirror/flip stay two independent
 	// booleans in the config — this is only how a camera presents them, and how
 	// every camera UI worth copying does.
@@ -1188,6 +1200,130 @@
 		}
 	}
 
+	// Scene presets. Which one is "on" is DERIVED by comparing the current tone
+	// values against the table, never stored: there is no fifth piece of state
+	// to keep in step with the four that already exist, and a preset the user
+	// has since nudged reports itself as Custom without anyone having to
+	// remember to clear a flag.
+	function renderScene(container, tone) {
+		const byKey = {};
+		tone.forEach(f => { byKey[f.key] = f; });
+		// Only offer presets we can actually apply in full. A build missing one
+		// of the four knobs would otherwise get a control that half-works.
+		if (!LIVE_PRESETS.every(p => Object.keys(p.v).every(k => byKey[k]))) return;
+
+		const row = el('div', 'mj-scene-row');
+		const chips = LIVE_PRESETS.map(p => {
+			const b = el('button', 'mj-scene-chip');
+			b.type = 'button';
+			b.textContent = p.label;
+			b.addEventListener('click', () => {
+				Object.keys(p.v).forEach(k => setLive(byKey[k], p.v[k]));
+			});
+			row.appendChild(b);
+			return b;
+		});
+		container.appendChild(row);
+
+		const status = el('div', 'mj-scene-status');
+		status.innerHTML = '<span class="mj-pip"></span><span></span>';
+		container.appendChild(status);
+		const pip = status.querySelector('.mj-pip');
+		const text = status.querySelector('span:last-child');
+
+		const sync = () => {
+			const cur = {};
+			Object.keys(byKey).forEach(k => { cur[k] = Number(byKey[k].getValue()); });
+			const hit = LIVE_PRESETS.find(p =>
+				Object.keys(p.v).every(k => cur[k] === p.v[k]));
+			chips.forEach((b, i) => {
+				const on = !!hit && LIVE_PRESETS[i].id === hit.id;
+				b.classList.toggle('mj-scene-chip-on', on);
+				b.setAttribute('aria-pressed', on ? 'true' : 'false');
+			});
+			// "Stock" and "Neutral" are the same four numbers, but they are not
+			// the same statement: one says the camera is untouched, the other
+			// that a preset was chosen. The first is what somebody inheriting
+			// this camera needs to hear.
+			const off = tone.filter(f => f.schema.default !== undefined &&
+				Number(f.getValue()) !== Number(f.schema.default)).length;
+			let head, tail;
+			if (hit && hit.id === 'neutral') {
+				head = 'Stock';
+				tail = '— every value at its factory default';
+			} else if (hit) {
+				head = hit.label;
+				tail = '— unmodified preset';
+			} else {
+				head = 'Custom';
+				tail = '— ' + off + (off === 1 ? ' value differs' : ' values differ') + ' from stock';
+			}
+			pip.style.opacity = off ? '1' : '0.25';
+			text.innerHTML = '<b>' + esc(head) + '</b> ' + esc(tail);
+		};
+		tone.forEach(f => {
+			f.control.addEventListener('input', sync);
+			f.control.addEventListener('change', sync);
+		});
+		state.liveSync.push(sync);
+		sync();
+	}
+
+	// The luma histogram. Everything it needs is already in the browser — the
+	// decoded picture — so this costs the camera nothing and needs no endpoint.
+	function renderLuma(container) {
+		if (!window.MajesticLuma) return;
+		const wrap = el('div', 'mj-luma');
+		wrap.innerHTML =
+			'<div class="mj-luma-plot">' +
+			'<svg viewBox="0 0 ' + window.MajesticLuma.BINS + ' 100" preserveAspectRatio="none" aria-hidden="true">' +
+			'<path class="mj-luma-path" d=""></path>' +
+			'<path class="mj-luma-mid" d="M' + (window.MajesticLuma.BINS / 2) + ' 0 V100"></path>' +
+			'</svg>' +
+			'<span class="mj-luma-clip mj-luma-clip-l" hidden></span>' +
+			'<span class="mj-luma-clip mj-luma-clip-r" hidden></span>' +
+			'</div>' +
+			'<div class="mj-luma-read"><span class="mj-luma-verdict"></span>' +
+			'<span class="mj-luma-scale">Y&#8242; 0&#8211;255</span></div>';
+		container.appendChild(wrap);
+
+		const pathEl = wrap.querySelector('.mj-luma-path');
+		const clipL = wrap.querySelector('.mj-luma-clip-l');
+		const clipR = wrap.querySelector('.mj-luma-clip-r');
+		const verdict = wrap.querySelector('.mj-luma-verdict');
+		const meanEl = container.parentNode.querySelector('.mj-luma-mean');
+
+		const sampler = window.MajesticLuma.start({
+			video: () => {
+				// Whichever element the swap currently has on screen; the MSE
+				// player replaces its node on every reconnect.
+				const a = document.getElementById('mj-live-video');
+				const b = document.getElementById('mj-live-video-b');
+				if (a && a.style.display !== 'none' && a.readyState >= 2) return a;
+				if (b && b.style.display !== 'none' && b.readyState >= 2) return b;
+				return a || b;
+			},
+			onData: (r) => {
+				pathEl.setAttribute('d', r.path);
+				// One per cent is the threshold worth a warning: below it you
+				// are looking at a specular highlight or a genuinely black
+				// corner, not at an exposure that needs moving.
+				const lo = r.low >= 0.01, hi = r.high >= 0.01;
+				clipL.hidden = !lo;
+				clipR.hidden = !hi;
+				const parts = [];
+				if (lo) parts.push((r.low * 100).toFixed(1) + '% crushed');
+				if (hi) parts.push((r.high * 100).toFixed(1) + '% blown');
+				verdict.className = 'mj-luma-verdict' + (parts.length ? ' mj-luma-warn' : ' mj-luma-ok');
+				verdict.textContent = parts.length ? parts.join(' · ') : 'no clipping';
+				if (meanEl) meanEl.textContent = 'mean ' + Math.round(r.mean);
+			},
+		});
+		// Torn down with the rest of the leaf, so a section change does not
+		// leave a timer reading a detached element four navigations later.
+		state.liveCleanup.push(() => sampler.stop());
+	}
+
 	function renderLive(form) {
 		const fields = liveFields();
 		const withVideo = !!window.MajesticVideo;
@@ -1250,6 +1386,10 @@
 		const useGeo = !!(mirror && flip);
 
 		const hasTone = fields.some(f => f !== mirror && f !== flip);
+		// Scene above tone: it is the coarse move you make first, and the four
+		// sliders are what you refine it with.
+		const sceneBody = hasTone
+			? liveGroup(colA, 'Scene', 'starting points, then tune by eye') : null;
 		const toneBody = hasTone ? liveGroup(colA, 'Tone', 'saved with the page') : null;
 
 		for (const f of fields) {
@@ -1270,6 +1410,24 @@
 			rall.addEventListener('click', resetLiveAll);
 			foot.appendChild(rall);
 			toneBody.appendChild(foot);
+		}
+
+		// The tone fields as mounted, which is what the scene chips set and the
+		// status line reads.
+		const toneFields = state.fields.filter(f =>
+			f.schema && f.schema['x-live'] && f.type === 'integer');
+		if (sceneBody && toneFields.length) renderScene(sceneBody, toneFields);
+
+		// Analysis first in the right column: it is what you look at while the
+		// left hand is on a slider.
+		if (withVideo) {
+			// The group's note slot carries the running mean rather than a
+			// caption — a number that changes is worth more there than a word
+			// that does not.
+			const lumaBody = liveGroup(colB, 'Luma', 'mean —');
+			const note = lumaBody.parentNode.querySelector('.mj-live-note');
+			if (note) note.className = 'mj-live-note mj-luma-mean';
+			renderLuma(lumaBody);
 		}
 
 		if (useGeo) {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1248,7 +1248,13 @@
 			const off = tone.filter(f => f.schema.default !== undefined &&
 				Number(f.getValue()) !== Number(f.schema.default)).length;
 			let head, tail;
-			if (hit && hit.id === 'neutral') {
+			// "Stock" is a claim about the SCHEMA's defaults, so it is answered
+			// by comparing against them — not by matching the Neutral row of a
+			// table that hard-codes 50. On a build whose defaults are not 50,
+			// matching Neutral and being at the factory setting are different
+			// facts, and saying the second when only the first is true is the
+			// one lie this line must never tell.
+			if (!off) {
 				head = 'Stock';
 				tail = '— every value at its factory default';
 			} else if (hit) {

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -91,6 +91,11 @@ fi
 # behaviours for the stage mj-settings.js builds client-side.
 %>
 <script src="/a/preview-hero.js"></script>
+<%
+# The luma histogram is computed in the browser off the decoded picture, so it
+# needs nothing from the camera and no endpoint of its own.
+%>
+<script src="/a/mj-luma.js"></script>
 <script src="/a/mj-settings.js" defer></script>
 
 <% fi %>


### PR DESCRIPTION
Second half of #235, stacked on #237.

Two things the panel could not answer before.

### The histogram

*"Am I blowing the sky or crushing the shadows"* is the commonest install fault and the one thing a preview at this size will not tell you by eye. The answer is already in the browser — the decoded picture is sitting in the `<video>` element — so a 160×90 canvas readback four times a second computes it for free and **the camera does no work at all**. No endpoint, no majestic change, nothing per-frame on a 32 MB board.

The two clipping fractions are the point; the shape is context. Anything over 1% of pixels in the first or last bucket lights an amber band on that edge and says how much.

The maths lives in `www/a/mj-luma.js` rather than in `mj-settings.js` because **it fails silently**: a histogram computed with the wrong coefficients, the wrong bucket edges or the wrong denominator still draws a plausible shape over a live picture, and nobody reviewing a screenshot can tell that "2.1% blown" is out by a factor of three. `tests/luma.test.js` drives it with frames whose answer is known by construction — flat black, flat white, a quarter/quarter mix, a 256-step ramp — and pins the two off-by-ones that would otherwise ship looking fine:

- 255 landing one past the last bucket, so **a blown-out sky reports no clipping at all**;
- Rec.601 coefficients on 709 content (each primary lands in a different bucket under 601, 709 and a plain average, so the test can tell them apart).

It buckets the **rounded** 8-bit code value. The 709 coefficients do not sum to exactly 1 in binary, so a grey pixel at 128 computes as 127.99999999999999 and truncates one bucket low; on a greyscale ramp that shows up as buckets of 3 and 5 where every one should hold 4. That is the one case where a reader can check the answer by eye, so it is worth getting exactly right.

The vertical scale is logarithmic. Linearly the shadow and highlight tails — the part worth looking at — flatten into an invisible smear along the axis: a bucket at 1% of the peak would draw 0.94% tall. The test pins that it draws as a bar instead.

### Scene presets

Four coarse starting points above the sliders that refine them. Which one is lit is **derived** by comparing the current values against the table, never stored, so there is no fifth piece of state to keep in step with the four that already exist, and a preset the user has since nudged reports itself as Custom without anyone having to remember to clear a flag.

They set tone only — a preset must never quietly change which way up the picture is — and the panel calls them starting points, because a preset presented as an answer is worse than no preset: every install has its own light. **The values are my judgement and want a pass against real scenes on real hardware**; treat them as a first cut. Neutral reads as "Stock, every value at its factory default" rather than as a preset name, which is what somebody inheriting a camera needs to hear.

The sampler is torn down through `stopLivePreview()` with the rest of the leaf, so leaving the section does not leave a timer reading a detached element four navigations later.

One collision worth recording: `.mj-chip` was already taken by the Live page's on-video status badge, which is `position: absolute` — so the preset row laid out as four buttons stacked in the top-right corner of the viewport. Renamed to `.mj-scene-chip`. Neither `node --check` nor the unit tests can see that; only looking at the running page can.

### Verified on an hi3516av300 against a real stream

- at stock the lab scene reads mean 33 with 13.0% crushed and the amber band on the left; lifting brightness to 85 moves the mean to 128 and clears it
- each slider moves the plot, except hue — a chroma rotation leaves luma unchanged by definition, which is the right answer rather than a miss
- Low light sets 60/42/38/50 and names itself; nudging one value drops to "Custom — 1 value differs from stock"
- leaving the section stops the sampler, with exactly one running again on return
