### PR TITLE
The signature bar answers three questions, not six

### DIFF
--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -743,8 +743,20 @@ report_log() {
 	pre "$1" "small" "$2"
 }
 
+# The bar answers three questions -- which camera am I on, what hardware is
+# it, what firmware does it run -- and nothing more; MAC, flash and SoC family
+# live on the Dashboard. The stock hostname is <soc>-<sensor>, so each
+# hardware word appears only when the hostname does not already say it: a
+# renamed camera reads "front-door, hi3516av300, imx415, 2.6.08.29-lite",
+# a stock one collapses to "hi3516av300-imx415, 2.6.08.29-lite".
 generate_signature() {
-	echo "${soc} (${soc_family} family), $sensor, ${flash_size} MB ${flash_type} flash, ${fw_version}-${fw_variant}, ${network_hostname}, ${network_macaddr}" > $signature_file
+	local sig="$network_hostname"
+	local lower=$(echo "$network_hostname" | tr 'A-Z' 'a-z')
+	case "$lower" in *"$soc"*) ;; *) sig="$sig, $soc" ;; esac
+	[ "$sensor" != "unknown" ] && case "$lower" in *"$sensor"*) ;; *) sig="$sig, $sensor" ;; esac
+	sig="$sig, ${fw_version}-${fw_variant}"
+	sig="${sig#, }"
+	esc "$sig" > $signature_file
 }
 
 signature() {

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -751,9 +751,13 @@ report_log() {
 # a stock one collapses to "hi3516av300-imx415, 2.6.08.29-lite".
 generate_signature() {
 	local sig="$network_hostname"
+	# Compare lowered copies on both sides -- soc and sensor come from
+	# fw_setenv-able variables, so their case is the user's, not ours.
 	local lower=$(echo "$network_hostname" | tr 'A-Z' 'a-z')
-	case "$lower" in *"$soc"*) ;; *) sig="$sig, $soc" ;; esac
-	[ "$sensor" != "unknown" ] && case "$lower" in *"$sensor"*) ;; *) sig="$sig, $sensor" ;; esac
+	local soc_l=$(echo "$soc" | tr 'A-Z' 'a-z')
+	local sensor_l=$(echo "$sensor" | tr 'A-Z' 'a-z')
+	case "$lower" in *"$soc_l"*) ;; *) sig="$sig, $soc" ;; esac
+	[ "$sensor_l" != "unknown" ] && case "$lower" in *"$sensor_l"*) ;; *) sig="$sig, $sensor" ;; esac
 	sig="$sig, ${fw_version}-${fw_variant}"
 	sig="${sig#, }"
 	esc "$sig" > $signature_file


### PR DESCRIPTION
Every page opened on a six-part line — `hi3516av300 (hi3516cv500 family), imx415, 32 MB nor flash, 2.6.08.29-lite, hi3516av300-imx415, 2c:6f:51:10:e7:da` — in a bar whose job is orientation. Most of those facts already live on the Dashboard, which is also the one page that hides the bar (`hide_signature=1`).

The bar now answers three questions:

1. **Which camera am I on** — the hostname, first.
2. **What hardware is it** — SoC and sensor, but each appended only when the hostname does not already contain it (case-insensitive). The stock hostname is `<soc>-<sensor>`, so a stock camera collapses to `hi3516av300-imx415, 2.6.08.29-lite`; a renamed one reads `front-door, hi3516av300, imx415, 2.6.08.29-lite`; a hostname naming only one half gets just the missing half. A sensor of `unknown` is skipped rather than printed mid-line.
3. **What firmware does it run** — `fw_version-fw_variant`, unchanged.

SoC family, flash size/type and MAC are dropped from the bar.

The line is also HTML-escaped via `esc` before it lands in `/tmp/webui/signature.txt` — it never was, and `header.cgi` renders it raw while the hostname is user-settable.

Verified on hardware (hi3516av300): stock and renamed-hostname renderings both checked live, `haserl -d | sh -n` passes, and hostname edits regenerate the line because `fw-network.cgi` already calls `update_caminfo`. The dedup/edge cases (case-insensitive match, unknown sensor, empty SoC, escaping) were exercised under busybox ash.