### PR TITLE
Live adjustments: discarding a knob puts the camera back too

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -616,10 +616,18 @@
 
 	const isLive = (f) => !!(f.schema && f.schema['x-live']);
 
+	// A save that is on the wire owns the live values. It has handed the camera
+	// the dragged ones on purpose, and state.initial does not catch up until the
+	// response comes back — so for that window `liveDrift()` reports a
+	// difference that is about to stop being one, and a revert built from it
+	// would undo the save.
+	let liveSaving = 0;
+
 	// Whether the camera is running something this page has not saved. Dragging
 	// a knob POSTs it to the SDK immediately; that is a runtime write and never
 	// reaches config.json, so nothing else on the page can tell.
 	function liveDrift() {
+		if (liveSaving) return false;
 		return state.fields.some(f => isLive(f) && f.getValue() !== state.initial[f.dot]);
 	}
 
@@ -630,6 +638,11 @@
 	// browser Back, which does not even prompt — so this lives in the teardown
 	// every one of those paths already runs through rather than at any of them.
 	function revertLive() {
+		// The debounced write is the discarded edit, still 120ms from being
+		// sent. postLive serialises, so leaving it queued would put it AFTER the
+		// revert and hand the camera back the very values being thrown away —
+		// a fast navigation right after a drag would have undone the undo.
+		if (liveTimer) { clearTimeout(liveTimer); liveTimer = null; }
 		if (!state.fields.length || !liveDrift()) return;
 		postLive(liveQuery(liveSaved));
 	}
@@ -645,6 +658,14 @@
 	// here would only re-create it facing the other way.
 	function wireUnloadRevert() {
 		const onHide = (ev) => {
+			// Same reason as in revertLive: a queued write would be the discarded
+			// edit arriving after the revert. There is no chaining it here — the
+			// beacon leaves outside liveWrite because nothing can be awaited on
+			// the way out — so cancelling is the whole of the ordering guarantee,
+			// and it covers everything except a write already on the wire when
+			// the tab closed. That one can still be reordered by the server, and
+			// this page has no way to stop it.
+			if (liveTimer) { clearTimeout(liveTimer); liveTimer = null; }
 			if (ev.persisted || !state.fields.length || !liveDrift()) return;
 			const q = liveQuery(liveSaved);
 			if (q && navigator.sendBeacon) navigator.sendBeacon('/api/v1/image?' + q);
@@ -2503,8 +2524,14 @@
 		if (!dirty.length) return;
 
 		const body = {};
+		// What each field was worth when the body was built, not when the
+		// response comes back: the snapshot below has to record what was
+		// actually sent, and a knob can be dragged again while the POST is in
+		// flight.
+		const sent = new Map();
 		for (const f of dirty) {
 			let val = f.getValue();
+			sent.set(f, val);
 			// array-typed schema fields (MultiRect: roi/crop/privacyMasks) post as a
 			// list of strings, not a comma-joined scalar.
 			if (f.schema && f.schema.type === 'array')
@@ -2517,6 +2544,7 @@
 		btn.textContent = 'Saving…';
 		setToolbarMsg('');
 		clearError();
+		liveSaving++;
 		try {
 			const res = await apiFetch('/api/v1/config', {
 				method: 'POST',
@@ -2529,6 +2557,13 @@
 				showError('Save failed (HTTP ' + res.status + '). ' + txt);
 				return;
 			}
+			// The camera now holds these, so the snapshot the revert is built
+			// from has to say so before anything can read it again. refresh()
+			// sets the same values a moment later from the config itself — but
+			// it can throw, and leaving state.initial stale through a failed
+			// refresh would let a later discard "revert" the camera to values
+			// that are no longer what was saved (#259).
+			sent.forEach((v, f) => { state.initial[f.dot] = v; });
 			await refresh();
 			// Image knobs (x-live) apply instantly; everything structural
 			// (resolution, codec, fps, ...) only takes effect after majestic
@@ -2539,6 +2574,7 @@
 		} catch (e) {
 			showError('Save failed: ' + e.message);
 		} finally {
+			liveSaving--;
 			btn.disabled = false;
 			btn.textContent = 'Save Changes';
 			updateDirty();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -562,6 +562,11 @@
 	}
 
 	function stopLivePreview() {
+		// The camera is the first thing this leaf changed outside its own
+		// subtree, and it used to be the one thing teardown left behind (#259).
+		// Before the fields go, put it back where they say it is.
+		revertLive();
+
 		// Anything this leaf wired outside its own subtree — document-level
 		// listeners for hold-to-compare, timers — is undone here. The subtree
 		// itself goes with form.innerHTML, but a listener on `document` would
@@ -595,6 +600,57 @@
 		const d = f.schema ? f.schema.default : undefined;
 		if (d === undefined) return liveValue(f);
 		return f.type === 'boolean' ? (toBool(d) ? 1 : 0) : d;
+	}
+
+	// What the config says this knob is, as /api/v1/image wants it. state.initial
+	// is snapshotted from config.json at mount, so it is at once what the
+	// controls will read after a re-render and what the camera has to be put
+	// back to. It holds getValue()'s strings — 'true'/'false' for a switch —
+	// while the endpoint wants 1/0, which is the whole reason this is not just
+	// `state.initial[f.dot]`.
+	function liveSaved(f) {
+		const v = state.initial[f.dot];
+		if (v === undefined) return liveValue(f);
+		return f.type === 'boolean' ? (toBool(v) ? 1 : 0) : v;
+	}
+
+	const isLive = (f) => !!(f.schema && f.schema['x-live']);
+
+	// Whether the camera is running something this page has not saved. Dragging
+	// a knob POSTs it to the SDK immediately; that is a runtime write and never
+	// reaches config.json, so nothing else on the page can tell.
+	function liveDrift() {
+		return state.fields.some(f => isLive(f) && f.getValue() !== state.initial[f.dot]);
+	}
+
+	// Put the camera back where the controls say it is. Discarding used to drop
+	// the FORM and nothing else: the sliders came back at their saved values
+	// while the ISP kept the dragged ones, and the controls were the ones lying
+	// (#259). Reported for the section switch, but the same hole was open on
+	// browser Back, which does not even prompt — so this lives in the teardown
+	// every one of those paths already runs through rather than at any of them.
+	function revertLive() {
+		if (!state.fields.length || !liveDrift()) return;
+		postLive(liveQuery(liveSaved));
+	}
+
+	// A reload, or a closed tab, abandons the edit exactly as a section switch
+	// does — and it is the one path a normal request cannot cover, because the
+	// fetch dies with the document. sendBeacon is queued by the browser and
+	// outlives it.
+	//
+	// Not on a bfcache hide: that page is coming back with its controls still
+	// where they were dragged to, so the camera should be waiting for it. The
+	// bug this fixes is the controls and the camera disagreeing, and reverting
+	// here would only re-create it facing the other way.
+	function wireUnloadRevert() {
+		const onHide = (ev) => {
+			if (ev.persisted || !state.fields.length || !liveDrift()) return;
+			const q = liveQuery(liveSaved);
+			if (q && navigator.sendBeacon) navigator.sendBeacon('/api/v1/image?' + q);
+		};
+		window.addEventListener('pagehide', onHide);
+		return () => window.removeEventListener('pagehide', onHide);
 	}
 
 	// The query string /api/v1/image takes, over ALL x-live fields — sending
@@ -1545,6 +1601,11 @@
 		// nothing: they render in the row below, where a switch has room to be a
 		// switch rather than a fifth cell of a four-cell instrument.
 		const hasTone = fields.some(f => f.sub.type === 'integer');
+
+		// Out here rather than beside the stage: the knobs write to the camera
+		// whether or not the player scripts loaded, so the promise to put it
+		// back is not the picture's to keep.
+		state.liveCleanup.push(wireUnloadRevert());
 
 		// The deck is now two cards, not one. The first is the knob strip: the
 		// Tone rows laid ACROSS it, directly under the picture, with nothing


### PR DESCRIPTION
Closes #259, reported by @usa-.

Drag Brightness until the picture changes, navigate away, confirm *"Discard and switch sections?"*,
come back: the slider reads 50 again and the picture is still dark. The controls and the camera
disagree, and the controls are the ones lying.

### Why

The knobs write to the camera **as they are dragged** — `pushLive` POSTs every `x-live` field to
`/api/v1/image` — and that is a *runtime* write. It never reaches `/etc/majestic.yaml`, so
`state.config`, and the `state.initial` snapshot taken from it, never learn it happened. Discarding
then dropped the **form** and nothing else: `load()` calls `stopLivePreview()`, which disposed the
player and the leaf's document-level listeners, and there was no revert path anywhere in the file.

### Where the fix goes

In that teardown, not at the prompt. The prompt is only one of the ways out — **browser Back reaches
`load()` through `onPopState` and does not even ask**, which was the same desync with no dialog in
front of it. Every path that abandons the leaf already runs through `stopLivePreview()`.

`liveQuery(valueOf)` was already parameterised for exactly this (hold-to-compare posts defaults
through it), so the revert is `postLive(liveQuery(liveSaved))`, with `liveSaved` mapping
`state.initial`'s `'true'`/`'false'` strings to the `1`/`0` the endpoint wants. It writes only when an
`x-live` field actually differs, so navigating away from an untouched panel still posts nothing.

A **reload or a closed tab** abandons the edit the same way, and is the one path a normal request
cannot cover because the fetch dies with the document — `sendBeacon` on `pagehide` is queued by the
browser and outlives it. Deliberately *not* on a bfcache hide: that page comes back with its controls
still dragged, so the camera should be waiting for it; reverting there would re-create the bug facing
the other way.

### Verified by measuring the picture, not the config

The config was never what was wrong, so checking it would have proved nothing. Mean luma of
`/image.jpg` reads **23 / 110 / 211** at `luminance` 0 / 50 / 100 on this hi3516av300, which is enough
to tell a real desync from a no-op.

Before:

```
1. at rest        saved=50 shown=50 picture=110.3
2. dragged to 15  posted luminance=15                picture=43.9
3. discarded      posted (nothing)                   picture=43.8
4. back on Live   saved=50 shown=50                  picture=43.8   <- desync
```

After:

```
1. at rest        saved=50 shown=50 picture=111.3
2. dragged to 15  posted luminance=15                picture=45.0
3. discarded      posted luminance=50                picture=112.1
4. back on Live   saved=50 shown=50                  picture=112.8  <- in sync
```

And the other four paths:

| path | result |
|---|---|
| browser Back (no prompt) | dragged 43.4 → posts the revert → **109** |
| clean switch, nothing dragged | posts **nothing** |
| full reload while dragged | 43.7 → **109.8**, through the beacon |
| hold-to-compare | still pairs defaults then live values |
| Save, then switch | posts **nothing**; the saved value holds at 176.7 |

`npm test`, `tools/lint-templates.sh` and `npm run build:dist` pass; no CSS or markup changed, so
`bootstrap.min.css` is untouched.

No unit test: `revertLive` lives inside mj-settings.js's IIFE with no export seam, and building one
is a larger refactor than this change should carry. The five paths above were driven end to end
against the camera instead.
