### PR TITLE
Live adjustments: the picture takes the width, and the knobs ride under it

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -243,6 +243,53 @@ body > main > .container > h2 {
 	margin: 2rem 0 1.5rem;
 }
 
+/* The settings page prints its own title, at the top of the rail rather than in
+   a band above both columns — see the note in mj-settings.cgi. Smaller than the
+   page heading it replaces because it now shares a 261px column with the tree
+   it names, and because at 32px it was the loudest thing on a page whose
+   subject is a list of settings. */
+.mj-rail-title {
+	margin: 0 0 0.75rem;
+	color: var(--bs-primary);
+	font-size: 1.25rem;
+	font-weight: 500;
+	line-height: 1.3;
+}
+
+/* Only this page widens, and only because of the one thing on it that can use a
+   bigger monitor. Bootstrap's shared 1320px cap meant the Live preview was
+   exactly 966x543 on a 1080p screen and on a 1440p one alike — the container was
+   what stopped it, not the window (#239). Every other page keeps the cap; a
+   ceiling stays, because a settings form whose rows run the width of a 4K
+   monitor is not a form anyone can read. */
+#page-mj-settings > main > .container {
+	max-width: min(96vw, 2400px);
+}
+
+/* Once the container is free to grow, a quarter-width rail is 437px of mostly
+   nothing on a 1080p screen — a column of one-word labels, sized as a fraction
+   of a page whose width now comes from the monitor. So the rail takes what the
+   tree needs and the form column takes the rest, which on that screen hands the
+   picture another 60px of width. Below md the two stack and the percentages
+   never applied anyway, hence the same breakpoint Bootstrap uses. */
+@media (min-width: 768px) {
+	#page-mj-settings .row > .col-md-3 {
+		width: 20rem;
+	}
+
+	/* min-width:0 is the load-bearing half: a flex item's default min-width is
+	   auto, so the column refuses to shrink below its content's min-content
+	   width and wraps under the rail instead — which is exactly what happened
+	   at 1024, where the knob strip's four cells want more than the 663px left
+	   over. */
+	#page-mj-settings #mj-settings-form-col {
+		flex: 1 1 0;
+		width: auto;
+		max-width: none;
+		min-width: 0;
+	}
+}
+
 /* The read-out beside a form — "Current connection", the firmware versions,
    a tunnel's state. It is the same job the Live deck's readouts do, so it
    reads the same way: the term in the micro-caps every label on the page now
@@ -967,21 +1014,30 @@ mark {
 }
 
 /* The stage. Sized from the viewport height the same way .mj-stage is on the
-   Live page, and for the same reason turned up one notch: here the deck has to
-   stay on screen too, or you are scrolling between the slider you are dragging
-   and the picture you are dragging it for. The floor stops it collapsing on a
-   short window; the 16:9 box never changes, and a stream of another shape is
-   contained inside it rather than reflowing the page.
+   Live page: the floor stops it collapsing on a short window, the 16:9 box never
+   changes, and a stream of another shape is contained inside it rather than
+   reflowing the page.
 
-   The 31rem reserve is what buys the deck its room, and it is measured rather
-   than guessed: at 30rem the fourth slider overflowed a 1280x800 window by ONE
-   pixel, which is not a margin — it is the same answer landing either way on a
-   machine whose font metrics differ slightly. 31rem puts all four knobs and the
-   picture on screen together at every common laptop size. */
+   The reserve is what the picture gives back, and what it buys has changed
+   (#239). It used to be 31rem, holding room for the whole two-column deck to sit
+   under the picture — which on a 1340x708 window drove the width below the 28rem
+   floor, so the picture stopped responding to the window at all and simply
+   centred itself in 407px of empty column. It bought nothing there either: the
+   deck ran 253px past the fold regardless.
+
+   Now the deck's first row is a single 76px strip of knobs, and the reserve
+   holds room for exactly that: the picture takes whatever is left once the four
+   Tone knobs have their place on screen. That is the same guarantee as before —
+   a knob and the effect it has, visible together — but expressed as geometry
+   instead of as a constant that has to be re-derived every time the chrome above
+   the panel changes. It decomposes as the stage's own top offset (the rail and
+   form columns start at 134px now that the title band is gone, plus the section
+   head) + 12px + the 76px strip + 16px, and the fractional rem keeps that
+   arithmetic legible rather than rounded into a lie. */
 .mj-live-stage {
 	position: relative;
-	width: min(100%, max(28rem, calc((100vh - 31rem) * 1.77778)));
-	width: min(100%, max(28rem, calc((100dvh - 31rem) * 1.77778)));
+	width: min(100%, max(28rem, calc((100vh - 17.6rem) * 1.77778)));
+	width: min(100%, max(28rem, calc((100dvh - 17.6rem) * 1.77778)));
 	margin-inline: auto;
 	aspect-ratio: 16 / 9;
 	background: #0d0f14;
@@ -989,6 +1045,18 @@ mark {
 	border-radius: var(--bs-border-radius-lg);
 	overflow: hidden;
 	box-shadow: var(--bs-box-shadow);
+}
+
+/* When the runtime toggles cannot fit on the picture they take a row under it
+   (mj-settings.js:dockRuntime), and that row is 52px the reserve above does not
+   know about — at 1440x600 it put the fourth knob 31px below the fold. So the
+   reserve grows by exactly that row while it exists. The feedback is
+   stabilising rather than oscillating: docking narrows the stage, which can
+   only make the bar fit less well, so it stays docked; dockRuntime carries the
+   hysteresis that stops the boundary flip-flopping. */
+.mj-live-stage.mj-live-docked {
+	width: min(100%, max(28rem, calc((100vh - 21rem) * 1.77778)));
+	width: min(100%, max(28rem, calc((100dvh - 21rem) * 1.77778)));
 }
 
 /* object-fit: contain, so a 4:3 or square-cropped sensor is letterboxed in a
@@ -1012,14 +1080,34 @@ mark {
 }
 
 /* Always visible, unlike the Live page's bar: the LEDs below are camera state,
-   and state you have to wave a mouse at to read is state nobody reads. */
+   and state you have to wave a mouse at to read is state nobody reads.
+
+   It does not wrap. Wrapping is what took 104px of a 290px picture on a 540px
+   phone — 42% of the frame, before the light-monitor sentence was drawn at all
+   (#239) — and a bar that grows upwards over the picture defeats the point of
+   making the picture bigger. One row, and what does not fit moves off the
+   picture rather than on top of more of it. */
 .mj-live-bar {
 	position: absolute;
 	inset: auto 0.75rem 0.75rem;
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
+}
+
+/* Nothing in the bar shrinks. A shrunk group is a control with a wrapped label
+   or a clipped one, and it also hides the overflow from the only code that can
+   do anything about it: dockRuntime measures each child's scrollWidth against
+   the bar's, which is only the truth while the children are their natural
+   size. The sentence is the exception — it has an ellipsis and a title, so it
+   is allowed to give way. */
+.mj-live-bar > * {
+	flex: 0 0 auto;
+}
+
+.mj-live-bar > .mj-hud-chip {
+	flex: 0 1 auto;
 }
 
 .mj-hud-end {
@@ -1142,8 +1230,66 @@ mark {
 	color: #d8dbe4;
 }
 
+/* A sentence in a row that cannot wrap. It is the only shrinkable thing in the
+   bar, so it is the one that gives way rather than pushing the controls out of
+   reach; the title carries the rest, and below md it is off the picture
+   altogether (mj-settings.js:dockRuntime). */
+.mj-live-bar .mj-hud-chip {
+	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
 .mj-hud-chip a {
 	color: #fff;
+}
+
+/* Where the runtime toggles go when the picture is too small to carry them —
+   mj-settings.js:dockRuntime moves the same nodes here below md. Full-width
+   targets, on a surface rather than on glass, because the ground behind them is
+   the page now and not the picture. */
+.mj-live-rt-mount {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-top: 0.6rem;
+}
+
+.mj-live-rt-mount .mj-hud-rt {
+	flex: 1 1 auto;
+	background: var(--bs-tertiary-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: var(--bs-border-radius);
+}
+
+.mj-live-rt-mount .mj-hrt {
+	flex: 1 1 0;
+	justify-content: center;
+	min-height: 2.75rem;
+	color: var(--bs-secondary-color);
+}
+
+.mj-live-rt-mount .mj-hrt:hover {
+	background: rgba(var(--bs-body-color-rgb), 0.06);
+	color: var(--bs-body-color);
+}
+
+.mj-live-rt-mount .mj-hrt-in:checked + .mj-hrt {
+	background: rgba(var(--bs-body-color-rgb), 0.1);
+	color: var(--bs-body-color);
+}
+
+.mj-live-rt-mount .mj-hud-chip {
+	flex: 1 1 auto;
+	background: var(--bs-tertiary-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: var(--bs-border-radius);
+	color: var(--bs-secondary-color);
+}
+
+.mj-live-rt-mount .mj-hud-chip a {
+	color: var(--bs-body-color);
 }
 
 .mj-live-hint {
@@ -1183,6 +1329,46 @@ mark {
 
 .mj-live-col-b {
 	flex: 0 0 23rem;
+	border-left: 1px solid var(--bs-border-color);
+}
+
+/* ── the knob strip ─────────────────────────────────────────────────────────
+   The Tone group laid out across the deck instead of down it: 76px against the
+   186px the same four rows cost stacked. That difference is the picture's — it
+   is the whole reserve, and therefore the whole of what #239 asked for. The
+   strip is its own card so the row under it can be a second one, and so the
+   knobs sit directly under the picture they change with nothing between. */
+.mj-live-strip {
+	display: flex;
+	align-items: center;
+	margin-top: 0.75rem;
+	padding: 0 0.5rem;
+	background: var(--bs-card-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: var(--bs-border-radius-lg);
+	box-shadow: var(--bs-box-shadow-sm);
+}
+
+.mj-live-strip-foot {
+	flex: 0 0 auto;
+	padding: 0 1rem 0 1.15rem;
+	border-left: 1px solid var(--bs-border-color);
+	align-self: stretch;
+	display: flex;
+	align-items: center;
+}
+
+/* The deck's second row: Scene, Luma and Orientation side by side rather than
+   the 405px two-column block they used to make. Shallow enough that on a 1080p
+   window the whole panel is on screen again, and the picture never paid for it.
+   Luma takes the slack because a histogram is the one of the three that is
+   worth more the wider it gets. */
+.mj-live-col-scene {
+	flex: 0 0 17rem;
+}
+
+.mj-live-col-geo {
+	flex: 0 0 15rem;
 	border-left: 1px solid var(--bs-border-color);
 }
 
@@ -1235,6 +1421,55 @@ mark {
 	font-weight: 600;
 	letter-spacing: 0.07em;
 	text-transform: uppercase;
+}
+
+/* In the strip the row turns a quarter: name and readout on the first line, the
+   track with the whole of the second. Beside each other in a quarter of the
+   deck's width the track would be ~90px to drag on — the same complaint the
+   stacked breakpoint already answers this way, so the shape is the one the
+   phone layout established rather than a third arrangement. Grid, not
+   flex-wrap, because the row's source order is name/track/value/delta/reset and
+   only areas can put the track last without reordering the markup. */
+@media (min-width: 992px) {
+	.mj-live-strip .mj-live-row {
+		flex: 1 1 0;
+		min-width: 0;
+		display: grid;
+		grid-template-columns: 1fr auto auto auto;
+		grid-template-areas:
+			"name num delta rst"
+			"track track track track";
+		align-items: center;
+		gap: 0.35rem 0.4rem;
+		padding: 0.85rem 1.15rem;
+	}
+
+	.mj-live-strip .mj-live-row + .mj-live-row {
+		border-left: 1px solid var(--bs-border-color);
+	}
+
+	.mj-live-strip .mj-live-name {
+		grid-area: name;
+		flex: none;
+	}
+
+	.mj-live-strip .mj-live-track {
+		grid-area: track;
+		height: 1.25rem;
+	}
+
+	.mj-live-strip .mj-live-num {
+		grid-area: num;
+		width: 2.25rem;
+	}
+
+	.mj-live-strip .mj-live-delta {
+		grid-area: delta;
+	}
+
+	.mj-live-strip .mj-live-rst {
+		grid-area: rst;
+	}
 }
 
 .mj-live-track {
@@ -1577,10 +1812,29 @@ mark {
 		flex-direction: column;
 	}
 
-	.mj-live-col-b {
+	.mj-live-col-b,
+	.mj-live-col-geo {
 		flex: 1 1 auto;
 		border-left: 0;
 		border-top: 1px solid var(--bs-border-color);
+	}
+
+	.mj-live-col-scene {
+		flex: 1 1 auto;
+	}
+
+	/* Stacked the strip is just the Tone group again, one knob per row — four
+	   quarter-width tracks are a desk layout, not a ladder one. */
+	.mj-live-strip {
+		flex-direction: column;
+		align-items: stretch;
+		padding: 0.4rem 1.5rem 0.7rem;
+	}
+
+	.mj-live-strip-foot {
+		align-self: flex-start;
+		padding: 0.4rem 0 0.2rem;
+		border-left: 0;
 	}
 
 	/* Two lines, and the track gets the whole of the second one: sharing a row
@@ -1656,6 +1910,21 @@ mark {
 		min-height: 2.75rem;
 		padding-top: 0.75rem;
 		padding-bottom: 0.75rem;
+	}
+}
+
+/* The bar does not wrap, so on a phone something has to give, and it is this
+   label: at 390px "Hold to compare" broke onto a second line and made the bar
+   30% of a 197px picture. The icon and its title carry it — the same trade the
+   snapshot and fullscreen buttons have always made, and the reason the button
+   grew a title attribute. */
+@media (max-width: 767.98px) {
+	.mj-live-bar .mj-hud-btn span {
+		display: none;
+	}
+
+	.mj-live-bar .mj-hud-btn {
+		padding-inline: 0.85rem;
 	}
 }
 /* Responsive-embed wrapper: a plain block div sizes width:100% correctly to the

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -971,7 +971,11 @@
 			one('toggle-ircut', ICON.ircut, 'IR&#8209;cut') +
 			one('toggle-light', ICON.lamp, 'Lamp', 'mj-hrt-amber') +
 			'</span>' +
-			'<span class="mj-hud-chip mj-glass" id="mj-lightmon" hidden>' +
+			// A sentence in a bar that cannot wrap: on the picture it truncates
+			// with the title carrying the rest, and below md dockRuntime moves
+			// it off the picture entirely, where it has a line to itself.
+			'<span class="mj-hud-chip mj-glass" id="mj-lightmon" hidden' +
+			' title="Light monitor is driving night, IR-cut and the lamp">' +
 			'<a href="mj-settings.cgi?tab=nightMode">Light monitor is driving night, IR&#8209;cut and the lamp</a>' +
 			'</span>';
 	}
@@ -987,8 +991,25 @@
 			'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
 			'<video id="mj-live-video-b" autoplay muted playsinline class="mj-live-video" style="display:none"></video>' +
 			'<div class="mj-live-bar">' +
+			// The stream picker rides the picture, first in the bar, exactly
+			// where the Live page keeps it — and as the same component, not a
+			// second copy of it: `mj-hud mj-seg` is the pair of classes that
+			// page's markup carries, so the glass, the label colours and the
+			// focus ring are all inherited rather than restated. It used to sit
+			// beside the section heading, which is a different control in a
+			// different place for the same job on two pages of one product.
+			'<span class="mj-hud mj-seg" role="group" aria-label="Stream">' +
+			'<input type="radio" class="mj-seg-in" name="mj-live-stream" id="mj-live-s0" autocomplete="off">' +
+			'<label class="mj-seg-lbl" for="mj-live-s0">Main</label>' +
+			'<input type="radio" class="mj-seg-in" name="mj-live-stream" id="mj-live-s1" autocomplete="off">' +
+			'<label class="mj-seg-lbl" for="mj-live-s1" id="mj-live-sub" hidden>Sub</label>' +
+			'</span>' +
 			runtimeHtml() +
-			'<button type="button" class="mj-hud-btn mj-glass" id="mj-live-compare">' +
+			// The label is dropped below md (the bar does not wrap, and at 390px
+			// it was the one thing that did not fit), so the title has to carry
+			// it there — same trade the snapshot and fullscreen icons make.
+			'<button type="button" class="mj-hud-btn mj-glass" id="mj-live-compare"' +
+			' title="Hold to compare" aria-label="Hold to compare">' +
 			ICON.compare + '<span>Hold to compare</span></button>' +
 			'<span class="mj-hud-end">' +
 			'<button type="button" class="mj-hud-ico mj-glass" id="mj-live-snap" hidden aria-label="Snapshot" title="Snapshot"></button>' +
@@ -999,6 +1020,126 @@
 		stage.querySelector('#mj-live-fs').innerHTML = ICON.fs;
 		form.appendChild(stage);
 		return stage;
+	}
+
+	// The bar does not wrap any more — wrapping took 42% of a 290px picture on a
+	// 540px phone (#239) — so when it will not fit, the widest group moves off
+	// the picture instead of stacking on top of more of it. The runtime toggles
+	// are the ones that move: they are the widest, they are state rather than
+	// player controls, and under the picture they get full-width touch targets
+	// instead of being the thing that scrolls out of reach. What stays is the
+	// player's own row — channel, compare, snapshot, fullscreen.
+	//
+	// MEASURED, not a breakpoint. The stage's width comes from the window's
+	// HEIGHT as much as its width, and the bar holds a different set of controls
+	// on different cameras — no substream, no lamp pin, the light-monitor
+	// sentence instead of the three switches — so the width at which it stops
+	// fitting is a property of this camera in this window, and no media query
+	// knows it. Every child is flex:0 0 auto (see bootstrap.override.css), which
+	// is what makes scrollWidth its natural width rather than its squeezed one.
+	//
+	// Relocation rather than two copies, the same way preview-ptz.js moves the
+	// pad into the stage: one set of inputs means wireRuntime() keeps driving
+	// the controls the person is looking at, whichever side of the picture edge
+	// that is.
+	function dockRuntime(stage, mount) {
+		const bar = stage.querySelector('.mj-live-bar');
+		const gap = 8;
+		const movable = () => [
+			bar.querySelector('.mj-hud-rt') || mount.querySelector('.mj-hud-rt'),
+			bar.querySelector('#mj-lightmon') || mount.querySelector('#mj-lightmon'),
+		].filter(Boolean);
+
+		const move = (to) => {
+			movable().forEach(n => {
+				if (n.parentNode === to) return;
+				n.classList.toggle('mj-glass', to === bar);
+				// Before the compare button, which is where it sits in the bar;
+				// appended in the mount, which holds nothing else.
+				if (to === bar) bar.insertBefore(n, bar.querySelector('#mj-live-compare'));
+				else to.appendChild(n);
+			});
+		};
+
+		const widthOf = (nodes) => nodes.reduce((w, n) => w + n.scrollWidth + gap, 0);
+
+		// What the group costs the bar, remembered from the last time it was in
+		// it. While it is docked its width cannot be measured — in the mount the
+		// switches stretch to the full column — so this is the only figure there
+		// is, and it is why undocking is decided on a remembered number rather
+		// than a fresh one. If it has gone stale the next pass corrects it, and
+		// the stage clips rather than reflows in the meantime.
+		let cost = 0;
+		let docked = false;
+		let pending = false;
+
+		const place = () => {
+			pending = false;
+			const room = bar.clientWidth;
+			// A stage that has not been laid out yet answers 0 and would dock
+			// everything; the observers below fire again with a real width.
+			if (!room) return;
+			const extras = movable();
+			if (!docked) cost = widthOf(extras.filter(n => !n.hidden));
+			const rest = [...bar.children].filter(n => !n.hidden && extras.indexOf(n) < 0);
+			const need = rest.reduce((w, n) => w + n.scrollWidth, 0) +
+				gap * Math.max(0, rest.length - 1) + cost;
+			// Hysteresis, and it is load-bearing rather than polish: docking
+			// adds a row under the picture, the stage's reserve grows to hold
+			// it (.mj-live-docked) and the stage therefore NARROWS — so the
+			// measurement that follows a dock is taken in less room than the one
+			// that caused it. Without a band to come back through, a window
+			// sitting exactly on the boundary would dock, narrow, undock, widen,
+			// for as long as it was open.
+			const want = docked ? need > room - 24 : need > room;
+			// Nothing moves unless the answer changed. That is what makes the
+			// mutation observer below safe: a pass that writes to the DOM would
+			// wake it, and a pass woken by its own writes never stops.
+			if (want === docked) return;
+			move(want ? mount : bar);
+			docked = want;
+			mount.hidden = !want;
+			stage.classList.toggle('mj-live-docked', want);
+		};
+
+		const later = () => {
+			if (pending) return;
+			pending = true;
+			requestAnimationFrame(place);
+		};
+
+		place();
+
+		// Two things change what the bar needs without changing the bar. The
+		// snapshot and fullscreen buttons start hidden and are revealed only
+		// once preview-hero.js knows the camera has jpeg.enabled and the browser
+		// has the fullscreen API — that is +76px arriving a second late, and it
+		// is what made a 1024x700 window measure as fitting and then overflow.
+		// The brand font is the other: header.cgi loads it media="print" so a
+		// camera with no internet still paints, and Montserrat is wider than the
+		// system stack it replaces.
+		let mo = null;
+		if (window.MutationObserver) {
+			mo = new MutationObserver(later);
+			mo.observe(bar, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden'] });
+		}
+		if (document.fonts && document.fonts.ready) document.fonts.ready.then(later);
+
+		// ResizeObserver on the bar rather than on the window: the bar's width
+		// changes when the rail, the container or the stream's aspect ratio
+		// changes, none of which is a window resize.
+		let ro = null;
+		if (window.ResizeObserver) {
+			ro = new ResizeObserver(later);
+			ro.observe(bar);
+		} else {
+			window.addEventListener('resize', later);
+		}
+		return () => {
+			if (mo) mo.disconnect();
+			if (ro) ro.disconnect();
+			else window.removeEventListener('resize', later);
+		};
 	}
 
 	// The night/IR/light runtime toggles. They live on this page rather than on
@@ -1355,8 +1496,8 @@
 			window.MajesticTransport);
 
 		// The only place the leaf names itself — the rail's active item says it
-		// too — with the stream picker on the same line rather than in a card
-		// header of its own.
+		// too. The stream picker used to share this line; it is on the picture
+		// now (renderStage), so what is left is the heading and its rule.
 		//
 		// An <h3> despite the micro-caps styling, and not a <span>: revealSection()
 		// focuses `form h3` after a navigation so the section announces itself to
@@ -1365,13 +1506,7 @@
 		const head = el('div', 'mj-live-head');
 		head.innerHTML =
 			'<h3 class="mj-cap">Live adjustments</h3>' +
-			'<span class="mj-live-rule"></span>' +
-			'<span class="mj-seg" role="group" aria-label="Stream">' +
-			'<input type="radio" class="mj-seg-in" name="mj-live-stream" id="mj-live-s0" autocomplete="off">' +
-			'<label class="mj-seg-lbl" for="mj-live-s0">Main</label>' +
-			'<input type="radio" class="mj-seg-in" name="mj-live-stream" id="mj-live-s1" autocomplete="off">' +
-			'<label class="mj-seg-lbl" for="mj-live-s1" id="mj-live-sub" hidden>Sub</label>' +
-			'</span>';
+			'<span class="mj-live-rule"></span>';
 		form.appendChild(head);
 
 		if (withVideo) {
@@ -1389,20 +1524,15 @@
 				if (offFs) state.liveCleanup.push(offFs);
 				window.MajesticHero.wireSnapshot(stage.querySelector('#mj-live-snap'));
 			}
+			const rtMount = el('div', 'mj-live-rt-mount');
+			form.appendChild(rtMount);
+			state.liveCleanup.push(dockRuntime(stage, rtMount));
+
 			const note = el('p', 'mj-live-hint');
-			note.textContent = 'Night, IR-cut and the lamp are on the picture because they are runtime state: ' +
-				'pressing one changes the camera for every viewer immediately, and none of them is part of Save.';
+			note.textContent = 'Night, IR-cut and the lamp are runtime state: pressing one changes ' +
+				'the camera for every viewer immediately, and none of them is part of Save.';
 			form.appendChild(note);
 		}
-
-		// The deck: one card split by a rule, so tone and orientation read as
-		// one instrument rather than as two unrelated panels.
-		const deck = el('div', 'mj-live-deck');
-		const colA = el('div', 'mj-live-col');
-		const colB = el('div', 'mj-live-col mj-live-col-b');
-		deck.appendChild(colA);
-		deck.appendChild(colB);
-		form.appendChild(deck);
 
 		// The pad replaces the two switches only when BOTH halves of it are
 		// there. A build that marks just one of them x-live — or that marks some
@@ -1410,24 +1540,41 @@
 		const mirror = fields.find(f => f.key === 'mirror' && f.sub.type === 'boolean');
 		const flip = fields.find(f => f.key === 'flip' && f.sub.type === 'boolean');
 		const useGeo = !!(mirror && flip);
+		// The strip is for knobs, so it is integers that decide whether there is
+		// one. A build that marks only booleans x-live has no strip and loses
+		// nothing: they render in the row below, where a switch has room to be a
+		// switch rather than a fifth cell of a four-cell instrument.
+		const hasTone = fields.some(f => f.sub.type === 'integer');
 
-		const hasTone = fields.some(f => f !== mirror && f !== flip);
-		// Tone starts the left column, with nothing above it: whatever sits
-		// between the picture and the first slider comes straight off the one
-		// guarantee this panel owes, which is that a knob and the effect it has
-		// are on screen together (#239). Scene used to be there and cost 111px,
-		// which put Brightness exactly on the fold at 1440x900.
-		//
-		// Scene goes UNDER the sliders rather than into the other column. It
-		// sets those same four values, so it belongs beside them; and the two
-		// columns have to carry comparable weight or the deck is mostly empty
-		// on one side — parking it on the right left 282px of nothing under
-		// "Reset all to stock".
-		const toneBody = hasTone ? liveGroup(colA, 'Tone', 'saved with the page') : null;
+		// The deck is now two cards, not one. The first is the knob strip: the
+		// Tone rows laid ACROSS it, directly under the picture, with nothing
+		// between. Four rows stacked cost 186px and the strip costs 76, and that
+		// difference is what the picture grew by — the reserve in
+		// bootstrap.override.css holds room for this strip and nothing else, so
+		// the guarantee stays "a knob and the effect it has, together" while the
+		// picture takes everything left over (#239).
+		const strip = el('div', 'mj-live-strip');
+		if (hasTone) form.appendChild(strip);
+
+		// The second card carries what is worth having but not worth the
+		// picture's height: Scene, Luma and Orientation, side by side rather
+		// than as the 405px two-column block they used to make. Shallow enough
+		// that on a 1080p window the whole panel is on screen again.
+		const deck = el('div', 'mj-live-deck');
+		const colScene = el('div', 'mj-live-col mj-live-col-scene');
+		const colLuma = el('div', 'mj-live-col');
+		const colGeo = el('div', 'mj-live-col mj-live-col-geo');
+		deck.appendChild(colScene);
+		deck.appendChild(colLuma);
+		deck.appendChild(colGeo);
+		form.appendChild(deck);
 
 		for (const f of fields) {
 			const geoField = useGeo && (f === mirror || f === flip);
-			const box = geoField ? colB : (toneBody || colA);
+			// The geometry checkboxes stay real fields — hidden — beside the pad
+			// that replaces them, so Save and dirty tracking never learn any of
+			// this happened.
+			const box = (!geoField && f.sub.type === 'integer') ? strip : colGeo;
 			const field = renderField(box, f.dot, f.key, f.sub,
 				getDotted(state.config, f.dot), { live: true, hidden: geoField });
 			if (!field) continue;
@@ -1435,30 +1582,31 @@
 			state.initial[f.dot] = field.getValue();
 		}
 
-		if (toneBody) {
-			const foot = el('div', 'mj-live-foot');
+		// Last cell of the strip rather than a footer under it: a footer would
+		// be another line between the picture and the row below, and this is a
+		// control that belongs to the four beside it.
+		if (hasTone) {
+			const foot = el('div', 'mj-live-strip-foot');
 			const rall = el('button', 'mj-live-linkbtn');
 			rall.type = 'button';
-			rall.innerHTML = ICON.reset + '<span>Reset all to stock</span>';
+			rall.innerHTML = ICON.reset + '<span>Stock</span>';
+			rall.title = 'Reset all four to their factory defaults';
 			rall.addEventListener('click', resetLiveAll);
 			foot.appendChild(rall);
-			toneBody.appendChild(foot);
+			strip.appendChild(foot);
 		}
 
-		// Under the sliders it drives, and last in the left column so it never
-		// pushes them away from the picture.
 		const toneFields = state.fields.filter(f =>
 			f.schema && f.schema['x-live'] && f.type === 'integer');
 		if (hasTone && toneFields.length) {
-			renderScene(liveGroup(colA, 'Scene', 'starting points, then tune by eye'),
-				toneFields);
+			renderScene(liveGroup(colScene, 'Scene', 'starting points'), toneFields);
 		}
 
 		if (withVideo) {
 			// The group's note slot carries the running mean rather than a
 			// caption — a number that changes is worth more there than a word
 			// that does not.
-			const lumaBody = liveGroup(colB, 'Luma', 'mean —');
+			const lumaBody = liveGroup(colLuma, 'Luma', 'mean —');
 			const note = lumaBody.parentNode.querySelector('.mj-live-note');
 			if (note) note.className = 'mj-live-note mj-luma-mean';
 			renderLuma(lumaBody);
@@ -1467,19 +1615,29 @@
 		if (useGeo) {
 			const mf = state.fields.find(f => f.dot === mirror.dot);
 			const ff = state.fields.find(f => f.dot === flip.dot);
-			if (mf && ff) renderGeometry(liveGroup(colB, 'Orientation', ''), mf, ff);
+			if (mf && ff) renderGeometry(liveGroup(colGeo, 'Orientation', ''), mf, ff);
 		}
 
 		// Every group above is conditional — on the schema, and on which player
 		// scripts loaded — so an empty column is reachable rather than
 		// hypothetical: without the player there is no Luma, and a build that
-		// marks only one of mirror/flip x-live has no Orientation either, which
-		// between them leave the right column holding nothing. It is 23rem wide
-		// with a divider whether or not anything is in it, so it would squeeze
-		// the surviving controls and add a blank section once stacked. Drop
-		// whatever came out empty instead of enumerating the combinations.
-		[colA, colB].forEach(c => { if (!c.childElementCount) c.remove(); });
+		// marks only one of mirror/flip x-live has no Orientation either. A cell
+		// is a fixed width with a divider whether or not anything is in it, so
+		// an empty one would squeeze its neighbours and add a blank section once
+		// stacked. Drop whatever came out empty instead of enumerating the
+		// combinations. colGeo is judged on what is VISIBLE in it: with the pad
+		// mounted it holds the two hidden checkboxes as well, and without the
+		// pad it may hold nothing but them — a cell that renders as a divider
+		// and 15rem of nothing.
+		if (!colGeo.querySelector('.mj-live-grp, .mj-live-row:not([hidden])')) {
+			// The hidden fields go with it. They are detached, not destroyed:
+			// state.fields still holds them, and getValue()/Save read the
+			// control, which does not care whether it is in the document.
+			colGeo.remove();
+		}
+		[colScene, colLuma].forEach(c => { if (!c.childElementCount) c.remove(); });
 		if (!deck.childElementCount) deck.remove();
+		if (hasTone && !strip.querySelector('.mj-live-row')) strip.remove();
 	}
 
 	const isGroup = (sub) => !!(sub && sub.type === 'object' && sub.properties);

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -3,6 +3,14 @@
 
 <%
 page_title="Camera Settings"
+# The page title is rendered by this page rather than by header.cgi, at the top
+# of the rail instead of in a full-width band above both columns. The band cost
+# 94px of every window — a 2rem margin, a 32px heading and the row's gutter —
+# and it bought a second copy of a name the rail's active item and the browser
+# tab already carry. In the rail it costs the picture nothing: the two columns
+# start at the same y, and the rail is the taller of them anyway. It is still a
+# real <h2>, so the document keeps its heading (#239).
+hide_title=1
 # ?tab= now names a section, not a category. Left empty the client picks the
 # first leaf of the first group; defaulting to "image" would have resolved to
 # the section of that name rather than the group, which is a different page.
@@ -54,6 +62,7 @@ fi
 	%>
 	<div class="col-12 col-md-3">
 		<div class="sticky-md-top" id="mj-settings-side">
+			<h2 class="mj-rail-title"><%= $page_title %></h2>
 			<%
 			# Hidden until mj-settings.js unhides it: with no JS the box would be
 			# a control that silently does nothing.


### PR DESCRIPTION
Closes #239. The direction is **A + C**, picked by @usa- from
[the three at openipc.github.io/majestic-webui/live-adjustments/](https://openipc.github.io/majestic-webui/live-adjustments/),
along with their ask that the channel switch be a chip on the video "as it is on the Live page".

### Why the empty space was not the problem

The preview's width came from `(100dvh − 31rem) × 16/9` with a `28rem` floor. On the reporter's
**1340 × 708** window the height term fell *below* that floor, so the picture stopped responding to
the window entirely and centred itself in 407 px of empty column — widening the page would only have
widened the gutter. And the 31 rem it gave back bought nothing at that size: the deck ran 253 px past
the fold anyway, so the co-visibility the reserve existed to protect was already lost.

### What the reserve holds now

Room for one 76 px strip of knobs, and the picture takes everything left over. Same guarantee —
a knob and the effect it has, on screen together — but as geometry rather than a constant that has to
be re-derived whenever the chrome above the panel changes. Three things pay for it:

- The Tone group lies **across** the deck instead of down it: 76 px against 186.
- Scene, Luma and Orientation become one shallow full-width row instead of the 405 px two-column
  block, so from 1080p up the whole panel is on screen again.
- The "Camera Settings" band moves into the rail, where it costs the picture nothing. It was 94 px of
  every window — a `2rem` margin, a 32 px heading and the row's gutter — for a second copy of a name
  the rail's active item and the browser tab already carry. Still a real `<h2>`.

The **1320 px container cap** goes with it, on this page only: it, not the monitor, was why
1920 × 1080 and 2560 × 1440 both showed exactly 966 × 543. A quarter-width rail beside a fluid
container would have been 437 px of one-word labels, so the rail takes what the tree needs and the
column takes the rest.

Measured on a hi3516av300:

| window | before | after | area |
|---|---|---|---|
| 1340 × 708 | 448 × 252 | **758 × 426** | 2.9× |
| 1440 × 900 | 718 × 404 | **1038 × 584** | 2.1× |
| 1920 × 1080 | 966 × 543 | **1419 × 798** | 2.2× |
| 2560 × 1440 | 966 × 543 | **2056 × 1157** | 4.5× |

The four Tone knobs are above the fold at every one of them.

### The channel switch

Onto the picture as `mj-hud mj-seg` — the Live page's own pair of classes, so the glass, the label
colours and the focus ring are inherited rather than restated. It was a different control in a
different place for the same job on two pages of one product. The section head keeps its `<h3>`,
which `revealSection()` still focuses (#222).

### The bar no longer wraps

Wrapping is what took 104 px of a 290 px picture on a 540 px phone — 42% of the frame, before the
light-monitor sentence was drawn at all — and a bar that grows upward over the picture defeats the
point of making the picture bigger. When it will not fit, the runtime toggles move off the picture
into a row under it: widest group, state rather than player controls, and there they get full-width
touch targets instead of being what scrolls out of reach.

**That decision is measured, not a breakpoint.** The stage's width comes from the window's *height* as
much as its width — 1440 × 600 needs the toggles docked and 1200 × 800 does not — and the bar holds a
different set of controls on different cameras (no substream, no lamp pin, the light-monitor sentence
instead of the three switches). No media query knows that. Every child of the bar is `flex: 0 0 auto`
so `scrollWidth` is its natural width rather than its squeezed one; the pass writes to the DOM only
when the answer changes, which is what makes the `MutationObserver` safe; and the observers cover the
two things that change what the bar needs *without changing the bar* — the snapshot and fullscreen
buttons arriving once `preview-hero.js` has checked for them, and the brand font landing after first
paint. Both of those looked fine in the browser and were caught by measuring on the camera.

Docking adds a row, so the reserve grows by it while it exists; the hysteresis in `dockRuntime` is
what stops a window sitting exactly on the boundary from docking, narrowing, undocking and widening
for as long as it is open.

### Verified on the lab hi3516av300 (imx415, lite)

Geometry swept at 1340×708, 1440×900, 1920×1080, 2560×1440, 1440×600, 1280×800, 1200×800, 1024×700,
768×1024, 540×928 and 390×844 — no bar overflow at any of them, docking exactly where the measurement
says it is needed, four knobs above the fold on every desktop and laptop size.

Interactions re-driven end to end against the camera's API: dragging a knob (`POST /api/v1/image` with
all six values, row marked dirty, Save appears), a Scene chip, **Stock**, hold-to-compare (two posts,
defaults then live) and the orientation pad. The light-monitor path was exercised by turning
`nightMode.lightMonitor` on through the API and back off again — that is the case in the reporter's
screenshot, and the sentence now sits under the picture instead of over half of it.

`npm test`, `tools/lint-templates.sh` and `npm run build:dist` all pass; `bootstrap.min.css` is
unchanged (no new Bootstrap classes).

Left open deliberately: #259, the separate sync bug @usa- found in the same thread.
