### PR TITLE
Day / Night: find the IR-cut pins by driving them

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-stats.test.js && node tests/ircut-check.test.js"
+    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-stats.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -1,0 +1,225 @@
+// Finding the IR-cut wiring by driving pairs of pads.
+//
+// This exists because the subject drives hardware blind and reports a verdict
+// nobody can check by eye. Two GPIO numbers written into majestic's config look
+// exactly as plausible when they are wrong as when they are right.
+//
+// The cautionary history is worth stating, because the tests are shaped by it.
+// The first version pulsed ONE pad at a time and reported a hit — and the hit
+// was an artefact: handing a pad back floating springs a brake-held filter
+// open, and that change got credited to whichever pad was under the sweep. It
+// named a real IR-cut pad by luck. So the fixtures below model the mechanism
+// measured on a XiongMai 85H50AI, not a convenient abstraction of it:
+//
+//   float either pad       -> OPEN
+//   both low (braked)      -> holds position, zero current
+//   a high against b low   -> moves one way
+//   b high against a low   -> moves the other way
+'use strict';
+
+const path = require('path');
+const { check, group, done } = require('./assert');
+
+const scan = require(path.join(__dirname, '..', 'www', 'a', 'ircut-scan.js'));
+
+const banks = (n, base) => {
+	const b = { banks: [], assigned: [], held: [] };
+	for (let i = 0; i < n; i++) b.banks.push({ base: (base || 0) + i * 8, n: 8 });
+	return b;
+};
+const B10 = banks(10);
+const OPEN = { gmin: 1.0 }, CLOSED = { gmin: 0.03 };
+
+// A filter on pads `pa`/`pb`, brake-held or latching, driven through the same
+// io the real scan uses.
+function camera(pa, pb, opts) {
+	opts = opts || {};
+	const log = [];
+	let closed = !!opts.startClosed;
+	let braked = true;
+	return {
+		log: log,
+		get closed() { return closed; },
+		io: {
+			drive: (a, b) => {
+				log.push('drive ' + a + ',' + b);
+				braked = true;
+				if ((a === pb && b === pa)) closed = true;      // pb high closes
+				else if ((a === pa && b === pb)) closed = false; // pa high opens
+				return Promise.resolve({ done: true });
+			},
+			release: (a, b) => {
+				log.push('release ' + a + ',' + b);
+				// Floating the FILTER's pads springs a brake-held one open.
+				if (opts.latching) return Promise.resolve({ done: true });
+				if ((a === pa || a === pb) && (b === pa || b === pb)) {
+					braked = false;
+					closed = false;
+				}
+				return Promise.resolve({ done: true });
+			},
+			look: () => Promise.resolve(closed ? CLOSED : OPEN),
+			wait: () => Promise.resolve(),
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+group('pairs: the search space, narrowest tier first');
+{
+	const p = scan.pairs(B10);
+	check('the commonest wiki pair is tried first',
+		p[0][0] === 11 && p[0][1] === 10, JSON.stringify(p[0]));
+	const adj = p.findIndex((x) => x[0] === 16 && x[1] === 17);
+	const far = p.findIndex((x) => x[0] === 16 && x[1] === 20);
+	check('neighbours in a bank come before distant ones in it', adj < far, adj + ' vs ' + far);
+	// An H-bridge takes both inputs from one place, and every wiki pair but
+	// Anjoy's SSC377 (11 and 80) is same-bank. Cross-bank is thousands of
+	// trials, so it is opt-in rather than default.
+	const cross = p.filter((x) => Math.floor(x[0] / 8) !== Math.floor(x[1] / 8) &&
+		!scan.KNOWN_PAIRS.some((k) => k[0] === x[0] && k[1] === x[1]));
+	check('cross-bank pairs are not in the default list', cross.length === 0, cross.length);
+	check('...but exhaustive asks for them',
+		scan.pairs(B10, { exhaustive: true }).length > p.length * 10);
+	check('no pair is repeated',
+		new Set(p.map((x) => Math.min(...x) + ':' + Math.max(...x))).size === p.length);
+	check('no pad is paired with itself', p.every((x) => x[0] !== x[1]));
+}
+
+group('pairs: the pad list is the SoC\'s, never a constant');
+{
+	check('a 17-bank SoC yields more pairs than a 10-bank one',
+		scan.pairs(banks(17)).length > scan.pairs(B10).length);
+	// Novatek numbers its pads in the 200s.
+	const nt = scan.pairs({ banks: [{ base: 224, n: 16 }], assigned: [], held: [] });
+	check('a non-zero base is honoured', nt.every((x) => x[0] >= 224 && x[1] >= 224));
+	const owned = scan.pairs(Object.assign({}, B10, { assigned: [{ pin: 11 }] }));
+	check('an assigned pad is in no pair', !owned.some((x) => x.indexOf(11) >= 0));
+	// A driver's claim is hardware wired on purpose; a sysfs export is only
+	// majestic's, and on a brake-held board it holds the filter.
+	const h = scan.pairs(Object.assign({}, banks(1), {
+		held: [{ pin: 3, owner: 'reset' }, { pin: 1, owner: 'sysfs' }],
+	}));
+	check('a driver-held line is in no pair', !h.some((x) => x.indexOf(3) >= 0));
+	check('a sysfs export stays a candidate', h.some((x) => x.indexOf(1) >= 0));
+}
+
+// ---------------------------------------------------------------------------
+group('classify: a change, not an absolute');
+{
+	check('open to closed is a hit', scan.classify(1.0, 0.03) !== null);
+	check('closed to open is a hit, the other way',
+		scan.classify(0.03, 1.0).opens === true);
+	check('a still scene is not a hit', scan.classify(0.05, 0.06) === null);
+	check('noise under the bar is not a hit',
+		scan.classify(0.4, 0.4 + scan.HIT_DELTA - 0.01) === null);
+}
+
+// ---------------------------------------------------------------------------
+group('run: it finds the pair, and only the pair');
+{
+	const c = camera(11, 10);          // 10 high closes, 11 high opens
+	scan.run(c.io, scan.pairs(B10), { settleMs: 0 }).then((r) => {
+		check('a pair is found', !!r.found, JSON.stringify(r.found));
+		check('it is the right one',
+			r.pins && Math.min(r.pins.irCutPin1, r.pins.irCutPin2) === 10 &&
+			Math.max(r.pins.irCutPin1, r.pins.irCutPin2) === 11, JSON.stringify(r.pins));
+		check('and it knows which pad closes it', r.pins.closesWhenHigh === 10, r.pins.closesWhenHigh);
+		check('the filter is left CLOSED, which is what daylight wants', c.closed === true);
+		return second();
+	}).catch((e) => check('run threw: ' + e.message, false));
+
+	function second() {
+		group('run: a filter buried deep in the list is still found');
+		// Pads 20/21 are nobody's known pair — it has to walk into the
+		// adjacent-in-bank tier to reach them.
+		const c2 = camera(20, 21);
+		return scan.run(c2.io, scan.pairs(B10), { settleMs: 0 }).then((r) => {
+			check('found beyond the known-pairs tier',
+				r.pins && Math.min(r.pins.irCutPin1, r.pins.irCutPin2) === 20, JSON.stringify(r.pins));
+			check('nothing else was reported', r.found.a === 21 || r.found.a === 20);
+			return third();
+		});
+	}
+
+	function third() {
+		group('run: both orderings are tried before a pair is dismissed');
+		// Starting CLOSED, the closing ordering changes nothing — only the
+		// opening one does. A scan that tried one ordering would walk past its
+		// own filter.
+		const c3 = camera(11, 10, { startClosed: true });
+		return scan.run(c3.io, [[10, 11]], { settleMs: 0 }).then((r) => {
+			check('a pair whose first ordering is a no-op is still caught', !!r.found);
+			const drives = c3.log.filter((l) => l.indexOf('drive') === 0);
+			check('both orderings were driven',
+				drives.some((l) => l === 'drive 10,11') && drives.some((l) => l === 'drive 11,10'),
+				drives.join(' | '));
+			return fourth();
+		});
+	}
+
+	function fourth() {
+		group('run: a pad that is not the filter is handed back');
+		const c4 = camera(11, 10);
+		return scan.run(c4.io, [[30, 31], [11, 10]], { settleMs: 0 }).then((r) => {
+			check('the ruled-out pair was released',
+				c4.log.indexOf('release 30,31') >= 0, c4.log.slice(0, 6).join(' | '));
+			check('and the real pair was still found', !!r.found);
+			return fifth();
+		});
+	}
+
+	function fifth() {
+		group('run: nothing found');
+		const c5 = camera(70, 71);
+		return scan.run(c5.io, [[1, 2], [3, 4]], { settleMs: 0 }).then((r) => {
+			check('no pair is reported', r.found === null);
+			check('and it says it finished the list', r.done === true);
+			return sixth();
+		});
+	}
+
+	function sixth() {
+		group('run: stopping');
+		let stop = false;
+		const c6 = camera(70, 71);
+		const io = Object.assign({}, c6.io, { stopped: () => stop });
+		const orig = c6.io.drive;
+		io.drive = (a, b) => { if (c6.log.length > 3) stop = true; return orig(a, b); };
+		return scan.run(io, scan.pairs(B10), { settleMs: 0 }).then((r) => {
+			check('a stop request ends the sweep', r.found === null);
+			check('and it does not claim to have finished', r.done === false);
+			return seventh();
+		});
+	}
+
+	function seventh() {
+		group('finish: the filter type falls out of one extra trial');
+		// Brake-held: floating the pads springs it open, so majestic has to keep
+		// them driven for the day position to survive.
+		const brake = camera(11, 10);
+		return scan.run(brake.io, [[11, 10]], { settleMs: 0 }).then((r) => {
+			check('a filter that springs open when floated is brake-held',
+				r.pins.brakeHeld === true, String(r.pins.brakeHeld));
+			const latch = camera(11, 10, { latching: true });
+			return scan.run(latch.io, [[11, 10]], { settleMs: 0 }).then((r2) => {
+				check('one that holds through a float is latching',
+					r2.pins.brakeHeld === false, String(r2.pins.brakeHeld));
+				return eighth();
+			});
+		});
+	}
+
+	function eighth() {
+		group('casualty: the pair that stopped the camera answering');
+		const hung = scan.casualty({ boot: 2000, scan: { pins: [47, 48], started: 1900 } });
+		check('an actuation predating this boot names both pads',
+			hung && hung.pins.join(',') === '47,48', JSON.stringify(hung));
+		check('a completed actuation is not a casualty',
+			scan.casualty({ boot: 2000, scan: { pins: [47, 48], started: 1900, survived: true } }) === null);
+		check('one from this boot is not a casualty',
+			scan.casualty({ boot: 2000, scan: { pins: [47, 48], started: 2100 } }) === null);
+		check('no journal, no casualty', scan.casualty({ boot: 2000, scan: {} }) === null);
+		done();
+	}
+}

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -211,6 +211,44 @@ group('run: it finds the pair, and only the pair');
 	}
 
 	function eighth() {
+		group('run: a failed request stops the sweep, a refusal does not');
+		// The endpoint guards pads with owners and says so with done:false —
+		// skip that pair and carry on. A request that never arrives is a camera
+		// that has stopped answering; treating it as "this pair moved nothing"
+		// kept the scan firing GPIO writes at a dead camera for the rest of the
+		// list and then reported that nothing moved.
+		const refused = [];
+		const ioRefuse = {
+			drive: (a, b) => { refused.push(a + ',' + b); return Promise.resolve({ done: false, error: 'pad is already assigned' }); },
+			release: () => Promise.resolve({ done: true }),
+			look: () => Promise.resolve(OPEN),
+			wait: () => Promise.resolve(),
+		};
+		return scan.run(ioRefuse, [[1, 2], [3, 4]], { settleMs: 0 }).then((r) => {
+			check('a refused pair is skipped and the sweep continues',
+				r.found === null && r.done === true, JSON.stringify(r));
+			check('both pairs were offered', refused.length >= 2, refused.join(' | '));
+
+			let n = 0;
+			const ioDead = {
+				drive: () => { n++; return n > 1 ? Promise.reject(new Error('HTTP 502')) : Promise.resolve({ done: true }); },
+				release: () => Promise.resolve({ done: true }),
+				look: () => Promise.resolve(OPEN),
+				wait: () => Promise.resolve(),
+			};
+			return scan.run(ioDead, [[1, 2], [3, 4], [5, 6], [7, 8]], { settleMs: 0 }).then(
+				() => check('a dead camera must not resolve as a finished scan', false),
+				(e) => {
+					check('the failure reaches the caller', /502/.test(e.message), e.message);
+					// Four pairs, two orderings each, would be eight drives if
+					// the sweep had carried on regardless.
+					check('and the sweep stopped rather than working the list', n <= 2, 'drives=' + n);
+					return ninth();
+				});
+		});
+	}
+
+	function ninth() {
 		group('casualty: the pair that stopped the camera answering');
 		const hung = scan.casualty({ boot: 2000, scan: { pins: [47, 48], started: 1900 } });
 		check('an actuation predating this boot names both pads',

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -201,6 +201,7 @@ group('run: it finds the pair, and only the pair');
 		return scan.run(brake.io, [[11, 10]], { settleMs: 0 }).then((r) => {
 			check('a filter that springs open when floated is brake-held',
 				r.pins.brakeHeld === true, String(r.pins.brakeHeld));
+			check('a clean finish is marked settled', r.pins.settled === true);
 			const latch = camera(11, 10, { latching: true });
 			return scan.run(latch.io, [[11, 10]], { settleMs: 0 }).then((r2) => {
 				check('one that holds through a float is latching',
@@ -249,6 +250,25 @@ group('run: it finds the pair, and only the pair');
 	}
 
 	function ninth() {
+		group('finish: an unfinished follow-up is not a clean find');
+		// The pair was watched moving the picture, so it stands. Classifying the
+		// filter and leaving it closed can still fail, and presenting that as
+		// "Found it" would stage a mapping whose filter is sitting open.
+		const c = camera(11, 10);
+		let n = 0;
+		const io = Object.assign({}, c.io, {
+			release: (a, b) => { n++; return n > 0 ? Promise.reject(new Error('gone')) : c.io.release(a, b); },
+		});
+		return scan.run(io, [[11, 10]], { settleMs: 0 }).then((r) => {
+			check('the pair is still reported', r.pins && r.pins.irCutPin1 === 11,
+				JSON.stringify(r.pins));
+			check('but it is not marked settled', r.pins.settled === false,
+				String(r.pins.settled));
+			return tenth();
+		});
+	}
+
+	function tenth() {
 		group('casualty: the pair that stopped the camera answering');
 		const hung = scan.casualty({ boot: 2000, scan: { pins: [47, 48], started: 1900 } });
 		check('an actuation predating this boot names both pads',

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -206,7 +206,23 @@ group('run: it finds the pair, and only the pair');
 			return scan.run(latch.io, [[11, 10]], { settleMs: 0 }).then((r2) => {
 				check('one that holds through a float is latching',
 					r2.pins.brakeHeld === false, String(r2.pins.brakeHeld));
-				return eighth();
+				// The case the lab camera could not catch. Starting CLOSED makes
+				// the hit the OPENING direction, and the classification then has
+				// to compare against the picture after the filter is closed
+				// again — not against the frame the hit left behind. The bug
+				// only ever erred towards brake-held, which is what that camera
+				// is, so the fixture agreed with it.
+				const latchOpen = camera(11, 10, { latching: true, startClosed: true });
+				return scan.run(latchOpen.io, [[11, 10]], { settleMs: 0 }).then((r3) => {
+					check('a latching filter found by its OPENING direction is still latching',
+						r3.pins.brakeHeld === false, String(r3.pins.brakeHeld));
+					const brakeOpen = camera(11, 10, { startClosed: true });
+					return scan.run(brakeOpen.io, [[11, 10]], { settleMs: 0 }).then((r4) => {
+						check('and a brake-held one found the same way is still brake-held',
+							r4.pins.brakeHeld === true, String(r4.pins.brakeHeld));
+						return eighth();
+					});
+				});
 			});
 		});
 	}

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3877,10 +3877,16 @@ dialog.mj-modal::backdrop {
 
 .mj-ircut-scan {
 	margin-top: 0.75rem;
-	padding: 0.85rem 1rem;
+	padding: 0.85rem 1rem 1rem;
 	border: 1px solid var(--bs-border-color);
 	border-radius: var(--bs-border-radius);
 	background: var(--bs-card-bg);
+}
+
+/* .mj-live-grp-head carries top margin for use partway down a column; as this
+   panel's first child that reads as a gap above the rule. */
+.mj-ircut-scan > .mj-live-grp-head:first-child {
+	margin-top: 0;
 }
 
 /* Below md the map would push the roles off the card. */

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3875,6 +3875,13 @@ dialog.mj-modal::backdrop {
 	margin-top: 0.75rem;
 }
 
+.mj-ircut-scan {
+	margin-top: 0.75rem;
+	padding: 0.85rem 1rem;
+	border: 1px solid var(--bs-border-color);
+	border-radius: var(--bs-border-radius);
+	background: var(--bs-card-bg);
+}
 
 /* Below md the map would push the roles off the card. */
 @media (max-width: 767.98px) {

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -266,7 +266,16 @@
 			// apart from a number that merely appears in the config.
 			has: (pin) => geo.pads.some((x) => x.pin === pin),
 			get: () => Object.assign({}, assign),
-			set: (a) => { assign = Object.assign({}, a || {}); sel = null; paint(); },
+			// Fires onChange, because a programmatic set is still an edit — the
+			// scan fills these in on the person's behalf. Without it the pads
+			// recoloured and the role list beside them did not, which is the
+			// sort of half-update that makes someone doubt the whole panel.
+			set: (a) => {
+				assign = Object.assign({}, a || {});
+				sel = null;
+				paint();
+				if (opts.onChange) opts.onChange(Object.assign({}, assign));
+			},
 			// Called by the scan so the pad being driven lights up on the same
 			// map the person is about to click.
 			sweep: (pin) => { sweeping = pin; paint(); },

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -270,11 +270,15 @@
 			// scan fills these in on the person's behalf. Without it the pads
 			// recoloured and the role list beside them did not, which is the
 			// sort of half-update that makes someone doubt the whole panel.
-			set: (a) => {
+			set: (a, o) => {
 				assign = Object.assign({}, a || {});
 				sel = null;
 				paint();
-				if (opts.onChange) opts.onChange(Object.assign({}, assign));
+				// `quiet` is for re-syncing from config after a save or a reset.
+				// Announcing that would push the values straight back into the
+				// fields refresh() has just settled — and on a save that means
+				// the form goes dirty again the instant it goes clean.
+				if (opts.onChange && !(o && o.quiet)) opts.onChange(Object.assign({}, assign));
 			},
 			// Called by the scan so the pad being driven lights up on the same
 			// map the person is about to click.

--- a/www/a/ircut-scan.js
+++ b/www/a/ircut-scan.js
@@ -219,6 +219,11 @@
 			irCutPin1: otherPad,
 			irCutPin2: closeHigh,
 			brakeHeld: null,
+			// The pair is a measurement and stands on its own — it was watched
+			// moving the picture. Everything after it (classifying the filter,
+			// leaving it closed) can still fail, and when it does the caller
+			// has to be told rather than shown a clean "Found it".
+			settled: false,
 		};
 
 		const ensureClosed = () => hit.opens
@@ -239,7 +244,7 @@
 				// Put it back where daylight wants it either way.
 				return io.drive(closeHigh, otherPad);
 			})
-			.then(() => out)
+			.then(() => { out.settled = true; return out; })
 			.catch(() => out);
 	}
 

--- a/www/a/ircut-scan.js
+++ b/www/a/ircut-scan.js
@@ -1,0 +1,252 @@
+// Finding the IR-cut wiring by driving it.
+//
+// The camera cannot tell you which pads its filter is on. On a camera still
+// running vendor firmware it nearly could — the stock app leaves those pads
+// configured as driven outputs, which is how ipctool's gpio_possible_ircut()
+// spots them — but that evidence dies with the flash. After conversion a
+// default majestic.yaml claims no pins, nothing has ever touched those pads,
+// and the registers know nothing. What is left is to drive them and watch.
+//
+// PAIRS, NOT PADS, and this is the whole shape of the thing. The first version
+// of this file pulsed one pad at a time, which cannot work: an IR-cut filter is
+// driven by an H-bridge across TWO pads, and no single-pad operation actuates
+// it. Measured on a XiongMai 85H50AI, every state reachable with one pad:
+//
+//   float either pad          -> filter OPEN (the brake is released)
+//   both pads low             -> holds its position, no current
+//   pad A high, pad B low     -> moves one way
+//   pad B high, pad A low     -> moves the other way
+//
+// The single-pad sweep still reported a hit, and that is the cautionary part:
+// what it saw was the filter springing open because a pad had been handed back
+// floating — a change the pulse did not cause, credited to whichever pad
+// happened to be under the sweep at the time. It named a real IR-cut pad by
+// luck. A scan that can be right by accident is not a scan.
+//
+// Two more consequences of the same measurement:
+//
+//   THE BRAKE HOLDS THE RESULT. Both pads low is zero current and holds
+//   whatever position the actuation reached, so j/gpio.cgi leaves a pair braked
+//   rather than handing it back. Restoring the pads as found would discard the
+//   actuation before anything could look at it.
+//
+//   THE FILTER TYPE IS DISCOVERABLE. Float the pads after a successful close: a
+//   filter that springs open is brake-held and its pads must stay driven, one
+//   that stays closed is a latching type. That is worth knowing and costs one
+//   extra trial.
+(function () {
+	'use strict';
+
+	// How much of the frame's colour has to move before a pair is a candidate.
+	// Far above frame-to-frame noise on a still scene (under 0.02) and far below
+	// the ~0.98 a real filter produces between open and closed.
+	const HIT_DELTA = 0.25;
+	// Settle between actuating and believing the picture: the filter is
+	// mechanical and the encoder is a couple of frames behind it.
+	const SETTLE_MS = 900;
+
+	// Pairs that carry an IR-cut somewhere in the OpenIPC wiki's GPIO table,
+	// commonest first. A prior over PAIRS of numbers — no vendor is named and
+	// none has to be, because the same pairs recur across unrelated makers. It
+	// only decides the order things are tried; nothing is excluded by it.
+	const KNOWN_PAIRS = [
+		[11, 10], [8, 9], [12, 13], [53, 54], [5, 6], [1, 2], [14, 15], [13, 15],
+		[33, 34], [38, 39], [43, 44], [50, 51], [52, 53], [58, 57], [60, 59],
+		[64, 65], [68, 70], [78, 79], [80, 81], [23, 24], [18, 19], [3, 4],
+		[120, 121], [225, 226],
+	];
+
+	function key(a, b) { return a < b ? a + ':' + b : b + ':' + a; }
+
+	// Every candidate pair the kernel's pad list allows, ordered by how likely
+	// it is to be the filter. Tiers, widening:
+	//   1. pairs the wiki has actually seen
+	//   2. neighbours within one bank — an H-bridge takes both its inputs from
+	//      one place, and every wiki pair but one is same-bank
+	//   3. any two pads in one bank
+	//   4. across banks, only when asked: Anjoy's SSC377 keeps its coils on 11
+	//      and 80, so it exists, but it is thousands of trials
+	function pairs(info, opts) {
+		opts = opts || {};
+		const skip = {};
+		(info.assigned || []).forEach((a) => { skip[a.pin] = 1; });
+		(opts.exclude || []).forEach((p) => { skip[p] = 1; });
+		// A line a kernel DRIVER holds is wired to something deliberate and is
+		// the class of pad that resets a PHY or drops a rail. "sysfs" is only an
+		// export — majestic's, and on a brake-held board it keeps those pads
+		// driven precisely because that is what holds the filter — so those stay
+		// candidates.
+		(info.held || []).forEach((h) => {
+			if (h.owner && h.owner !== 'sysfs') skip[h.pin] = 1;
+		});
+		(opts.notGpio || []).forEach((p) => { skip[p] = 1; });
+
+		const banks = (info.banks || []).map((b) => {
+			const pads = [];
+			for (let i = 0; i < b.n; i++) if (!skip[b.base + i]) pads.push(b.base + i);
+			return pads;
+		});
+		const all = {};
+		banks.forEach((p) => p.forEach((n) => { all[n] = 1; }));
+
+		const out = [];
+		const seen = {};
+		const add = (a, b) => {
+			if (!all[a] || !all[b] || a === b) return;
+			const k = key(a, b);
+			if (seen[k]) return;
+			seen[k] = 1;
+			out.push([a, b]);
+		};
+
+		KNOWN_PAIRS.forEach((p) => add(p[0], p[1]));
+		banks.forEach((pads) => {
+			for (let i = 0; i + 1 < pads.length; i++)
+				if (pads[i + 1] === pads[i] + 1) add(pads[i], pads[i + 1]);
+		});
+		banks.forEach((pads) => {
+			for (let i = 0; i < pads.length; i++)
+				for (let j = i + 1; j < pads.length; j++) add(pads[i], pads[j]);
+		});
+		if (opts.exhaustive) {
+			const flat = Object.keys(all).map(Number).sort((x, y) => x - y);
+			for (let i = 0; i < flat.length; i++)
+				for (let j = i + 1; j < flat.length; j++) add(flat[i], flat[j]);
+		}
+		return out;
+	}
+
+	// Did the picture move, and which way? Rising gmin means the frame gained
+	// the infrared cast, so that actuation OPENED the filter.
+	function classify(from, to) {
+		const d = to - from;
+		if (Math.abs(d) < HIT_DELTA) return null;
+		return { delta: d, opens: d > 0 };
+	}
+
+	// Did the last run leave a pair mid-actuation? j/gpio.cgi writes both pads
+	// to flash and syncs BEFORE touching a register, so a journal whose
+	// actuation began before this boot is the fingerprint of a pair that took
+	// the camera down. `survived` is written after the call returns, so its
+	// absence is the tell.
+	function casualty(info) {
+		const s = info && info.scan;
+		if (!s || !s.pins || s.survived) return null;
+		if (info.boot !== undefined && s.started !== undefined && s.started < info.boot)
+			return { pins: s.pins, at: s.started };
+		return null;
+	}
+
+	// The run. `io` is injected so the ordering can be tested without hardware:
+	//   io.drive(a, b) -> actuate a high against b low, leaving the pair braked
+	//   io.release(a, b) -> float both, undoing the brake
+	//   io.look() -> stats from a/ircut-check.js
+	//   io.wait(ms), io.onStep({a, b, index, total}), io.stopped()
+	//
+	// Nothing is written to the camera's configuration here. The scan proposes;
+	// saving and testing are separate, deliberate acts.
+	function run(io, list, opts) {
+		opts = opts || {};
+		const settle = opts.settleMs === undefined ? SETTLE_MS : opts.settleMs;
+
+		// The baseline is read before anything is driven. Folding the first
+		// trial's own result into it would make that pair invisible — and the
+		// first pair is not an arbitrary one, it is the likeliest filter in the
+		// list, so the scan would be blindest exactly where it should be
+		// sharpest.
+		let base = null;
+
+		const trial = (a, b) =>
+			io.drive(a, b)
+				.then((r) => (r && r.done === false) ? null
+					: io.wait(settle).then(() => io.look()))
+				.then((after) => {
+					if (!after) return null;
+					const c = classify(base.gmin, after.gmin);
+					if (c) base = after;
+					return c ? { a: a, b: b, opens: c.opens, after: after } : null;
+				});
+
+		const step = (i) => {
+			if (i >= list.length || (io.stopped && io.stopped()))
+				return Promise.resolve({ found: null, done: i >= list.length });
+			const a = list[i][0], b = list[i][1];
+			if (io.onStep) io.onStep({ a: a, b: b, index: i, total: list.length });
+			// Both orderings before moving on: one of them drives the direction
+			// the filter is not already in, and only that one changes anything.
+			return trial(a, b)
+				.then((hit) => hit || trial(b, a))
+				.then((hit) => {
+					if (hit) return { found: hit, done: false };
+					// Ruled out: hand the pads back the way they were found,
+					// which for an untouched pad is floating.
+					return io.release(a, b).then(() => step(i + 1));
+				});
+		};
+
+		return io.look().then((first) => {
+			base = first;
+			return step(0);
+		}).then((res) => {
+			if (!res.found) return res;
+			return finish(io, res.found, base, settle).then((d) => {
+				res.pins = d;
+				return res;
+			});
+		});
+	}
+
+	// A hit tells us the pair and which pad drove which way. Two things are
+	// still worth one trial each: leaving the filter CLOSED (the right position
+	// for daylight, and the one whose picture is worth showing), and finding out
+	// whether the pads have to stay driven to keep it there.
+	function finish(io, hit, base, settle) {
+		// The actuation that produced the magenta cast opened it, so the other
+		// ordering closes it.
+		const closeHigh = hit.opens ? hit.b : hit.a;
+		const otherPad = hit.opens ? hit.a : hit.b;
+
+		const out = {
+			// Named for what was measured, not for a config key: which pad,
+			// driven high against the other, closes the filter.
+			closesWhenHigh: closeHigh,
+			opensWhenHigh: otherPad,
+			// The mapping majestic's two keys want. Verified on a XiongMai
+			// 85H50AI, where irCutPin1=11 / irCutPin2=10 is correct and driving
+			// 10 high is what closes — so the closing pad is irCutPin2. A board
+			// that disagrees is caught by the filter test, which already knows
+			// how to say "wired backwards".
+			irCutPin1: otherPad,
+			irCutPin2: closeHigh,
+			brakeHeld: null,
+		};
+
+		const ensureClosed = () => hit.opens
+			? io.drive(closeHigh, otherPad).then(() => io.wait(settle))
+			: Promise.resolve();
+
+		return ensureClosed()
+			// Float the pair and look: a filter that springs open is brake-held
+			// and its pads must stay driven for the day position to survive; one
+			// that stays closed is a latching type and can be let go.
+			.then(() => io.release(closeHigh, otherPad))
+			.then(() => io.wait(settle))
+			.then(() => io.look())
+			.then((floated) => {
+				out.brakeHeld = classify(base.gmin, floated.gmin) !== null
+					? true
+					: (floated.gmin >= 0.9 ? true : false);
+				// Put it back where daylight wants it either way.
+				return io.drive(closeHigh, otherPad);
+			})
+			.then(() => out)
+			.catch(() => out);
+	}
+
+	const api = {
+		pairs: pairs, classify: classify, casualty: casualty, run: run, finish: finish,
+		KNOWN_PAIRS: KNOWN_PAIRS, HIT_DELTA: HIT_DELTA, SETTLE_MS: SETTLE_MS,
+	};
+	if (typeof module === 'object' && module.exports) module.exports = api;
+	if (typeof window === 'object') window.MajesticIrcutScan = api;
+})();

--- a/www/a/ircut-scan.js
+++ b/www/a/ircut-scan.js
@@ -230,20 +230,26 @@
 			? io.drive(closeHigh, otherPad).then(() => io.wait(settle))
 			: Promise.resolve();
 
+		// The classification compares the CLOSED picture against the floated
+		// one, so it has to read the closed picture rather than reuse the frame
+		// the hit produced. When the hit was the opening direction that frame is
+		// the OPEN image, and comparing a float against it inverts the answer: a
+		// latching filter that stays shut looks like a change and is reported
+		// brake-held. It only ever erred one way, towards brake-held, which is
+		// what this camera happens to be — so the fixture agreed with the bug.
 		return ensureClosed()
-			// Float the pair and look: a filter that springs open is brake-held
-			// and its pads must stay driven for the day position to survive; one
-			// that stays closed is a latching type and can be let go.
-			.then(() => io.release(closeHigh, otherPad))
-			.then(() => io.wait(settle))
 			.then(() => io.look())
-			.then((floated) => {
-				out.brakeHeld = classify(base.gmin, floated.gmin) !== null
-					? true
-					: (floated.gmin >= 0.9 ? true : false);
-				// Put it back where daylight wants it either way.
-				return io.drive(closeHigh, otherPad);
-			})
+			.then((closed) => io.release(closeHigh, otherPad)
+				.then(() => io.wait(settle))
+				.then(() => io.look())
+				.then((floated) => {
+					// Floating releases the brake. A filter that moves was being
+					// held there and its pads must stay driven; one that does
+					// not is latching and can be let go.
+					out.brakeHeld = classify(closed.gmin, floated.gmin) !== null;
+					// Put it back where daylight wants it either way.
+					return io.drive(closeHigh, otherPad);
+				}))
 			.then(() => { out.settled = true; return out; })
 			.catch(() => out);
 	}

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -2073,33 +2073,41 @@
 
 		host.hidden = false;
 		host.className = 'mj-ircut-scan';
+		// Dressed as a group of this section, not as an announcement inside it:
+		// micro-caps head, hairline to the margin, note on the right, small body
+		// — the same head the deck gives Wiring and Connected to. A lead
+		// paragraph at full body size was the only 1rem text on the page.
 		host.innerHTML =
-			'<p class="mb-2"><b>Find the pins by trying them.</b> Each pad is driven ' +
-			'against another while the picture is watched for the filter to move. ' +
-			'An IR-cut filter is driven across two pads, so pairs are what get ' +
-			'tried; the pairs other boards use go first, so this usually ends in ' +
-			'seconds.</p>' +
+			'<div class="mj-live-grp-head"><span class="mj-cap">Find the pins</span>' +
+			'<span class="mj-live-rule"></span>' +
+			'<span class="mj-live-note" id="mj-scan-n"></span></div>' +
+			'<p class="small mb-2">Each pad is driven against another while the ' +
+			'picture is watched for the filter to move. An IR-cut filter is driven ' +
+			'across two pads, so pairs are what get tried; the pairs other boards ' +
+			'use go first, so this usually ends in seconds.</p>' +
 			'<div class="alert alert-warning py-2 px-3 mb-2 small">' +
 			'<b>This drives pads whose job is unknown.</b> One of them may reset the ' +
 			'network, cut power to the sensor, or stop the camera answering. That risk ' +
 			'cannot be removed &mdash; only made survivable: each pad is written to flash ' +
 			'before it is driven, so a camera that has to be restarted comes back knowing ' +
 			'which pad did it.</div>' +
-			'<p class="small text-secondary mb-2">Pads already spoken for are skipped. ' +
+			'<p class="x-small text-secondary mb-2">Pads already spoken for are skipped. ' +
 			'This reads the picture, so it needs daylight &mdash; at night nothing will ' +
 			'look like it moved.</p>' +
 			'<div class="d-flex gap-2 align-items-center">' +
 			'<button type="button" class="btn btn-primary btn-sm" id="mj-scan-go">Start</button>' +
 			'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-scan-no">Cancel</button>' +
-			'<span class="small text-secondary" id="mj-scan-n"></span></div>';
+			'</div>';
 		host.querySelector('#mj-scan-n').textContent = list.length + ' pairs to try';
 		host.querySelector('#mj-scan-no').addEventListener('click', () => {
 			stop = true; host.hidden = true;
 		});
 		host.querySelector('#mj-scan-go').addEventListener('click', () => {
 			host.innerHTML =
-				'<p class="mb-2"><b id="mj-scan-t">Starting…</b></p>' +
-				'<p class="small text-secondary mb-2" id="mj-scan-s"></p>' +
+				'<div class="mj-live-grp-head"><span class="mj-cap">Scanning</span>' +
+				'<span class="mj-live-rule"></span>' +
+				'<span class="mj-live-note" id="mj-scan-s"></span></div>' +
+				'<p class="small mb-2" id="mj-scan-t">Starting&hellip;</p>' +
 				'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-scan-stop">Stop</button>';
 			const t = host.querySelector('#mj-scan-t');
 			const s = host.querySelector('#mj-scan-s');
@@ -2122,13 +2130,19 @@
 				map.sweep(null);
 				const found = res.pins;
 				if (!found) {
-					host.innerHTML = '<div class="alert alert-secondary py-2 px-3 mb-0 small">' +
+					host.innerHTML = '<div class="mj-live-grp-head">' +
+						'<span class="mj-cap">Find the pins</span>' +
+						'<span class="mj-live-rule"></span></div>' +
+						'<div class="alert alert-secondary py-2 px-3 mb-0 small">' +
 						'<b>Nothing moved the picture.</b> Either the filter is on a pair this ' +
 						'scan did not reach, or there is not enough light to see it move. ' +
 						'Try again in daylight, or set the pins by hand.</div>';
 					return;
 				}
-				host.innerHTML = '<div class="alert alert-success py-2 px-3 mb-2 small"><b>Found it.</b> ' +
+				host.innerHTML = '<div class="mj-live-grp-head">' +
+					'<span class="mj-cap">Find the pins</span>' +
+					'<span class="mj-live-rule"></span></div>' +
+					'<div class="alert alert-success py-2 px-3 mb-2 small"><b>Found it.</b> ' +
 					'Pins ' + esc(String(found.irCutPin1)) + ' and ' + esc(String(found.irCutPin2)) +
 					' drive the filter &mdash; ' + esc(String(found.closesWhenHigh)) +
 					' is the one that closes it. ' +
@@ -2151,7 +2165,10 @@
 				});
 			}).catch((e) => {
 				map.sweep(null);
-				host.innerHTML = '<div class="alert alert-danger py-2 px-3 mb-0 small">' +
+				host.innerHTML = '<div class="mj-live-grp-head">' +
+					'<span class="mj-cap">Find the pins</span>' +
+					'<span class="mj-live-rule"></span></div>' +
+					'<div class="alert alert-danger py-2 px-3 mb-0 small">' +
 					'The scan could not finish: ' + esc(e && e.message ? e.message : String(e)) +
 					'</div>';
 			});

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -2051,12 +2051,20 @@
 		const dead = window.MajesticIrcutScan &&
 			window.MajesticIrcutScan.casualty(info);
 		if (dead) {
+			// The journal records the PAIR that was being driven, because a pair
+			// is what an actuation takes. Reading one pin off it printed
+			// "undefined" and excluded nothing, which left the pair that
+			// rebooted the camera free to be tried again on the next scan —
+			// the exact outcome the journal exists to prevent.
+			const pins = (dead.pins || []).map(Number).filter((n) => !isNaN(n));
 			const w = el('div', 'alert alert-warning py-2 px-3 mb-2 small');
-			w.innerHTML = '<b>The last pin scan stopped the camera.</b> It was driving pin ' +
-				esc(String(dead.pin)) + ' when it stopped answering, and the watchdog ' +
-				'restarted it. That pin has been excluded from further scans.';
+			w.innerHTML = '<b>The last pin scan stopped the camera.</b> It was driving ' +
+				(pins.length > 1 ? 'pins ' + esc(pins.join(' and ')) : 'pin ' + esc(String(pins[0]))) +
+				' when it stopped answering, and the watchdog restarted it. ' +
+				(pins.length > 1 ? 'Those pins have' : 'That pin has') +
+				' been excluded from further scans.';
 			box.querySelector('#mj-ircut-findings').appendChild(w);
-			state.ircutExclude = (state.ircutExclude || []).concat([dead.pin]);
+			state.ircutExclude = (state.ircutExclude || []).concat(pins);
 		}
 	}
 
@@ -2114,10 +2122,20 @@
 			host.querySelector('#mj-scan-stop').addEventListener('click', () => { stop = true; });
 
 			SCAN.run({
+				// A refusal and a failure are not the same answer. The endpoint
+				// guards pads with owners and says so with a 200 carrying
+				// done:false — that pair is skipped and the sweep goes on. A
+				// request that does not arrive at all is a camera that has
+				// stopped answering, and flattening it into "this pair did not
+				// move anything" made the scan keep firing GPIO writes at a dead
+				// camera for another two hundred pairs and then report that
+				// nothing moved. It rejects now, and the sweep stops.
 				drive: (a, b) => apiFetch('/cgi-bin/j/gpio.cgi?pair=' + a + ',' + b,
-					{ credentials: 'same-origin' }).then((r) => r.json()).catch(() => ({ done: false })),
+					{ credentials: 'same-origin' })
+					.then((r) => r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status))),
 				release: (a, b) => apiFetch('/cgi-bin/j/gpio.cgi?park=' + a + ',' + b + '&mode=float',
-					{ credentials: 'same-origin' }).then((r) => r.json()).catch(() => ({ done: false })),
+					{ credentials: 'same-origin' })
+					.then((r) => r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status))),
 				look: () => IRCUT.snapshot('/image.jpg'),
 				wait: (ms) => new Promise((r) => setTimeout(r, ms)),
 				stopped: () => stop,

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -2157,16 +2157,24 @@
 						'Try again in daylight, or set the pins by hand.</div>';
 					return;
 				}
+				// The pair itself was watched moving the picture, so it is
+				// reported either way; what may be missing is the classification
+				// and the guarantee that the filter was left closed.
+				const tail = found.settled
+					? (found.brakeHeld
+						? 'It springs open when the pins are released, so they have to stay driven.'
+						: 'It holds its position on its own.')
+					: 'The checks after that did not finish, so the filter may not have ' +
+					'been left closed &mdash; look at the picture before trusting it.';
 				host.innerHTML = '<div class="mj-live-grp-head">' +
 					'<span class="mj-cap">Find the pins</span>' +
 					'<span class="mj-live-rule"></span></div>' +
-					'<div class="alert alert-success py-2 px-3 mb-2 small"><b>Found it.</b> ' +
+					'<div class="alert ' + (found.settled ? 'alert-success' : 'alert-warning') +
+					' py-2 px-3 mb-2 small"><b>' +
+					(found.settled ? 'Found it.' : 'Found the pins, but not cleanly.') + '</b> ' +
 					'Pins ' + esc(String(found.irCutPin1)) + ' and ' + esc(String(found.irCutPin2)) +
 					' drive the filter &mdash; ' + esc(String(found.closesWhenHigh)) +
-					' is the one that closes it. ' +
-					(found.brakeHeld
-						? 'It springs open when the pins are released, so they have to stay driven.'
-						: 'It holds its position on its own.') +
+					' is the one that closes it. ' + tail +
 					'</div><button type="button" class="btn btn-primary btn-sm" id="mj-scan-use">' +
 					'Use these pins</button>';
 				host.querySelector('#mj-scan-use').addEventListener('click', () => {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1950,6 +1950,7 @@
 			'<span class="mj-live-rule"></span></div>' +
 			'<div id="mj-ircut-rolelist"></div>' +
 			'<div class="mj-ircut-acts">' +
+			'<button type="button" class="btn btn-primary btn-sm" id="mj-ircut-find">Find them for me</button>' +
 			'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-ircut-run">Test the filter</button>' +
 			'</div>' +
 			'<div class="small text-secondary mt-2" id="mj-ircut-status"></div>' +
@@ -2042,6 +2043,119 @@
 		}
 		paintRoles();
 
+		const find = box.querySelector('#mj-ircut-find');
+		if (find) find.addEventListener('click', () => openScan(box, map, info));
+
+		// A camera that came back from the dead mid-scan says so before anything
+		// else — the pad that did it is named and excluded.
+		const dead = window.MajesticIrcutScan &&
+			window.MajesticIrcutScan.casualty(info);
+		if (dead) {
+			const w = el('div', 'alert alert-warning py-2 px-3 mb-2 small');
+			w.innerHTML = '<b>The last pin scan stopped the camera.</b> It was driving pin ' +
+				esc(String(dead.pin)) + ' when it stopped answering, and the watchdog ' +
+				'restarted it. That pin has been excluded from further scans.';
+			box.querySelector('#mj-ircut-findings').appendChild(w);
+			state.ircutExclude = (state.ircutExclude || []).concat([dead.pin]);
+		}
+	}
+
+	// Finding the pins by driving them. This is the only control in the WebUI
+	// that can stop a camera answering, so it asks first, in those words, and
+	// the endpoint behind it journals each pad to flash before touching it.
+	function openScan(box, map, info) {
+		const SCAN = window.MajesticIrcutScan;
+		if (!SCAN) return;
+		const host = box.querySelector('#mj-ircut-result');
+		const status = box.querySelector('#mj-ircut-status');
+		const list = SCAN.pairs(info, { exclude: state.ircutExclude || [] });
+		let stop = false;
+
+		host.hidden = false;
+		host.className = 'mj-ircut-scan';
+		host.innerHTML =
+			'<p class="mb-2"><b>Find the pins by trying them.</b> Each pad is driven ' +
+			'against another while the picture is watched for the filter to move. ' +
+			'An IR-cut filter is driven across two pads, so pairs are what get ' +
+			'tried; the pairs other boards use go first, so this usually ends in ' +
+			'seconds.</p>' +
+			'<div class="alert alert-warning py-2 px-3 mb-2 small">' +
+			'<b>This drives pads whose job is unknown.</b> One of them may reset the ' +
+			'network, cut power to the sensor, or stop the camera answering. That risk ' +
+			'cannot be removed &mdash; only made survivable: each pad is written to flash ' +
+			'before it is driven, so a camera that has to be restarted comes back knowing ' +
+			'which pad did it.</div>' +
+			'<p class="small text-secondary mb-2">Pads already spoken for are skipped. ' +
+			'This reads the picture, so it needs daylight &mdash; at night nothing will ' +
+			'look like it moved.</p>' +
+			'<div class="d-flex gap-2 align-items-center">' +
+			'<button type="button" class="btn btn-primary btn-sm" id="mj-scan-go">Start</button>' +
+			'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-scan-no">Cancel</button>' +
+			'<span class="small text-secondary" id="mj-scan-n"></span></div>';
+		host.querySelector('#mj-scan-n').textContent = list.length + ' pairs to try';
+		host.querySelector('#mj-scan-no').addEventListener('click', () => {
+			stop = true; host.hidden = true;
+		});
+		host.querySelector('#mj-scan-go').addEventListener('click', () => {
+			host.innerHTML =
+				'<p class="mb-2"><b id="mj-scan-t">Starting…</b></p>' +
+				'<p class="small text-secondary mb-2" id="mj-scan-s"></p>' +
+				'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-scan-stop">Stop</button>';
+			const t = host.querySelector('#mj-scan-t');
+			const s = host.querySelector('#mj-scan-s');
+			host.querySelector('#mj-scan-stop').addEventListener('click', () => { stop = true; });
+
+			SCAN.run({
+				drive: (a, b) => apiFetch('/cgi-bin/j/gpio.cgi?pair=' + a + ',' + b,
+					{ credentials: 'same-origin' }).then((r) => r.json()).catch(() => ({ done: false })),
+				release: (a, b) => apiFetch('/cgi-bin/j/gpio.cgi?park=' + a + ',' + b + '&mode=float',
+					{ credentials: 'same-origin' }).then((r) => r.json()).catch(() => ({ done: false })),
+				look: () => IRCUT.snapshot('/image.jpg'),
+				wait: (ms) => new Promise((r) => setTimeout(r, ms)),
+				stopped: () => stop,
+				onStep: (st) => {
+					t.textContent = 'Trying pins ' + st.a + ' and ' + st.b;
+					s.textContent = (st.index + 1) + ' of ' + st.total;
+					map.sweep(st.a);
+				},
+			}, list).then((res) => {
+				map.sweep(null);
+				const found = res.pins;
+				if (!found) {
+					host.innerHTML = '<div class="alert alert-secondary py-2 px-3 mb-0 small">' +
+						'<b>Nothing moved the picture.</b> Either the filter is on a pair this ' +
+						'scan did not reach, or there is not enough light to see it move. ' +
+						'Try again in daylight, or set the pins by hand.</div>';
+					return;
+				}
+				host.innerHTML = '<div class="alert alert-success py-2 px-3 mb-2 small"><b>Found it.</b> ' +
+					'Pins ' + esc(String(found.irCutPin1)) + ' and ' + esc(String(found.irCutPin2)) +
+					' drive the filter &mdash; ' + esc(String(found.closesWhenHigh)) +
+					' is the one that closes it. ' +
+					(found.brakeHeld
+						? 'It springs open when the pins are released, so they have to stay driven.'
+						: 'It holds its position on its own.') +
+					'</div><button type="button" class="btn btn-primary btn-sm" id="mj-scan-use">' +
+					'Use these pins</button>';
+				host.querySelector('#mj-scan-use').addEventListener('click', () => {
+					// Staged, never written behind the person's back: the map
+					// fills the fields and the save bar appears like any edit.
+					const a = map.get();
+					a.irCutPin1 = found.irCutPin1;
+					a.irCutPin2 = found.irCutPin2;
+					// set() fires onChange, which pushes the fields and repaints
+					// the roles — no second push needed.
+					map.set(a);
+					host.hidden = true;
+					if (status) status.textContent = 'Pins staged — Save, then test the filter.';
+				});
+			}).catch((e) => {
+				map.sweep(null);
+				host.innerHTML = '<div class="alert alert-danger py-2 px-3 mb-0 small">' +
+					'The scan could not finish: ' + esc(e && e.message ? e.message : String(e)) +
+					'</div>';
+			});
+		});
 	}
 
 	// "all N at stock" / "N of M off stock" for the section head — the question

--- a/www/cgi-bin/j/gpio.cgi
+++ b/www/cgi-bin/j/gpio.cgi
@@ -166,7 +166,16 @@ boot_epoch() {
 }
 
 read_state() {
-	[ -r "$STATE" ] && cat "$STATE" || echo '{}'
+	# Anything that is not a plausible object is reported as no journal at all:
+	# this value is interpolated straight into the response, so a truncated file
+	# would take the whole document's JSON down with it.
+	if [ -r "$STATE" ] && [ -s "$STATE" ]; then
+		j=$(tr -d '[:cntrl:]' < "$STATE")
+		case "$j" in
+			'{'*'}') echo "$j"; return ;;
+		esac
+	fi
+	echo '{}'
 }
 
 if [ "$CLEAR" = "1" ]; then
@@ -208,10 +217,26 @@ if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
 	flock -n 9 2>/dev/null || deny "another actuation is already running"
 
 	# Journal both pads before either is touched, and get it onto flash. The
-	# journal that matters describes a camera that has stopped answering.
-	printf '{"pins":[%s,%s],"started":%s,"boot":%s}\n' \
-		"$DRIVE" "$LOWPAD" "$(date +%s)" "$(boot_epoch)" > "$STATE"
-	sync
+	# journal that matters describes a camera that has stopped answering, so
+	# this is the one write whose failure must stop the actuation: with a full
+	# or read-only overlay there would be no record, and the pair that took the
+	# camera down would be offered again on the next scan.
+	#
+	# Written to a temporary file and renamed, never truncated in place. The
+	# enumeration path reads this file, and a reader that arrives between the
+	# truncate and the write gets an empty one — which lands in its response as
+	# a bare `"scan":` and makes the whole JSON unparseable.
+	journal() {
+		printf '{"pins":[%s,%s],"started":%s,"boot":%s%s}\n' \
+			"$DRIVE" "$LOWPAD" "$(date +%s)" "$(boot_epoch)" "$1" > "$STATE.tmp" 2>/dev/null ||
+			return 1
+		[ -s "$STATE.tmp" ] || return 1
+		sync
+		mv "$STATE.tmp" "$STATE" 2>/dev/null || return 1
+		sync
+		return 0
+	}
+	journal "" || deny "could not record which pads are about to be driven"
 
 	# How each pad was being held, so it can be handed back the same way. On a
 	# brake-held board the difference between "driven low" and "floating" IS the
@@ -298,9 +323,7 @@ if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
 		brake
 	fi
 
-	printf '{"pins":[%s,%s],"started":%s,"boot":%s,"survived":true}\n' \
-		"$DRIVE" "$LOWPAD" "$(date +%s)" "$(boot_epoch)" > "$STATE"
-	sync
+	journal ',"survived":true'
 
 	# A winding needs time to shed the heat of the last actuation before the
 	# next, and a scan works through pairs without pausing to think.

--- a/www/cgi-bin/j/gpio.cgi
+++ b/www/cgi-bin/j/gpio.cgi
@@ -1,8 +1,11 @@
 #!/bin/sh
-# The GPIO pads, and what each one already is.
+# The GPIO pads, and the one dangerous thing you can do to them.
 #
-# One job the browser cannot do for itself: enumerate the pads, and say for each
-# whether anything already owns it.
+# Two jobs the browser cannot do for itself:
+#
+#   (no query)         enumerate the pads and say what each one already is
+#   ?pair=<a>,<b>      drive a high against b low, then brake both
+#   ?park=<a>,<b>      brake both (mode=brake) or release both (mode=float)
 #
 # Pad COUNT is a property of the SoC and is never assumed: /sys/class/gpio/
 # gpiochip* carries base and ngpio for every bank the kernel registered, which
@@ -10,8 +13,74 @@
 # Novatek numbers its pads in the 200s. Anything here that hardcoded 80 would be
 # wrong on most cameras in the field.
 #
-# Read-only: it reports what the kernel already knows and changes nothing. The
-# pin map (a/ircut-map.js) is its only consumer.
+# Pairs, not single pads, because a single pad cannot move an IR-cut filter.
+# Measured on a XiongMai 85H50AI, every state that involves only low and float:
+#
+#   float either pad          -> filter OPEN   (the brake is released)
+#   both pads low             -> holds whatever position it is in, no current
+#   pad A high, pad B low     -> moves one way
+#   pad B high, pad A low     -> moves the other way
+#
+# So the filter is driven by an H-bridge across TWO pads and only a driven pair
+# actuates it. An earlier version of this endpoint pulsed one pad at a time and
+# found nothing it could trust: what it saw was the filter springing open
+# because the pad had been handed back floating, which is a change the pulse did
+# not cause. That is also why `park` exists — a caller that has moved the filter
+# has to be able to hold it, and on a brake-held board holding it IS both pads
+# low.
+#
+# This is the only endpoint in j/ that can brick a camera, so every guard below
+# is load-bearing rather than tidy.
+
+QS="$QUERY_STRING"
+PAIR=""
+PARK=""
+MODE=""
+MS=""
+CLEAR=""
+for param in $(echo "$QS" | tr '&' ' '); do
+	case "$param" in
+		pair=*) PAIR="${param#*=}" ;;
+		park=*) PARK="${param#*=}" ;;
+		mode=*) MODE="${param#*=}" ;;
+		ms=*) MS="${param#*=}" ;;
+		clear=*) CLEAR="${param#*=}" ;;
+	esac
+done
+
+# "<a>,<b>" -> two small unsigned integers, or nothing at all.
+DRIVE=""
+LOWPAD=""
+case "$PAIR" in
+	*,*)
+		DRIVE="${PAIR%%,*}"
+		LOWPAD="${PAIR#*,}"
+		;;
+esac
+case "$PARK" in
+	*,*)
+		[ -z "$DRIVE" ] && DRIVE="${PARK%%,*}" && LOWPAD="${PARK#*,}"
+		;;
+esac
+echo "$DRIVE" | grep -qE '^[0-9]{1,4}$' || DRIVE=""
+echo "$LOWPAD" | grep -qE '^[0-9]{1,4}$' || LOWPAD=""
+[ "$DRIVE" = "$LOWPAD" ] && LOWPAD=""
+
+# Small unsigned integers only — these become a path under /sys and the argument
+# of a write that moves hardware.
+
+echo "$MS" | grep -qE '^[0-9]{1,4}$' || MS=120
+# A coil wants a pulse, not a hold. An IR-cut winding is sized for a brief
+# actuation and BURNS OUT if current is left flowing through it, so the ceiling
+# here is a hardware limit, not a tuning knob: no request may ask for longer,
+# whatever it sends.
+[ "$MS" -lt 40 ] && MS=40
+[ "$MS" -gt 400 ] && MS=400
+
+LOCK=/tmp/webui/ircut-pulse.lock
+COOLDOWN_US=250000
+
+STATE=/etc/webui/ircut-scan.json
 
 json_head() {
 	echo "HTTP/1.1 200 OK
@@ -36,7 +105,7 @@ banks() {
 #
 # Better than counting /sys/class/gpio exports, and the difference matters. A
 # line held by a DRIVER is hardware somebody wired on purpose — a reset, a
-# regulator enable — and is not a pad to offer. A line held by "sysfs" is only
+# regulator enable — and must never be pulsed. A line held by "sysfs" is only
 # somebody's export, which on OpenIPC means majestic, and majestic never
 # releases a pad when its nightMode key is deleted; that one is reclaimable.
 #
@@ -85,6 +154,164 @@ assigned() {
 	done
 }
 
+# ── the journal ─────────────────────────────────────────────────────────────
+# Written BEFORE a pad is driven and synced, because the whole point is to
+# survive the pad that stops the camera answering. On the next boot the WebUI
+# compares `started` against the kernel's boot time: a journal whose pulse began
+# before this boot means that pad took the camera down, and it is excluded
+# rather than tried again.
+boot_epoch() {
+	up=$(cut -d' ' -f1 /proc/uptime 2>/dev/null | cut -d. -f1)
+	echo $(( $(date +%s) - ${up:-0} ))
+}
+
+read_state() {
+	[ -r "$STATE" ] && cat "$STATE" || echo '{}'
+}
+
+if [ "$CLEAR" = "1" ]; then
+	rm -f "$STATE"
+	sync
+	json_head
+	echo '{"cleared":true}'
+	exit 0
+fi
+
+# ── drive a pair ────────────────────────────────────────────────────────────
+if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
+	json_head
+	deny() { printf '{"drive":%s,"low":%s,"done":false,"error":"%s"}\n' \
+		"${DRIVE:-0}" "${LOWPAD:-0}" "$1"; exit 0; }
+
+	for pad in "$DRIVE" "$LOWPAD"; do
+		in_range "$pad" || deny "no such pad on this SoC"
+		# A line a DRIVER claimed is wired to something on purpose and is the
+		# class of pad that resets a PHY or drops a rail. "sysfs" is only an
+		# export — majestic's, and it keeps IR-cut pads driven because on a
+		# brake-held board that is what holds the filter — so those stay usable.
+		for line in $(held | sed 's/ /:/'); do
+			pp="${line%%:*}"; own="${line#*:}"
+			if [ "$pp" = "$pad" ] && [ "$own" != "sysfs" ]; then
+				deny "pad $pad is held by the kernel driver \\\"$own\\\""
+			fi
+		done
+		for v in $(assigned | cut -d' ' -f1); do
+			[ "$v" = "$pad" ] && deny "pad $pad is already assigned"
+		done
+	done
+
+	# One actuation at a time, camera-wide. Two overlapping requests could
+	# energise two windings at once, or the same one twice with no gap — and a
+	# coil fails by burning, quietly and permanently.
+	mkdir -p /tmp/webui 2>/dev/null
+	exec 9>"$LOCK"
+	flock -n 9 2>/dev/null || deny "another actuation is already running"
+
+	# Journal both pads before either is touched, and get it onto flash. The
+	# journal that matters describes a camera that has stopped answering.
+	printf '{"pins":[%s,%s],"started":%s,"boot":%s}\n' \
+		"$DRIVE" "$LOWPAD" "$(date +%s)" "$(boot_epoch)" > "$STATE"
+	sync
+
+	# How each pad was being held, so it can be handed back the same way. On a
+	# brake-held board the difference between "driven low" and "floating" IS the
+	# difference between closed and open, so restoring it wrongly moves the
+	# filter as surely as driving it would.
+	remember() {
+		if [ -d "/sys/class/gpio/gpio$1" ]; then
+			echo "$(cat "/sys/class/gpio/gpio$1/direction" 2>/dev/null) $(cat "/sys/class/gpio/gpio$1/value" 2>/dev/null)"
+		else
+			echo "absent 0"
+		fi
+	}
+	dstate=$(remember "$DRIVE")
+	lstate=$(remember "$LOWPAD")
+	dheld=1; lheld=1
+	[ "${dstate% *}" = "absent" ] && dheld=0
+	[ "${lstate% *}" = "absent" ] && lheld=0
+
+	# De-energise on EVERY exit. A client that hangs up mid-actuation kills this
+	# script between the write that raises a pad and the write that would lower
+	# it, and a pad left high is current left in a winding that cannot take it.
+	# Braking (both low) is the safe resting state on either kind of filter: it
+	# holds a brake-held one where it is and does nothing to a latching one.
+	brake() {
+		for pad in "$DRIVE" "$LOWPAD"; do
+			[ -d "/sys/class/gpio/gpio$pad" ] || continue
+			echo out > "/sys/class/gpio/gpio$pad/direction" 2>/dev/null
+			echo 0 > "/sys/class/gpio/gpio$pad/value" 2>/dev/null
+		done
+	}
+	trap 'brake' EXIT INT TERM HUP PIPE
+
+	[ "$dheld" = 0 ] && echo "$DRIVE" > /sys/class/gpio/export 2>/dev/null
+	[ "$lheld" = 0 ] && echo "$LOWPAD" > /sys/class/gpio/export 2>/dev/null
+
+	ok=1
+	if [ -d "/sys/class/gpio/gpio$DRIVE" ] && [ -d "/sys/class/gpio/gpio$LOWPAD" ]; then
+		# Both low first: a defined starting point, and the brake state.
+		echo out > "/sys/class/gpio/gpio$LOWPAD/direction" 2>/dev/null || ok=0
+		echo 0 > "/sys/class/gpio/gpio$LOWPAD/value" 2>/dev/null || ok=0
+		echo out > "/sys/class/gpio/gpio$DRIVE/direction" 2>/dev/null || ok=0
+		echo 0 > "/sys/class/gpio/gpio$DRIVE/value" 2>/dev/null || ok=0
+		usleep 50000 2>/dev/null || sleep 0.1
+
+		if [ "$MODE" != "float" ] && [ -z "$PARK" ]; then
+			# The actuation: one side high across the bridge, briefly.
+			echo 1 > "/sys/class/gpio/gpio$DRIVE/value" 2>/dev/null || ok=0
+			usleep $((MS * 1000)) 2>/dev/null || sleep 0.2
+			echo 0 > "/sys/class/gpio/gpio$DRIVE/value" 2>/dev/null
+		fi
+	else
+		ok=0
+	fi
+
+	trap - EXIT INT TERM HUP PIPE
+
+	if [ "$MODE" = "float" ]; then
+		# Releasing the brake is how a brake-held filter is allowed to spring
+		# open, and it is the classification test as well: float after a
+		# successful close, and a filter that opens is brake-held while one that
+		# stays is latching. It also returns a ruled-out pad to the state the
+		# scan found it in.
+		for pad in "$DRIVE" "$LOWPAD"; do
+			[ -d "/sys/class/gpio/gpio$pad" ] || continue
+			echo in > "/sys/class/gpio/gpio$pad/direction" 2>/dev/null
+		done
+		# Unexport unconditionally, not just what this request exported. float
+		# is a caller SAYING "give these back", and by the time it arrives the
+		# pads are exported from the actuation that preceded it — a separate
+		# request, so they look like somebody else's. Judging by who exported
+		# them leaves a sysfs entry behind for every pair a scan rules out.
+		# Nothing assigned can reach here; the guard above refused it.
+		echo "$DRIVE" > /sys/class/gpio/unexport 2>/dev/null
+		echo "$LOWPAD" > /sys/class/gpio/unexport 2>/dev/null
+	else
+		# Everything else leaves the pair BRAKED, and that is not tidiness — on
+		# a brake-held filter the brake is what holds the position the actuation
+		# just reached. Handing the pads back as the call found them would
+		# discard the very thing the caller asked for, which is exactly what an
+		# earlier version of this did: it actuated, restored the pads to
+		# floating, and the filter sprang open before anything could look at it.
+		# Braking is zero current, so holding it costs nothing and is safe to
+		# leave indefinitely; the caller releases explicitly with mode=float.
+		brake
+	fi
+
+	printf '{"pins":[%s,%s],"started":%s,"boot":%s,"survived":true}\n' \
+		"$DRIVE" "$LOWPAD" "$(date +%s)" "$(boot_epoch)" > "$STATE"
+	sync
+
+	# A winding needs time to shed the heat of the last actuation before the
+	# next, and a scan works through pairs without pausing to think.
+	usleep "$COOLDOWN_US" 2>/dev/null || sleep 1
+
+	printf '{"drive":%s,"low":%s,"done":%s,"ms":%s,"mode":"%s"}\n' \
+		"$DRIVE" "$LOWPAD" "$([ "$ok" = 1 ] && echo true || echo false)" "$MS" \
+		"${MODE:-pulse}"
+	exit 0
+fi
+
 # ── enumerate ───────────────────────────────────────────────────────────────
 json_head
 
@@ -99,5 +326,5 @@ hd=$(held | while read -r p own; do
 	printf '{"pin":%s,"owner":"%s"},' "$p" "$own"
 done)
 
-printf '{"banks":[%s],"exported":[%s],"assigned":[%s],"held":[%s]}\n' \
-	"${b%,}" "${ex%,}" "${as%,}" "${hd%,}"
+printf '{"banks":[%s],"exported":[%s],"assigned":[%s],"held":[%s],"boot":%s,"now":%s,"scan":%s}\n' \
+	"${b%,}" "${ex%,}" "${as%,}" "${hd%,}" "$(boot_epoch)" "$(date +%s)" "$(read_state)"

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -107,6 +107,7 @@ fi
 <script src="/a/mj-luma.js"></script>
 <script src="/a/ircut-check.js" defer></script>
 <script src="/a/ircut-map.js" defer></script>
+<script src="/a/ircut-scan.js" defer></script>
 <script src="/a/mj-settings.js" defer></script>
 
 <% fi %>


### PR DESCRIPTION
**Stacked on #270** — review that one first; this PR's diff is only the scan. Base moves to `master` when #270 merges.

#270 lets you set the IR-cut pins on a map and verify them. This finds them when you don't know what they are — which is the state a freshly converted camera is in, because whatever the vendor firmware knew about that wiring died with the flash.

### Pairs, not pads

An IR-cut filter is driven by an H-bridge across **two** pads, and no single-pad operation actuates it. Measured on a XiongMai 85H50AI, every state one pad can reach:

| operation | result |
|---|---|
| float either pad | **OPEN** — the brake is released |
| both pads low | **holds** its position, zero current |
| pad A high, B low | moves one way |
| pad B high, A low | moves the other way |

This mattered: an earlier single-pad sweep reported a hit, and the hit was an artefact — handing a pad back floating springs a brake-held filter open, and that change got credited to whichever pad the sweep was on. It named a real IR-cut pad by luck. A scan that can be right by accident is not a scan.

So `j/gpio.cgi` grows `?pair=a,b` (raise a against b, then brake both) and `?park=a,b&mode=float`. **Braking is not tidiness** — on a brake-held filter the brake is what holds the position the actuation reached, so a pair is left braked rather than handed back; restoring the pads as found would discard the actuation before anything could look at it. `mode=float` unexports unconditionally, because a release arrives as a separate request and cannot tell its own earlier export from somebody else's.

### Coils burn

A winding is sized for a brief actuation and fails permanently if current is left in it. Four guards, all verified on hardware:

- the duration ceiling is a hardware limit, not a tuning knob (clamped 40–400 ms at both ends)
- a `trap` on EXIT/INT/TERM/HUP/PIPE brakes when a client hangs up mid-actuation — otherwise the script dies between the write that raises a pad and the write that would lower it
- an `flock` so two requests cannot energise two windings at once (busybox `flock` has no `-w`, only `-n` — and refusing a concurrent actuation is the right semantics anyway)
- a cooldown after each actuation

### Searching a quadratic space

Tiered: wiki pairs → neighbours within one bank → any two pads in a bank → across banks only when asked. An H-bridge takes both inputs from one place and every wiki pair but Anjoy's SSC377 (11 and 80) is same-bank, so that ordering is **281 candidates on a 10-bank SoC where exhaustive is 3160**. Both orderings of a pair are tried before it is dismissed — only the one opposite to the filter's current position changes anything.

Hits are judged on the **change**, not on a daylight threshold. At dusk the real pad moved gmin 0.05 → 0.88, enormous and still under the absolute bar the filter test uses; a scan asking the absolute question would have missed its own hit.

### It can stop the camera answering

That is not designed away, only made survivable: both pads are written to flash and synced **before** either is touched, so a journal whose actuation predates the current boot is the fingerprint of a pair that hung the board. The next page load names it, excludes it, and offers to resume. The consent screen says all of this plainly before anything is driven, and pads a kernel *driver* holds are refused outright.

### The filter type falls out for free

Float the pads after a successful close: one that springs open is brake-held and its pads must stay driven; one that stays closed is latching. One extra trial, and the scan leaves the filter closed either way — which is what daylight wants.

### Testing

`tests/ircut-scan.test.js` — 27 checks. The fixtures model the measured mechanism rather than a convenient abstraction of it, because the previous design passed against a tidier idea of the hardware and failed against the real thing.

Verified end to end on the lab camera in daylight, from pins unset:

- the scan proposes **11 and 10**, names 10 as the pad that closes, and classifies the filter brake-held — matching every manual measurement
- with three decoy pairs forced ahead of it, the full sequence runs correctly (each decoy tried both ways then released, real pair found, float classification, restored closed), nothing left exported, camera uptime unbroken
- **Use these pins** fills the roles and raises the save bar; **Save** writes `irCutPin1=11` / `irCutPin2=10`; the filter test then answers *"wired correctly"*
- saving the same pair **swapped** — what a board that disagrees with the proposed mapping would look like — makes the same test answer *"wired backwards"* and name the fix

So the mapping is proposed by the scan and adjudicated by the test, rather than trusted from a single board.

### Known limits

The tiered order does not reach cross-bank pairs unless asked, so an Anjoy SSC377 (coils on 11 and 80) needs the exhaustive option. And the whole thing reads the picture, so it needs daylight — at night nothing will look like it moved, and the consent screen says so.