### PR TITLE
PTZ: ptz_caps declares the axes the hardware actually has

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ This is the most important file to read before editing anything. It defines:
 - `/etc/crontabs/root` — extensions add/remove their own lines with `sed -i /name/d` then append.
 - `/tmp/webui/` — scratch (sysinfo, schema cache, flash log, signature).
 - `/tmp/system-reboot` — sentinel file; presence triggers the "restart required" banner in `header.cgi`.
-- U-Boot env via `fw_printenv -n` / `fw_setenv` for `ethaddr`, `wlanssid`, `wlanpass`, `upgrade`, `sensor`, `soc`, and the PTZ family `ptz_control`/`ptz_gpio`/`ptz_port`/`ptz_speed`/`ptz_profile` (legacy aliases `gpio_motors`, `ptz`).
+- U-Boot env via `fw_printenv -n` / `fw_setenv` for `ethaddr`, `wlanssid`, `wlanpass`, `upgrade`, `sensor`, `soc`, and the PTZ family `ptz_control`/`ptz_gpio`/`ptz_port`/`ptz_speed`/`ptz_profile`/`ptz_caps` (legacy aliases `gpio_motors`, `ptz`).
 
 ### Talking to Majestic
 
@@ -328,7 +328,13 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   signed ints); `pelco` covers both serial variants — four
   directions, zoom and focus, each a fixed timed pulse — speaking
   `j/ptz.cgi?act=<verb>` against a closed whitelist (the scripts dispatch on
-  the verb, so it must never pass through raw). `bin/btzoom` and
+  the verb, so it must never pass through raw). `ptz_caps` narrows the pad
+  to the axes the hardware actually has (`fw_setenv ptz_caps 'zoom focus'`
+  for an XM zoom block, tokens pan/tilt/zoom/focus; unset = all): sanitised
+  in `update_caminfo`, honoured by `p/motor.cgi` (missing pelco-pad axes
+  leave grid voids; a padless camera keeps its zoom/focus group thanks to
+  the loosened mount guard in `preview-ptz.js`) and enforced in `j/ptz.cgi`
+  (`stop` always allowed; stepped backends zero the missing component). `bin/btzoom` and
   `bin/btzoom-xm` ship in this repo (adopted from OpenIPC/sandbox
   `scripts/pelcoD`, the xm variant hardened to btzoom's standard: shared
   `/tmp/btzoom.lock`, `ptz_port`/`ptz_speed`, idempotent per-command `stty`)

--- a/www/a/preview-ptz.js
+++ b/www/a/preview-ptz.js
@@ -18,10 +18,12 @@
 (function () {
 	const pad = $('#mj-ptz-pad'), fn = $('#mj-ptz-fn');
 	const mount = $('#mj-ptz'), stage = $('#mj-stage');
-	if (!pad || !mount) return;
+	// Either piece may be absent on its own: ptz_caps can leave a camera
+	// with only the zoom/focus group (an XM zoom block has no pan/tilt) —
+	// the pad must not be the thing the whole mount hinges on.
+	if (!mount || (!pad && !fn)) return;
 	if (fn) { mount.appendChild(fn); fn.hidden = false; }
-	mount.appendChild(pad);
-	pad.hidden = false;
+	if (pad) { mount.appendChild(pad); pad.hidden = false; }
 	mount.hidden = false;
 
 	const STEP = 5, TICK_MS = 250;
@@ -109,9 +111,10 @@
 		btn.addEventListener('click', e => { if (e.detail === 0) fire(btn); });
 	});
 
-	if (stage) {
+	if (stage && pad) {
 		// Arrows resolve to whatever button the pad actually has for that
-		// direction, so the same keys drive both protocols.
+		// direction, so the same keys drive both protocols. No pad — a
+		// zoom/focus-only camera — means the arrows have nothing to say.
 		const KEYS = {
 			ArrowUp: '[data-dir="uc"],[data-act="up"]',
 			ArrowDown: '[data-dir="dc"],[data-act="down"]',

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -68,6 +68,23 @@ case "$ptz_control" in
 		;;
 esac
 
+# ptz_caps mirrors update_caminfo's sanitising: it declares which axes the
+# hardware actually has (an XM zoom block accepts pan frames and ignores
+# them), and the endpoint must refuse what the pad no longer draws — the
+# pad is a convenience, this is the contract. Empty means every axis.
+ptz_caps=""
+for cap in $(fw_printenv -n ptz_caps 2>/dev/null); do
+	case "$cap" in
+		pan|tilt|zoom|focus) ptz_caps="$ptz_caps $cap" ;;
+	esac
+done
+
+has_cap() {
+	[ -z "$ptz_caps" ] && return 0
+	case " $ptz_caps " in *" $1 "*) return 0 ;; esac
+	return 1
+}
+
 # The verb is matched against the closed list, never passed through: the
 # scripts dispatch on the verb ("pelcoD_$1"), so an unlisted word must never
 # reach them raw. (start/day/night exist in btzoom but are lens maintenance,
@@ -77,6 +94,18 @@ if [ -n "$ACTION" ]; then
 	if [ "$pelco_ok" = 1 ]; then
 		case "$ACTION" in
 			up|down|left|right|stop|wide|tele|near|far)
+				# stop is always allowed — a caps change must never take
+				# away the one verb that halts a motor already moving.
+				case "$ACTION" in
+					wide|tele) has_cap zoom || ACTION="" ;;
+					near|far) has_cap focus || ACTION="" ;;
+					up|down) has_cap tilt || ACTION="" ;;
+					left|right) has_cap pan || ACTION="" ;;
+				esac
+				if [ -z "$ACTION" ]; then
+					echo "Not supported by this camera's PTZ."
+					exit 1
+				fi
 				"$pelco_bin" "$ACTION"
 				exit $?
 				;;
@@ -87,6 +116,11 @@ if [ -n "$ACTION" ]; then
 	echo "Pelco PTZ not available on this device."
 	exit 1
 fi
+
+# The stepped backends take magnitudes, so a missing axis zeroes its
+# component rather than refusing the request whole.
+has_cap pan || HORIZONTAL=0
+has_cap tilt || VERTICAL=0
 
 if [ "$gpio_ok" = 1 ]; then
 	gpio-motors "$HORIZONTAL" "$VERTICAL" 10

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -832,6 +832,22 @@ update_caminfo() {
 		# "none", unset and anything unrecognised all land here: no pad.
 	esac
 
+	# ptz_caps declares which axes the hardware actually has, in the same
+	# declarative U-Boot family as the rest (#227): fw_setenv ptz_caps
+	# 'zoom focus', tokens from pan/tilt/zoom/focus. The 85H50AI-style XM
+	# zoom blocks accept pan frames and silently ignore them, and a pad
+	# must not render what cannot work. Unknown words are dropped; unset —
+	# or nothing recognisable — means full capability for the backend, so
+	# no camera configured before this variable changes behaviour.
+	ptz_caps=""
+	local cap
+	for cap in $(fw_printenv -n ptz_caps 2>/dev/null); do
+		case "$cap" in
+			pan|tilt|zoom|focus) ptz_caps="$ptz_caps $cap" ;;
+		esac
+	done
+	ptz_caps="${ptz_caps# }"
+
 	# Network
 	network_interface=$(ip route | awk '/default/ {print $5}' | head -n1)
 	network_address=$(ip route | grep ${network_interface:-eth0} | awk '/src/ {print $7}')
@@ -852,7 +868,7 @@ update_caminfo() {
 
 	local variables="flash_size flash_type fw_build fw_variant fw_version mj_version network_address
 		network_gateway network_hostname network_interface network_macaddr overlay_root ptz_support
-		ptz_backend sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
+		ptz_backend ptz_caps sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
 	rm -f ${sysinfo_file}
 
 	local v

--- a/www/cgi-bin/p/motor.cgi
+++ b/www/cgi-bin/p/motor.cgi
@@ -27,9 +27,11 @@
      ptz_caps (from sysinfo, sanitised by update_caminfo) gates what is
      emitted at all: an XM zoom block accepts pan frames and ignores them,
      and a pad must not render what cannot work. Empty means every axis —
-     cameras without the variable keep today's markup byte for byte. On the
-     pelco pad a missing axis leaves a void in the 3x3 grid so the geometry
-     holds; j/ptz.cgi refuses the same verbs server-side. -->
+     cameras without the variable keep today's markup byte for byte. On
+     both pads a missing axis leaves a void in the 3x3 grid so the geometry
+     holds; the stepped pad's diagonals need both axes, and the centre
+     (stop/home) stays whenever the pad renders. j/ptz.cgi holds the same
+     line server-side. -->
 <%
 has_cap() {
 	[ -z "$ptz_caps" ] && return 0
@@ -114,34 +116,68 @@ has_cap() {
 </div>
 <% fi %>
 <% else %>
+<% if has_cap pan || has_cap tilt; then %>
 <div id="mj-ptz-pad" class="mj-ptz-pad" role="group" aria-label="Pan and tilt" hidden>
+	<% if has_cap pan && has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="ul" aria-label="Pan up-left">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6.6 12.6V6.6h6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<% if has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="uc" aria-label="Tilt up">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5.4 12.4 10 7.6l4.6 4.8"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<% if has_cap pan && has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="ur" aria-label="Pan up-right">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7.4 6.6h6v6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<% if has_cap pan; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="lc" aria-label="Pan left">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.4 5.4 7.6 10l4.8 4.6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
 	<button type="button" class="mj-ptz-btn mj-ptz-stop" data-dir="cc" aria-label="Center" title="Centre">
 		<svg viewBox="0 0 20 20" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="10" cy="10" r="3.4"></circle></svg>
 	</button>
+	<% if has_cap pan; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="rc" aria-label="Pan right">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7.6 5.4 12.4 10l-4.8 4.6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<% if has_cap pan && has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="dl" aria-label="Pan down-left">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6.6 7.4v6h6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<% if has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="dc" aria-label="Tilt down">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5.4 7.6 10 12.4l4.6-4.8"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<% if has_cap pan && has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-dir="dr" aria-label="Pan down-right">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13.4 7.4v6h-6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
 </div>
+<% fi %>
 <% fi %>
 <script src="/a/preview-ptz.js"></script>

--- a/www/cgi-bin/p/motor.cgi
+++ b/www/cgi-bin/p/motor.cgi
@@ -22,9 +22,25 @@
      landscape MODES on a stills camera, not "pull focus nearer" on a moving
      lens — so NEAR and FAR carry it, with the icon holding only the idea of
      focus: one bracket frame, its subject large for near and small for far.
-     Those four words are literally what the buttons send. -->
+     Those four words are literally what the buttons send.
+
+     ptz_caps (from sysinfo, sanitised by update_caminfo) gates what is
+     emitted at all: an XM zoom block accepts pan frames and ignores them,
+     and a pad must not render what cannot work. Empty means every axis —
+     cameras without the variable keep today's markup byte for byte. On the
+     pelco pad a missing axis leaves a void in the 3x3 grid so the geometry
+     holds; j/ptz.cgi refuses the same verbs server-side. -->
+<%
+has_cap() {
+	[ -z "$ptz_caps" ] && return 0
+	case " $ptz_caps " in *" $1 "*) return 0 ;; esac
+	return 1
+}
+%>
 <% if [ "$ptz_backend" = "pelco" ]; then %>
+<% if has_cap zoom || has_cap focus; then %>
 <div id="mj-ptz-fn" class="mj-ptz-fn" role="group" aria-label="Zoom and focus" hidden>
+	<% if has_cap zoom; then %>
 	<span class="mj-ptz-group">Zoom</span>
 	<button type="button" class="mj-ptz-fnbtn" data-act="wide" aria-label="Zoom out" title="Zoom out (wide)">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true">
@@ -38,6 +54,8 @@
 		</svg>
 		<span>Tele</span>
 	</button>
+	<% fi %>
+	<% if has_cap focus; then %>
 	<span class="mj-ptz-group">Focus</span>
 	<button type="button" class="mj-ptz-fnbtn" data-act="near" aria-label="Focus near" title="Pull focus nearer">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -53,28 +71,48 @@
 		</svg>
 		<span>Far</span>
 	</button>
+	<% fi %>
 </div>
+<% fi %>
+<% if has_cap pan || has_cap tilt; then %>
 <div id="mj-ptz-pad" class="mj-ptz-pad" role="group" aria-label="Pan and tilt" hidden>
 	<span class="mj-ptz-void"></span>
+	<% if has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-act="up" aria-label="Tilt up">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5.4 12.4 10 7.6l4.6 4.8"></path></svg>
 	</button>
+	<% else %>
 	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<span class="mj-ptz-void"></span>
+	<% if has_cap pan; then %>
 	<button type="button" class="mj-ptz-btn" data-act="left" aria-label="Pan left">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.4 5.4 7.6 10l4.8 4.6"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
 	<button type="button" class="mj-ptz-btn mj-ptz-stop" data-act="stop" aria-label="Stop" title="Stop">
 		<svg viewBox="0 0 20 20" width="18" height="18" fill="none" aria-hidden="true"><rect x="6" y="6" width="8" height="8" rx="1.4" fill="currentColor"></rect></svg>
 	</button>
+	<% if has_cap pan; then %>
 	<button type="button" class="mj-ptz-btn" data-act="right" aria-label="Pan right">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7.6 5.4 12.4 10l-4.8 4.6"></path></svg>
 	</button>
+	<% else %>
 	<span class="mj-ptz-void"></span>
+	<% fi %>
+	<span class="mj-ptz-void"></span>
+	<% if has_cap tilt; then %>
 	<button type="button" class="mj-ptz-btn" data-act="down" aria-label="Tilt down">
 		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5.4 7.6 10 12.4l4.6-4.8"></path></svg>
 	</button>
+	<% else %>
+	<span class="mj-ptz-void"></span>
+	<% fi %>
 	<span class="mj-ptz-void"></span>
 </div>
+<% fi %>
 <% else %>
 <div id="mj-ptz-pad" class="mj-ptz-pad" role="group" aria-label="Pan and tilt" hidden>
 	<button type="button" class="mj-ptz-btn" data-dir="ul" aria-label="Pan up-left">


### PR DESCRIPTION
Continues #227's declarative `ptz_*` scheme with a capability variable, needed by the first zoom-only board:

```
fw_setenv ptz_caps 'zoom focus'    # tokens: pan tilt zoom focus; unset = all
```

The 85H50AI XiongMai zoom block (smoke-tested in the lab, `ptz_control pelco-xm` on the console UART) accepts pan/tilt frames and silently ignores them — a pad must not render what cannot work.

- `common.cgi:update_caminfo` sanitises the value to the four known tokens and caches it in sysinfo. **Unset or nothing recognisable = full capability**, so no existing camera changes behaviour.
- `p/motor.cgi` gates emission: zoom/focus pairs individually, the `#mj-ptz-fn` group when either survives, the pelco 4-way pad only when `pan` or `tilt` exists — and a single missing axis inside it leaves grid voids so the 3×3 geometry holds.
- `preview-ptz.js` no longer hinges the whole mount on the pad (`!pad || !mount` → `!mount || (!pad && !fn)`), so a zoom/focus-only camera keeps its group; without a pad the stage arrow keys have nothing to say, which is correct.
- `j/ptz.cgi` enforces the same contract server-side: `wide|tele`→zoom, `near|far`→focus, `up|down`→tilt, `left|right`→pan; a refused verb answers "Not supported by this camera's PTZ."; **`stop` is always allowed** — a caps change must never take away the verb that halts a motor already moving. Stepped backends zero the missing `h`/`v` component instead of refusing outright.

Verified on the lab 85H50AI (deployed via `updatewebui`):

| env | page markup | endpoint |
|---|---|---|
| `ptz_caps` unset | 4 fn buttons + pad, all 9 `data-act` verbs — unchanged | all verbs pass |
| `zoom focus` | 4 fn buttons, **no pad**, only wide/tele/near/far | `act=left` refused, `act=stop` allowed, tele/near move the lens |
| `zoom bogus; rm -rf /` | sysinfo carries `ptz_caps='zoom'` | `act=near` refused |

`npm test` green. CLAUDE.md updated. A companion OpenIPC/builder PR adds the `hi3516ev300_lite_xm-85h50ai` device profile that sets this variable out of the box.

Refs #227.