### PR TITLE
PTZ: unset ptz_control means no pad, and the XiongMai Pelco variant joins the switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ This is the most important file to read before editing anything. It defines:
 - `/etc/crontabs/root` — extensions add/remove their own lines with `sed -i /name/d` then append.
 - `/tmp/webui/` — scratch (sysinfo, schema cache, flash log, signature).
 - `/tmp/system-reboot` — sentinel file; presence triggers the "restart required" banner in `header.cgi`.
-- U-Boot env via `fw_printenv -n` / `fw_setenv` for `ethaddr`, `wlanssid`, `wlanpass`, `upgrade`, `sensor`, `soc`, `gpio_motors`.
+- U-Boot env via `fw_printenv -n` / `fw_setenv` for `ethaddr`, `wlanssid`, `wlanpass`, `upgrade`, `sensor`, `soc`, and the PTZ family `ptz_control`/`ptz_gpio`/`ptz_port`/`ptz_speed`/`ptz_profile` (legacy aliases `gpio_motors`, `ptz`).
 
 ### Talking to Majestic
 
@@ -308,26 +308,34 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   a `:has()`-conditional `margin-bottom`, and — since `.mj-stage` is
   `overflow: hidden`, which is what rounds the picture's corners — that clip
   moves onto `.mj-stage-media` and `.mj-bar` for the duration. `:fullscreen`
-  puts the pad back on the video, the one phone case with height to spare. **Three PTZ backends**, detected in
+  puts the pad back on the video, the one phone case with height to spare. **Four PTZ backends**, detected in
   `common.cgi:update_caminfo` into `ptz_backend` (cached in sysinfo like
   `ptz_support`). The switch is U-Boot `ptz_control` (#227): `gpio`
-  (`gpio-motors` binary; pins in `ptz_gpio` — though the binary itself still
-  reads legacy `gpio_motors`, so set that one until the firmware utility
-  learns the new name), `pelco-d` (`/usr/bin/btzoom`; `ptz_port` default
-  `/dev/ttyAMA0`, `ptz_speed` default 115200 from a whitelist of standard
-  rates), `motor` (`/usr/bin/motor`; profile in `ptz_profile`, legacy `ptz`
-  value as fallback), or `none`. With `ptz_control` unset the pre-#227
-  detection stands (legacy `gpio_motors`/`ptz` vars), so field cameras keep
-  their pads; `j/ptz.cgi` honours the same switch. `gpio` and `motor` are
+  (`gpio-motors` binary; pins in `ptz_gpio`, legacy `gpio_motors` accepted
+  as an alias on both sides since firmware#2341), `pelco-d`
+  (`/usr/bin/btzoom`; `ptz_port` default `/dev/ttyAMA0`, `ptz_speed`
+  default 115200 from a whitelist of standard rates), `pelco-xm`
+  (`/usr/bin/btzoom-xm`, the XiongMai near-Pelco UART protocol from
+  sandbox#31 — same nine verbs and the same pad, its own framing and
+  checksum, `ptz_port` default `/dev/ttyAMA1`), or `motor`
+  (`/usr/bin/motor`; profile in `ptz_profile`, legacy `ptz` value as
+  fallback). **Unset means no PTZ**, exactly like `none` — the reporter of
+  #227 ruled that a camera without `ptz_control` shows no pad, so the old
+  auto-detection from `gpio_motors`/`ptz` alone is gone and a legacy-configured
+  camera must `fw_setenv ptz_control <method>` once; `j/ptz.cgi` honours the
+  same switch. `gpio` and `motor` are
   stepped eight-way pads speaking `j/ptz.cgi?h=&v=` (validated as small
-  signed ints); `pelco` is the community Pelco-D serial mod — four
+  signed ints); `pelco` covers both serial variants — four
   directions, zoom and focus, each a fixed timed pulse — speaking
-  `j/ptz.cgi?act=<verb>` against a closed whitelist (btzoom execs
-  `pelcoD_$1`, so the verb must never pass through raw). `bin/btzoom` ships
-  in this repo (adopted from OpenIPC/sandbox `scripts/pelcoD`) so a Pelco
-  camera needs only `fw_setenv ptz_control pelco-d`. A held
+  `j/ptz.cgi?act=<verb>` against a closed whitelist (the scripts dispatch on
+  the verb, so it must never pass through raw). `bin/btzoom` and
+  `bin/btzoom-xm` ship in this repo (adopted from OpenIPC/sandbox
+  `scripts/pelcoD`, the xm variant hardened to btzoom's standard: shared
+  `/tmp/btzoom.lock`, `ptz_port`/`ptz_speed`, idempotent per-command `stty`)
+  so a Pelco camera needs only `fw_setenv ptz_control pelco-d` (or
+  `pelco-xm`). A held
   Pelco button strings pulses end-to-end via the one-request-in-flight
-  guard — btzoom answers only after its pulse ends. To render either pad on
+  guard — the script answers only after its pulse ends. To render either pad on
   a camera without hardware: set the env vars, `touch`+`chmod +x` fake
   binaries, and remove `/tmp/webui/sysinfo.txt` (no reboot needed).
 - **Two clocks, and the page says which one it is printing.** Every second in

--- a/bin/btzoom-xm
+++ b/bin/btzoom-xm
@@ -1,0 +1,217 @@
+#!/bin/sh
+# PTZ control over the XiongMai UART protocol — Pelco-D-shaped but not
+# Pelco-D: its own sync byte, direction-bit layout and mod-100 checksum.
+# Origin: OpenIPC/sandbox scripts/pelcoD/btzoom-xm (sandbox#31), whose
+# frame/checksum logic is ported 1:1 from the vendor main.c
+# (send_cmd/set_focus/init_ptz). Adopted here (#227) with the same
+# scaffolding btzoom carries, so `fw_setenv ptz_control pelco-xm` is all a
+# camera needs: the port comes from U-Boot ptz_port (default /dev/ttyAMA1,
+# the UART the origin hardcoded), the rate from ptz_speed against the same
+# whitelist, one invocation holds the wire at a time, and the port is set
+# raw before every command instead of only in `start`.
+#
+# Every movement is a timed pulse: command, half a second, stop. The camera
+# ends its own move, which is why the WebUI paces a held button by waiting
+# for each request to answer rather than counting ticks.
+
+PORT=$(fw_printenv -n ptz_port 2>/dev/null)
+[ -n "$PORT" ] || PORT=/dev/ttyAMA1
+SPEED=$(fw_printenv -n ptz_speed 2>/dev/null)
+case "$SPEED" in
+	# A rate stty would refuse must not kill the command whole; the popular
+	# rates are plenty, and anything else falls back to the old default.
+	1200|2400|4800|9600|19200|38400|57600|115200) ;;
+	*) SPEED=115200 ;;
+esac
+DELAY='sleep .5'
+# btzoom's lock, name included: the lock protects the UART wire, and only
+# one Pelco variant is ever the configured backend.
+LOCK=/tmp/btzoom.lock
+
+ADDR=1          # addressPTZ in main.c
+SYNC=197        # 0xC5 - SYNC byte used when AUTO_FOCUS is defined (main.c default)
+TERM_BYTE=92    # 0x5C - frame terminator byte
+
+if [ -z "$1" ]; then
+	echo "Usage: $0 [start], [stop], [wide], [tele], [far], [near], [up], [down], [left], [right]"
+	echo "Note: day/night switching has no known send command in main.c (XM protocol only"
+	echo "      parses incoming DAY/NIGHT reports) and is therefore not implemented here."
+	exit 0
+fi
+
+# One invocation on the wire at a time — see btzoom for the full rationale
+# (interleaved frames corrupt each other, a dead holder must not wedge the
+# camera, a caller that cannot have the port within ~2s reports that).
+i=0
+until mkdir "$LOCK" 2>/dev/null; do
+	if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+		rmdir "$LOCK" 2>/dev/null
+		continue
+	fi
+	i=$((i + 1))
+	if [ "$i" -ge 40 ]; then
+		echo "PTZ port is busy."
+		exit 1
+	fi
+	sleep .05
+done
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+
+# The port must be raw at the right rate before any frame goes out, and a
+# freshly booted camera has had nobody set it. Cheap and idempotent, so it
+# runs for every command. The init frame is different: main.c sends it once
+# at startup, so it stays in `start` rather than preceding every pulse.
+stty -F "$PORT" "$SPEED" raw -echo -onlcr 2>/dev/null
+
+# byte_esc <decimal value 0-255> -> literal text "\NNN" (octal, for later
+# expansion by "printf %b"). Octal \NNN is POSIX-guaranteed for %b, unlike
+# \xHH which some /bin/sh printf builtins (e.g. dash) don't support at all.
+byte_esc() {
+	printf '\\%03o' "$1"
+}
+
+# xm_send <panSpeed> <tiltSpeed> <zoomSpeed>
+#   panSpeed/tiltSpeed: -100..100, zoomSpeed: -1, 0, 1
+# Mirrors send_cmd() in main.c exactly, including the direction-bit layout.
+xm_send() {
+	panSpeed=$1
+	tiltSpeed=$2
+	zoomSpeed=$3
+
+	command1=0
+	command2=0
+
+	if [ "$panSpeed" -lt 0 ]; then
+		command2=$((command2 | 0x04))
+		panSpeed=$((0 - panSpeed))
+	elif [ "$panSpeed" -gt 0 ]; then
+		command2=$((command2 | 0x02))
+	fi
+	data1=$((panSpeed * 63 / 100))
+
+	if [ "$tiltSpeed" -lt 0 ]; then
+		command2=$((command2 | 0x10))
+		tiltSpeed=$((0 - tiltSpeed))
+	elif [ "$tiltSpeed" -gt 0 ]; then
+		command2=$((command2 | 0x08))
+	fi
+	data2=$((tiltSpeed * 63 / 100))
+
+	if [ "$zoomSpeed" -lt 0 ]; then
+		command2=$((command2 | 0x40))
+	elif [ "$zoomSpeed" -gt 0 ]; then
+		command2=$((command2 | 0x20))
+	fi
+
+	checksum=$(( (ADDR + command1 + command2 + data1 + data2) % 100 ))
+
+	frame=$(byte_esc "$SYNC")$(byte_esc "$ADDR")$(byte_esc "$command1")$(byte_esc "$command2")$(byte_esc "$data1")$(byte_esc "$data2")$(byte_esc "$checksum")$(byte_esc "$TERM_BYTE")
+	printf '%b' "$frame" > "$PORT"
+}
+
+# xm_focus near|far
+# Mirrors set_focus() in main.c - NOTE: main.c computes the checksum from
+# command1=command2=0 *before* setting the near/far bit, so the checksum
+# byte is always 1 for both directions. Reproduced as-is for wire compatibility.
+xm_focus() {
+	command1=0
+	command2=0
+	data1=0
+	data2=0
+	checksum=$(( (ADDR + command1 + command2 + data1 + data2) % 100 ))
+
+	if [ "$1" = "near" ]; then
+		command1=1
+	else
+		command2=$((0x80))
+	fi
+
+	frame=$(byte_esc "$SYNC")$(byte_esc "$ADDR")$(byte_esc "$command1")$(byte_esc "$command2")$(byte_esc "$data1")$(byte_esc "$data2")$(byte_esc "$checksum")$(byte_esc "$TERM_BYTE")
+	printf '%b' "$frame" > "$PORT"
+}
+
+# init[] array from main.c, sent once by init_ptz()
+xm_init() {
+	printf '%b' '\245\173\236\360\357\356\340\364' > "$PORT"
+}
+
+xm_stop() {
+	xm_send 0 0 0
+}
+
+xm_start() {
+	stty -F "$PORT" "$SPEED" raw -echo -onlcr
+	$DELAY
+	xm_init
+}
+
+xm_left() {
+	xm_send 100 0 0
+	$DELAY
+	xm_stop
+}
+
+xm_right() {
+	xm_send -100 0 0
+	$DELAY
+	xm_stop
+}
+
+xm_up() {
+	xm_send 0 100 0
+	$DELAY
+	xm_stop
+}
+
+xm_down() {
+	xm_send 0 -100 0
+	$DELAY
+	xm_stop
+}
+
+xm_tele() {
+	xm_send 0 0 1
+	$DELAY
+	xm_stop
+}
+
+xm_wide() {
+	xm_send 0 0 -1
+	$DELAY
+	xm_stop
+}
+
+xm_near() {
+	xm_focus near
+	$DELAY
+	xm_stop
+}
+
+xm_far() {
+	xm_focus far
+	$DELAY
+	xm_stop
+}
+
+xm_day() {
+	echo "day: not supported - main.c has no XM send-command for this" >&2
+	exit 1
+}
+
+xm_night() {
+	echo "night: not supported - main.c has no XM send-command for this" >&2
+	exit 1
+}
+
+# Closed dispatch, same stance as btzoom: the verb arrives from j/ptz.cgi's
+# whitelist, but this script must not be the layer that trusts that. The
+# origin execed "xm_$1" raw.
+case "$1" in
+	start|stop|day|night|wide|tele|far|near|up|down|left|right)
+		"xm_$1"
+		;;
+	*)
+		echo "Unknown command: $1"
+		exit 1
+		;;
+esac

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -1,10 +1,12 @@
 #!/bin/sh
-# PTZ handler for all three backends. Two request shapes:
+# PTZ handler for every backend U-Boot ptz_control can name. Two request
+# shapes:
 #
 #   ?h=<±N>&v=<±N>   step move — GPIO stepper (gpio-motors) or profile motor
-#                    (/usr/bin/motor + U-Boot ptz=)
-#   ?act=<verb>      timed pulse — Pelco-D over serial (/usr/bin/btzoom +
-#                    U-Boot ptz=): up down left right stop wide tele near far
+#                    (/usr/bin/motor)
+#   ?act=<verb>      timed pulse — Pelco-D (/usr/bin/btzoom) or the XiongMai
+#                    variant (/usr/bin/btzoom-xm) over serial:
+#                    up down left right stop wide tele near far
 #
 # Both shapes answer 200 first, like the rest of j/; the pad never reads the
 # body. act= wins when both are present — a caller that sends both knows the
@@ -36,20 +38,24 @@ echo "$HORIZONTAL" | grep -qE '^-?[0-9]{1,2}$' || HORIZONTAL=0
 echo "$VERTICAL" | grep -qE '^-?[0-9]{1,2}$' || VERTICAL=0
 
 # The same switch update_caminfo honours (#227): ptz_control names the
-# method outright; unset falls back to the pre-#227 detection so nothing in
-# the field breaks; "none" (or an unknown method) serves nobody.
+# method outright. Unset means no PTZ, same as "none" or an unknown method —
+# the reporter ruled that a camera without ptz_control serves nobody, so the
+# old auto-detection from gpio_motors/ptz alone is gone.
 ptz_control=$(fw_printenv -n ptz_control 2>/dev/null)
-ptz=$(fw_printenv -n ptz 2>/dev/null)
 
 pelco_ok=0
+pelco_bin=""
 gpio_ok=0
 motor_ok=0
 profile=""
 case "$ptz_control" in
-	pelco-d) [ -x /usr/bin/btzoom ] && pelco_ok=1 ;;
+	# Two Pelco-shaped serial protocols, one verb set: btzoom is classic
+	# Pelco-D, btzoom-xm the XiongMai near-Pelco wire (sandbox#31).
+	pelco-d) pelco_bin=/usr/bin/btzoom; [ -x "$pelco_bin" ] && pelco_ok=1 ;;
+	pelco-xm) pelco_bin=/usr/bin/btzoom-xm; [ -x "$pelco_bin" ] && pelco_ok=1 ;;
 	gpio)
-		# Binary AND a pin list (either name — the binary itself still reads
-		# the legacy one), mirroring update_caminfo.
+		# Binary AND a pin list (either name — the binary reads ptz_gpio
+		# first, legacy gpio_motors second), mirroring update_caminfo.
 		if command -v gpio-motors >/dev/null 2>&1 &&
 			{ [ -n "$(fw_printenv -n ptz_gpio 2>/dev/null)" ] || [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; }; then
 			gpio_ok=1
@@ -57,34 +63,28 @@ case "$ptz_control" in
 		;;
 	motor)
 		profile=$(fw_printenv -n ptz_profile 2>/dev/null)
-		[ -n "$profile" ] || profile="$ptz"
-		[ -x /usr/bin/motor ] && [ -n "$profile" ] && motor_ok=1
-		;;
-	none) ;;
-	"")
-		[ -x /usr/bin/btzoom ] && [ -n "$ptz" ] && pelco_ok=1
-		command -v gpio-motors >/dev/null 2>&1 && [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && gpio_ok=1
-		profile="$ptz"
+		[ -n "$profile" ] || profile=$(fw_printenv -n ptz 2>/dev/null)
 		[ -x /usr/bin/motor ] && [ -n "$profile" ] && motor_ok=1
 		;;
 esac
 
-# The verb is matched against the closed list, never passed through: btzoom
-# execs "pelcoD_$1", so an unlisted word would call whatever function the
-# query string names. (start/day/night exist in btzoom but are lens
-# maintenance, not viewing controls — not reachable from here.)
+# The verb is matched against the closed list, never passed through: the
+# scripts dispatch on the verb ("pelcoD_$1"), so an unlisted word must never
+# reach them raw. (start/day/night exist in btzoom but are lens maintenance,
+# not viewing controls — not reachable from here.) Both Pelco variants take
+# the same nine verbs, which is why one pad serves them both.
 if [ -n "$ACTION" ]; then
 	if [ "$pelco_ok" = 1 ]; then
 		case "$ACTION" in
 			up|down|left|right|stop|wide|tele|near|far)
-				/usr/bin/btzoom "$ACTION"
+				"$pelco_bin" "$ACTION"
 				exit $?
 				;;
 		esac
 		echo "Unknown PTZ action."
 		exit 1
 	fi
-	echo "Pelco-D PTZ not available on this device."
+	echo "Pelco PTZ not available on this device."
 	exit 1
 fi
 

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -784,25 +784,28 @@ update_caminfo() {
 	# WebUI
 	ui_password=$(grep root /etc/shadow | cut -d: -f2)
 	# PTZ preview controls. The switch is the U-Boot ptz_control variable
-	# (#227): it names the method — "gpio" (gpio-motors, pins in ptz_gpio or
-	# the legacy gpio_motors, which the gpio-motors binary itself still
-	# reads), "pelco-d" (btzoom over serial, port/rate in ptz_port and
-	# ptz_speed), "motor" (a motor profile in ptz_profile or the legacy ptz
-	# value), or "none". An explicit method is trusted but still needs its
-	# binary — a pad whose every press fails is worse than no pad. With
-	# ptz_control unset, the pre-#227 detection stands so no camera in the
-	# field loses its pad: gpio wins over a profile wins over Pelco, because
-	# the stepped protocols carry magnitudes the Pelco pulses cannot.
+	# (#227): it names the method — "gpio" (gpio-motors, pins in ptz_gpio,
+	# with the legacy gpio_motors as an alias on both sides), "pelco-d"
+	# (btzoom over serial, port/rate in ptz_port and ptz_speed), "pelco-xm"
+	# (btzoom-xm, the XiongMai UART protocol — same verbs, same pad,
+	# different wire), or "motor" (a motor profile in ptz_profile or the
+	# legacy ptz value). An explicit method is trusted but still needs its
+	# binary — a pad whose every press fails is worse than no pad. Unset
+	# means no PTZ, exactly like "none": the reporter of #227 ruled that a
+	# camera without ptz_control shows no pad, so the old auto-detection
+	# from gpio_motors/ptz alone is gone and a field camera configured that
+	# way must set ptz_control once.
 	# The backend decides which pad p/motor.cgi draws — gpio and motor are
-	# stepped eight-way pan/tilt, Pelco-D is four directions in timed pulses
-	# plus zoom and focus.
+	# stepped eight-way pan/tilt, the Pelco variants are four directions in
+	# timed pulses plus zoom and focus.
 	ptz_support=""; ptz_backend=""
 	ptz_control=$(fw_printenv -n ptz_control 2>/dev/null)
 	case "$ptz_control" in
 		gpio)
 			# The binary AND a pin list: gpio-motors without pins errors on
 			# every press, and the pad must not render what cannot work. The
-			# binary itself still reads the legacy name, so either satisfies.
+			# binary reads ptz_gpio first and falls back to the legacy name,
+			# so either satisfies.
 			if command -v gpio-motors >/dev/null 2>&1 &&
 				{ [ -n "$(fw_printenv -n ptz_gpio 2>/dev/null)" ] || [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ]; }; then
 				ptz_support="1"; ptz_backend="gpio"
@@ -810,6 +813,11 @@ update_caminfo() {
 			;;
 		pelco-d)
 			if [ -x /usr/bin/btzoom ]; then
+				ptz_support="1"; ptz_backend="pelco"
+			fi
+			;;
+		pelco-xm)
+			if [ -x /usr/bin/btzoom-xm ]; then
 				ptz_support="1"; ptz_backend="pelco"
 			fi
 			;;
@@ -821,16 +829,7 @@ update_caminfo() {
 				ptz_support="1"; ptz_backend="motor"
 			fi
 			;;
-		none) ;;
-		"")
-			if [ -n "$(fw_printenv -n gpio_motors 2>/dev/null)" ] && command -v gpio-motors >/dev/null 2>&1; then
-				ptz_support="1"; ptz_backend="gpio"
-			elif [ -x /usr/bin/motor ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
-				ptz_support="1"; ptz_backend="motor"
-			elif [ -x /usr/bin/btzoom ] && [ -n "$(fw_printenv -n ptz 2>/dev/null)" ]; then
-				ptz_support="1"; ptz_backend="pelco"
-			fi
-			;;
+		# "none", unset and anything unrecognised all land here: no pad.
 	esac
 
 	# Network


### PR DESCRIPTION
Two follow-ups from @flyrouter's latest comments on #227.

## Unset `ptz_control` now means no PTZ

flyrouter ruled on the standing migration question: *"`ptz_control none` is equivalent to having no ptz_control in the ENV at all… if ptz_control is absent, it doesn't need to be used."* So the pre-#227 auto-detection branch (legacy `gpio_motors`/`ptz` vars alone) is removed from both `common.cgi:update_caminfo` and `j/ptz.cgi`: unset, `none`, and anything unrecognised all serve nobody.

**Migration note:** a field camera configured only with the legacy variables must now `fw_setenv ptz_control <method>` once. The legacy *value* names keep working inside the explicit methods (`ptz_gpio` falls back to `gpio_motors`, `ptz_profile` to `ptz`) — those match what the binaries read.

## `ptz_control pelco-xm` → `bin/btzoom-xm`

The XiongMai UART protocol flyrouter merged as OpenIPC/sandbox#31 — Pelco-D-shaped but with its own sync byte, direction-bit layout and mod-100 checksum. Kept as a **separate script** rather than merged into btzoom: the two share zero wire format, and what they do share (lock, port/speed resolution, dispatch) is the scaffolding this adoption ports over:

- `ptz_port` from U-Boot env, default `/dev/ttyAMA1` (the UART the origin hardcoded); `ptz_speed` against the same whitelist as btzoom, default 115200.
- The same `/tmp/btzoom.lock` one-invocation-on-the-wire guard — it protects the UART, and only one Pelco variant is ever the configured backend.
- Idempotent `stty` before every command (a freshly booted camera has had nobody run `start`); the XM init frame stays in `start` only, faithful to the vendor `main.c` which sends it once.
- Closed `case` dispatch instead of the origin's raw `xm_$1` exec.

The frame logic itself is untouched: **every verb's output byte-compared identical** to the sandbox script (harness redirected `PORT` to files, append mode so both frames of a pulse are captured).

Both variants answer the same nine verbs, so the pelco pad, `preview-ptz.js` and `j/ptz.cgi`'s whitelist serve them unchanged — the endpoint only picks the binary (`pelco_bin`). No frontend, test, or packaging changes.

## Verified on the lab hi3516ev300 (deployed via `updatewebui`, fake stepped binaries + real pelco scripts with `ptz_port` pointed at a file)

| state | `ptz_support`/`ptz_backend` | endpoint |
|---|---|---|
| legacy `gpio_motors`+`ptz` set, `ptz_control` unset | none — the cutover | `h/v` and `act` both refused |
| `gpio` + pins | `1`/`gpio` | fake ran: `gpio-motors 5 -5 10` |
| `motor` + `ptz_profile` | `1`/`motor` | fake ran: `motor myprof -2 3` |
| `pelco-d` | `1`/`pelco` | btzoom wrote Pelco-D frames to `ptz_port` |
| `pelco-xm` | `1`/`pelco` | btzoom-xm wrote XM frames (`C5…5C`); `act=day`/`act=init` refused |
| `none` | none | — |
| `pelco-xm` without the binary | none — explicit method still needs its binary | — |

Live page renders the pelco pad (6 pad elements) under `pelco-xm` and none with `ptz_control` unset. `npm test` green. CLAUDE.md updated (unset semantics, `pelco-xm`, and the now-stale "gpio-motors still reads the legacy name" caveat dropped — firmware#2341 merged).

A companion PR to OpenIPC/builder moves the three `customizer.sh` files from `gpio_motors` to `ptz_gpio` + `ptz_control gpio`, so those devices keep their pads across this cutover.

Refs #227.