### PR TITLE
Live View: the delay headline gets an independent second witness

### DIFF
--- a/tests/preview-stats.test.js
+++ b/tests/preview-stats.test.js
@@ -262,6 +262,17 @@ g('the sender-report cross-check: one clock, both ends', () => {
 		remoteTs: 5002000, remoteAt: 100000 });
 	check('no anchor key, no SR figure',
 		env3.el('mj-ns-fp').textContent.indexOf('sender report') < 0);
+
+	// Staleness: six seconds without a new sample forgets the figure — a
+	// frozen stream must not wear a current measurement's label. (The
+	// screen-wait sample ages out on its own 3 s window too, so the sum
+	// left standing is camera 58 + network 30.)
+	env.tickClock(6000);
+	env.stats.tick({ cam: { c2s: '58ms', sr: '900000:5000000' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	check('a stale cross-check is forgotten, headline falls back to the sum',
+		env.el('mj-ns-fp').textContent.indexOf('sender report') < 0 &&
+		env.el('mj-ns-lat').textContent === '≈88');
 });
 
 g('the screen leg: measured vsync wait joins decode', () => {

--- a/tests/preview-stats.test.js
+++ b/tests/preview-stats.test.js
@@ -42,7 +42,7 @@ function boot() {
 	let metricsFn = null;
 	const sandbox = {
 		window: {},
-		performance: { now: () => nowMs },
+		performance: { now: () => nowMs, timeOrigin: 0 },
 		requestAnimationFrame: (f) => f(),
 		document: {
 			getElementById(id) { return els[id] || (els[id] = makeEl(id)); },
@@ -198,6 +198,70 @@ g('the camera leg carries sampling and readout once fps is known', () => {
 	env3.stats.tick({ cam: { c2s: '~2ms' }, rttMs: 60 });
 	check('no fps, no model — the bare pipeline stands',
 		env3.el('mj-ns-lat').textContent === '≈' + Math.round(2 + 30));
+});
+
+g('the sender-report cross-check: one clock, both ends', () => {
+	// The camera's sr= anchor says RTP 900000 was captured at camera-clock
+	// 5,000,000 ms. The frame on the glass is RTP 1,080,000 — 2000 ms of
+	// 90 kHz later — so it was captured at 5,002,000. The camera's clock
+	// read 5,002,000 at its last SR (browser epoch 100,000), and the frame
+	// appeared at browser epoch 100,160 → camera-now 5,002,160. The frame
+	// on the glass is 160 ms old; the leg sum (58+30) agrees within
+	// tolerance, so the whole-path figure takes the headline.
+	const env = boot();
+	const v = env.mkEl('live-video');
+	v.hidden = false;
+	let vfc = null;
+	v.requestVideoFrameCallback = (fn) => { vfc = fn; };
+	env.stats.tick({ cam: { c2s: '58ms', sr: '900000:5000000' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	vfc(0, { expectedDisplayTime: 100160, presentationTime: 100150,
+		rtpTimestamp: 1080000 });
+	env.tickClock(500);
+	env.stats.tick({ cam: { c2s: '58ms', sr: '900000:5000000' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	check('the SR figure takes the headline when the two agree',
+		env.el('mj-ns-lat').textContent === '≈160');
+	check('and the fine print names it as the headline source',
+		env.el('mj-ns-fp').textContent.indexOf(
+			'end-to-end via sender report 160 ms — headline') >= 0);
+
+	// Divergent: a frame a full second old against a ~100 ms leg sum (58
+	// camera + 30 network + the probe's own 10 ms screen wait) stays a
+	// diagnostic and leaves the sum on the headline.
+	const env2 = boot();
+	const v2 = env2.mkEl('live-video');
+	v2.hidden = false;
+	let vfc2 = null;
+	v2.requestVideoFrameCallback = (fn) => { vfc2 = fn; };
+	env2.stats.tick({ cam: { c2s: '58ms', sr: '900000:5000000' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	vfc2(0, { expectedDisplayTime: 101000, presentationTime: 100990,
+		rtpTimestamp: 1080000 });
+	env2.tickClock(500);
+	env2.stats.tick({ cam: { c2s: '58ms', sr: '900000:5000000' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	check('a divergent SR figure leaves the sum on the headline',
+		env2.el('mj-ns-lat').textContent === '≈98');
+	check('and is disclosed as diverging',
+		env2.el('mj-ns-fp').textContent.indexOf('diverges from leg sum 98 ms') >= 0);
+
+	// No sr= key — an estimated camera never emits one — no figure at all,
+	// however many browser-side pieces exist.
+	const env3 = boot();
+	const v3 = env3.mkEl('live-video');
+	v3.hidden = false;
+	let vfc3 = null;
+	v3.requestVideoFrameCallback = (fn) => { vfc3 = fn; };
+	env3.stats.tick({ cam: { c2s: '~58ms' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	vfc3(0, { expectedDisplayTime: 100160, presentationTime: 100150,
+		rtpTimestamp: 1080000 });
+	env3.tickClock(500);
+	env3.stats.tick({ cam: { c2s: '~58ms' }, rttMs: 60,
+		remoteTs: 5002000, remoteAt: 100000 });
+	check('no anchor key, no SR figure',
+		env3.el('mj-ns-fp').textContent.indexOf('sender report') < 0);
 });
 
 g('the screen leg: measured vsync wait joins decode', () => {

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -42,9 +42,13 @@ window.MajesticStats = (function () {
 	// the headline keeps saying "at least".
 	let dispEmaMs = null;
 	let dispSeenAt = 0;
+	// The frame on the glass, named the way the camera can name it too: its
+	// RTP timestamp, plus the browser-epoch instant it became visible.
+	let shownFrame = null;
 	let refreshMs = null;
 	const armed = [];
 	let lossEma = null;
+	let srG2gEma = null;
 	let wired = false;
 	// Measured encoder output per channel, bytes/s, from the 2 s heartbeat —
 	// what the "camera sending" row shows. The configured bitrate is a
@@ -137,6 +141,13 @@ window.MajesticStats = (function () {
 				if (d >= 0 && d < 1000) {
 					dispEmaMs = dispEmaMs == null ? d : dispEmaMs + (d - dispEmaMs) / 8;
 					dispSeenAt = performance.now();
+				}
+				if (typeof md.rtpTimestamp === 'number') {
+					shownFrame = {
+						rtp: md.rtpTimestamp,
+						atEpoch: performance.timeOrigin + md.expectedDisplayTime,
+						seenAt: performance.now(),
+					};
 				}
 			}
 			v.requestVideoFrameCallback(loop);
@@ -271,6 +282,7 @@ window.MajesticStats = (function () {
 			p = null;
 			hold = { buf: null, dec: null };
 			lossEma = null;
+			srG2gEma = null;
 		}
 		const good = p && dt > 0.25 && dt < 5;
 
@@ -326,12 +338,51 @@ window.MajesticStats = (function () {
 		const parts = [camMs, net, hold.buf, screen];
 		let total = null;
 		parts.forEach((v) => { if (v != null) total = (total || 0) + v; });
+
+		// The sender-report cross-check, all in the CAMERA's clock so browser
+		// skew cancels. Three facts meet: the camera's sr= anchor pairs an
+		// RTP timestamp with its capture wall time (kernel-measured, so the
+		// key only exists on anchored cameras — self-gating); the display
+		// probe names the frame on the glass by RTP timestamp and the
+		// browser-epoch instant it appeared; and remote-outbound-rtp says
+		// what time the camera's clock read at its last sender report,
+		// against the browser-epoch arrival of that report. Then
+		// capture(frame) = anchor_wall + (rtp delta)/90 and camera-now at
+		// the display instant = remoteTs + elapsed — their difference is
+		// capture→display of the exact frame shown, biased low by one-way
+		// network delay (~rtt/2), which the ≈ owns. (The obvious spec route,
+		// inbound-rtp.estimatedPlayoutTimestamp, is obsolete and absent from
+		// current Chrome — measured, not assumed.)
+		if (cam.sr && s.remoteTs != null && s.remoteAt != null &&
+			shownFrame && performance.now() - shownFrame.seenAt < 2000) {
+			const a = /^(\d+):(\d+)$/.exec(cam.sr);
+			if (a) {
+				// 32-bit wrap-safe RTP delta, then ticks → ms at 90 kHz.
+				const dRtp = (shownFrame.rtp - (+a[1])) | 0;
+				const captureCam = (+a[2]) + dRtp / 90;
+				const camAtDisplay =
+					s.remoteTs + (shownFrame.atEpoch - s.remoteAt);
+				const g = camAtDisplay - captureCam;
+				if (isFinite(g) && g > 0 && g < 10000) {
+					srG2gEma = srG2gEma == null ? g
+						: srG2gEma + (g - srG2gEma) / 4;
+				}
+			}
+		}
+
+		// Prefer the cross-check for the headline only while the two ways of
+		// measuring agree — a sum that drifts from an independent whole-path
+		// measurement is a diagnostic, not a reason to print the larger lie.
+		// The legs keep their own numbers either way; they explain the
+		// composition, the headline states the total.
+		const srOk = srG2gEma != null && total != null &&
+			Math.abs(srG2gEma - total) <= Math.max(150, total * 0.5);
 		if (total != null && (net != null || c2s)) {
-			els.lat.textContent = '≈' + Math.round(total);
+			els.lat.textContent = '≈' + Math.round(srOk ? srG2gEma : total);
 			els.latSub.textContent = c2s
 				? (c2s.approx ? 'glass to glass, at least' : 'glass to glass')
 				: 'network + player; the camera’s share is not included';
-			window.MjCharts.pushSpark(latSpark, total);
+			window.MjCharts.pushSpark(latSpark, srOk ? srG2gEma : total);
 			// The breakdown renders only with all four legs: three segments
 			// that sum to less than the number above them would read as a
 			// mistake, not a measurement.
@@ -421,6 +472,11 @@ window.MajesticStats = (function () {
 		fp.push('jitter ' + (s.jitterMs || 0) + ' ms · round trip ' +
 			(s.rttMs != null ? s.rttMs + ' ms' : '-') +
 			' · audio in ' + (cam['audio-in'] || '-'));
+		if (srG2gEma != null) {
+			fp.push('end-to-end via sender report ' + Math.round(srG2gEma) +
+				' ms' + (srOk ? ' — headline' : ' — diverges from leg sum ' +
+				(total != null ? Math.round(total) : '-') + ' ms'));
+		}
 		if (camModel) {
 			fp.push('camera @' + Math.round(camModel.fps) + ' fps: sampling ~' +
 				Math.round(camModel.sampling) + ' ms (\u00bd frame)' +
@@ -537,6 +593,7 @@ window.MajesticStats = (function () {
 		lastTickAt = 0;
 		hold = { buf: null, dec: null };
 		lossEma = null;
+		srG2gEma = null;
 	}
 
 	function setOpen(o) {

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -49,6 +49,7 @@ window.MajesticStats = (function () {
 	const armed = [];
 	let lossEma = null;
 	let srG2gEma = null;
+	let srSeenAt = 0;
 	let wired = false;
 	// Measured encoder output per channel, bytes/s, from the 2 s heartbeat —
 	// what the "camera sending" row shows. The configured bitrate is a
@@ -366,8 +367,16 @@ window.MajesticStats = (function () {
 				if (isFinite(g) && g > 0 && g < 10000) {
 					srG2gEma = srG2gEma == null ? g
 						: srG2gEma + (g - srG2gEma) / 4;
+					srSeenAt = nowMs;
 				}
 			}
+		}
+		// A cross-check that stopped updating — the video froze, the anchor
+		// or the SR went away — is not a current measurement and must not
+		// keep wearing one's label. Forgotten, not merely hidden: an old
+		// average blended into a resumed stream would describe neither.
+		if (srG2gEma != null && nowMs - srSeenAt > 5000) {
+			srG2gEma = null;
 		}
 
 		// Prefer the cross-check for the headline only while the two ways of

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -201,6 +201,17 @@ window.MajesticWebRTC = (function () {
 						// says we sent, the other says it arrived.
 						s.micPackets = r.packetsSent || 0;
 					} else if (
+						r.type === 'remote-outbound-rtp' && r.kind === 'video') {
+						// The camera's clock as of its last sender report,
+						// and when that report landed here — the pair that
+						// lets the panel say what time it is on the camera
+						// without trusting the browser's own wall clock.
+						if (typeof r.remoteTimestamp === 'number' &&
+							typeof r.timestamp === 'number') {
+							s.remoteTs = r.remoteTimestamp;
+							s.remoteAt = r.timestamp;
+						}
+					} else if (
 						r.type === 'candidate-pair' && r.nominated &&
 						r.state === 'succeeded') {
 						s.rttMs = Math.round((r.currentRoundTripTime || 0) * 1000);


### PR DESCRIPTION
The follow-up the panel plan deferred: an independent whole-path check on the summed delay legs, now live on kernel-anchored cameras.

The originally planned construction (inbound-rtp's `estimatedPlayoutTimestamp`) turned out to be obsolete spec — current Chrome does not report the key at all. What browsers do give is better: `requestVideoFrameCallback` names the exact frame on the glass by RTP timestamp. Combined with a capture anchor the camera publishes on its stats line (only where its kernel measured one — the figure can never silently change meaning on estimated-grade cameras) and the camera-clock-now that `remote-outbound-rtp` supplies, the panel computes capture→display of the frame actually being shown, every term in the camera's clock so browser skew cancels, biased low only by one-way network delay.

While this figure and the leg sum agree it takes the headline and the sparkline and the fine print says so (`end-to-end via sender report 123 ms — headline`); when they diverge, the sum stays and the divergence is disclosed — a sum drifting from an independent measurement is a diagnostic, not a reason to print the larger number as truth. Verified live: the two methods bracket each other ~20 ms apart on a wired camera, matching the stated error bound. Three new vm test cases (agree/diverge/no-anchor); suite at 383 checks green.

Needs a majestic build that emits the `sr=` key; older builds simply never produce the figure and the panel behaves exactly as before.