### PR TITLE
Live View: the radios follow the channel the camera actually serves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,21 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   matters: WebRTC negotiates, so it can fail where MSE cannot (Firefox offers
   only H.264 Baseline whatever it can decode), which is why a player reporting
   `'fallback'` asks for the other transport rather than for MJPEG.
+  WebRTC's `?stream=` is a **preference, not an order** — the camera can serve
+  the other channel. An upcoming majestic states the served channel outright in
+  a `served` signalling reply (channel, requested, reason code) right after the
+  SDP answer; the player adopts it internally (so re-picking the fallen-from
+  channel is a real renegotiation, not a no-op) and hands it to the page via
+  `onServed`. The page then treats it as authoritative — the chip (including
+  Auto's always-on label, previously silent when the two channels shared a
+  size), the adaptation toast's baseline, and on a mismatch against an explicit
+  pick the radios move to the served channel (by writing `.checked`, never by
+  firing `change` — `goToStream()` must not re-enter and the remembered
+  preference must stay the viewer's own) while the dismissible `#mj-served`
+  toast names why (`unavailable` / `undecodable`; the page words the sentence).
+  In Auto the radios and message stay untouched — nothing was betrayed and the
+  chip is the disclosure. On an older majestic no `served` ever arrives and the
+  frame-size inference below stands, radios unmoved — today's behaviour.
   `mj-settings.cgi` does **not** share the `preview()` markup — its live tab is
   built client-side by `renderLive()` in `mj-settings.js` (`.mj-live-video`
   elements), though it loads all four preview player scripts. `preview()`

--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -19,7 +19,8 @@ const IDS = [
 	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
 	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note', 'mj-stats',
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
-	'mj-stream-auto', 'mj-auto', 'mj-sub', 'mj-talk', 'mj-talk-ctl',
+	'mj-stream-auto', 'mj-auto', 'mj-served', 'mj-served-why', 'mj-sub',
+	'mj-talk', 'mj-talk-ctl',
 	'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w', 'mj-transport-m', 'mj-transport-ctl',
 	'mj-transport-lbl', 'mj-vol',
 	'mj-player', 'mj-stage', 'toggle-ircut', 'toggle-light', 'toggle-night',
@@ -41,8 +42,11 @@ function load(cfg) {
 	const env = { made: [], els: {}, observed: [] };
 	IDS.forEach((id) => { env.els['#' + id] = makeEl(id); });
 	// As the markup ships them: the Sub and Auto labels start hidden and are
-	// revealed only where a second stream exists.
-	['mj-sub', 'mj-auto'].forEach((id) => { env.els['#' + id].hidden = true; });
+	// revealed only where a second stream exists; the served-channel message
+	// starts hidden until a mismatch is announced.
+	['mj-sub', 'mj-auto', 'mj-served'].forEach((id) => {
+		env.els['#' + id].hidden = true;
+	});
 	// And as the markup ships the inputs: unreachable until the configuration
 	// says there is a second stream.
 	['mj-stream-1', 'mj-stream-auto'].forEach((id) => {
@@ -333,9 +337,11 @@ const tick = (n) => new Promise((r) => setTimeout(r, n || 60));
 
 	group('Auto claims nothing over WebRTC when sizes cannot distinguish');
 	{
-		// Identically-sized channels make a WebRTC fallback undetectable, so
-		// the label would be a guess — and a guess about "which stream is
-		// this" is worse than silence (#240 tracks the authoritative fix).
+		// Identically-sized channels make a WebRTC fallback undetectable to
+		// the size inference, so the label would be a guess — and a guess
+		// about "which stream is this" is worse than silence. This is the
+		// old-daemon path: a majestic with the `served` reply states the
+		// channel outright (#240), covered by the groups below.
 		const env = load({
 			box: [800, 450], main: '1280x720', sub: '1280x720',
 			picked: 'auto', transport: 'webrtc',
@@ -377,6 +383,106 @@ const tick = (n) => new Promise((r) => setTimeout(r, n || 60));
 		live.opts.onCodec('h264', 'h264', 1280, 720);
 		check('an unrecognised size claims nothing',
 			env.el('mj-badge').textContent.indexOf('stream') === -1,
+			env.el('mj-badge').textContent);
+	}
+
+	group('the camera\'s own served answer beats indistinguishable sizes');
+	{
+		// The `served` signalling reply (#240): with both channels sized
+		// alike the inference above stays silent, but the camera saying
+		// "channel 0" outright is not a guess. This is Auto's case — the
+		// chip always names Auto's channel when it truthfully can.
+		const env = load({
+			box: [800, 450], main: '1280x720', sub: '1280x720',
+			picked: 'auto', transport: 'webrtc',
+		});
+		await tick();
+		const live = env.made[0];
+		live.say('playing');
+		live.opts.onCodec('h264', 'h264', 1280, 720);
+		live.opts.onServed({ channel: 0, requested: null, reason: '' });
+		check('the chip names the channel the camera stated',
+			/ · Main stream$/.test(env.el('mj-badge').textContent),
+			env.el('mj-badge').textContent);
+		check('no message without a betrayed request',
+			env.el('mj-served').hidden === true);
+	}
+
+	group('a served mismatch moves the radio and explains itself');
+	{
+		// The viewer asked for Main; the camera answered with Sub and said
+		// why. The controls follow reality — without re-entering the stream
+		// switch or overwriting the remembered preference — and the message
+		// carries the reason (#240).
+		const env = load({
+			main: '1920x1080', sub: '1920x1080', picked: 0,
+			transport: 'webrtc',
+		});
+		await tick();
+		const live = env.made[0];
+		check('opens on the remembered Main', live.opts.stream === 0,
+			'stream=' + live.opts.stream);
+		live.say('playing');
+		live.opts.onCodec('h264', 'h264', 1920, 1080);
+		live.opts.onServed({ channel: 1, requested: 0, reason: 'undecodable' });
+		check('the Sub radio is now the checked one',
+			env.el('mj-stream-1').checked === true &&
+			env.el('mj-stream-0').checked === false);
+		check('the message is shown', env.el('mj-served').hidden === false);
+		check('and names the cause',
+			env.el('mj-served-why').textContent.indexOf('decode') !== -1,
+			env.el('mj-served-why').textContent);
+		check('the player was not re-cut', live.streamSet === null,
+			'streamSet=' + live.streamSet);
+		check('the remembered preference was not overwritten',
+			env.stored === undefined, String(env.stored));
+		// The radio now tells the truth, so the chip has no betrayal to
+		// report.
+		check('the chip carries no mismatch note',
+			env.el('mj-badge').textContent.indexOf('stream') === -1,
+			env.el('mj-badge').textContent);
+
+		// Dismissed is dismissed: the same session re-stating the same
+		// fallback (a reconnect, an audio renegotiation) must not resurrect
+		// the message.
+		env.el('mj-served').fire('click');
+		check('a click dismisses it', env.el('mj-served').hidden === true);
+		live.opts.onServed({ channel: 1, requested: 0, reason: 'undecodable' });
+		check('the same answer does not re-show it',
+			env.el('mj-served').hidden === true);
+
+		// But a fresh user pick re-arms it: asking again deserves an answer
+		// again.
+		env.el('mj-stream-0').checked = true;
+		env.el('mj-stream-0').fire('change');
+		check('re-picking reaches the player', live.streamSet === 0,
+			'streamSet=' + live.streamSet);
+		live.opts.onServed({ channel: 1, requested: 0, reason: 'undecodable' });
+		check('a repeated fallback after a re-pick is news again',
+			env.el('mj-served').hidden === false);
+	}
+
+	group('in Auto a served mismatch keeps Auto checked and stays quiet');
+	{
+		// Auto delegated the choice, so nothing was betrayed: the radios stay
+		// Auto's, no message shows, and the chip (which always names Auto's
+		// channel) is the disclosure.
+		const env = load({
+			box: [320, 180], main: '1920x1080', sub: '640x360',
+			picked: 'auto', transport: 'webrtc',
+		});
+		await tick();
+		const live = env.made[0];
+		check('Auto asked for Sub', live.opts.stream === 1,
+			'stream=' + live.opts.stream);
+		live.say('playing');
+		live.opts.onCodec('h264', 'h264', 1920, 1080);
+		live.opts.onServed({ channel: 0, requested: 1, reason: 'unavailable' });
+		check('Auto stays checked',
+			env.el('mj-stream-auto').checked === true);
+		check('no message in Auto', env.el('mj-served').hidden === true);
+		check('the chip names what is actually served',
+			/ · Main stream$/.test(env.el('mj-badge').textContent),
 			env.el('mj-badge').textContent);
 	}
 

--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -442,6 +442,16 @@ const tick = (n) => new Promise((r) => setTimeout(r, n || 60));
 			env.el('mj-badge').textContent.indexOf('stream') === -1,
 			env.el('mj-badge').textContent);
 
+		// A reopen inside the fallen-back session (audio toggle, network
+		// reconnect) requests the ADOPTED channel and is answered with a
+		// match — but the viewer's own ask is still unmet, so the standing
+		// explanation must not vanish on an audio toggle.
+		live.opts.onServed({ channel: 1, requested: 1, reason: '' });
+		check('a reopen echo does not clear the explanation',
+			env.el('mj-served').hidden === false);
+		check('nor move the radios',
+			env.el('mj-stream-1').checked === true);
+
 		// Dismissed is dismissed: the same session re-stating the same
 		// fallback (a reconnect, an audio renegotiation) must not resurrect
 		// the message.
@@ -449,6 +459,9 @@ const tick = (n) => new Promise((r) => setTimeout(r, n || 60));
 		check('a click dismisses it', env.el('mj-served').hidden === true);
 		live.opts.onServed({ channel: 1, requested: 0, reason: 'undecodable' });
 		check('the same answer does not re-show it',
+			env.el('mj-served').hidden === true);
+		live.opts.onServed({ channel: 1, requested: 1, reason: '' });
+		check('and a reopen echo after dismissal stays dismissed',
 			env.el('mj-served').hidden === true);
 
 		// But a fresh user pick re-arms it: asking again deserves an answer

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -23,7 +23,8 @@ const SRCS = [A('preview-swap.js'), A('preview-page.js')];
 const IDS = [
 	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
 	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note', 'mj-stats',
-	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1', 'mj-sub',
+	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
+	'mj-served', 'mj-served-why', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w',
 	'mj-transport-m', 'mj-transport-ctl', 'mj-transport-lbl',
 	'mj-vol', 'mj-player', 'mj-stage',
@@ -310,6 +311,32 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			env.made[0].streamSet === 1, 'live=' + env.made[0].streamSet);
 		check('the trial followed the viewer to Sub',
 			trial.streamSet === 1, 'trial=' + trial.streamSet);
+	}
+
+	group('a served mismatch moves the radios without cutting anything');
+	{
+		// The camera's `served` reply moves the radios by writing .checked,
+		// which fires no change event. The regression this guards: a reflect
+		// that re-entered goToStream() would setStream() the session that
+		// just answered — cutting it — and could loop against the camera's
+		// next fallback.
+		const env = load('webrtc');
+		await tick();
+		const live = env.made[0];
+		live.say('playing');
+		const before = env.made.length;
+		env.el('mj-stream-0').checked = true;
+		// As the markup ships it, so "is up" below means it was shown here.
+		env.el('mj-served').hidden = true;
+		live.opts.onServed({ channel: 1, requested: 0, reason: 'unavailable' });
+		check('the radios follow the camera',
+			env.el('mj-stream-1').checked === true &&
+			env.el('mj-stream-0').checked === false);
+		check('the session was not re-cut', live.streamSet === null,
+			'streamSet=' + live.streamSet);
+		check('no new player was made', env.made.length === before,
+			'made=' + env.made.length);
+		check('the message is up', env.el('mj-served').hidden === false);
 	}
 
 	done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1698,6 +1698,13 @@ mark {
 	to { opacity: 1; transform: none; }
 }
 
+/* The served-channel message shares the toast's glass but its own slot,
+   below the adaptation toast, so a fallback and a rate change can both be
+   on screen without either covering the other. */
+.mj-served-toast {
+	top: 5.2rem;
+}
+
 /* ── on-video chrome ────────────────────────────────────────────────────────
    The same vocabulary the Live adjustments deck uses — black glass, micro-caps
    labels, a lit indicator where there is state, stroked 20px icons — so the

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -90,7 +90,7 @@
 	});
 	stage.addEventListener('pointerdown', e => {
 		if (e.pointerType !== 'touch') return;
-		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-adapt')) return;
+		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-adapt, #mj-served')) return;
 		if (stage.classList.contains('mj-show')) {
 			stage.classList.remove('mj-show');
 			clearTimeout(hideTimer);

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -183,6 +183,13 @@
 	// `served`, and the second telling would just be noise.
 	let servedCh = null;
 	let servedShownKey = '';
+	// The channel the viewer themselves asked for, distinct from `stream`:
+	// after a fallback the page and player adopt the served channel, so every
+	// internal reopen (audio, reconnect) requests it and is answered with a
+	// match — but the viewer's own ask is still unmet, and the standing
+	// explanation must not vanish on an audio toggle. null until a request is
+	// betrayed or the viewer picks; goToStream() is what changes their mind.
+	let wantedCh = null;
 	// Per channel too: videoN.bitrate, for the toast's "back to configured".
 	let cfgKbps = [0, 0];
 	// WebRTC takes ?stream= as a preference, not an order: the camera can
@@ -285,13 +292,26 @@
 		const mismatch = servedCh !== null && info.requested !== null &&
 			info.channel !== info.requested;
 		if (!mismatch) {
-			// Served as asked (or nothing was asked): any standing message
-			// now describes a session that no longer exists.
+			// A match the viewer never asked for is not good news: a reopen
+			// inside a fallen-back session requests the adopted channel and
+			// is answered with it, while the viewer's own ask stands unmet.
+			// Leave the explanation exactly as it is — up if it was up,
+			// dismissed if they dismissed it.
+			if (wantedCh !== null && servedCh !== null &&
+				servedCh !== wantedCh) {
+				setChip();
+				return;
+			}
+			// Served as the viewer asked (or nothing was asked): any
+			// standing message describes a mismatch that no longer exists.
 			servedShownKey = '';
 			hideServedMsg();
 			setChip();
 			return;
 		}
+		// The betrayed ask, remembered past the adoption below — the daemon
+		// echoes exactly what this page requested.
+		wantedCh = info.requested;
 		if (!autoOn) {
 			// The controls tell the truth: the session — player included, it
 			// adopted the channel itself — is on servedCh, so the page and
@@ -442,6 +462,7 @@
 		if (!usingWebRTC) {
 			servedCh = null;
 			servedShownKey = '';
+			wantedCh = null;
 			hideServedMsg();
 		}
 		syncAudioCtl();
@@ -898,9 +919,11 @@
 		// The two channels are two encoders; the baseline and any toast on
 		// screen describe the one being left.
 		if (window.MajesticAdapt) window.MajesticAdapt.reset();
-		// A deliberate change invalidates the camera's last served answer and
-		// re-arms the message: the next session speaks for itself, and if it
-		// falls back again that is news worth repeating.
+		// A deliberate change is the viewer changing their mind: it becomes
+		// the new ask, invalidates the camera's last served answer, and
+		// re-arms the message — the next session speaks for itself, and if
+		// it falls back again that is news worth repeating.
+		wantedCh = n;
 		servedCh = null;
 		servedShownKey = '';
 		hideServedMsg();
@@ -917,6 +940,7 @@
 		if (!autoOn) return;
 		// Any standing mismatch message belonged to a manual pick; handing
 		// the choice to Auto withdraws the request it was explaining.
+		wantedCh = null;
 		servedShownKey = '';
 		hideServedMsg();
 		// Acting immediately rather than waiting for a resize: the person just

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -29,6 +29,7 @@
 	const initial = $('#live-video');
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
+	const servedEl = $('#mj-served'), servedWhy = $('#mj-served-why');
 	let jpegOn = false;
 	mjConfig().then(cfg => {
 		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
@@ -174,6 +175,14 @@
 	// reported about its own picture.
 	let chipMedia = null, chipFps = 0;
 	let cfgFps = [0, 0];
+	// The camera's own statement of which channel this WebRTC session serves,
+	// from the `served` signalling reply — or null on an older majestic, over
+	// MSE, and between sessions, in which case the size inference below stands
+	// in. servedShownKey remembers which mismatch the message has already
+	// announced: a reconnect or audio renegotiation re-delivers the same
+	// `served`, and the second telling would just be noise.
+	let servedCh = null;
+	let servedShownKey = '';
 	// Per channel too: videoN.bitrate, for the toast's "back to configured".
 	let cfgKbps = [0, 0];
 	// WebRTC takes ?stream= as a preference, not an order: the camera can
@@ -192,6 +201,9 @@
 	// configured bitrate would be the wrong endpoint for its steps.
 	function servedStream() {
 		const asked = stream ? 1 : 0;
+		// The camera said outright — no inference needed. Older daemons never
+		// say, and everything below is the fallback for them.
+		if (usingWebRTC && servedCh !== null) return servedCh;
 		if (!usingWebRTC || !chipMedia) return asked;
 		const want = sizeOf[asked], other = sizeOf[asked ? 0 : 1];
 		if (!want || !other) return asked;
@@ -205,14 +217,15 @@
 		// Auto's radios never say which channel it picked, so the chip
 		// always does (#184) — but only when it can say truthfully. Over MSE
 		// the subscription is exact, so `stream` IS the served channel; over
-		// WebRTC the identity is inferred from frame size, and with a size
-		// unset or the two channels sized alike the inference proves
-		// nothing, so the chip claims nothing rather than guessing (#240
-		// tracks getting this authoritatively from the camera). A manual
-		// pick speaks only on a mismatch — the radio already names the
-		// intent, so the chip only reports betrayal.
+		// WebRTC a new majestic states the channel in the signalling (#240),
+		// and only on an older one is the identity inferred from frame size —
+		// where a size unset or the two channels sized alike proves nothing,
+		// so the chip claims nothing rather than guessing. A manual pick
+		// speaks only on a mismatch — the radio already names the intent, so
+		// the chip only reports betrayal.
 		if (autoOn) {
-			if (usingWebRTC && (!sizeOf[0] || !sizeOf[1] ||
+			if (usingWebRTC && servedCh === null &&
+				(!sizeOf[0] || !sizeOf[1] ||
 				(sizeOf[0].w === sizeOf[1].w && sizeOf[0].h === sizeOf[1].h))) {
 				return '';
 			}
@@ -229,6 +242,77 @@
 			chipMedia.w + '×' + chipMedia.h +
 			(fps ? ' · ' + Math.round(fps) + ' fps' : '') +
 			servedNote();
+	}
+
+	// The served-channel message: why the channel the viewer picked is not the
+	// one playing. Unlike the adaptation toast it does not time out — the
+	// mismatch is a standing condition, not a moment — so it stays until
+	// dismissed, until the cause goes away, or until the viewer changes
+	// something (stream, transport) that makes it stale.
+	const streamName = (n) => n === 0 ? 'Main stream' : 'Sub stream';
+
+	function hideServedMsg() {
+		if (servedEl) servedEl.hidden = true;
+	}
+
+	function showServedMsg(info) {
+		if (!servedEl || !servedWhy) return;
+		const req = streamName(info.requested), got = streamName(info.channel);
+		// The page words the sentence; the camera only names the cause. An
+		// unknown code from a future daemon still gets an honest generic line.
+		servedWhy.textContent =
+			info.reason === 'unavailable'
+				? req + ' isn’t available right now — showing ' +
+					got + ' instead.'
+			: info.reason === 'undecodable'
+				? 'This browser’s WebRTC can’t decode the ' + req +
+					'’s format — showing ' + got + ' instead.'
+			: 'The camera couldn’t serve the ' + req +
+				' — showing ' + got + ' instead.';
+		servedEl.hidden = false;
+	}
+
+	// What a `served` reply from the camera does to this page: the chip, the
+	// adaptation baseline (through servedStream()), and — on a mismatch with
+	// an explicit pick — the radios and the message. The radios are moved by
+	// writing .checked, which fires no change event: goToStream() must not
+	// re-enter (it would cut the session that just told us this), and the
+	// remembered preference must stay the viewer's own — a daemon fallback is
+	// not a choice, and next page load should ask for their channel again.
+	function applyServed(info) {
+		servedCh = (info.channel === 0 || info.channel === 1)
+			? info.channel : null;
+		const mismatch = servedCh !== null && info.requested !== null &&
+			info.channel !== info.requested;
+		if (!mismatch) {
+			// Served as asked (or nothing was asked): any standing message
+			// now describes a session that no longer exists.
+			servedShownKey = '';
+			hideServedMsg();
+			setChip();
+			return;
+		}
+		if (!autoOn) {
+			// The controls tell the truth: the session — player included, it
+			// adopted the channel itself — is on servedCh, so the page and
+			// the radios follow. The viewer's original radio is now
+			// genuinely unchecked, which is what makes re-picking it a real
+			// change event and a real renegotiation.
+			stream = servedCh;
+			if (s0) s0.checked = servedCh === 0;
+			if (s1) s1.checked = servedCh === 1;
+			const key = info.requested + '>' + info.channel + ':' + info.reason;
+			if (key !== servedShownKey) {
+				servedShownKey = key;
+				showServedMsg(info);
+			}
+		}
+		// In Auto the radios stay Auto's and no message shows: no explicit
+		// request was betrayed, and the chip (which in Auto always names the
+		// channel) is the disclosure. Auto's own `stream` is left alone so
+		// autoApply()'s want === stream comparison keeps meaning "nothing to
+		// do" rather than oscillating against the camera's fallback.
+		setChip();
 	}
 	// Talkback is deliberately NOT carried across a transport switch or a
 	// reattach. Everything else here is a preference; this one holds a live
@@ -353,6 +437,13 @@
 		// describe a session that is gone. Back on WebRTC it re-adopts from
 		// the first tick rather than announcing whatever moved while away.
 		if (window.MajesticAdapt && !usingWebRTC) window.MajesticAdapt.reset();
+		// Same for the served-channel answer and its message: both belong to
+		// a WebRTC session. MSE serves the number it is given or nothing.
+		if (!usingWebRTC) {
+			servedCh = null;
+			servedShownKey = '';
+			hideServedMsg();
+		}
 		syncAudioCtl();
 		// The outgoing player's destroy() released the microphone, so talkback
 		// comes back up off whatever the new one is doing.
@@ -487,6 +578,11 @@
 		// old transport's dimensions and fps on the chip for ever (WebRTC
 		// self-heals through its per-second stats; MSE has no such path).
 		let heldMedia = null;
+		// The camera's served-channel answer arrives right after the SDP
+		// answer — for a trial, well before promotion. Held for the same
+		// reason heldMedia is: moving the radios for a session that may yet
+		// be thrown away would announce a switch that never happened.
+		let heldServed = null;
 		return {
 			onState: (s, d) => {
 				onState(s, d);
@@ -497,11 +593,19 @@
 					applyMedia(heldMedia);
 					heldMedia = null;
 				}
+				if (heldServed && isLive()) {
+					applyServed(heldServed);
+					heldServed = null;
+				}
 			},
 			onCodec: (codec, cs, w, h) => {
 				const m = { codec: codec, w: w, h: h };
 				if (!isLive()) { heldMedia = m; return; }
 				applyMedia(m);
+			},
+			onServed: (info) => {
+				if (!isLive()) { heldServed = info; return; }
+				applyServed(info);
 			},
 			// null means we asked for audio and the camera had none to give (mic
 			// off or not producing). Reflect that on the control rather than
@@ -794,6 +898,12 @@
 		// The two channels are two encoders; the baseline and any toast on
 		// screen describe the one being left.
 		if (window.MajesticAdapt) window.MajesticAdapt.reset();
+		// A deliberate change invalidates the camera's last served answer and
+		// re-arms the message: the next session speaks for itself, and if it
+		// falls back again that is news worth repeating.
+		servedCh = null;
+		servedShownKey = '';
+		hideServedMsg();
 		if (player) player.setStream(n);
 		const t = swap.trial();
 		if (t) t.setStream(n);
@@ -805,6 +915,10 @@
 	if (autoCtl) autoCtl.addEventListener('change', () => {
 		autoOn = autoCtl.checked;
 		if (!autoOn) return;
+		// Any standing mismatch message belonged to a manual pick; handing
+		// the choice to Auto withdraws the request it was explaining.
+		servedShownKey = '';
+		hideServedMsg();
 		// Acting immediately rather than waiting for a resize: the person just
 		// asked for the best fit, and the window is already the size it is.
 		lastAutoAt = 0;
@@ -824,6 +938,16 @@
 			userPickedStream = true;
 			MajesticTransport.chooseStream('preview', n === 2 ? 'auto' : n);
 		});
+	});
+
+	// Dismissing the served-channel message. A click anywhere on it counts —
+	// the × is a real button for the keyboard, but a toast small enough to
+	// need aim is a toast that gets missed. stopPropagation for the same
+	// reason preview-adapt.js does it: a tap on the stage toggles the control
+	// bar, and dismissing a message should not also flip the chrome.
+	if (servedEl) servedEl.addEventListener('click', (ev) => {
+		if (ev && ev.stopPropagation) ev.stopPropagation();
+		hideServedMsg();
 	});
 
 	// Follow the size, debounced — a drag fires continuously, and the rate limit

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -54,6 +54,10 @@ window.MajesticWebRTC = (function () {
 		// callbacks the caller may omit rather than something it must handle.
 		const onMic = opts.onMic || function () {};
 		const onStats = opts.onStats || function () {};
+		// The camera's own statement of which channel this session serves —
+		// newer daemons send it right after the answer; older ones never will,
+		// and the caller's size inference stands in.
+		const onServed = opts.onServed || function () {};
 		let stream = opts.stream | 0;
 
 		let pc = null, ws = null, statsTimer = null, signalTimer = null;
@@ -606,6 +610,25 @@ window.MajesticWebRTC = (function () {
 					// and parsed at the next poll, so the two sides are read
 					// out together rather than a tick apart.
 					camLine = m.data || '';
+				} else if (m.reply === 'served') {
+					// The camera says outright which channel this session
+					// serves — ?stream= was only ever a preference. Adopt it:
+					// setStream() no-ops when asked for the channel it thinks
+					// it has, so without this a viewer re-picking the channel
+					// the camera fell back from would press a button that does
+					// nothing. Adopted, that re-pick is a real renegotiation —
+					// and a mid-session reconnect re-requests the channel that
+					// actually worked instead of replaying the fallback.
+					if (typeof m.channel === 'number') {
+						stream = m.channel | 0;
+						onServed({
+							channel: m.channel | 0,
+							requested: typeof m.requested === 'number'
+								? m.requested | 0 : null,
+							reason: typeof m.reason === 'string'
+								? m.reason : '',
+						});
+					}
 				} else if (m.reply === 'busy') {
 					// Full, not incapable — every slot is taken and this same
 					// offer would be answered once one frees. Same move as a

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -529,6 +529,16 @@ preview() {
 			<span id="mj-adapt-why" class="mj-adapt-why"></span>
 			<button type="button" class="mj-adapt-close" aria-label="Dismiss">×</button>
 		</p>
+		<!-- The served-channel message (preview-page.js): why the channel the
+		     viewer picked is not the one playing, from the camera's own
+		     `served` signalling reply on a new enough majestic. Unlike the
+		     adaptation toast it does not time out — the mismatch stands for
+		     the whole session — so it stays until dismissed or stale. Slotted
+		     below the adaptation toast so all three overlays can show. -->
+		<p id="mj-served" class="mj-adapt-toast mj-served-toast small" role="status" hidden>
+			<span id="mj-served-why"></span>
+			<button type="button" class="mj-adapt-close" aria-label="Dismiss">×</button>
+		</p>
 		<!-- PTZ mount. Empty and hidden on every camera; p/motor.cgi (included
 		     by preview.cgi only when the hardware exists) emits the pad after
 		     the player and preview-ptz.js relocates it in here. -->


### PR DESCRIPTION
Fixes #240.

## The problem

WebRTC's `?stream=` is a preference, not an order: when the camera cannot serve the selected channel (classically a main stream on `profile: high`, which no browser's WebRTC offer accepts) it serves the other one. The chip learned to say so in #225 — but only by matching frame sizes against configured sizes, which proves nothing when the two channels share a size or a size is unset, and the radios kept showing the channel that was not playing. @usa- called that short of ideal, and he was right: the controls should reflect reality, with a message explaining why the switch could not be performed.

## What changes

**An upcoming majestic build states the served channel authoritatively in the signalling** — a `served` reply right after the SDP answer carrying the channel, the request it answered, and a machine-readable reason code on a mismatch. This page half consumes it:

- **The player adopts the channel internally** (`preview-webrtc.js`). `setStream()` no-ops on equality, so without adoption re-picking the channel the camera fell back from would press a button that does nothing. Adopted, a re-pick genuinely renegotiates.
- **The radios tell the truth** (`preview-page.js`). On a mismatch against an explicit pick they move to the served channel — by writing `.checked`, never by firing `change`, so the stream-switch machinery is not re-entered and the **remembered preference stays the viewer's own**: the next page load asks for their channel again, and is answered (and explained) again if it still cannot be served.
- **A dismissible message says why**, in the toast vocabulary under the chip: *"This browser's WebRTC can't decode the Main stream's format — showing Sub stream instead."* / *"Sub stream isn't available right now — …"*. No auto-hide — the mismatch is a standing condition, not a moment. It hides on dismiss, on a served answer that matches, on a stream or transport change, and on handing the choice to Auto. A dedupe key keeps reconnects from re-announcing the same fallback.
- **Auto stays quiet**: no radio moves and no message — Auto expressed no channel intent, so nothing was betrayed — but the chip, which always names Auto's channel, now does so **even when both channels are sized identically** (the deliberate silence #184 left "until #240 lands").
- The adaptation toast's baseline follows the authoritative channel through the same `servedStream()` it already reads.

**Compatibility both ways**: an older majestic sends no `served`, so the size inference stays as the fallback and every path degrades to exactly today's behaviour; an older page ignores the new reply. MSE is untouched — `/ws/video` serves the number it is given or nothing.

## Tests

Both vm suites gained groups driving `onServed` directly: the authoritative answer beating indistinguishable sizes, the radio reflect with no `setStream` re-entry and no preference overwrite, dismissal holding against a repeated `served`, a fresh pick re-arming the message, and the Auto quiet path. `npm test` green.

## Verified on hardware

Five lab cameras across three vendors (SigmaStar infinity6e, Ingenic T31, HiSilicon cv300 / ev200 family / cv500 with 4K video0), with the matching majestic build: protocol probes for honoured / no-preference / unavailable / undecodable, plus browser end-to-end — radio snaps to the served channel, message wording correct, dismissal sticks, re-pick renegotiates and re-announces, a reload with the preference remembered re-requests and re-explains, and the honoured 4K case plays with the radio unmoved and no message.

Not in this diff, noted as follow-up: the mj-settings Live tab has its own Main/Sub radios and could take the same ~8-line reflect; it has no chip or message container today and degrades identically to before.