### PR TITLE
Settings: the heading's quiet tag survives a trip to another tab

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2962,8 +2962,14 @@ mark {
    Firefox do, Safari answers :focus-visible for any focus() it did not watch
    the mouse cause, and drew its default ring round every section title (#222).
    So revealSection() also states the modality outright: a pointer pick tags
-   the heading .mj-focus-quiet (dropped again on blur), and that rule needs no
-   guessing from the engine. Keyboard picks get neither and keep the ring. */
+   the heading .mj-focus-quiet, and that rule needs no guessing from the
+   engine. Keyboard picks get neither and keep the ring.
+
+   The tag is set on every pick and never removed on blur, which is what the
+   second report on #222 was: switching browser tabs blurs the heading and
+   focuses it again on return, so a tag dropped at blur left the ring to come
+   back — and only for people who switch tabs with the keyboard, since that is
+   what makes the engine call the restored focus "visible". */
 #mj-settings-form h3[tabindex]:focus:not(:focus-visible),
 #mj-settings-form h3.mj-focus-quiet:focus {
 	outline: none;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -446,10 +446,20 @@
 		const h = form.querySelector('h3');
 		if (h) {
 			h.tabIndex = -1;
-			if (byPointer) {
-				h.classList.add('mj-focus-quiet');
-				h.addEventListener('blur', () => h.classList.remove('mj-focus-quiet'), { once: true });
-			}
+			// Set to match this pick, every time, and never taken off on blur.
+			//
+			// Blur was the obvious moment to drop it and it is the wrong one:
+			// switching browser tabs blurs the heading, and coming back focuses
+			// it again with no new intent from anyone in between. The tag was
+			// gone by then, so the ring reappeared on return — and only
+			// sometimes, because it depends on whether the tab was switched with
+			// the keyboard, which is what makes the engine call the restored
+			// focus "visible" (#222).
+			//
+			// Leaving it costs nothing. tabindex -1 keeps the heading out of the
+			// tab order, so nothing but this function can focus it, and this
+			// function sets the tag both ways on every pick.
+			h.classList.toggle('mj-focus-quiet', !!byPointer);
 			h.focus({ preventScroll: true });
 		}
 


### PR DESCRIPTION
Second report on #222: the ring still appears, **sometimes**, after switching to another browser tab and coming back.

## Why the first fix missed it

The mute works two ways: a `:focus-visible` arm for engines that agree a script-set focus after a pointer pick is not "visible", and a `.mj-focus-quiet` tag for Safari, which does not. The tag was dropped on `blur`:

```js
h.addEventListener('blur', () => h.classList.remove('mj-focus-quiet'), { once: true });
```

Blur is the obvious moment and it is the wrong one. **Switching browser tabs blurs the heading, and returning focuses it again** — with no new intent from anyone in between. By then the tag is gone, so the only thing left holding the ring off is the `:focus-visible` arm. And that arm answers "visible" exactly when the last interaction was a keyboard one — which switching tabs with `Ctrl`/`Cmd`+`Tab` is.

That is also what "sometimes" means: it depends on whether the reporter left the tab with the keyboard or by clicking another one.

## The fix

The tag follows the pick and nothing else, set both ways on every call:

```js
h.classList.toggle('mj-focus-quiet', !!byPointer);
```

Leaving it on a heading that no longer has focus costs nothing, because the rule only applies while focused. And `tabindex="-1"` keeps the heading out of the tab order, so nothing but `revealSection()` can focus it and nothing but `revealSection()` needs to decide.

That form is correct by construction rather than by timing, which is the point — the previous version depended on `blur` meaning "the user has moved on", and a tab switch is a blur that means the opposite.

## One more, on the way

`toggle()` also fixes a smaller bug: picking the same section again **by keyboard**, after an earlier pointer pick, kept the stale tag and suppressed a ring the keyboard user should have had. The old code only ever added.

## Testing

`npm test` and `npm run build:dist` both pass, but neither covers this: the settings page has no harness, and what broke here is browser focus behaviour across a tab switch, which a stub cannot reproduce honestly. It was found by reading the sequence the report describes and reasoning about when `blur` fires — so it is worth someone repeating the reporter's exact steps, with the keyboard, before this is called closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
