### PR TITLE
PTZ: the AF button, backed by majestic's autofocus engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,15 @@ The decisive check is `probe_write`/`probe_seen`: a stamp written to the partiti
   in `update_caminfo`, honoured by `p/motor.cgi` (missing pelco-pad axes
   leave grid voids; a padless camera keeps its zoom/focus group thanks to
   the loosened mount guard in `preview-ptz.js`) and enforced in `j/ptz.cgi`
-  (`stop` always allowed; stepped backends zero the missing component). `bin/btzoom` and
+  (`stop` always allowed; stepped backends zero the missing component).
+  **Autofocus** is majestic's engine, not a script: with
+  `.isp.autofocus.enabled` true in majestic's config AND a focus axis,
+  `update_caminfo` sets `af_support`, the pelco pad grows an **AF** button
+  (`data-act="af"`), and `j/ptz.cgi` maps it to majestic's `GET /autofocus`
+  (polling `/autofocus/status` so the pad's request-lifetime pacing holds);
+  after a successful `wide`/`tele` it also fires `GET /autofocus?settle` —
+  the engine waits for btzoom's port lock to go quiet, so a held zoom's
+  pulse train finishes before the one queued pass runs. `bin/btzoom` and
   `bin/btzoom-xm` ship in this repo (adopted from OpenIPC/sandbox
   `scripts/pelcoD`, the xm variant hardened to btzoom's standard: shared
   `/tmp/btzoom.lock`, `ptz_port`/`ptz_speed`, idempotent per-command `stty`)

--- a/www/a/preview-ptz.js
+++ b/www/a/preview-ptz.js
@@ -85,11 +85,15 @@
 	}
 
 	// The centre is a single press on both pads: the stepped backends call it
-	// home/park (board-defined), Pelco calls it stop.
-	const isCentre = btn => btn.dataset.dir === 'cc' || btn.dataset.act === 'stop';
+	// home/park (board-defined), Pelco calls it stop. AF is single-press for
+	// the opposite reason: a pass takes seconds, and a held button would
+	// queue a fresh pass the moment each one finished — "one shot" must
+	// mean one, however long the finger stays down.
+	const isSingle = btn => btn.dataset.dir === 'cc' ||
+		btn.dataset.act === 'stop' || btn.dataset.act === 'af';
 
 	mount.querySelectorAll('button').forEach(btn => {
-		if (isCentre(btn)) {
+		if (isSingle(btn)) {
 			// Stop first kills any hold still ticking (a keyboard hold can be
 			// live while the mouse presses Stop), then fires — and for Pelco
 			// the request itself is the un-droppable kind.

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -91,7 +91,12 @@ has_cap() {
 # not viewing controls — not reachable from here.) Both Pelco variants take
 # the same nine verbs, which is why one pad serves them both.
 af_enabled() {
-	has_cap focus &&
+	# The same three gates the pad's af_support carries: a usable backend
+	# (unset/none ptz_control keeps every PTZ procedure inactive, the #227
+	# ruling — the engine drives a motor this camera must actually have),
+	# the focus axis, and majestic's engine turned on.
+	{ [ "$pelco_ok" = 1 ] || [ "$gpio_ok" = 1 ] || [ "$motor_ok" = 1 ]; } &&
+		has_cap focus &&
 		[ "$(yaml-cli -g .isp.autofocus.enabled 2>/dev/null)" = "true" ]
 }
 
@@ -102,21 +107,39 @@ if [ -n "$ACTION" ]; then
 	# how the pad paces itself — but the trigger answers immediately, so a
 	# poll loop stands in for the pass's duration.
 	if [ "$ACTION" = "af" ]; then
-		if af_enabled; then
-			curl -s -m 2 "http://127.0.0.1/autofocus" > /dev/null
-		else
+		if ! af_enabled; then
 			echo "Autofocus not available on this camera."
 			exit 1
 		fi
+		r=$(curl -s -m 2 "http://127.0.0.1/autofocus")
+		case "$r" in
+			started|busy) ;;
+			*)
+				# A transport failure is not a pass: say so and fail, or the
+				# pad reads a dead engine as instant success.
+				echo "Autofocus: engine did not answer."
+				exit 1
+				;;
+		esac
+		# Hold the request while the pass runs — request lifetime is how the
+		# pad paces itself. An empty poll is a transport blip and is retried
+		# inside the same budget, never read as completion: releasing early
+		# would let a held button fire again while the engine owns the port.
 		i=0
 		s="running"
-		while [ $i -lt 45 ] && [ "$s" = "running" ]; do
+		while [ $i -lt 60 ]; do
 			sleep 1
 			s=$(curl -s -m 2 "http://127.0.0.1/autofocus/status")
-			i=$((i + 1))
+			case "$s" in
+				running|"") i=$((i + 1)) ;;
+				*) break ;;
+			esac
 		done
 		echo "Autofocus: ${s:-unknown}"
-		exit 0
+		case "$s" in
+			done*) exit 0 ;;
+			*) exit 1 ;;
+		esac
 	fi
 	if [ "$pelco_ok" = 1 ]; then
 		case "$ACTION" in

--- a/www/cgi-bin/j/ptz.cgi
+++ b/www/cgi-bin/j/ptz.cgi
@@ -90,7 +90,34 @@ has_cap() {
 # reach them raw. (start/day/night exist in btzoom but are lens maintenance,
 # not viewing controls — not reachable from here.) Both Pelco variants take
 # the same nine verbs, which is why one pad serves them both.
+af_enabled() {
+	has_cap focus &&
+		[ "$(yaml-cli -g .isp.autofocus.enabled 2>/dev/null)" = "true" ]
+}
+
 if [ -n "$ACTION" ]; then
+	# Autofocus is majestic's engine, not a pelco verb: the daemon reads the
+	# ISP's focus statistic and drives the same motor, holding btzoom's port
+	# lock. The request stays open while the pass runs — request lifetime is
+	# how the pad paces itself — but the trigger answers immediately, so a
+	# poll loop stands in for the pass's duration.
+	if [ "$ACTION" = "af" ]; then
+		if af_enabled; then
+			curl -s -m 2 "http://127.0.0.1/autofocus" > /dev/null
+		else
+			echo "Autofocus not available on this camera."
+			exit 1
+		fi
+		i=0
+		s="running"
+		while [ $i -lt 45 ] && [ "$s" = "running" ]; do
+			sleep 1
+			s=$(curl -s -m 2 "http://127.0.0.1/autofocus/status")
+			i=$((i + 1))
+		done
+		echo "Autofocus: ${s:-unknown}"
+		exit 0
+	fi
 	if [ "$pelco_ok" = 1 ]; then
 		case "$ACTION" in
 			up|down|left|right|stop|wide|tele|near|far)
@@ -107,7 +134,24 @@ if [ -n "$ACTION" ]; then
 					exit 1
 				fi
 				"$pelco_bin" "$ACTION"
-				exit $?
+				rc=$?
+				# A zoom step on a motorized lens leaves focus behind, so it
+				# books a one-shot pass. ?settle makes the engine wait for
+				# the port to go quiet first: a held button's pulse train
+				# never yields the quiet window, so the pass runs exactly
+				# once, after the zooming is over. Repeat triggers answer
+				# "busy" and collapse into that one pass.
+				if [ "$rc" = 0 ]; then
+					case "$ACTION" in
+						wide|tele)
+							af_enabled &&
+								curl -s -m 2 \
+									"http://127.0.0.1/autofocus?settle" \
+									> /dev/null
+							;;
+					esac
+				fi
+				exit $rc
 				;;
 		esac
 		echo "Unknown PTZ action."

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -848,6 +848,17 @@ update_caminfo() {
 	done
 	ptz_caps="${ptz_caps# }"
 
+	# Autofocus: the engine lives in majestic (GET /autofocus, #227's board
+	# being the first) and exists only when its config enables it; the pad's
+	# AF button additionally needs a focus axis to make sense. Cached like
+	# the rest so pages don't shell out per request.
+	af_support=""
+	if [ -n "$ptz_support" ] && [ "$(yaml-cli -g .isp.autofocus.enabled 2>/dev/null)" = "true" ]; then
+		case " ${ptz_caps:-focus} " in
+			*" focus "*) af_support="1" ;;
+		esac
+	fi
+
 	# Network
 	network_interface=$(ip route | awk '/default/ {print $5}' | head -n1)
 	network_address=$(ip route | grep ${network_interface:-eth0} | awk '/src/ {print $7}')
@@ -868,7 +879,7 @@ update_caminfo() {
 
 	local variables="flash_size flash_type fw_build fw_variant fw_version mj_version network_address
 		network_gateway network_hostname network_interface network_macaddr overlay_root ptz_support
-		ptz_backend ptz_caps sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
+		af_support ptz_backend ptz_caps sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
 	rm -f ${sysinfo_file}
 
 	local v

--- a/www/cgi-bin/p/motor.cgi
+++ b/www/cgi-bin/p/motor.cgi
@@ -74,6 +74,19 @@ has_cap() {
 		<span>Far</span>
 	</button>
 	<% fi %>
+	<% if [ -n "$af_support" ]; then %>
+	<!-- One-shot contrast autofocus: majestic's engine drives the same
+	     focus motor off the ISP's focus statistic. The icon is the focus
+	     bracket family with a filled subject: the camera choosing the
+	     distance itself. af_support already implies the focus axis. -->
+	<button type="button" class="mj-ptz-fnbtn" data-act="af" aria-label="Autofocus" title="Autofocus (one shot)">
+		<svg viewBox="0 0 20 20" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<path d="M3.2 7V3.6h3.4M16.8 7V3.6h-3.4M3.2 13v3.4h3.4M16.8 13v3.4h-3.4"></path>
+			<circle cx="10" cy="10" r="2.2" fill="currentColor" stroke="none"></circle>
+		</svg>
+		<span>AF</span>
+	</button>
+	<% fi %>
 </div>
 <% fi %>
 <% if has_cap pan || has_cap tilt; then %>


### PR DESCRIPTION
The WebUI half of the first HiSilicon autofocus (majestic's engine; the 85H50AI from #227 is the MVP board).

With `.isp.autofocus.enabled` true in majestic's config **and** a `focus` axis in `ptz_caps`, `update_caminfo` sets `af_support`, the pelco pad's focus group grows an **AF** button (the focus-bracket icon with a filled subject — the camera choosing the distance itself), and `j/ptz.cgi` maps `act=af` to majestic's `GET /autofocus`, polling `/autofocus/status` so the pad's request-lifetime pacing holds while the pass runs.

A zoom step on a motorized lens leaves focus behind, so a successful `wide`/`tele` also books a pass via `GET /autofocus?settle`: the engine waits for btzoom's port lock to go quiet, a held button's pulse train never yields the quiet window, and repeat triggers collapse into the one pass that runs after the zooming is over.

Verified on the lab 85H50AI (deployed via `updatewebui`):
- AF button renders exactly when enabled+focus (`af_support='1'` in sysinfo); gone when the config flips off.
- `act=af` through the pad path: `Autofocus: done fv=5131 peak=5411` — the request held open for the 27 s pass, from the pad's own pacing.
- `act=tele` books the settle pass — status `running` right after the pulse, converging to `done fv=5307 peak=5695` once quiet.
- Disabled camera: no button, `act=af` answers "Autofocus not available on this camera."; everything else untouched.

Cameras without the majestic engine never see any of this. Companion PRs: majestic (the engine), builder (85H50AI profile turns it on out of the box).

Refs #227.
