### PR TITLE
Settings: the generated sections learn the Live deck's vocabulary

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -55,10 +55,15 @@
 	height: 2.5rem;
 }
 
+/* Hints sit under the control they explain and are held to a readable measure:
+   full-column-width help set at nearly the size of the label above it competes
+   with the field rather than supporting it. */
 .hint {
-	font-size: 0.875rem;
-	margin-top: 0.2rem;
+	max-width: 22rem;
+	margin-top: 0.35rem;
 	margin-bottom: 0;
+	font-size: 0.78125rem;
+	line-height: 1.45;
 }
 
 .range span.show-value {
@@ -100,9 +105,16 @@
 }
 
 /* mj-settings rows put the per-field reset on the same line as the control
-   (.mj-ctl), so the caps above have to move onto the wrapper — capping only the
-   inner control would let .mj-ctl-in keep the full width and strand the ↺ out at
-   the card edge, attached to nothing. */
+   (.mj-ctl); the width caps below are on the wrapper rather than on the control
+   itself, or a select would stretch to the card edge.
+
+   The reset used to hug the end of the control, which meant it landed wherever
+   that control's cap happened to put it — six different x-positions down one
+   ISP column, because a number stops at 10rem, a select at 16, an array at 20
+   and a switch at its own width. It is pinned to the column's right edge now
+   (margin-left: auto on .mj-reset), so a column of resets is a rail rather than
+   a scatter. That only reads as deliberate because every row shares the edge:
+   the Live deck's rows already align their ↺ the same way. */
 .mj-ctl {
 	display: flex;
 	align-items: center;
@@ -130,15 +142,37 @@
 	max-width: 20rem;
 }
 
-/* A switch is as wide as its own label, so the glyph hugs the text instead of
-   sitting a card-width away from it. Shrink stays enabled (0 *1* auto): a
-   switch carries its label inline, unlike every other row where the <label> is
-   a block above the control and wraps on its own, so a no-shrink wrapper would
-   size to the unwrapped text and spill out of the column — which the 63-char
-   rtsp.fecAdaptive title did. min-width comes from .mj-ctl-in above, without
-   which flex-shrink alone still cannot go under the content width. */
+/* A boolean's label is a block above the switch now, like every other type's,
+   so the wrapper holds the switch and the lit word and nothing else. */
 .boolean .mj-ctl-in {
+	display: flex;
 	flex: 0 1 auto;
+	align-items: center;
+	gap: 0.55rem;
+}
+
+/* The word beside the switch. A switch states its position; it does not state
+   what the position means, and "Off" next to a lit dot is the vocabulary the
+   Live bar's toggles already use. */
+.mj-state {
+	font-size: 0.6875rem;
+	font-weight: 600;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+	color: var(--bs-tertiary-color);
+}
+
+.mj-state-on {
+	color: var(--bs-body-color);
+}
+
+/* The switch is the most repeated control in the form, and it was Bootstrap's
+   stock #0d6efd rather than the brand indigo: the compiled subset carries that
+   colour literally, because the theme swaps --bs-primary at runtime and the
+   compiled rule never reads it. Every other accent on the page already does. */
+.form-check-input:checked {
+	background-color: var(--bs-primary);
+	border-color: var(--bs-primary);
 }
 
 .x-small {
@@ -319,23 +353,80 @@ pre#output[data-cmd] {
 	border-left-color: var(--bs-warning);
 }
 
-/* The per-field reset is a bare ↺ beside its control. It used to be a "↺ reset"
-   link on a line of its own, which cost a row per field — about 160px over a
-   section the size of ISP / Exposure — and repeated the word 150-odd times down
-   the page. Muted until hovered so it never competes with the value. */
+/* The field's name, in the micro-caps the Live deck names its knobs in and the
+   rail names its categories in. It was body text at 1rem — the same size as the
+   value underneath it, so a column read as an alternating list of two equals
+   rather than as labelled controls. */
+.mj-row > .form-label {
+	margin-bottom: 0.3rem;
+	color: var(--bs-tertiary-color);
+	font-size: 0.6875rem;
+	font-weight: 600;
+	letter-spacing: 0.07em;
+	line-height: 1.5;
+	text-transform: uppercase;
+}
+
+.mj-row.mj-dirty > .form-label {
+	color: var(--bs-secondary-color);
+}
+
+/* Why a section is half empty, said once at the top of it rather than left for
+   the reader to wonder about: image is two rows because six of its eight knobs
+   are x-live and render on the Live leaf with the picture. */
+.mj-lifted {
+	max-width: 46rem;
+	margin: 0.9rem 0 0;
+	padding: 0.6rem 0.75rem;
+	background: var(--bs-tertiary-bg);
+	border-radius: var(--bs-border-radius);
+	color: var(--bs-secondary-color);
+	font-size: 0.8125rem;
+	line-height: 1.45;
+}
+
+/* The head's stock count goes amber for the same reason a row's rule does. */
+.mj-live-note.mj-off-stock {
+	color: var(--bs-warning);
+}
+
+/* The per-field reset. It used to be a "↺ reset" link on a line of its own,
+   which cost a row per field — about 160px over a section the size of ISP /
+   Exposure — and repeated the word 150-odd times down the page. Now it is the
+   Live deck's glyph on the control's line, pinned to the column's right edge,
+   and muted until hovered so it never competes with the value. */
 .mj-reset {
 	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.375rem;
+	height: 1.375rem;
+	margin-left: auto;
+	padding: 0;
+	border: 0;
+	border-radius: var(--bs-border-radius-sm);
+	background: none;
 	line-height: 1;
 	text-decoration: none;
 	color: var(--bs-tertiary-color);
+	opacity: 0.35;
+	transition: opacity var(--mj-ease), color var(--mj-ease);
 }
 
 .mj-reset:hover:not(:disabled) {
+	background: var(--bs-tertiary-bg);
 	color: var(--bs-primary);
+	opacity: 1;
+}
+
+.mj-reset:focus-visible {
+	opacity: 1;
+	outline: var(--bs-focus-ring-width) solid var(--bs-focus-ring-color);
 }
 
 .mj-reset:disabled {
-	opacity: 0.35;
+	opacity: 0.12;
 }
 
 /* ── settings navigation tree ───────────────────────────────────────────────
@@ -377,10 +468,22 @@ pre#output[data-cmd] {
 	background: var(--bs-tertiary-bg);
 }
 
+/* Marked by a surface and an indigo edge rather than filled with indigo. A
+   solid 306px slab was the loudest thing on a page whose subject is a list of
+   settings, and it spent the accent colour on "you are here" — which is the one
+   thing on the page nobody has to be told twice. */
 .mj-tree-sub .nav-link.active,
 .mj-tree-sub .nav-link.active:hover {
-	color: #fff;
-	background: var(--bs-primary);
+	color: var(--bs-body-color);
+	background: var(--bs-tertiary-bg);
+	border-left: 2px solid var(--bs-primary);
+	border-radius: 0 var(--bs-border-radius) var(--bs-border-radius) 0;
+	font-weight: 500;
+}
+
+/* the 2px edge would otherwise shift the label of the active row only */
+.mj-tree-sub .nav-link {
+	border-left: 2px solid transparent;
 }
 
 /* the count of fields a search matched inside a section: without it a section
@@ -394,7 +497,7 @@ pre#output[data-cmd] {
 }
 
 .nav-link.active .mj-tree-n {
-	color: rgba(255, 255, 255, 0.75);
+	color: var(--bs-secondary-color);
 }
 
 .mj-tree-caret {
@@ -517,6 +620,15 @@ mark {
    mj-settings.js, rather than a CSS multi-column box: a column box re-balances
    itself whenever a visibleWhen row appears or disappears, which shuffles
    unrelated rows across the fold — see layoutCols() (#189). */
+/* .card resolves to the page background theme-wide — --bs-card-bg is declared
+   but nothing reaches it — so a section card reads as an outline rather than a
+   surface. Set locally, the way the Live deck already sets it, because the real
+   fix touches every page in the repo and belongs in its own change. */
+#mj-settings-form .card {
+	background: var(--bs-card-bg);
+	border-color: var(--bs-border-color);
+}
+
 .mj-cols {
 	display: flex;
 	flex-direction: row;
@@ -529,6 +641,27 @@ mark {
 .mj-cols > .mj-col {
 	flex: 1 1 0;
 	min-width: 0;
+}
+
+/* A divider in the middle of the gutter, as the Live deck has between its two
+   panels. The negative margin puts the rule at the halfway point without taking
+   width off either column, so the two stay equal. */
+@media (min-width: 768px) {
+	.mj-cols > .mj-col + .mj-col {
+		margin-left: -1.25rem;
+		padding-left: 1.25rem;
+		border-left: 1px solid var(--bs-border-color);
+	}
+
+	/* Few enough rows to stay in one column: no divider, no empty half, and a
+	   measure that does not run a two-row section across the whole card. */
+	.mj-cols.mj-solo > .mj-col {
+		flex: 0 1 28rem;
+	}
+
+	.mj-cols.mj-solo > .mj-col + .mj-col {
+		display: none;
+	}
 }
 
 /* below md the two columns stack, which reads exactly like the single column
@@ -613,10 +746,17 @@ mark {
 	margin-bottom: 0.6rem;
 }
 
-/* The leaf's heading is a real <h3> (revealSection focuses it), so its default
-   heading margin and size have to come back off to read as a group label. */
-.mj-live-head h3 {
+/* The heading is a real <h3> (revealSection focuses it), so its default heading
+   margin and size have to come back off to read as a group label. Inside a card
+   it also has to out-rank `.card > .card-body h3` — (0,2,2), which silently
+   restored 18.4px secondary text over .mj-cap on every generated section — so
+   the id is carried here rather than left to source order, which would not have
+   helped. */
+.mj-live-head h3,
+#mj-settings-form .card > .card-body .mj-live-head h3 {
 	margin: 0;
+	color: var(--bs-tertiary-color);
+	font-size: 0.6875rem;
 	line-height: 1.4;
 }
 

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -620,12 +620,18 @@ mark {
    mj-settings.js, rather than a CSS multi-column box: a column box re-balances
    itself whenever a visibleWhen row appears or disappears, which shuffles
    unrelated rows across the fold — see layoutCols() (#189). */
-/* .card resolves to the page background theme-wide — --bs-card-bg is declared
-   but nothing reaches it — so a section card reads as an outline rather than a
-   surface. Set locally, the way the Live deck already sets it, because the real
-   fix touches every page in the repo and belongs in its own change. */
+/* Every .card in the repo paints as the page, and this is the mechanism:
+   Bootstrap re-declares --bs-card-bg *on .card itself*, so the theme's :root
+   value never reaches it. Measured on the running page — #1c1f27 at the root,
+   #14161c on the element — which is also why `background: var(--bs-card-bg)`
+   does not fix it: read from the card, that variable is already the body
+   background. The Live deck gets away with it only because .mj-live-deck is
+   not a .card and inherits the root value.
+
+   So take the surface from a token .card does not shadow. Fixing the shadowing
+   itself touches every page in the repo and belongs in its own change. */
 #mj-settings-form .card {
-	background: var(--bs-card-bg);
+	background: var(--bs-secondary-bg);
 	border-color: var(--bs-border-color);
 }
 
@@ -2245,6 +2251,12 @@ mark {
 	--bs-body-bg: #f4f5f9;
 	--bs-body-color: #1f2430;
 	--bs-secondary-bg: #eceef4;
+	/* The hover/active surface. The dark block has always set this and the
+	   light one never did, so every rule reaching for it here — the settings
+	   tree, the console, the recordings ribbon — fell through to Bootstrap's
+	   own near-white and marked nothing. A step down from the page, since on
+	   light the surface has to darken to stand out, not lighten. */
+	--bs-tertiary-bg: #e4e7f0;
 	--bs-card-bg: #ffffff;
 	--bs-border-color: #e2e5ee;
 	/* Dashboard chart series. Validated per theme for color-vision

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -687,9 +687,21 @@
 		} else {
 			const card = el('div', 'card');
 			const body = el('div', 'card-body');
-			const h = el('h3');
+			// The Live leaf's head, reused rather than imitated: micro-caps name,
+			// hairline, and a note on the right. Still an <h3> — revealSection()
+			// focuses it (#222) — with the heading's own size and margin taken off
+			// by .mj-live-head h3.
+			const head = el('div', 'mj-live-head');
+			const h = el('h3', 'mj-cap');
 			h.textContent = label(sec);
-			body.appendChild(h);
+			const note = el('span', 'mj-live-note');
+			note.id = 'mj-stock-note';
+			head.appendChild(h);
+			head.appendChild(el('span', 'mj-live-rule'));
+			head.appendChild(note);
+			body.appendChild(head);
+			const lifted = liftedNote(sec);
+			if (lifted) body.appendChild(lifted);
 			const cols = el('div', 'mj-cols');
 			cols.appendChild(el('div', 'mj-col'));
 			cols.appendChild(el('div', 'mj-col'));
@@ -719,6 +731,7 @@
 
 		applyVisibility();
 		layoutCols();
+		paintStock();
 
 		// renderField writes labels as plain text; with a query already active,
 		// the section just mounted has to pick up the marks too, or navigating
@@ -1469,16 +1482,78 @@
 		if (!deck.childElementCount) deck.remove();
 	}
 
+	const isGroup = (sub) => !!(sub && sub.type === 'object' && sub.properties);
+
+	// A section whose knobs were lifted onto the Live leaf looks half-empty and
+	// says nothing about why: image is two rows because six of its eight are
+	// x-live and render where the picture is. Only claims what is actually on
+	// that leaf — liveFields() is the same list renderLive() mounts, so a build
+	// whose live knobs live in another group gets no note rather than a wrong one.
+	function liftedNote(sec) {
+		const mine = liveFields().filter(f => f.section === sec);
+		if (!mine.length) return null;
+		const names = mine.map(f => liveLabel(f.key, f.sub).toLowerCase());
+		const list = names.length > 1
+			? names.slice(0, -1).join(', ') + ' and ' + names[names.length - 1]
+			: names[0];
+		const p = el('p', 'mj-lifted');
+		p.innerHTML = esc(list.charAt(0).toUpperCase() + list.slice(1)) +
+			' apply as you drag them, so they are on ' +
+			'<a href="?tab=' + LIVE_ID + '">Live adjustments</a> with the picture.';
+		return p;
+	}
+
+	// "all N at stock" / "N of M off stock" for the section head — the question
+	// the per-row ↺ can only answer one row at a time. Counted over what is on
+	// screen (a visibleWhen-hidden row is not one of the section's N from here)
+	// and over fields the schema records a default for, so the sentence is
+	// provable: a key with no recorded default can never be shown to be either.
+	// Measured against the default rather than against the last save, so it goes
+	// on saying "off stock" after Save — it is a fact about the camera.
+	function paintStock() {
+		const note = document.getElementById('mj-stock-note');
+		if (!note) return;
+		let shown = 0, known = 0, off = 0;
+		for (const f of state.fields) {
+			if (!f.p || f.p.style.display === 'none') continue;
+			shown++;
+			if (!f.schema || !Object.prototype.hasOwnProperty.call(f.schema, 'default')) continue;
+			known++;
+			if (String(f.getValue()) !== String(f.schema.default)) off++;
+		}
+		// The denominator is the rows on screen, so it matches what can be
+		// counted; "all at stock" carries no number at all, because the honest
+		// one is the number of *defaulted* fields and printing "all 9" beside
+		// twelve visible rows invites exactly the wrong reading.
+		note.textContent = !known ? ''
+			: off ? off + ' of ' + shown + ' off stock'
+				: 'all at stock';
+		note.classList.toggle('mj-off-stock', off > 0);
+	}
+
 	function renderProps(container, basePath, props) {
-		for (const key of Object.keys(props)) {
+		// Scalars first, object subtrees after. An object renders as a labelled
+		// group and everything below its heading reads as part of it, so a scalar
+		// sibling that happens to come later in the schema is captured by it:
+		// isp.blkCnt — memory blocks for the encoder — read as an iris setting,
+		// which is where nobody would look for it.
+		const keys = Object.keys(props);
+		const ordered = keys.filter(k => !isGroup(props[k])).concat(keys.filter(k => isGroup(props[k])));
+		for (const key of ordered) {
 			const dot = basePath + '.' + key;
 			if (EXCLUDE.has(dot)) continue;
 			if (dot === ROI_DOT) continue;        // renders on the Visual editor leaf
 			const sub = props[key];
 			if (sub && sub['x-live']) continue;   // live knobs render on their own leaf
-			if (sub && sub.type === 'object' && sub.properties) {
-				const h = el('h5', 'mt-4 mb-2 text-secondary');
-				h.textContent = sub.title || titleCase(key);
+			if (isGroup(sub)) {
+				// The Live deck's group head, verbatim: micro-caps name and a
+				// hairline to the column edge, rather than a 20px grey <h5> that
+				// outweighed every label under it.
+				const h = el('div', 'mj-live-grp-head');
+				const t = el('span', 'mj-cap');
+				t.textContent = sub.title || titleCase(key);
+				h.appendChild(t);
+				h.appendChild(el('span', 'mj-live-rule'));
 				container.appendChild(h);
 				renderProps(container, dot, sub.properties);
 				continue;
@@ -1521,20 +1596,32 @@
 			ctrl.control.addEventListener('input', update);
 			state.visUpdaters.push(update);
 			update();
-			// flipping a controller changes which rows exist, so a live search
-			// has to recount. Once per controller, not once per dependent field.
-			if (!controllers.has(ctrl)) {
-				controllers.add(ctrl);
-				const recount = () => { if (state.q.trim()) buildNav(); };
-				ctrl.control.addEventListener('change', recount);
-				ctrl.control.addEventListener('input', recount);
-			}
+			controllers.add(ctrl);
+		}
+		// Flipping a controller changes which rows exist, so anything that counts
+		// rows has to run again — once per controller, and only once every
+		// dependent row has been shown or hidden.
+		//
+		// Registered after the loop, not inside it: listeners fire in the order
+		// they were added, so attaching this beside the first dependent field's
+		// update() ran it after that one row and before the other seven. Setting
+		// isp.iris.type to DC reveals eight rows and the count read one of them —
+		// "1 of 13 off stock" against thirteen rows on a screen showing twenty.
+		for (const ctrl of controllers) {
+			const recount = () => { paintStock(); if (state.q.trim()) buildNav(); };
+			ctrl.control.addEventListener('change', recount);
+			ctrl.control.addEventListener('input', recount);
 		}
 	}
 
 	function runVisibility() {
 		(state.visUpdaters || []).forEach(u => u());
+		// what is on screen just changed, and the head counts what is on screen
+		paintStock();
 	}
+
+	// At or below this many visible rows a section stays in one column.
+	const SOLO_MAX = 4;
 
 	// Deal the section's rows into the two columns of .mj-cols.
 	//
@@ -1554,6 +1641,23 @@
 		// document order, wherever the last deal left them
 		const items = Array.from(a.children).concat(Array.from(b.children));
 		if (!items.length) return;
+
+		// A handful of rows does not want two columns. image is two rows once its
+		// six x-live knobs are on the Live leaf, and dealt in half that is one row
+		// beside one row across 966px of card. Under the cut they stay in one
+		// column at a readable measure and the second column is not drawn at all,
+		// divider included.
+		const shown = items.filter(it => it.offsetHeight).length;
+		const solo = shown <= SOLO_MAX;
+		box.classList.toggle('mj-solo', solo);
+		if (solo) {
+			if (b.childElementCount) {
+				const held = grabFocus(box);
+				items.forEach(it => a.appendChild(it));
+				restoreFocus(held);
+			}
+			return;
+		}
 
 		// Both columns are flex: 1 1 0, so each row already measures at the
 		// width it keeps on either side of the fold — nothing has to be moved
@@ -1587,7 +1691,7 @@
 		for (let i = 1; i <= items.length; i++) {
 			// a group heading belongs to the rows under it, so it must not be
 			// left as the last thing in a column
-			if (i < items.length && items[i - 1].tagName === 'H5') continue;
+			if (i < items.length && items[i - 1].classList.contains('mj-live-grp-head')) continue;
 			const n = seen[i];
 			const left = n ? y[n - 1] + rows[n - 1].h + rows[n - 1].mb : 0;
 			const right = n < rows.length ? rows[n].mt + total - y[n] : 0;
@@ -1761,14 +1865,42 @@
 			};
 			paint();
 		} else if (type === 'boolean') {
+			// The label goes above the switch, like every other type's, instead of
+			// beside it: a switch row was 26px where a select row is 64, so a
+			// column mixing the two had no rhythm, and the ↺ — which trails the
+			// control — sat at a different x on a boolean than on anything else.
+			// The lit word carries the state, the way the Live bar's toggles do:
+			// a bare switch states its position but not what the position means.
+			//
+			// Live rows keep the inline shape. They are not wrapped in .mj-ctl
+			// (see below), so the two-line form would leave the label stranded
+			// above a switch with no rail to line up against.
 			p = el('p', 'boolean mj-row' + liveCls);
-			p.innerHTML =
-				'<span class="form-check form-switch">' +
-				'<input type="checkbox" id="' + id + '" class="form-check-input">' +
-				'<label for="' + id + '" class="form-check-label">' + labelHtml + '</label>' +
-				'</span>';
+			p.innerHTML = live
+				? '<span class="form-check form-switch">' +
+					'<input type="checkbox" id="' + id + '" class="form-check-input">' +
+					'<label for="' + id + '" class="form-check-label">' + labelHtml + '</label>' +
+					'</span>'
+				: '<label for="' + id + '" class="form-label">' + labelHtml + '</label>' +
+					'<span class="form-check form-switch">' +
+					'<input type="checkbox" id="' + id + '" class="form-check-input">' +
+					'</span>' +
+					'<span class="mj-state" aria-hidden="true"></span>';
 			control = p.querySelector('input');
 			control.checked = toBool(eff);
+			const word = p.querySelector('.mj-state');
+			if (word) {
+				const paintState = () => {
+					word.textContent = control.checked ? 'On' : 'Off';
+					word.classList.toggle('mj-state-on', control.checked);
+				};
+				control.addEventListener('change', paintState);
+				// refresh() and onReset() push values in through setValue and fire
+				// no events, so the word has to be repainted on that path too —
+				// the same _set hatch the detent slider uses.
+				control._set = (v) => { control.checked = toBool(v); paintState(); };
+				paintState();
+			}
 		} else if (type === 'integer' && isNum(sub.maximum) && sub.maximum <= 100) {
 			p = el('p', 'range mj-row' + liveCls);
 			const min = isNum(sub.minimum) ? sub.minimum : 0;
@@ -1984,8 +2116,10 @@
 		if (!live) {
 			const reset = document.createElement('button');
 			reset.type = 'button';
-			reset.className = 'btn btn-sm btn-link p-0 mj-reset';
-			reset.textContent = '↺';
+			reset.className = 'mj-reset';
+			// The Live deck's glyph, not U+21BA: a text arrow is a different shape
+			// in every font stack, and these two controls do the same thing.
+			reset.innerHTML = ICON.reset;
 			reset.setAttribute('aria-label', 'Reset ' + desc + ' to default');
 			if (!hasDefault) {
 				reset.disabled = true;
@@ -2082,6 +2216,7 @@
 		}
 		state.dirtyN = n;
 		renderToolbar();
+		paintStock();
 	}
 
 	// One visibility rule for both buttons: show each only while its action can

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1519,7 +1519,16 @@
 			shown++;
 			if (!f.schema || !Object.prototype.hasOwnProperty.call(f.schema, 'default')) continue;
 			known++;
-			if (String(f.getValue()) !== String(f.schema.default)) off++;
+			// The default has to be serialised the way the control serialises its
+			// own value or the two are not comparable: an array control reads back
+			// as ", "-joined (getValue → _rows().join(', ')) while String([a,b])
+			// joins on a bare comma, so an untouched two-region default would count
+			// as off stock. Every array default majestic ships today is [], which
+			// stringifies to "" either way — this is the case that has not bitten
+			// yet, not the one that cannot.
+			const def = f.schema.default;
+			const defStr = Array.isArray(def) ? def.join(', ') : String(def);
+			if (String(f.getValue()) !== defStr) off++;
 		}
 		// The denominator is the rows on screen, so it matches what can be
 		// counted; "all at stock" carries no number at all, because the honest
@@ -1647,7 +1656,11 @@
 		// beside one row across 966px of card. Under the cut they stay in one
 		// column at a readable measure and the second column is not drawn at all,
 		// divider included.
-		const shown = items.filter(it => it.offsetHeight).length;
+		// Rows only: a group heading is not a setting, and counting it would spend
+		// a section's budget on its own furniture — four controls under one
+		// heading would be dealt into two columns while claiming to be under the
+		// limit.
+		const shown = items.filter(it => it.offsetHeight && it.classList.contains('mj-row')).length;
 		const solo = shown <= SOLO_MAX;
 		box.classList.toggle('mj-solo', solo);
 		if (solo) {


### PR DESCRIPTION
The Live adjustments leaf landed in #237 / #238 / #242 / #244 with micro-caps names, a hairline section head, a mono readout and a ghost reset on a fixed rail. Every *other* section on that page — the ones the schema generates — kept the old shape, so the page read as two products depending on which leaf you were on.

This carries the deck's vocabulary into the generated renderer. No new schema key, no new endpoint, no hand-written form: the same `renderField` dispatch, dressed the way the deck is.

### Measured on a lab hi3516ev300 at 1440

| | before | after |
|---|---|---|
| reset glyph, one ISP column | **6 different x-positions** | one rail, all seven on `x=835` |
| boolean row vs select row | 26px vs 64px | 54 vs 66 |
| field label | 1rem body text — the size of its own value | micro-caps `11px / 600 / .07em` |
| section card background | `#14161c`, identical to the page | `#1c1f27`, a surface |
| `?tab=image` | 2 rows dealt across a 966px card | one column, and it says where the other six went |

The reset landed where it did because it trailed whatever width each control's cap gave it — 10rem for a number, 16 for a select, 20 for an array, its own width for a switch. Pinning it to the column's right edge is what turns a scatter into a rail, and it only reads as deliberate because every row shares the edge, exactly as the deck's rows already do.

### The head's note

"all at stock", or "**N of M off stock**" in amber. It answers the question the per-row ↺ can only answer one row at a time.

It is measured against the schema's own default rather than against the last save, so it keeps saying so after Save — it is a fact about the camera, not about the edit. The denominator is the rows on screen so it matches what you can count, and "all at stock" deliberately carries no number: the honest one is the count of *defaulted* fields, and printing "all 9" beside twelve visible rows invites exactly the wrong reading.

### Also

- Booleans take the two-line shape — label above, switch plus the lit word beside it, the vocabulary the Live bar's toggles already use. A bare switch states its position but not what the position means.
- The two columns gain the divider the deck has between its panels; four rows or fewer stay in one column.
- `isp.blkCnt` — memory blocks for the encoder — rendered *under* the "Iris" heading, because the schema lists it after the iris object and everything below a group heading reads as part of that group. Scalars are emitted before object subtrees now.
- The rail's active row was a solid 306px indigo slab — the loudest thing on a page whose subject is a list of settings. Surface plus an indigo edge marks it just as clearly.
- The switch was Bootstrap's stock `#0d6efd` rather than the brand indigo: the compiled subset carries that colour literally and never reads `--bs-primary`.
- `.card` resolving to the page background is a theme-wide bug; it is worked around locally here, the way the deck already does, and the real fix is still its own change.

### A bug found on the way

`applyVisibility()` attached its recount listener beside the *first* dependent field's `update()`, so it ran after that one row and before the other seven. Setting `isp.iris.type` to `DC` reveals eight rows and the count saw one of them — the head read "1 of 13 off stock" on a screen showing twenty. The listener is attached after the loop now. The same staleness was under the search-match recount this shares, which is what it was written for.

### Verification

`npm test`, `tools/lint-templates.sh`, `tools/regen-bootstrap-css.sh` (byte-identical — the Bootstrap classes dropped from the reset and the group heading are still used elsewhere).

On the lab hi3516ev300, driven through CDP: image (2 rows, solo column, lifted note), isp (12 rows → 20 with iris on `DC`, and column A stays at 6 through the reveal, so #189's frozen deal is intact), nightMode (12), video0 (17, "2 of 17 off stock" — `rcMode` is `vbr` against a default of `avbr` and `fps` is 20 against a schema default of 0), and records. The Live leaf renders unchanged.
