### PR TITLE
Day / Night: the scan re-reads the pads, and a verdict does not outlive its wiring

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1880,6 +1880,12 @@
 		// the day one turns on it and a stale answer does not mis-word the
 		// verdict, it inverts it.
 		const start = ircutSample ? (ircutSample.ircut | 0) : 0;
+		// Snapshot the wiring now, not when the probe returns: it takes seconds
+		// and the map stays live throughout, so reading the fields at the end
+		// would stamp the verdict with an assignment it was never measured
+		// against — and syncVerdict() would then find them matching and keep a
+		// stale verdict on screen.
+		const testedOn = fieldAssign();
 
 		IRCUT.probe({
 			settleMs: 1500,
@@ -1909,7 +1915,10 @@
 				'Live adjustments to move it back. The test itself found: '
 				: '') + '<b>' + esc(v.title) + '</b> ' + esc(v.detail);
 			result.hidden = false;
-			state.ircutTestedOn = fieldAssign();
+			state.ircutTestedOn = testedOn;
+			// Edited while the probe ran: the verdict describes wiring that is
+			// no longer on screen, so it goes straight back out.
+			syncVerdict();
 		}).catch((e) => {
 			result.className = 'alert alert-danger py-2 px-3 mt-2 mb-0 small';
 			// A test that could not finish reports that it could not finish. It
@@ -1918,7 +1927,10 @@
 			result.textContent = 'The test could not finish: ' + (e && e.message ? e.message : e) +
 				'. The filter was left where it started.';
 			result.hidden = false;
-			state.ircutTestedOn = fieldAssign();
+			state.ircutTestedOn = testedOn;
+			// Edited while the probe ran: the verdict describes wiring that is
+			// no longer on screen, so it goes straight back out.
+			syncVerdict();
 		}).finally(() => {
 			ircutBusy = false;
 			btn.disabled = false;
@@ -1948,7 +1960,6 @@
 			if (f) f.setValue(a[k] === undefined ? '' : String(a[k]));
 		});
 		updateDirty();
-		syncVerdict();
 	}
 
 	// A pin the save cleared has to be GONE from the config, not set to
@@ -2003,6 +2014,12 @@
 	function syncVerdict() {
 		const r = document.getElementById('mj-ircut-result');
 		if (!r || r.hidden || !state.ircutTestedOn) return;
+		// The scan borrows this same element, and its own hit writes the pins
+		// it found — which lands here as a changed assignment. Hiding it then
+		// would take the Stop button away from a sweep that is still driving
+		// pads, on the one control in this UI that can stop a camera
+		// answering. Only ever hide a verdict.
+		if (r.classList.contains('mj-ircut-scan')) return;
 		if (state.ircutTestedOn !== fieldAssign()) {
 			r.hidden = true;
 			state.ircutTestedOn = null;
@@ -2184,6 +2201,9 @@
 		const SCAN = window.MajesticIrcutScan;
 		if (!SCAN) return;
 		const host = box.querySelector('#mj-ircut-result');
+		// Taking the element over destroys whatever verdict was in it, so the
+		// assignment that verdict was measured against stops meaning anything.
+		state.ircutTestedOn = null;
 		const status = box.querySelector('#mj-ircut-status');
 		const list = SCAN.pairs(info, { exclude: state.ircutExclude || [] });
 		let stop = false;
@@ -3042,6 +3062,10 @@
 		state.dirtyN = n;
 		renderToolbar();
 		paintStock();
+		// Every edit funnels through here — the map, a save, a per-row reset,
+		// and the four pin fields directly, which is the path that matters when
+		// the pad map could not be read and they are exposed as plain numbers.
+		syncVerdict();
 	}
 
 	// One visibility rule for both buttons: show each only while its action can
@@ -3257,7 +3281,6 @@
 		// The pads are only half of it; the role list is drawn from onChange,
 		// which `quiet` just skipped.
 		if (state.ircutRoles) state.ircutRoles();
-		syncVerdict();
 		syncTestBtn();
 		updateDirty();
 	}

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1909,6 +1909,7 @@
 				'Live adjustments to move it back. The test itself found: '
 				: '') + '<b>' + esc(v.title) + '</b> ' + esc(v.detail);
 			result.hidden = false;
+			state.ircutTestedOn = fieldAssign();
 		}).catch((e) => {
 			result.className = 'alert alert-danger py-2 px-3 mt-2 mb-0 small';
 			// A test that could not finish reports that it could not finish. It
@@ -1917,6 +1918,7 @@
 			result.textContent = 'The test could not finish: ' + (e && e.message ? e.message : e) +
 				'. The filter was left where it started.';
 			result.hidden = false;
+			state.ircutTestedOn = fieldAssign();
 		}).finally(() => {
 			ircutBusy = false;
 			btn.disabled = false;
@@ -1946,6 +1948,7 @@
 			if (f) f.setValue(a[k] === undefined ? '' : String(a[k]));
 		});
 		updateDirty();
+		syncVerdict();
 	}
 
 	// A pin the save cleared has to be GONE from the config, not set to
@@ -1980,6 +1983,30 @@
 			.filter((k) => isNumish(getDotted(state.config, 'nightMode.' + k)))
 			.map(roleName)
 			.filter(Boolean);
+	}
+
+	// The filter test's verdict names a wiring and a fix for it ("swap the two
+	// coils"), so it stops being true the moment the wiring is edited — and it
+	// is worst when it stays: a stale "wired backwards" tells someone to undo a
+	// swap they have already made. It is remembered as the assignment it was
+	// measured against and dropped as soon as that stops matching, which covers
+	// a map edit, a save, a per-row reset and the scan's proposal alike (#273).
+	function fieldAssign() {
+		const a = {};
+		PIN_KEYS.forEach((k) => {
+			const f = pinField(k);
+			a[k] = f ? String(f.getValue()) : '';
+		});
+		return JSON.stringify(a);
+	}
+
+	function syncVerdict() {
+		const r = document.getElementById('mj-ircut-result');
+		if (!r || r.hidden || !state.ircutTestedOn) return;
+		if (state.ircutTestedOn !== fieldAssign()) {
+			r.hidden = true;
+			state.ircutTestedOn = null;
+		}
 	}
 
 	function currentAssign() {
@@ -2107,7 +2134,26 @@
 		paintRoles();
 
 		const find = box.querySelector('#mj-ircut-find');
-		if (find) find.addEventListener('click', () => openScan(box, map, info));
+		// Re-read the pads rather than reusing the mount-time snapshot. That
+		// snapshot carries `assigned`, and pairs() skips every pad in it — so
+		// after clearing the pins and saving, the scan went on skipping the two
+		// pads it was being asked to find, and reported nothing. Reloading the
+		// page "fixed" it, which is the tell that the staleness was in here and
+		// not on the camera (#273). The pad list can also move underneath the
+		// page for reasons of its own, majestic releasing an export among them.
+		if (find) find.addEventListener('click', async () => {
+			let fresh = info;
+			try {
+				const r = await apiFetch('/cgi-bin/j/gpio.cgi',
+					{ credentials: 'same-origin' });
+				fresh = await r.json();
+				state.ircutInfo = fresh;
+			} catch (e) {
+				// The cached list is stale, not wrong: every pad it names is
+				// still a pad. Scanning with it beats refusing to scan.
+			}
+			openScan(box, map, fresh);
+		});
 
 		// A camera that came back from the dead mid-scan says so before anything
 		// else — the pad that did it is named and excluded.
@@ -3211,6 +3257,7 @@
 		// The pads are only half of it; the role list is drawn from onChange,
 		// which `quiet` just skipped.
 		if (state.ircutRoles) state.ircutRoles();
+		syncVerdict();
 		syncTestBtn();
 		updateDirty();
 	}


### PR DESCRIPTION
Two things #273 found after the rebuild landed.

## The scan found nothing until the page was reloaded

> *"If I unset the IR-cut pin settings, save the settings and start the search, it finds nothing. If I stop the search, reload the page, and start the search again, it finds the pins immediately."*

`openScan()` was handed the pad list fetched when the **panel mounted**, and `pairs()` skips every pad in its `assigned` set. Clear the pins, save, and that snapshot still named the two pads as spoken for — so the scan went on skipping the very pads it was being asked to find. Reloading the page "fixed" it, which is the tell that the staleness was in the page and not on the camera.

It re-reads the list when the scan is opened, and falls back to the cached one if that fetch fails: a stale list is out of date, not wrong, and scanning with it beats refusing to scan.

Measured on a Hi3516EV300 with all four pins cleared, driving the real page:

| | candidate pairs |
|---|---|
| scan without reloading, **before** | 254 — pads 11 and 10 skipped |
| scan without reloading, **after** | **281** |
| scan after a reload (the workaround) | 281 |

## A verdict outlived the wiring it was measured against

> *"Should messages like these disappear when any settings on the page are changed (or, maybe, only when the IR-cut filter pin settings are changed)?"*

Yes — and the second one. "The filter is wired backwards" names a fix (*swap the two coils*), so it stops being true the moment someone does that, and a stale copy tells them to undo the swap they have just made.

The verdict now remembers the assignment it was taken on and is dropped as soon as that stops matching, which covers a map edit, a save, a per-row reset and the scan's own proposal alike. **Only the pin fields invalidate it** — an unrelated setting on the same page does not, because the verdict is a statement about the wiring and nothing else.

Verified on the camera: the filter test reported "wired correctly", then moving the closing coil to another pad hid it immediately.

## Not in this PR

The third point — whether **"Majestic cannot move the IR-cut filter"** becomes annoying on the dashboard for someone with no IR-cut hardware — is a real design question and I have answered it on the issue rather than guessing at code here.

`npm test` green, `tools/lint-templates.sh` clean.