### PR TITLE
Live View: MSE joins the stats panel, and the two transports compare notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,15 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   served). Series
   ink is hardcoded to the dark dashboard's `--st-c*` values (the glass is
   theme-invariant; validated against it), drawn with `www/a/charts.js` — the
+  panel works on BOTH transports and is deliberately comparative: the MSE
+  player (`preview.js`) has its own `onStats` (socket bytes, buffer depth,
+  `getVideoPlaybackQuality`, a `waiting`-event stall counter), the panel's
+  MSE mode leads with `≥ buffer + screen` ("player alone; camera and network
+  are invisible over MSE"), grades from stalls and drops instead of
+  loss/rtt, drops the capacity row and estimate series (no feedback channel
+  IS the finding), and the `#mj-ns-vs` line remembers each transport's last
+  headline across switches so either view can quote the other — the A/B a
+  screenshot carries. `lastSeen` survives `reset()` on purpose —
   sparkline/axis-chart primitives extracted from `status.js`, now shared:
   colors are per-instance arguments and the debounced resize redraw lives in
   charts.js, so load `/a/charts.js` before any consumer —

--- a/tests/preview-stats.test.js
+++ b/tests/preview-stats.test.js
@@ -35,9 +35,9 @@ function makeEl(id) {
 	};
 }
 
-function boot() {
+function boot(nowStart) {
 	const els = Object.create(null);
-	let nowMs = 100000;
+	let nowMs = nowStart != null ? nowStart : 100000;
 	const pushedSparks = [], pushedCharts = [];
 	let metricsFn = null;
 	const sandbox = {
@@ -410,9 +410,9 @@ g('MSE tells its own story and remembers the other transport', () => {
 		configuredKbps: 1024, channel: 1 });
 	check('MSE headline is a floor, buffer-led',
 		env.el('mj-ns-lat').textContent === '≥800');
-	check('and says what it cannot see',
+	check('and says what the floor means in plain speech',
 		env.el('mj-ns-lat-sub').textContent ===
-			'player alone; camera and network are invisible over MSE');
+			'at least — includes the player buffer WebRTC skips');
 	check('the comparison line carries the WebRTC figure',
 		env.el('mj-ns-vs').hidden === false &&
 		env.el('mj-ns-vs').textContent.indexOf('WebRTC measured ≈88 ms') >= 0);
@@ -438,6 +438,14 @@ g('MSE tells its own story and remembers the other transport', () => {
 	check('repairs count the re-buffering',
 		env.el('mj-ns-repair').textContent.indexOf('re-buffered 1×') >= 0);
 
+	// Heavy dropping is visible failure, not "good".
+	env.tickClock(1000);
+	env.stats.tick({ transport: 'mse', bufferedMs: 900, rxBytes: 300000,
+		totalFrames: 160, droppedFrames: 20, stalls: 1,
+		configuredKbps: 1024, channel: 1 });
+	check('a heavy drop rate grades struggling',
+		env.el('mj-ns-grade').textContent === 'struggling');
+
 	// Back on WebRTC, the MSE figure becomes the comparison.
 	env.stats.reset();
 	env.tickClock(2000);
@@ -445,6 +453,61 @@ g('MSE tells its own story and remembers the other transport', () => {
 	check('the WebRTC view remembers what MSE held',
 		env.el('mj-ns-vs').hidden === false &&
 		env.el('mj-ns-vs').textContent.indexOf('MSE held ≥900 ms') >= 0);
+
+	// The stall stays with the session that stalled: after the round trip a
+	// fresh MSE session is judged on its own record.
+	env.stats.reset();
+	env.tickClock(2000);
+	env.stats.tick({ transport: 'mse', bufferedMs: 300, rxBytes: 400000,
+		totalFrames: 200, droppedFrames: 20, stalls: 1,
+		configuredKbps: 1024, channel: 1 });
+	env.tickClock(1000);
+	env.stats.tick({ transport: 'mse', bufferedMs: 300, rxBytes: 500000,
+		totalFrames: 230, droppedFrames: 20, stalls: 1,
+		configuredKbps: 1024, channel: 1 });
+	check('a prior session\'s stall does not brand the new one',
+		env.el('mj-ns-grade').textContent === 'excellent');
+});
+
+g('MSE counts the sensor legs once fps is known', () => {
+	// 20 fps → sampling 25 + readout 50 join the 800 ms buffer: the floor
+	// measures a journey comparable to WebRTC's, and reads honestly worse.
+	const env = boot();
+	env.stats.tick({ transport: 'mse', bufferedMs: 800, rxBytes: 100000,
+		totalFrames: 100, droppedFrames: 0, stalls: 0,
+		configuredKbps: 1024, configuredFps: 20, channel: 1 });
+	check('the floor carries sampling + readout + buffer',
+		env.el('mj-ns-lat').textContent === '≥875');
+	check('fine print admits what stays unmeasured',
+		env.el('mj-ns-fp').textContent.indexOf('encode/send unmeasured over MSE') >= 0);
+});
+
+g('the comparison line states the delta outright', () => {
+	const env = boot();
+	env.stats.tick({ cam: { c2s: '58ms' }, rttMs: 60, transport: 'webrtc' });
+	env.stats.reset();
+	env.tickClock(2000);
+	env.stats.tick({ transport: 'mse', bufferedMs: 800, rxBytes: 100000,
+		totalFrames: 100, droppedFrames: 0, stalls: 0,
+		configuredKbps: 1024, configuredFps: 20, channel: 1 });
+	check('MSE quotes WebRTC with the difference in its favor',
+		env.el('mj-ns-vs').textContent ===
+			'WebRTC measured ≈88 ms on this connection — 787 ms lower');
+});
+
+g('a fresh page never invents a stall', () => {
+	// performance.now() is under ten seconds for the page's first ten
+	// seconds; a zero lastStallAt must not read as a recent stall.
+	const env = boot(500);
+	env.stats.tick({ transport: 'mse', bufferedMs: 300, rxBytes: 100000,
+		totalFrames: 100, droppedFrames: 0, stalls: 0,
+		configuredKbps: 1024, channel: 1 });
+	env.tickClock(1000);
+	env.stats.tick({ transport: 'mse', bufferedMs: 300, rxBytes: 200000,
+		totalFrames: 130, droppedFrames: 0, stalls: 0,
+		configuredKbps: 1024, channel: 1 });
+	check('zero stalls near page start grade excellent',
+		env.el('mj-ns-grade').textContent === 'excellent');
 });
 
 done('preview-stats');

--- a/tests/preview-stats.test.js
+++ b/tests/preview-stats.test.js
@@ -394,4 +394,57 @@ g('the 2 s heartbeat: radio and egress rows', () => {
 		rowsAll.some((t) => t === 'WebRTC × 1') && rowsAll.some((t) => t === 'RTSP × 2'));
 });
 
+g('MSE tells its own story and remembers the other transport', () => {
+	const env = boot();
+	// A WebRTC session settles at ≈88 (58 camera + 30 network)…
+	env.stats.tick({ cam: { c2s: '58ms' }, rttMs: 60, transport: 'webrtc' });
+	check('webrtc headline first', env.el('mj-ns-lat').textContent === '≈88');
+	check('no comparison line before the other transport ran',
+		env.el('mj-ns-vs').hidden === true);
+	// …the person switches transports (the page resets the module)…
+	env.stats.reset();
+	env.tickClock(2000);
+	// …and MSE reports an 800 ms buffer.
+	env.stats.tick({ transport: 'mse', bufferedMs: 800, rxBytes: 100000,
+		totalFrames: 100, droppedFrames: 0, stalls: 0,
+		configuredKbps: 1024, channel: 1 });
+	check('MSE headline is a floor, buffer-led',
+		env.el('mj-ns-lat').textContent === '≥800');
+	check('and says what it cannot see',
+		env.el('mj-ns-lat-sub').textContent ===
+			'player alone; camera and network are invisible over MSE');
+	check('the comparison line carries the WebRTC figure',
+		env.el('mj-ns-vs').hidden === false &&
+		env.el('mj-ns-vs').textContent.indexOf('WebRTC measured ≈88 ms') >= 0);
+	check('no capacity row without a feedback channel',
+		env.el('mj-ns-r-cap').hidden === true);
+	check('the estimate legend chip is gone too',
+		env.el('mj-ns-leg-est').hidden === true);
+	check('MSE fine print names the transport and the buffer',
+		env.el('mj-ns-fp').textContent.indexOf('transport MSE') >= 0 &&
+		env.el('mj-ns-fp').textContent.indexOf('buffered 800 ms') >= 0);
+	check('talkback is honestly one-way',
+		env.el('mj-ns-fp').textContent.indexOf('one direction') >= 0);
+
+	// Rates and the stall grade need a second tick.
+	env.tickClock(1000);
+	env.stats.tick({ transport: 'mse', bufferedMs: 900, rxBytes: 228000,
+		totalFrames: 120, droppedFrames: 0, stalls: 1,
+		configuredKbps: 1024, channel: 1 });
+	check('delivered rate is the socket byte delta',
+		env.el('mj-ns-recv').textContent === '1.0 Mbit/s');
+	check('a fresh stall grades struggling',
+		env.el('mj-ns-grade').textContent === 'struggling');
+	check('repairs count the re-buffering',
+		env.el('mj-ns-repair').textContent.indexOf('re-buffered 1×') >= 0);
+
+	// Back on WebRTC, the MSE figure becomes the comparison.
+	env.stats.reset();
+	env.tickClock(2000);
+	env.stats.tick({ cam: { c2s: '58ms' }, rttMs: 60, transport: 'webrtc' });
+	check('the WebRTC view remembers what MSE held',
+		env.el('mj-ns-vs').hidden === false &&
+		env.el('mj-ns-vs').textContent.indexOf('MSE held ≥900 ms') >= 0);
+});
+
 done('preview-stats');

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -395,10 +395,13 @@
 	// none of these numbers, so the button would open an empty box. The
 	// checkbox keeps the person's answer across a transport switch, so the
 	// panel has to come back with it rather than needing a second click.
+	// Both transports have a story to tell now — MSE measures its own shape
+	// (buffer depth, stalls, delivered rate) and the camera-side sections
+	// come off /metrics either way — so the control follows only the person.
 	function syncStatsCtl() {
-		if (statsCtl) statsCtl.hidden = !usingWebRTC;
+		if (statsCtl) statsCtl.hidden = false;
 		if (statsBox) {
-			statsBox.hidden = !(usingWebRTC && statsBtn && statsBtn.checked);
+			statsBox.hidden = !(statsBtn && statsBtn.checked);
 			// The panel module renders its charts only while someone can see
 			// them, so it is told when that changes. Guarded like every
 			// window.Majestic* module: its file is not loaded under the tests.
@@ -668,7 +671,7 @@
 						configuredKbps: cfgKbps[ch],
 						configuredFps: cfgFps[ch],
 						channel: ch,
-						transport: 'webrtc',
+						transport: s.transport || 'webrtc',
 					}));
 				}
 				// The adaptation toast, fed the camera's own view of the

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -50,6 +50,11 @@ window.MajesticStats = (function () {
 	let lossEma = null;
 	let srG2gEma = null;
 	let srSeenAt = 0;
+	// Each transport's last settled headline, kept ACROSS transport switches
+	// and resets: putting the other protocol's number next to this one's is
+	// the comparison the whole panel exists for.
+	const lastSeen = { webrtc: null, mse: null };
+	let lastStallAt = 0;
 	let wired = false;
 	// Measured encoder output per channel, bytes/s, from the 2 s heartbeat —
 	// what the "camera sending" row shows. The configured bitrate is a
@@ -82,6 +87,7 @@ window.MajesticStats = (function () {
 			'<div class="mj-ns-hero"><span class="mj-ns-num" id="mj-ns-lat">–</span>' +
 				'<span class="mj-ns-unit">ms</span>' +
 				'<span class="mj-ns-sub" id="mj-ns-lat-sub">measuring…</span></div>' +
+			'<div class="mj-ns-note" id="mj-ns-vs" hidden></div>' +
 			'<div class="mj-ns-bar" id="mj-ns-bar" hidden>' +
 				'<span id="mj-ns-seg-cam" style="background:' + C1 + '"></span>' +
 				'<span id="mj-ns-seg-net" style="background:' + C2 + '"></span>' +
@@ -105,7 +111,7 @@ window.MajesticStats = (function () {
 			'<div class="mj-ns-chart" id="mj-ns-bw"></div>' +
 			'<div class="mj-ns-legend">' +
 				'<span>' + seg(C1) + 'received</span>' +
-				'<span>' + seg(C2) + 'link estimate</span></div>' +
+				'<span id="mj-ns-leg-est">' + seg(C2) + 'link estimate</span></div>' +
 			'<div class="mj-ns-note" id="mj-ns-repair"></div>' +
 		'</section>' +
 		'<section class="mj-ns-sec" id="mj-ns-radio" hidden>' +
@@ -204,7 +210,8 @@ window.MajesticStats = (function () {
 			segBuf: g('mj-ns-seg-buf'), segDec: g('mj-ns-seg-dec'),
 			lCam: g('mj-ns-l-cam'), lNet: g('mj-ns-l-net'),
 			lBuf: g('mj-ns-l-buf'), lDec: g('mj-ns-l-dec'),
-			grade: g('mj-ns-grade'),
+			grade: g('mj-ns-grade'), vs: g('mj-ns-vs'),
+			legEst: g('mj-ns-leg-est'),
 			rCap: g('mj-ns-r-cap'), capEst: g('mj-ns-cap-est'),
 			rSet: g('mj-ns-r-set'), set: g('mj-ns-set'),
 			send: g('mj-ns-send'), recv: g('mj-ns-recv'),
@@ -262,6 +269,7 @@ window.MajesticStats = (function () {
 		armDisplayProbe(document.getElementById('live-video'));
 		armDisplayProbe(document.getElementById('live-video-b'));
 		const cam = s.cam || {};
+		const mse = s.transport === 'mse';
 		const now = performance.now();
 		const dt = lastTickAt ? (now - lastTickAt) / 1000 : 0;
 		lastTickAt = now;
@@ -271,6 +279,8 @@ window.MajesticStats = (function () {
 			decodeTime: s.decodeTime || 0, framesDecoded: s.framesDecoded || 0,
 			packetsLost: s.packetsLost || 0, packetsReceived: s.packetsReceived || 0,
 			nack: s.nack || 0, rtx: parseInt(cam.rtx, 10) || 0,
+			rxBytes: s.rxBytes || 0, totalFrames: s.totalFrames || 0,
+			droppedFrames: s.droppedFrames || 0, stalls: s.stalls || 0,
 		};
 		// A cumulative counter that went BACKWARDS means the peer connection
 		// was rebuilt under us (preview-webrtc reconnects internally without
@@ -279,7 +289,8 @@ window.MajesticStats = (function () {
 		// that no longer exists. Forget them now rather than letting them
 		// decay through the new session's first seconds.
 		if (p && (prevT.packetsReceived < p.packetsReceived ||
-				prevT.jbEmitted < p.jbEmitted)) {
+				prevT.jbEmitted < p.jbEmitted ||
+				prevT.rxBytes < p.rxBytes)) {
 			p = null;
 			hold = { buf: null, dec: null };
 			lossEma = null;
@@ -336,7 +347,14 @@ window.MajesticStats = (function () {
 				fps: fpsNow };
 			camMs += sampling + readout;
 		}
-		const parts = [camMs, net, hold.buf, screen];
+		// On MSE the buffer leg is not a per-frame average but the DEPTH the
+		// element is sitting on — decoded future waiting to play, the number
+		// that separates this transport from WebRTC's jitter buffer. Camera
+		// and network legs do not exist here: TCP tells us nothing about
+		// either, which is the finding rather than a gap.
+		const parts = mse
+			? [null, null, s.bufferedMs != null ? s.bufferedMs : null, screen]
+			: [camMs, net, hold.buf, screen];
 		let total = null;
 		parts.forEach((v) => { if (v != null) total = (total || 0) + v; });
 
@@ -386,12 +404,31 @@ window.MajesticStats = (function () {
 		// composition, the headline states the total.
 		const srOk = srG2gEma != null && total != null &&
 			Math.abs(srG2gEma - total) <= Math.max(150, total * 0.5);
-		if (total != null && (net != null || c2s)) {
-			els.lat.textContent = '≈' + Math.round(srOk ? srG2gEma : total);
-			els.latSub.textContent = c2s
+		if (total != null && (net != null || c2s || mse)) {
+			const shown = srOk ? srG2gEma : total;
+			// '≥' on MSE, honestly: two of the four legs are unmeasurable
+			// over TCP, so the real figure can only be larger than this.
+			els.lat.textContent = (mse ? '≥' : '≈') + Math.round(shown);
+			els.latSub.textContent = mse
+				? 'player alone; camera and network are invisible over MSE'
+				: c2s
 				? (c2s.approx ? 'glass to glass, at least' : 'glass to glass')
 				: 'network + player; the camera’s share is not included';
-			window.MjCharts.pushSpark(latSpark, srOk ? srG2gEma : total);
+			window.MjCharts.pushSpark(latSpark, shown);
+			// The other transport's last figure, right under this one's:
+			// the A/B a screenshot can carry.
+			lastSeen[mse ? 'mse' : 'webrtc'] = { ms: shown, at: now };
+			const other = lastSeen[mse ? 'webrtc' : 'mse'];
+			if (other && now - other.at < 15 * 60 * 1000) {
+				els.vs.hidden = false;
+				els.vs.textContent = mse
+					? 'WebRTC measured ≈' + Math.round(other.ms) +
+						' ms on this connection — with the missing legs counted'
+					: 'MSE held ≥' + Math.round(other.ms) +
+						' ms here, player buffer alone';
+			} else {
+				els.vs.hidden = true;
+			}
 			// The breakdown renders only with all four legs: three segments
 			// that sum to less than the number above them would read as a
 			// mistake, not a measurement.
@@ -413,6 +450,7 @@ window.MajesticStats = (function () {
 			els.latSub.textContent = 'measuring…';
 			els.bar.hidden = true;
 			els.legend.hidden = true;
+			els.vs.hidden = true;
 		}
 
 		// Loss as a smoothed percentage of the last ticks, not the cumulative
@@ -431,8 +469,24 @@ window.MajesticStats = (function () {
 		// actually emits, what arrives.
 		const remb = parseInt(cam.remb, 10) || 0;
 		const capK = Math.max(s.availKbps || 0, remb);
-		const gr = gradeOf(lossEma || 0, s.rttMs || 0, s.jitterMs || 0,
-			parseInt(cam.enc, 10) || 0, s.configuredKbps || 0, capK);
+		// MSE has no loss counter and no round trip — TCP converts both into
+		// waiting. So the grade reads the two symptoms this transport CAN
+		// show: playback having stalled recently, and the element dropping
+		// frames to catch up.
+		let gr;
+		if (mse) {
+			if (good && prevT.stalls > p.stalls) lastStallAt = now;
+			const dropRate = good && prevT.totalFrames > p.totalFrames
+				? (prevT.droppedFrames - p.droppedFrames) /
+					(prevT.totalFrames - p.totalFrames) * 100
+				: 0;
+			gr = now - lastStallAt < 10000 ? ['struggling', WARN]
+				: dropRate > 5 ? ['good', OK]
+				: ['excellent', OK];
+		} else {
+			gr = gradeOf(lossEma || 0, s.rttMs || 0, s.jitterMs || 0,
+				parseInt(cam.enc, 10) || 0, s.configuredKbps || 0, capK);
+		}
 		els.grade.textContent = gr[0];
 		els.grade.style.color = gr[1];
 		els.rCap.hidden = !capK;
@@ -452,14 +506,28 @@ window.MajesticStats = (function () {
 		}
 		const vr = s.channel != null ? vencRate[s.channel] : null;
 		els.send.textContent = vr != null ? fmtBps(vr) : '-';
-		els.recv.textContent = fmtK(s.kbps || 0) +
-			(s.audioKbps ? ' + audio ' + fmtK(s.audioKbps) : '');
+		let recvK = s.kbps || 0;
+		if (mse) {
+			recvK = good && prevT.rxBytes >= p.rxBytes
+				? Math.round((prevT.rxBytes - p.rxBytes) * 8 / 1000 / dt)
+				: 0;
+		}
+		els.recv.textContent = fmtK(recvK) +
+			(!mse && s.audioKbps ? ' + audio ' + fmtK(s.audioKbps) : '');
+		// No estimate series on MSE: this transport HAS no feedback channel,
+		// and an empty legend chip would imply one is merely quiet.
+		if (els.legEst) els.legEst.hidden = mse;
 		window.MjCharts.pushChart(bwChart, [
-			(s.kbps || 0) / 1000, capK ? capK / 1000 : null,
+			recvK / 1000, !mse && capK ? capK / 1000 : null,
 		]);
 
 		// Repairs as rates: recovery working is the good news worth telling.
-		if (good) {
+		// On MSE there is nothing to repair — TCP already repaired it, and
+		// the price appears as buffering, which is what gets counted.
+		if (good && mse) {
+			els.repair.textContent = 're-buffered ' + (s.stalls || 0) +
+				'\u00d7 \u00b7 frames dropped ' + (prevT.droppedFrames || 0);
+		} else if (good) {
 			const rep = [];
 			rep.push('lost ' + (lossEma != null ? lossEma.toFixed(1) : '0.0') + '%');
 			const dNack = Math.max(0, prevT.nack - p.nack);
@@ -475,12 +543,19 @@ window.MajesticStats = (function () {
 		// Fine print: the counters the old table carried, for whoever is
 		// triaging an issue rather than reading the story.
 		const fp = [];
-		if (cam.ice) fp.push('ice ' + cam.ice + ' · dtls ' + cam.dtls + ' · media ' + cam.media);
-		fp.push((cam.remb ? 'estimate ' + cam.remb : 'estimate -') +
-			' · rtcp ' + (cam.rtcp || '-') + ' · keyframes ' + (cam.pli || '-'));
-		fp.push('jitter ' + (s.jitterMs || 0) + ' ms · round trip ' +
-			(s.rttMs != null ? s.rttMs + ' ms' : '-') +
-			' · audio in ' + (cam['audio-in'] || '-'));
+		if (mse) {
+			fp.push('transport MSE — fMP4 over WebSocket/TCP · no feedback channel');
+			fp.push('buffered ' + (s.bufferedMs != null ? Math.round(s.bufferedMs) : '-') +
+				' ms · re-buffered ' + (s.stalls || 0) + '\u00d7 · dropped ' +
+				(s.droppedFrames || 0) + ' of ' + (s.totalFrames || 0) + ' frames');
+		} else {
+			if (cam.ice) fp.push('ice ' + cam.ice + ' · dtls ' + cam.dtls + ' · media ' + cam.media);
+			fp.push((cam.remb ? 'estimate ' + cam.remb : 'estimate -') +
+				' · rtcp ' + (cam.rtcp || '-') + ' · keyframes ' + (cam.pli || '-'));
+			fp.push('jitter ' + (s.jitterMs || 0) + ' ms · round trip ' +
+				(s.rttMs != null ? s.rttMs + ' ms' : '-') +
+				' · audio in ' + (cam['audio-in'] || '-'));
+		}
 		if (srG2gEma != null) {
 			fp.push('end-to-end via sender report ' + Math.round(srG2gEma) +
 				' ms' + (srOk ? ' — headline' : ' — diverges from leg sum ' +
@@ -501,10 +576,11 @@ window.MajesticStats = (function () {
 				Math.round(1000 / refreshMs) + ' Hz');
 			fp.push(parts2.join(' · '));
 		}
-		fp.push('talkback ' + (s.micWanted
-			? (s.micSending ? 'sending' : 'offered, not accepted') +
-				' · ' + (s.micPackets || 0) + ' pkt'
-			: 'off'));
+		fp.push(mse ? 'talkback unavailable — MSE carries one direction'
+			: 'talkback ' + (s.micWanted
+				? (s.micSending ? 'sending' : 'offered, not accepted') +
+					' · ' + (s.micPackets || 0) + ' pkt'
+				: 'off'));
 		els.fp.textContent = fp.join('\n');
 	}
 

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -346,6 +346,15 @@ window.MajesticStats = (function () {
 			camModel = { sampling: sampling, readout: readout, pipe: camMs,
 				fps: fpsNow };
 			camMs += sampling + readout;
+		} else if (mse && frameT != null) {
+			// Sampling and readout are the sensor's, not the transport's:
+			// leaving them off the MSE floor made its headline read LOWER
+			// than WebRTC's full-path figure — the comparison inverted.
+			// Encode/send stays unmeasurable here, so the floor stays a
+			// floor.
+			camModel = { sampling: frameT / 2, readout: frameT, pipe: null,
+				fps: fpsNow };
+			camMs = frameT / 2 + frameT;
 		}
 		// On MSE the buffer leg is not a per-frame average but the DEPTH the
 		// element is sitting on — decoded future waiting to play, the number
@@ -353,7 +362,7 @@ window.MajesticStats = (function () {
 		// and network legs do not exist here: TCP tells us nothing about
 		// either, which is the finding rather than a gap.
 		const parts = mse
-			? [null, null, s.bufferedMs != null ? s.bufferedMs : null, screen]
+			? [camMs, null, s.bufferedMs != null ? s.bufferedMs : null, screen]
 			: [camMs, net, hold.buf, screen];
 		let total = null;
 		parts.forEach((v) => { if (v != null) total = (total || 0) + v; });
@@ -410,7 +419,7 @@ window.MajesticStats = (function () {
 			// over TCP, so the real figure can only be larger than this.
 			els.lat.textContent = (mse ? '≥' : '≈') + Math.round(shown);
 			els.latSub.textContent = mse
-				? 'player alone; camera and network are invisible over MSE'
+				? 'at least — includes the player buffer WebRTC skips'
 				: c2s
 				? (c2s.approx ? 'glass to glass, at least' : 'glass to glass')
 				: 'network + player; the camera’s share is not included';
@@ -420,12 +429,17 @@ window.MajesticStats = (function () {
 			lastSeen[mse ? 'mse' : 'webrtc'] = { ms: shown, at: now };
 			const other = lastSeen[mse ? 'webrtc' : 'mse'];
 			if (other && now - other.at < 15 * 60 * 1000) {
+				// The verdict in numbers, not left to inference: which
+				// transport is faster on THIS connection, and by how much.
+				const d = Math.round(shown - other.ms);
+				const rel = d > 0 ? Math.abs(d) + ' ms lower'
+					: d < 0 ? Math.abs(d) + ' ms higher' : 'the same';
 				els.vs.hidden = false;
 				els.vs.textContent = mse
 					? 'WebRTC measured ≈' + Math.round(other.ms) +
-						' ms on this connection — with the missing legs counted'
-					: 'MSE held ≥' + Math.round(other.ms) +
-						' ms here, player buffer alone';
+						' ms on this connection — ' + rel
+					: 'MSE held ≥' + Math.round(other.ms) + ' ms here — ' +
+						(d < 0 ? Math.abs(d) + ' ms more than now' : 'buffer-bound');
 			} else {
 				els.vs.hidden = true;
 			}
@@ -480,8 +494,14 @@ window.MajesticStats = (function () {
 				? (prevT.droppedFrames - p.droppedFrames) /
 					(prevT.totalFrames - p.totalFrames) * 100
 				: 0;
-			gr = now - lastStallAt < 10000 ? ['struggling', WARN]
-				: dropRate > 5 ? ['good', OK]
+			// lastStallAt is 0 until a stall really happened: near page start
+			// performance.now() itself is under ten seconds, and an
+			// unqualified age test branded every fresh session with a stall
+			// it never had. Heavy dropping is playback visibly failing, not
+			// "good" — the ladder demotes twice, like the WebRTC grade does.
+			const stalled = lastStallAt > 0 && now - lastStallAt < 10000;
+			gr = stalled || dropRate > 10 ? ['struggling', WARN]
+				: dropRate > 2 ? ['good', OK]
 				: ['excellent', OK];
 		} else {
 			gr = gradeOf(lossEma || 0, s.rttMs || 0, s.jitterMs || 0,
@@ -565,7 +585,9 @@ window.MajesticStats = (function () {
 			fp.push('camera @' + Math.round(camModel.fps) + ' fps: sampling ~' +
 				Math.round(camModel.sampling) + ' ms (\u00bd frame)' +
 				(camModel.readout ? ' + readout ~' + Math.round(camModel.readout) + ' ms' : '') +
-				' + pipeline ' + camModel.pipe + ' ms');
+				(camModel.pipe != null
+					? ' + pipeline ' + camModel.pipe + ' ms'
+					: ' + encode/send unmeasured over MSE'));
 		}
 		if (hold.dec != null || disp != null || refreshMs != null) {
 			const parts2 = [];
@@ -679,6 +701,11 @@ window.MajesticStats = (function () {
 		hold = { buf: null, dec: null };
 		lossEma = null;
 		srG2gEma = null;
+		// A stall belongs to the session that stalled; without this a real
+		// stall bled through an MSE→WebRTC→MSE round trip and branded the
+		// new session too. (lastSeen stays — the comparison line is the one
+		// thing that is SUPPOSED to outlive a switch.)
+		lastStallAt = 0;
 	}
 
 	function setOpen(o) {

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -22,6 +22,7 @@ window.MajesticVideo = (function () {
 		const onState = opts.onState || function () {};
 		const onCodec = opts.onCodec || function () {};
 		const onAudio = opts.onAudio || function () {};
+		const onStats = opts.onStats || null;
 		let stream = opts.stream | 0;
 		let ws = null, ms = null, sb = null, objUrl = null;
 		let queue = [], started = false, mime = null;
@@ -32,6 +33,13 @@ window.MajesticVideo = (function () {
 		// audio the outgoing one already had. See preview-swap.js.
 		let wantAudio = !!opts.audio;
 		let volume = opts.volume === undefined ? 1 : opts.volume;
+		// Player-lifetime counters for the stats panel, deliberately NOT
+		// reset on the internal reconnects: the panel differences them and
+		// treats a regression as "the session was rebuilt".
+		let statsTimer = null;
+		let rxBytes = 0;
+		let stallCount = 0;
+		function onWaiting() { stallCount++; }
 
 		const mseOk = ('MediaSource' in window);
 		const NO_SIGNAL_MS = 4000;
@@ -82,9 +90,13 @@ window.MajesticVideo = (function () {
 			nv.volume = volume;
 			if (old.parentNode) old.parentNode.replaceChild(nv, old);
 			old.removeEventListener('error', onVideoError);
+			old.removeEventListener('waiting', onWaiting);
 			try { old.removeAttribute('src'); old.load(); } catch (e) {}
 			video = nv;
 			video.addEventListener('error', onVideoError);
+			// A stall is the shape TCP loss takes on this transport: the
+			// picture waits for the retransmission WebRTC would have skipped.
+			video.addEventListener('waiting', onWaiting);
 		}
 
 		function onInit(info) {
@@ -134,6 +146,7 @@ window.MajesticVideo = (function () {
 		}
 
 		function onBinary(buf) {
+			rxBytes += buf.byteLength || 0;
 			queue.push(new Uint8Array(buf));
 			if (queue.length > MAX_QUEUE) queue.splice(0, queue.length - MAX_QUEUE);
 			pump();
@@ -220,8 +233,39 @@ window.MajesticVideo = (function () {
 
 		function audioSupported() { return !!audioPrefs; }
 
+		// What this transport can honestly measure about itself, once a
+		// second: the bytes the socket delivered, how much decoded future the
+		// element is sitting on (the number that separates it from WebRTC's
+		// jitter buffer), the element's own dropped-frame accounting, and how
+		// often playback had to wait. No RTT, no loss counter, no capacity
+		// estimate — TCP hides all three, which is not a measurement gap but
+		// the finding.
+		function statsTick() {
+			if (!started || closed) return;
+			const s = { transport: 'mse', rxBytes: rxBytes, stalls: stallCount };
+			try {
+				const q = video.getVideoPlaybackQuality &&
+					video.getVideoPlaybackQuality();
+				if (q) {
+					s.totalFrames = q.totalVideoFrames;
+					s.droppedFrames = q.droppedVideoFrames;
+				}
+			} catch (e) {}
+			try {
+				if (video.buffered.length) {
+					s.bufferedMs = Math.max(0,
+						(video.buffered.end(video.buffered.length - 1) -
+							video.currentTime) * 1000);
+				}
+			} catch (e) {}
+			s.width = video.videoWidth || 0;
+			s.height = video.videoHeight || 0;
+			onStats(s);
+		}
+
 		function destroy() {
 			closed = true;
+			if (statsTimer) { clearInterval(statsTimer); statsTimer = null; }
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			stop();
 		}
@@ -238,6 +282,7 @@ window.MajesticVideo = (function () {
 		}
 
 		open();
+		if (onStats) statsTimer = setInterval(statsTick, 1000);
 		return {
 			setStream: setStream, requestIdr: requestIdr,
 			setAudio: setAudio, setVolume: setVolume,


### PR DESCRIPTION
The parity follow-up the network-story panel deferred — built to show the **difference** between the transports with real measurements, not to fake equal numbers.

**MSE measures what MSE is** (`preview.js` gains `onStats`): socket bytes delivered per second, the element's **buffer depth** (decoded future waiting to play — the number that separates this transport from WebRTC's jitter buffer), `getVideoPlaybackQuality` dropped frames, and a **stall counter** off `waiting` events, because a stall is the shape TCP loss takes on this transport.

**The panel's MSE mode is honest about the asymmetry:**
- delay headline: `≥ buffer + screen` — *player alone; camera and network are invisible over MSE*;
- grade from stalls and drops instead of loss/rtt (TCP converts both into waiting);
- the capacity row and estimate chart series disappear — this transport *has no feedback channel*, which is the finding, not a gap;
- repairs become `re-buffered N×`; talkback owns up to being one-way;
- the camera-side sections (radio, serving split, measured encoder rate) work identically off the metrics heartbeat — an MSE viewer even sees itself in `Browser (MSE) × 1`.

**The comparison moment:** each transport's last settled headline survives transport switches on purpose, so either view quotes the other right under its own number — *"WebRTC measured ≈130 ms on this connection"* under MSE's ≥900, and *"MSE held ≥900 ms here, player buffer alone"* back on WebRTC. Switching the segmented picker is the A/B demo, and one screenshot carries both sides.

The stats toggle is transport-blind now (`syncStatsCtl`); no camera-side changes needed — everything MSE-side rides existing majestic endpoints. Verified live on the T31 through a full WebRTC → MSE → WebRTC round trip (comparison lines correct in both directions, stall grading firing on a real congested link). Fourteen new vm test cases; suite at 397 checks green.