### PR TITLE
btzoom-xm: compute the focus checksum over the bytes actually sent

### DIFF
--- a/bin/btzoom-xm
+++ b/bin/btzoom-xm
@@ -110,21 +110,27 @@ xm_send() {
 }
 
 # xm_focus near|far
-# Mirrors set_focus() in main.c - NOTE: main.c computes the checksum from
-# command1=command2=0 *before* setting the near/far bit, so the checksum
-# byte is always 1 for both directions. Reproduced as-is for wire compatibility.
+# Deliberately NOT a 1:1 mirror of set_focus() in main.c: that code computes
+# the checksum from command1=command2=0 *before* setting the near/far bit, so
+# every focus frame carries checksum 1 — and an MCU that validates the sum
+# discards them. On a real 85H50AI zoom block (lab, 2026-08) zoom and stop
+# moved while main.c's focus frames did nothing; the same frames with the
+# checksum computed over the actual bytes (near=2, far=29) drove the focus
+# motor both ways. A non-validating MCU accepts either, so correct is
+# strictly better.
 xm_focus() {
-	command1=0
-	command2=0
 	data1=0
 	data2=0
-	checksum=$(( (ADDR + command1 + command2 + data1 + data2) % 100 ))
 
 	if [ "$1" = "near" ]; then
 		command1=1
+		command2=0
 	else
+		command1=0
 		command2=$((0x80))
 	fi
+
+	checksum=$(( (ADDR + command1 + command2 + data1 + data2) % 100 ))
 
 	frame=$(byte_esc "$SYNC")$(byte_esc "$ADDR")$(byte_esc "$command1")$(byte_esc "$command2")$(byte_esc "$data1")$(byte_esc "$data2")$(byte_esc "$checksum")$(byte_esc "$TERM_BYTE")
 	printf '%b' "$frame" > "$PORT"


### PR DESCRIPTION
Found by smoke-testing #255 against real XiongMai hardware — an 85H50AI zoom block freshly converted to OpenIPC in the lab.

The origin `main.c` in OpenIPC/motors (and flyrouter's sandbox script ported 1:1 from it, which `bin/btzoom-xm` adopted faithfully) computes `set_focus`'s checksum from `command1=command2=0` **before** setting the near/far bit — every focus frame goes out with checksum 1. This MCU validates checksums: zoom/stop frames (whose sums are correct) moved the lens, while focus frames in the original encoding did nothing, in either direction. Recomputing the sum over the bytes actually sent (`near` → 2, `far` → 29) made the focus motor drive both ways.

Verified end to end through the shipped path on that camera: `fw_setenv ptz_control pelco-xm; fw_setenv ptz_port /dev/ttyAMA0`, then `j/ptz.cgi?act=tele` ×4 (261 KB frame → 78 KB: heavy zoom-in, focus left behind), `act=wide` back, and `act=near`/`act=far` pulses walking the JPEG size back up to a tack-sharp 212–228 KB. An MCU that skips validation accepts either form, so the corrected frame is strictly better than the wire-faithful one.

Board notes from the same session (not part of this diff): on the 85H50AI the MCU lives on **`/dev/ttyAMA0`** — the console UART — so `ptz_port` must be set to it and getty must be off that port; and the module is zoom+focus only (pan/tilt frames are accepted and ignored). The same checksum bug is worth fixing at the source in OpenIPC/motors `xm-uart/main.c` and in the sandbox script.

Refs #227.