### PR TITLE
Live adjustments: a knob and the picture it changes, on screen together

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -671,11 +671,17 @@ mark {
    stay on screen too, or you are scrolling between the slider you are dragging
    and the picture you are dragging it for. The floor stops it collapsing on a
    short window; the 16:9 box never changes, and a stream of another shape is
-   contained inside it rather than reflowing the page. */
+   contained inside it rather than reflowing the page.
+
+   The 31rem reserve is what buys the deck its room, and it is measured rather
+   than guessed: at 30rem the fourth slider overflowed a 1280x800 window by ONE
+   pixel, which is not a margin — it is the same answer landing either way on a
+   machine whose font metrics differ slightly. 31rem puts all four knobs and the
+   picture on screen together at every common laptop size. */
 .mj-live-stage {
 	position: relative;
-	width: min(100%, max(28rem, calc((100vh - 30rem) * 1.77778)));
-	width: min(100%, max(28rem, calc((100dvh - 30rem) * 1.77778)));
+	width: min(100%, max(28rem, calc((100vh - 31rem) * 1.77778)));
+	width: min(100%, max(28rem, calc((100dvh - 31rem) * 1.77778)));
 	margin-inline: auto;
 	aspect-ratio: 16 / 9;
 	background: #0d0f14;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1392,10 +1392,16 @@
 		const useGeo = !!(mirror && flip);
 
 		const hasTone = fields.some(f => f !== mirror && f !== flip);
-		// Scene above tone: it is the coarse move you make first, and the four
-		// sliders are what you refine it with.
-		const sceneBody = hasTone
-			? liveGroup(colA, 'Scene', 'starting points, then tune by eye') : null;
+		// Tone starts the left column, with nothing above it.
+		//
+		// Scene reads as the coarse move you make before the fine ones, so it
+		// belongs first — but putting it there cost 111px between the picture
+		// and the first slider, and on a 1440x900 laptop that pushed Brightness
+		// exactly onto the fold. The one thing this panel has to guarantee is
+		// that a knob and the picture it changes are on screen together (#239),
+		// and reading order does not outrank it. Scene moves to the head of the
+		// right column, where it is still the first thing in the deck you read
+		// and costs the sliders nothing.
 		const toneBody = hasTone ? liveGroup(colA, 'Tone', 'saved with the page') : null;
 
 		for (const f of fields) {
@@ -1418,14 +1424,15 @@
 			toneBody.appendChild(foot);
 		}
 
-		// The tone fields as mounted, which is what the scene chips set and the
-		// status line reads.
+		// Right column, top to bottom: the coarse entry point, the reading you
+		// watch while dragging, then geometry.
 		const toneFields = state.fields.filter(f =>
 			f.schema && f.schema['x-live'] && f.type === 'integer');
-		if (sceneBody && toneFields.length) renderScene(sceneBody, toneFields);
+		if (hasTone && toneFields.length) {
+			renderScene(liveGroup(colB, 'Scene', 'starting points, then tune by eye'),
+				toneFields);
+		}
 
-		// Analysis first in the right column: it is what you look at while the
-		// left hand is on a slider.
 		if (withVideo) {
 			// The group's note slot carries the running mean rather than a
 			// caption — a number that changes is worth more there than a word


### PR DESCRIPTION
Closes #239.

#237 already replaced the `max-width: 640px` cap with a viewport-derived stage, which is the first half of what #239 asks. The second half — *"any change has to keep a dragged slider and its effect visible together"* — did not actually hold, and I only found that by measuring it rather than looking at it.

At six window sizes against master, the picture and the first knob were **not** co-visible at 1280×800 or 1440×900. The Scene block sat between them and cost 111px; on a 1440×900 laptop that put Brightness exactly on the fold.

Scene reads as the coarse move you make before the fine ones, so above Tone is where it belongs on reading order alone. But reading order does not outrank the one guarantee this panel exists to give. It moves to the head of the right column — still the first thing in the deck you read, and it costs the sliders nothing. Tone now starts the left column with the stage directly above it.

The reserve in the stage's height goes 30rem → 31rem, and that number is measured rather than guessed: at 30rem the fourth slider overflowed a 1280×800 window **by one pixel**, which is not a margin — it is the same answer landing either way on a machine whose font metrics differ slightly.

|  viewport  | picture + 1st knob | picture + all knobs |     stage      |
|------------|--------------------|---------------------|----------------|
| 1280×800   | no → **YES**       | no → **YES**        | 540×304 (1.1×) |
| 1440×900   | no → **YES**       | no → **YES**        | 718×404 (1.9×) |
| 1440×1080  | YES → YES          | no → **YES**        | 966×543 (3.5×) |
| 1920×1080  | YES → YES          | no → **YES**        | 966×543 (3.5×) |
| 1920×1440  | YES → YES          | YES → YES           | 966×543 (3.5×) |
| 2560×1440  | YES → YES          | YES → YES           | 966×543 (3.5×) |

The multiplier is stage area against the panel this replaced, which was a fixed 520×292 at every window size.

Verified on an hi3516av300: the scene chips, histogram, orientation pad and sampler teardown all behave as before — only where Scene sits has changed.