### PR TITLE
Day / Night: "not connected" has to mean not connected

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3895,3 +3895,22 @@ dialog.mj-modal::backdrop {
 		flex-direction: column;
 	}
 }
+
+/* The pin popover's close control. Clicking the pad again dismisses it and so
+   does Escape, but neither is discoverable, and a panel with no visible way out
+   reads as stuck (#273). */
+.mj-pinmap-x {
+	flex: 0 0 auto;
+	margin-left: auto;
+	padding: 0 0.25rem;
+	border: 0;
+	background: none;
+	color: var(--bs-tertiary-color);
+	font-size: 1rem;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.mj-pinmap-x:hover {
+	color: var(--bs-body-color);
+}

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -60,8 +60,8 @@
 	// The four things a pad can be. Colours are the dashboard's validated
 	// series set, so a pad and its row in the list always agree.
 	const ROLES = [
-		{ key: 'irCutPin1', label: 'Filter, closing coil', hint: 'pulls the shutter in for daylight', color: '#4c60d8' },
-		{ key: 'irCutPin2', label: 'Filter, opening coil', hint: 'lets infrared through at night', color: '#0d9488' },
+		{ key: 'irCutPin1', label: 'IR-cut filter, closing coil', hint: 'pulls the shutter in for daylight', color: '#4c60d8' },
+		{ key: 'irCutPin2', label: 'IR-cut filter, opening coil', hint: 'lets infrared through at night', color: '#0d9488' },
 		{ key: 'backlightPin', label: 'Infrared lamp', hint: 'the illuminator ring', color: '#c96a2e' },
 		{ key: 'lightSensorPin', label: 'Daylight sensor', hint: 'photocell that says when it is dark', color: '#8a5cd8' },
 	];
@@ -168,6 +168,8 @@
 			if (opts.onChange) opts.onChange(Object.assign({}, assign));
 		}
 
+		function close() { sel = null; paint(); }
+
 		function buildPop(pin) {
 			pop.innerHTML = '';
 			const head = el('div', 'mj-pinmap-pop-head');
@@ -178,6 +180,15 @@
 			note.textContent = notGpio[pin] ? ('carries ' + notGpio[pin] + ' right now')
 				: (owned[pin] || 'free');
 			head.appendChild(note);
+			// Somewhere to press. Clicking the pad again closes it too and
+			// Escape works, but neither is discoverable, and a panel with no
+			// visible way out reads as stuck.
+			const x = el('button', 'mj-pinmap-x');
+			x.type = 'button';
+			x.setAttribute('aria-label', 'Close');
+			x.innerHTML = '&times;';
+			x.addEventListener('click', close);
+			head.appendChild(x);
 			pop.appendChild(head);
 			ROLES.forEach((r) => {
 				const b = el('button', 'mj-pinmap-role');
@@ -256,6 +267,23 @@
 			pop.hidden = false;
 		}
 
+		// Escape and a click outside, the two things anyone tries first. The
+		// listeners live on the document because the click that dismisses is by
+		// definition not on the popover; both no-op once the map is gone.
+		const onKey = (e) => {
+			if (e.key === 'Escape' && sel !== null) { e.stopPropagation(); close(); }
+		};
+		const onDown = (e) => {
+			if (sel === null) return;
+			if (pop.contains(e.target)) return;
+			// A pad handles its own click, and swallowing it here would make
+			// selecting a different pad take two presses.
+			if (e.target.closest && e.target.closest('.mj-pin')) return;
+			close();
+		};
+		document.addEventListener('keydown', onKey);
+		document.addEventListener('pointerdown', onDown);
+
 		paint();
 		host.appendChild(wrap);
 
@@ -284,6 +312,13 @@
 			// map the person is about to click.
 			sweep: (pin) => { sweeping = pin; paint(); },
 			select: (pin) => { sel = pin; paint(); },
+			close: close,
+			// The map outlives a section change only if nothing tears it down,
+			// so hand the caller the way to unhook the document listeners.
+			destroy: () => {
+				document.removeEventListener('keydown', onKey);
+				document.removeEventListener('pointerdown', onDown);
+			},
 		};
 	}
 

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1821,6 +1821,15 @@
 		const why = testBlocker();
 		btn.disabled = !!why;
 		btn.title = why || 'Moves the filter and compares the picture in both positions.';
+		// The reason goes on the page, not only in the title. A tooltip is not
+		// an explanation on a touchscreen, where there is no hover at all, and
+		// a control that refuses without saying why is the thing this whole
+		// panel exists to stop happening.
+		const note = document.getElementById('mj-ircut-why');
+		if (note) {
+			note.textContent = why || '';
+			note.hidden = !why;
+		}
 	}
 
 	function paintFindings() {
@@ -1929,6 +1938,29 @@
 		updateDirty();
 	}
 
+	// Majestic's config API can set a key but not remove one: POSTing "" or null
+	// to an integer writes 0, and 0 is a real GPIO. So "not connected" saved
+	// through the ordinary form produced a camera configured to drive pad 0,
+	// with no missing-pin warning anywhere because the key was, technically,
+	// set. The save writes what is set; this removes what is not, and waits for
+	// majestic to re-read the file so the refresh that follows sees the truth.
+	async function ircutUnsetCleared() {
+		if (state.sec !== 'nightMode') return;
+		const gone = PIN_KEYS.filter((k) => {
+			const f = pinField(k);
+			return f && String(f.getValue()) === '' && isNumish(getDotted(state.config, 'nightMode.' + k));
+		});
+		if (!gone.length) return;
+		try {
+			await apiFetch('/cgi-bin/j/gpio.cgi?unset=' + gone.join(','),
+				{ credentials: 'same-origin' });
+			// The endpoint signals majestic a second later — it is the httpd
+			// answering the request and cannot be reloaded inline — so the
+			// config is only true after that lands.
+			await new Promise((r) => setTimeout(r, 1600));
+		} catch (e) { /* the save itself stood; refresh will show what took */ }
+	}
+
 	function currentAssign() {
 		const a = {};
 		PIN_KEYS.forEach((k) => {
@@ -1953,6 +1985,7 @@
 			'<button type="button" class="btn btn-primary btn-sm" id="mj-ircut-find">Find them for me</button>' +
 			'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-ircut-run">Test the filter</button>' +
 			'</div>' +
+			'<div class="small text-secondary mt-2" id="mj-ircut-why" hidden></div>' +
 			'<div class="small text-secondary mt-2" id="mj-ircut-status"></div>' +
 			'<div id="mj-ircut-result" class="small" hidden></div>' +
 			'</div></div>';
@@ -1999,6 +2032,9 @@
 			soc: (window.mjSoc || '') + (info.banks ? ' · ' + info.banks.length + ' banks' : ''),
 			onChange: (a) => { pushAssign(a); paintRoles(); },
 		});
+		// load() rebuilds the panel on every section change, so the previous
+		// map's document listeners have to come off with it.
+		if (state.ircutMap && state.ircutMap.destroy) state.ircutMap.destroy();
 		state.ircutMap = map;
 
 		function paintRoles() {
@@ -3027,6 +3063,7 @@
 			// refresh would let a later discard "revert" the camera to values
 			// that are no longer what was saved (#259).
 			sent.forEach((v, f) => { state.initial[f.dot] = v; });
+			await ircutUnsetCleared();
 			await refresh();
 			// Image knobs (x-live) apply instantly; everything structural
 			// (resolution, codec, fps, ...) only takes effect after majestic

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -585,6 +585,15 @@
 		(state.liveCleanup || []).forEach(fn => { try { fn(); } catch (e) { /* teardown is best-effort */ } });
 		state.liveCleanup = [];
 
+		// The pin map puts keydown and pointerdown on `document`, which is
+		// exactly the kind of listener the comment above is about: it has to
+		// come off when the section goes, not when a replacement happens to
+		// mount, or Escape keeps being intercepted from another tab entirely.
+		if (state.ircutMap && state.ircutMap.destroy) {
+			try { state.ircutMap.destroy(); } catch (e) { /* best-effort */ }
+			state.ircutMap = null;
+		}
+
 		// Through the swap, which closes the trial as well as the player on
 		// screen. Destroying only state.previewPlayer would leave a transport
 		// still being judged behind on every visit — a live socket nobody has a
@@ -1944,21 +1953,25 @@
 	// with no missing-pin warning anywhere because the key was, technically,
 	// set. The save writes what is set; this removes what is not, and waits for
 	// majestic to re-read the file so the refresh that follows sees the truth.
-	async function ircutUnsetCleared() {
+	async function ircutUnsetCleared(cleared) {
 		if (state.sec !== 'nightMode') return;
-		const gone = PIN_KEYS.filter((k) => {
-			const f = pinField(k);
-			return f && String(f.getValue()) === '' && isNumish(getDotted(state.config, 'nightMode.' + k));
-		});
+		const gone = (cleared || []).map((f) => f.dot.slice('nightMode.'.length))
+			.filter((k) => PIN_KEYS.indexOf(k) >= 0 &&
+				isNumish(getDotted(state.config, 'nightMode.' + k)));
 		if (!gone.length) return;
-		try {
-			await apiFetch('/cgi-bin/j/gpio.cgi?unset=' + gone.join(','),
-				{ credentials: 'same-origin' });
-			// The endpoint signals majestic a second later — it is the httpd
-			// answering the request and cannot be reloaded inline — so the
-			// config is only true after that lands.
-			await new Promise((r) => setTimeout(r, 1600));
-		} catch (e) { /* the save itself stood; refresh will show what took */ }
+		const r = await apiFetch('/cgi-bin/j/gpio.cgi?unset=' + gone.join(','),
+			{ credentials: 'same-origin' });
+		if (!r.ok) throw new Error('HTTP ' + r.status);
+		const out = await r.json();
+		// The endpoint judges each removal by reading the key back, so `failed`
+		// means the key is still there. Saying nothing would leave someone
+		// believing a coil is disconnected while it is still configured.
+		if (out.failed && out.failed.length)
+			throw new Error('these could not be cleared: ' + out.failed.join(', '));
+		// It signals majestic a second later — it is the httpd answering the
+		// request and cannot be reloaded inline — so the config is only true
+		// after that lands.
+		await new Promise((res) => setTimeout(res, 1600));
 	}
 
 	function currentAssign() {
@@ -2032,9 +2045,10 @@
 			soc: (window.mjSoc || '') + (info.banks ? ' · ' + info.banks.length + ' banks' : ''),
 			onChange: (a) => { pushAssign(a); paintRoles(); },
 		});
-		// load() rebuilds the panel on every section change, so the previous
-		// map's document listeners have to come off with it.
-		if (state.ircutMap && state.ircutMap.destroy) state.ircutMap.destroy();
+		// Leaving the section while this fetch was in flight means the panel
+		// this map belongs to is already gone; mounting it now would strand a
+		// second set of document listeners with nothing to remove them.
+		if (state.sec !== 'nightMode') { map.destroy(); return; }
 		state.ircutMap = map;
 
 		function paintRoles() {
@@ -3019,8 +3033,15 @@
 
 	async function onSubmit(ev) {
 		ev.preventDefault();
-		const dirty = state.fields.filter(f => f.getValue() !== state.initial[f.dot]);
-		if (!dirty.length) return;
+		const all = state.fields.filter(f => f.getValue() !== state.initial[f.dot]);
+		// A cleared pin must never be SENT. Majestic writes "" as 0, applies it
+		// on the same round trip, and 0 is a real pad — the wiki lists it as
+		// RESET on several boards — so posting the clear and tidying up
+		// afterwards drives pad 0 for as long as the cleanup takes. These are
+		// removed from the config instead, by ircutUnsetCleared() below.
+		const cleared = all.filter(f => PIN_DOTS[f.dot] && String(f.getValue()) === '');
+		const dirty = all.filter(f => cleared.indexOf(f) < 0);
+		if (!all.length) return;
 
 		const body = {};
 		// What each field was worth when the body was built, not when the
@@ -3045,16 +3066,18 @@
 		clearError();
 		liveSaving++;
 		try {
-			const res = await apiFetch('/api/v1/config', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				credentials: 'same-origin',
-				body: JSON.stringify(body),
-			});
-			if (!res.ok) {
-				const txt = await safeText(res);
-				showError('Save failed (HTTP ' + res.status + '). ' + txt);
-				return;
+			if (dirty.length) {
+				const res = await apiFetch('/api/v1/config', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					credentials: 'same-origin',
+					body: JSON.stringify(body),
+				});
+				if (!res.ok) {
+					const txt = await safeText(res);
+					showError('Save failed (HTTP ' + res.status + '). ' + txt);
+					return;
+				}
 			}
 			// The camera now holds these, so the snapshot the revert is built
 			// from has to say so before anything can read it again. refresh()
@@ -3063,7 +3086,13 @@
 			// refresh would let a later discard "revert" the camera to values
 			// that are no longer what was saved (#259).
 			sent.forEach((v, f) => { state.initial[f.dot] = v; });
-			await ircutUnsetCleared();
+			try {
+				await ircutUnsetCleared(cleared);
+			} catch (e) {
+				showError('Saved, but clearing a pin failed: ' +
+					(e && e.message ? e.message : e) +
+					'. The camera may still be configured to drive it.');
+			}
 			await refresh();
 			// Image knobs (x-live) apply instantly; everything structural
 			// (resolution, codec, fps, ...) only takes effect after majestic

--- a/www/cgi-bin/fw-editor.cgi
+++ b/www/cgi-bin/fw-editor.cgi
@@ -17,6 +17,13 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 			else
 				[ -f "${editor_file}.backup" ] && rm "${editor_file}.backup"
 				echo "$editor_text" > "$editor_file"
+				# Majestic's own file is the one case where writing it is not
+				# the whole job - see majestic_reload in p/common.cgi. Without
+				# this the edit sat there unread until a reboot, and the next
+				# save from the settings page overwrote it first.
+				if [ "$editor_file" = "$(get_config)" ] && majestic_reload; then
+					redirect_to "${SCRIPT_NAME}?f=${editor_file}" "success" "File saved. Majestic is picking it up now, so video restarts in a moment."
+				fi
 				redirect_to "${SCRIPT_NAME}?f=${editor_file}" "success" "File saved."
 			fi
 			;;

--- a/www/cgi-bin/fw-restore.cgi
+++ b/www/cgi-bin/fw-restore.cgi
@@ -1,16 +1,91 @@
 #!/usr/bin/haserl
 <%in p/common.cgi %>
 <%
-[ -z "$GET_f" ] && set_error_flag "Nothing to restore."
+# Restore Majestic's configuration file to the one the firmware shipped.
+#
+# The path still arrives in ?f= because that is the link mj-configuration.cgi
+# writes, but it is now checked against the one file this page offers rather
+# than used as given. Taken as given, a single request restored /rom's copy of
+# whatever it named over the live one, and /rom holds every file the firmware
+# ships - most of them nothing to do with this page and a good deal more
+# consequential than a video setting.
+config=$(get_config)
+rom=$(get_config /rom)
 
-file=$GET_f
-[ ! -f "/rom/${file}" ] && set_error_flag "File /rom/${file} not found!"
+[ "$GET_f" = "$config" ] || set_error_flag "Nothing to restore."
+[ -f "$rom" ] || set_error_flag "The firmware has no copy of ${config} to restore."
 [ -n "$error" ] && redirect_back
 
-cp "/rom/${file}" "${file}"
-if [ $? -eq 0 ]; then
-	redirect_back "success" "File ${file} restored to firmware defaults."
+# Where a write to / physically lands. The rootfs is a read-only squashfs
+# pivoted to /rom with a writable overlay on top, so restoring by copying
+# /rom's file back leaves an overlay copy that hides the firmware's own file
+# for good - including the newer one the next firmware upgrade delivers (#202).
+# Taking the overlay copy away instead leaves the firmware's file showing
+# through, which is what a reset to defaults means on this filesystem, and it
+# leaves the page's "changes from defaults" diff genuinely empty afterwards.
+#
+# Only on the 4.x "overlay". The 3.10 out-of-tree "overlayfs" goes on serving a
+# cached merged view of a directory whose upper layer was edited underneath it,
+# and writing the file back through the merged path in the same request then
+# lands ovl_rename on a stale dentry - a kernel warning out of drop_nlink, on a
+# T31, first time it was tried. There the file is simply written the ordinary
+# way below and the overlay copy stays, exactly as it did before.
+upper=$(awk '$2 == "/" && $3 == "overlay" {
+	n = split($4, o, ",")
+	for (i = 1; i <= n; i++)
+		if (o[i] ~ /^upperdir=/) { print substr(o[i], 10); exit }
+}' /proc/mounts)
+[ -n "$upper" ] && [ -d "$upper" ] && [ "$upper" != "/" ] || upper=
+
+settle() {
+	sync
+	[ -w /proc/sys/vm/drop_caches ] && echo 3 > /proc/sys/vm/drop_caches
+	return 0
+}
+
+# The firmware's file at $1, atomically and without widening the mode. cp
+# settles the mode from the umask this process happened to inherit, which is
+# not the same on every build - measured at 0077 on two cameras and 0022 on a
+# third, where the restore turned a 0600 file that can hold cleartext stream
+# credentials into a 0644 one. The mode the file already had is the mode it
+# keeps, and it is set on the temporary file before any content goes into it.
+put_rom() {
+	local dst="$1"
+	local mode=$(stat -c%a "$dst" 2>/dev/null)
+	local tmp="${dst}.restore.$$"
+	local rc
+	[ -n "$mode" ] || mode=$(stat -c%a "$rom")
+	rm -f "$tmp"
+	touch "$tmp" && chmod "$mode" "$tmp" && cat "$rom" > "$tmp" &&
+		mv "$tmp" "$dst"
+	rc=$?
+	rm -f "$tmp"
+	return $rc
+}
+
+# The removal is made in the overlay's own directory, never through the merged
+# path: rm "$config" writes a whiteout, which hides the firmware's copy instead
+# of revealing it, and Majestic would then come up on its built-in defaults
+# rather than on the ones this board was shipped with. The file cannot go
+# missing in between either - the lower layer is what is left holding it.
+if [ -n "$upper" ] && [ -f "${upper}${config}" ]; then
+	rm -f "${upper}${config}"
+	settle
+	# If the merged view has not caught up, put the content back where it was
+	# taken from rather than writing through the merged path: one request that
+	# touches both is the mixture the comment above is about.
+	cmp -s "$rom" "$config" || { put_rom "${upper}${config}"; settle; }
+fi
+
+cmp -s "$rom" "$config" || put_rom "$config"
+sync
+cmp -s "$rom" "$config" || redirect_back "danger" "Cannot restore ${config}!"
+
+# Restoring the file is only half of it: see majestic_reload in p/common.cgi
+# for what the other half is and why leaving it out loses the reset entirely.
+if majestic_reload; then
+	redirect_back "success" "${config} restored to firmware defaults. Majestic is picking them up now, so video restarts in a moment."
 else
-	redirect_back "danger" "Cannot restore ${file}!"
+	redirect_back "warning" "${config} restored to firmware defaults, but Majestic is not running to be told. It will read the file when it next starts."
 fi
 %>

--- a/www/cgi-bin/j/gpio.cgi
+++ b/www/cgi-bin/j/gpio.cgi
@@ -4,6 +4,7 @@
 # Two jobs the browser cannot do for itself:
 #
 #   (no query)         enumerate the pads and say what each one already is
+#   ?unset=<keys>      remove nightMode pin keys from the config outright
 #   ?pair=<a>,<b>      drive a high against b low, then brake both
 #   ?park=<a>,<b>      brake both (mode=brake) or release both (mode=float)
 #
@@ -38,6 +39,7 @@ PARK=""
 MODE=""
 MS=""
 CLEAR=""
+UNSET=""
 for param in $(echo "$QS" | tr '&' ' '); do
 	case "$param" in
 		pair=*) PAIR="${param#*=}" ;;
@@ -45,6 +47,7 @@ for param in $(echo "$QS" | tr '&' ' '); do
 		mode=*) MODE="${param#*=}" ;;
 		ms=*) MS="${param#*=}" ;;
 		clear=*) CLEAR="${param#*=}" ;;
+		unset=*) UNSET="${param#*=}" ;;
 	esac
 done
 
@@ -183,6 +186,37 @@ if [ "$CLEAR" = "1" ]; then
 	sync
 	json_head
 	echo '{"cleared":true}'
+	exit 0
+fi
+
+# ── unset pin keys ──────────────────────────────────────────────────────────
+# Majestic's config API can set a key but not remove one. POSTing "" or null to
+# an integer writes **0** — and 0 is a real GPIO — so "not connected" saved
+# through the ordinary form gives you a camera configured to drive pad 0, with
+# no missing-pin warning anywhere because the key is, technically, set.
+#
+# yaml-cli is the sanctioned way to edit that file, so removal goes through it
+# here. The key list is a CLOSED whitelist: these names reach a command line,
+# and the four pin keys are the only ones this endpoint has any business
+# removing.
+if [ -n "$UNSET" ]; then
+	json_head
+	done_keys=""
+	for k in $(echo "$UNSET" | tr ',' ' '); do
+		case "$k" in
+			irCutPin1|irCutPin2|backlightPin|lightSensorPin)
+				yaml-cli -d ".nightMode.$k" >/dev/null 2>&1
+				done_keys="$done_keys $k"
+				;;
+		esac
+	done
+	# Majestic re-reads the file on SIGHUP; without it the daemon keeps driving
+	# the pads the deleted keys named. Backgrounded behind a short sleep,
+	# because majestic is the httpd serving THIS request — signalling it inline
+	# reloads the process mid-response and the caller gets nothing back.
+	[ -n "$done_keys" ] && (sleep 1; killall -1 majestic) >/dev/null 2>&1 &
+	u=$(for k in $done_keys; do printf '"%s",' "$k"; done)
+	printf '{"unset":[%s]}\n' "${u%,}"
 	exit 0
 fi
 

--- a/www/cgi-bin/j/gpio.cgi
+++ b/www/cgi-bin/j/gpio.cgi
@@ -202,11 +202,23 @@ fi
 if [ -n "$UNSET" ]; then
 	json_head
 	done_keys=""
+	failed_keys=""
 	for k in $(echo "$UNSET" | tr ',' ' '); do
 		case "$k" in
 			irCutPin1|irCutPin2|backlightPin|lightSensorPin)
 				yaml-cli -d ".nightMode.$k" >/dev/null 2>&1
-				done_keys="$done_keys $k"
+				# Judged on the file, not on the exit status. `yaml-cli -d`
+				# returns 1 for a key that was already absent as well as for one
+				# it could not remove, so the status cannot tell success from
+				# failure — but reading the key back can. A delete that did not
+				# take must not be reported as one, or the caller carries on
+				# believing a coil is disconnected while it is still configured
+				# as pad 0.
+				if yaml-cli -g ".nightMode.$k" >/dev/null 2>&1; then
+					failed_keys="$failed_keys $k"
+				else
+					done_keys="$done_keys $k"
+				fi
 				;;
 		esac
 	done
@@ -216,7 +228,8 @@ if [ -n "$UNSET" ]; then
 	# reloads the process mid-response and the caller gets nothing back.
 	[ -n "$done_keys" ] && (sleep 1; killall -1 majestic) >/dev/null 2>&1 &
 	u=$(for k in $done_keys; do printf '"%s",' "$k"; done)
-	printf '{"unset":[%s]}\n' "${u%,}"
+	fl=$(for k in $failed_keys; do printf '"%s",' "$k"; done)
+	printf '{"unset":[%s],"failed":[%s]}\n' "${u%,}" "${fl%,}"
 	exit 0
 fi
 

--- a/www/cgi-bin/mj-configuration.cgi
+++ b/www/cgi-bin/mj-configuration.cgi
@@ -19,7 +19,8 @@
 			%>
 			<div class="d-flex gap-2 mt-3">
 				<a class="btn btn-outline-secondary" href="fw-editor.cgi?f=<%= $(get_config) %>">Edit</a>
-				<a class="btn btn-danger" href="fw-restore.cgi?f=<%= $(get_config) %>">Reset to defaults</a>
+				<a class="btn btn-danger" href="fw-restore.cgi?f=<%= $(get_config) %>"
+					data-confirm="Put every camera setting back to what the firmware shipped?&#10;&#10;This takes effect at once: video restarts on the default settings and everything configured since is gone.">Reset to defaults</a>
 			</div>
 		</div></div>
 	</div>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -423,6 +423,37 @@ get_config() {
 	echo ${1}/etc/majestic.yaml
 }
 
+# Make Majestic re-read its configuration file (issue #308).
+#
+# Majestic parses the file once and then holds the whole configuration in
+# memory, and config_save() writes that whole tree back. So a file replaced
+# underneath it is not merely invisible - the settings page keeps serving the
+# values Majestic still holds - it is temporary: the next save from anywhere,
+# a field on the settings page or an ONVIF client, puts the old values back on
+# disk and the edit is gone with no sign that it ever happened.
+#
+# SIGHUP is what re-reads it: reload_sdk() parses the file from scratch (built-
+# in defaults first, then whatever the file says) and rebuilds the pipeline on
+# the result. /api/v1/{config,set,reset} already do this for their own writes;
+# anything that writes the file directly has to say so here.
+#
+# Detached and delayed, because tearing the pipeline down closes every
+# connection the web server holds - and that includes the one this CGI's own
+# answer is still travelling on. Signalling in line restored the file and then
+# left the browser hanging on two of three cameras, which reads exactly like
+# the camera having crashed. Two seconds is several times what a page on these
+# boards takes to finish, so the redirect and the page it lands on are both
+# served before anything is torn down.
+#
+# The redirections are not tidiness either: the background job inherits the
+# pipe the web server reads this CGI's output from, and while it holds that
+# pipe open the answer is never finished at all.
+majestic_reload() {
+	pidof majestic >/dev/null 2>&1 || return 1
+	(sleep 2; killall -1 majestic) </dev/null >/dev/null 2>&1 &
+	return 0
+}
+
 # Best-effort clock fix for HTTPS (issue #44): a fresh flash boots with the
 # stale build timestamp until ntpd converges, so HTTPS to GitHub fails
 # ("certificate not yet valid"). Try a quick blocking NTP sync; if that is


### PR DESCRIPTION
Fixes the four things @usa- found in #273. All verified on a camera.

### Clearing a role configured pin 0

The one that matters. **Majestic's config API can set a key but not remove one** — POSTing `""` *or* `null` to an integer key writes **0**, and 0 is a real GPIO:

```
POST {"nightMode":{"irCutPin1":""}}    -> irCutPin1: 0
POST {"nightMode":{"irCutPin1":null}}  -> irCutPin1: 0
GET  /api/v1/reset?key=nightMode.irCutPin1 -> 404   (no declared default)
```

So setting all four roles to **Not connected** and saving gave you a camera configured to drive pad 0 four times over, pad 0 lit on the map, and — worst — **no missing-pin warning on the dashboard**, because the keys were technically set.

`j/gpio.cgi` grows an `unset` action that removes them through `yaml-cli`, which is what CLAUDE.md prescribes for editing that file, behind a **closed whitelist** of the four pin keys since these names reach a command line. Verified that `unset=system.webPort,video0.fps` changes nothing.

The reload is backgrounded exactly like `j/mj-apply.cgi`'s, because **majestic is the httpd answering the request** and signalling it inline reloads the process mid-response — the first version of this hung the request and returned nothing, which is how I found out.

> Worth raising daemon-side separately: there is currently no way to unset an optional config key over the API. `reset` only restores declared defaults, and `irCutPin1` has none. This PR works around that; it doesn't fix it.

### A disabled button that said why only in its tooltip

`testBlocker()`'s reason went into `btn.title` and nowhere else — which is not an explanation on a touchscreen, where there's no hover at all. That is also why the report says the button was disabled *with no cause*: the cause existed, in a tooltip, unreachable. It's on the page now, under the button.

### The pin popover had no way out

Clicking the pad again dismissed it, and that was the only way. It now has a **×**, answers **Escape**, and closes on a click anywhere outside; the document listeners are removed when the section is rebuilt.

### The filter roles didn't say which filter

`Filter, closing coil` → **`IR-cut filter, closing coil`**, per the report.

### Verified

Clearing all four leaves the keys **absent** from `majestic.yaml` and from `config.json` rather than set to 0, no pad lit, the dashboard raising *"Majestic cannot move the IR-cut filter"*, and the Test button disabled with its reason visible. A wired camera still round-trips scan → save → *"wired correctly"*. Full suite passes.