### PR TITLE
Live View: an idling estimate cannot call a LAN struggling

### DIFF
--- a/tests/preview-stats.test.js
+++ b/tests/preview-stats.test.js
@@ -139,11 +139,29 @@ g('capacity story and adaptation coloring', () => {
 });
 
 g('a crushed link grades struggling even with clean loss', () => {
+	// The stream is testing the link (estimate under 2× delivered), and the
+	// link carries under half the configured target: real congestion.
 	const env = boot();
-	env.stats.tick({ cam: { remb: '39kbps', enc: '512' },
-		configuredKbps: 1024, kbps: 18, rttMs: 58, channel: 1 });
+	env.stats.tick({ cam: { remb: '400kbps', enc: '512' },
+		configuredKbps: 1024, kbps: 350, rttMs: 58, channel: 1 });
 	check('capacity below half the configured target is struggling',
 		env.el('mj-ns-grade').textContent === 'struggling');
+	check('a tested estimate reads as approximately capacity',
+		env.el('mj-ns-cap-est').textContent === '≈400 kbit/s');
+});
+
+g('an idling estimate cannot call a LAN struggling', () => {
+	// Quiet scene on a wired LAN: the stream sends a trickle, the estimator
+	// idles at a small multiple of it, a transient bind drags enc down —
+	// none of which is evidence about the link. Loss 0, rtt tiny:
+	// excellent, whatever the estimator mumbles.
+	const env = boot();
+	env.stats.tick({ cam: { remb: '1250kbps', enc: '1250' },
+		configuredKbps: 4096, kbps: 500, rttMs: 5, channel: 0 });
+	check('grade stays excellent on a LAN with a quiet scene',
+		env.el('mj-ns-grade').textContent === 'excellent');
+	check('an idle estimate is shown as a floor, not capacity',
+		env.el('mj-ns-cap-est').textContent === '≥1.3 Mbit/s');
 });
 
 g('grade words move on loss and round trip', () => {

--- a/tests/preview-stats.test.js
+++ b/tests/preview-stats.test.js
@@ -150,6 +150,29 @@ g('a crushed link grades struggling even with clean loss', () => {
 		env.el('mj-ns-cap-est').textContent === '≈400 kbit/s');
 });
 
+g('a high idle browser estimate cannot mask a binding camera one', () => {
+	// The camera's remb (400) is what adaptation acts on and it is genuinely
+	// binding against 350 kbit/s delivered; the browser's idle 2500 must not
+	// launder the grade back to excellent.
+	const env = boot();
+	env.stats.tick({ cam: { remb: '400kbps', enc: '512' },
+		configuredKbps: 1024, kbps: 350, availKbps: 2500, rttMs: 20, channel: 1 });
+	check('the binding camera estimate wins the grade',
+		env.el('mj-ns-grade').textContent === 'struggling');
+	check('while the display row honestly shows the larger figure as a floor',
+		env.el('mj-ns-cap-est').textContent === '≥2.5 Mbit/s');
+});
+
+g('nothing delivered means nothing tested', () => {
+	const env = boot();
+	env.stats.tick({ cam: { remb: '2kbps', enc: '512' },
+		configuredKbps: 1024, kbps: 0, rttMs: 5, channel: 1 });
+	check('a stopped stream cannot grade struggling off a tiny estimate',
+		env.el('mj-ns-grade').textContent === 'excellent');
+	check('and its estimate renders as a floor',
+		env.el('mj-ns-cap-est').textContent === '≥2 kbit/s');
+});
+
 g('an idling estimate cannot call a LAN struggling', () => {
 	// Quiet scene on a wired LAN: the stream sends a trickle, the estimator
 	// idles at a small multiple of it, a transient bind drags enc down —

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -263,10 +263,15 @@ window.MajesticStats = (function () {
 	// an estimate below twice the delivered rate is a fact about the link,
 	// one above it is the estimator idling — and an adaptation triggered by
 	// an idling estimator is the same false positive one step removed.
-	function gradeOf(lossPct, rtt, jitterMs, encK, cfgK, capK, recvK) {
-		const capMeaningful = capK > 0 && capK < 2 * Math.max(recvK || 0, 1);
-		const adapting = encK > 0 && capMeaningful;
-		const crushed = adapting && cfgK > 0 && capK < cfgK / 2;
+	function gradeOf(lossPct, rtt, jitterMs, encK, cfgK, rembK, recvK) {
+		// The grade reads the estimate ADAPTATION acts on — the camera-side
+		// remb — not the larger of two estimates: a high idle browser figure
+		// must not mask a binding camera one. And nothing is "tested" while
+		// nothing was delivered: recvK 0 means the stream is not flowing,
+		// which is its own story, not evidence about capacity.
+		const meaningful = recvK > 0 && rembK > 0 && rembK < 2 * recvK;
+		const adapting = encK > 0 && meaningful;
+		const crushed = adapting && cfgK > 0 && rembK < cfgK / 2;
 		if (lossPct > 5 || rtt > 500) return ['poor', BAD];
 		if (lossPct > 1 || rtt > 250 || jitterMs > 100 || crushed)
 			return ['struggling', WARN];
@@ -515,7 +520,7 @@ window.MajesticStats = (function () {
 				: ['excellent', OK];
 		} else {
 			gr = gradeOf(lossEma || 0, s.rttMs || 0, s.jitterMs || 0,
-				parseInt(cam.enc, 10) || 0, s.configuredKbps || 0, capK,
+				parseInt(cam.enc, 10) || 0, s.configuredKbps || 0, remb,
 				s.kbps || 0);
 		}
 		els.grade.textContent = gr[0];
@@ -524,7 +529,7 @@ window.MajesticStats = (function () {
 		if (capK) {
 			// A saturated link's estimate approximates capacity; an idle
 			// one only proves the link carries at least what arrived.
-			const tested = capK < 2 * Math.max(s.kbps || 0, 1);
+			const tested = (s.kbps || 0) > 0 && capK < 2 * (s.kbps || 0);
 			els.capEst.textContent = (tested ? '≈' : '≥') + fmtK(capK);
 		}
 		const cfgK = s.configuredKbps;

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -254,9 +254,19 @@ window.MajesticStats = (function () {
 	// camera gave the link less to carry — a storm graded "excellent" on
 	// those alone (seen in the lab, picture a blocky mess) is the adaptation
 	// hiding its own evidence.
-	function gradeOf(lossPct, rtt, jitterMs, encK, cfgK, capK) {
-		const adapting = encK > 0;
-		const crushed = adapting && cfgK > 0 && capK > 0 && capK < cfgK / 2;
+	//
+	// But the estimate itself is only evidence when the stream is testing
+	// the link: an idle REMB sits at a small multiple of whatever trickle
+	// arrives, and taking it at face value graded a quiet scene on a wired
+	// LAN "struggling" (called out from the field, rightly, as nonsense).
+	// The same rule the camera's own vote follows (majestic's bwe policy):
+	// an estimate below twice the delivered rate is a fact about the link,
+	// one above it is the estimator idling — and an adaptation triggered by
+	// an idling estimator is the same false positive one step removed.
+	function gradeOf(lossPct, rtt, jitterMs, encK, cfgK, capK, recvK) {
+		const capMeaningful = capK > 0 && capK < 2 * Math.max(recvK || 0, 1);
+		const adapting = encK > 0 && capMeaningful;
+		const crushed = adapting && cfgK > 0 && capK < cfgK / 2;
 		if (lossPct > 5 || rtt > 500) return ['poor', BAD];
 		if (lossPct > 1 || rtt > 250 || jitterMs > 100 || crushed)
 			return ['struggling', WARN];
@@ -505,12 +515,18 @@ window.MajesticStats = (function () {
 				: ['excellent', OK];
 		} else {
 			gr = gradeOf(lossEma || 0, s.rttMs || 0, s.jitterMs || 0,
-				parseInt(cam.enc, 10) || 0, s.configuredKbps || 0, capK);
+				parseInt(cam.enc, 10) || 0, s.configuredKbps || 0, capK,
+				s.kbps || 0);
 		}
 		els.grade.textContent = gr[0];
 		els.grade.style.color = gr[1];
 		els.rCap.hidden = !capK;
-		if (capK) els.capEst.textContent = '≈' + fmtK(capK);
+		if (capK) {
+			// A saturated link's estimate approximates capacity; an idle
+			// one only proves the link carries at least what arrived.
+			const tested = capK < 2 * Math.max(s.kbps || 0, 1);
+			els.capEst.textContent = (tested ? '≈' : '≥') + fmtK(capK);
+		}
 		const cfgK = s.configuredKbps;
 		const enc = parseInt(cam.enc, 10) || 0;
 		els.rSet.hidden = !cfgK && !enc;


### PR DESCRIPTION
Field report from a wired LAN, verbatim: *"Bullshit. I'm in local network."* Right.

The connection grade took the receiver's bandwidth estimate at face value as capacity. But an estimate only tests the link while the stream is filling it — idle, it sits at a small multiple of whatever trickle arrives, a transient camera-side bind drags `enc` down, and the grade's *crushed* term (capacity below half the configured rate) branded a quiet scene on a gigabit network **struggling**.

The fix applies browser-side the same rule the camera's vote already follows: the adaptation and capacity terms count only while the estimate is below ~2× the delivered rate — otherwise it is the estimator idling and says nothing about the link. The *link can carry* row wears the same honesty: a tested estimate renders `≈` (roughly capacity), an idle one `≥` (the link carries at least this).

Two new test cases (a genuinely crushed link still grades struggling; a LAN with a quiet scene grades excellent with the `≥` floor shown); suite at 406 checks. Verified live on the av300: a minute's watch shows excellent/good with `≥` capacities, no struggling. The camera-side half of the same disease (the encoder parked at the 90 % hold cap by a boundary-riding estimate) is the companion majestic PR.