### PR TITLE
Live: when the player chain runs out, the page says so

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -17,7 +17,8 @@ const SRCS = [A('preview-swap.js'), A('preview-page.js')];
 
 const IDS = [
 	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
-	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note', 'mj-stats',
+	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note',
+	'mj-note-why', 'mj-stats',
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
 	'mj-stream-auto', 'mj-auto', 'mj-served', 'mj-served-why', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl',

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -25,6 +25,7 @@ const IDS = [
 	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note',
 	'mj-note-why', 'mj-stats',
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
+	'mj-stream-auto', 'mj-auto',
 	'mj-served', 'mj-served-why', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w',
 	'mj-transport-m', 'mj-transport-ctl', 'mj-transport-lbl',
@@ -85,7 +86,9 @@ function makePlayers(env) {
 // a config that never lands. Most tests want that — a config arriving would
 // re-attach underneath the players they are driving by hand — but the fallback
 // reads jpeg.enabled and behaves differently on each answer, so it needs one.
-function load(pickedTransport, cfg) {
+// `cfgDelay` puts the answer past the page's CONFIG_WAIT_MS deadline, which is
+// the case where jpegOn is false only because nothing is known yet.
+function load(pickedTransport, cfg, cfgDelay) {
 	const env = { made: [], els: {} };
 	IDS.forEach((id) => { env.els['#' + id] = makeEl(id); });
 	// Swap in a fresh node under the same id, as replaceChild does.
@@ -128,7 +131,11 @@ function load(pickedTransport, cfg) {
 		// the players directly, and a config that landed would re-attach
 		// underneath them. When one is supplied it wins the first attach's
 		// race, so nothing re-attaches later either.
-		mjConfig: () => (cfg ? Promise.resolve(cfg) : new Promise(() => {})),
+		mjConfig: () => (cfg
+			? (cfgDelay
+				? new Promise((r) => setTimeout(() => r(cfg), cfgDelay))
+				: Promise.resolve(cfg))
+			: new Promise(() => {})),
 		mjGet: (c, k) => (cfg ? cfg[k] : undefined),
 		apiFetch: () => Promise.reject(new Error('no network in tests')),
 		setTimeout, clearTimeout, setInterval, clearInterval,
@@ -333,6 +340,80 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		check('with the message withdrawn', env.el('mj-served').hidden === true);
 		check('and the picker naming what is playing',
 			env.el('mj-transport-m').checked === true);
+	}
+
+	// Radios fire no change event when the one already selected is pressed, so
+	// a retry hung only off the change handler could be reached solely by
+	// asking for a channel the viewer did not want.
+	group('pressing the channel already selected is the retry');
+	{
+		const env = load('mse', { 'jpeg.enabled': true });
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		check('Main is still lit — it is what was asked for',
+			env.el('mj-stream-0').checked === true);
+		// A press of the lit radio: click only, no change, as a browser does.
+		env.el('mj-stream-0').fire('click');
+		check('the chain was started again', env.made.length === 2,
+			'made=' + env.made.length);
+		check('on the same channel', env.made[1].opts.stream === 0,
+			String(env.made[1].opts.stream));
+		check('and the fallback picture is gone',
+			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
+	}
+
+	group('a channel that does move retries exactly once');
+	{
+		const env = load('mse', { 'jpeg.enabled': true });
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		// The browser order for a radio that moves: click, then change.
+		env.el('mj-stream-1').fire('click');
+		env.el('mj-stream-1').fire('change');
+		check('one new player, not two', env.made.length === 2,
+			'made=' + env.made.length);
+		check('asked for Sub', env.made[1].opts.stream === 1,
+			String(env.made[1].opts.stream));
+		// The change handler still runs goToStream(), which reaches the new
+		// player — but only ever for the channel it was just opened with, and
+		// both players no-op setStream() for the channel they already have.
+		check('and never for a channel it was not opened on',
+			env.made[1].streamSet === null || env.made[1].streamSet === 1,
+			'streamSet=' + env.made[1].streamSet);
+	}
+
+	group('Auto retries even when it picks the stream already set');
+	{
+		const env = load('mse', { 'jpeg.enabled': true });
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		// autoApply() returns before goToStream() when its pick equals the
+		// current stream, so the change handler alone would do nothing.
+		env.el('mj-stream-auto').fire('click');
+		check('the chain was started again', env.made.length === 2,
+			'made=' + env.made.length);
+	}
+
+	// jpegOn is false before the config lands as well as when JPEG is off, and
+	// the first attach does not wait for the config past CONFIG_WAIT_MS.
+	group('a config that lands after the fallback re-decides it');
+	{
+		const env = load('mse', { 'jpeg.enabled': true }, 2600);
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		check('with nothing known, it says unavailable and offers the remedy',
+			env.el('mj-badge').textContent === 'unavailable' &&
+			env.el('mj-note').style.display === '',
+			env.el('mj-badge').textContent);
+		await new Promise((r) => setTimeout(r, 1600));
+		check('once the camera answers, the picture it could show is shown',
+			env.el('live-mjpeg').src === '/mjpeg', env.el('live-mjpeg').src);
+		check('the chip names it', env.el('mj-badge').textContent === 'MJPEG',
+			env.el('mj-badge').textContent);
+		check('and the note that offered a remedy it did not need is down',
+			env.el('mj-note').style.display === 'none');
+		check('nothing was re-attached behind it', env.made.length === 1,
+			'made=' + env.made.length);
 	}
 
 	group('a cloned MSE element does not strand the swap');

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -22,7 +22,8 @@ const SRCS = [A('preview-swap.js'), A('preview-page.js')];
 
 const IDS = [
 	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
-	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note', 'mj-stats',
+	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note',
+	'mj-note-why', 'mj-stats',
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
 	'mj-served', 'mj-served-why', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w',
@@ -80,7 +81,11 @@ function makePlayers(env) {
 	return { mse: impl('mse'), webrtc: impl('webrtc') };
 }
 
-function load(pickedTransport) {
+// `cfg` is a flat map of dotted keys, or omitted for the historic behaviour:
+// a config that never lands. Most tests want that — a config arriving would
+// re-attach underneath the players they are driving by hand — but the fallback
+// reads jpeg.enabled and behaves differently on each answer, so it needs one.
+function load(pickedTransport, cfg) {
 	const env = { made: [], els: {} };
 	IDS.forEach((id) => { env.els['#' + id] = makeEl(id); });
 	// Swap in a fresh node under the same id, as replaceChild does.
@@ -119,10 +124,12 @@ function load(pickedTransport) {
 		MajesticWebRTC: impls.webrtc,
 		MajesticTransport: win.MajesticTransport,
 		$: (sel) => env.els[sel],
-		// Never resolves: every test here drives the players directly, and a
-		// config that landed would re-attach underneath them.
-		mjConfig: () => new Promise(() => {}),
-		mjGet: () => undefined,
+		// Never resolves unless a test asked for one: every test here drives
+		// the players directly, and a config that landed would re-attach
+		// underneath them. When one is supplied it wins the first attach's
+		// race, so nothing re-attaches later either.
+		mjConfig: () => (cfg ? Promise.resolve(cfg) : new Promise(() => {})),
+		mjGet: (c, k) => (cfg ? cfg[k] : undefined),
 		apiFetch: () => Promise.reject(new Error('no network in tests')),
 		setTimeout, clearTimeout, setInterval, clearInterval,
 		Promise: Promise,
@@ -245,12 +252,87 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		check('the dead player still holds the screen for now', !first.destroyed);
 
 		// And MSE cannot run either.
-		second.say('mjpeg');
+		second.say('mjpeg', 'undecodable h265');
 		check('the dead player is finally released', first.destroyed);
 		check('the failed replacement too', second.destroyed);
-		check('and the page falls through to MJPEG',
-			env.el('mj-badge').textContent === 'MJPEG',
+		// No JPEG channel on this camera, so there is no picture to fall
+		// through to and the chip must not name a format nothing is sending.
+		check('the chip says the stream is unavailable',
+			env.el('mj-badge').textContent === 'unavailable',
 			env.el('mj-badge').textContent);
+		check('the note is showing', env.el('mj-note').style.display === '',
+			env.el('mj-note').style.display);
+		check('and it carries the reason, codec and all',
+			/H265/.test(env.el('mj-note-why').textContent),
+			env.el('mj-note-why').textContent);
+		check('neither transport is lit any more',
+			env.el('mj-transport-w').checked === false &&
+			env.el('mj-transport-m').checked === false);
+	}
+
+	// #274: the page reached the end of the chain and went on describing the
+	// session it had lost — MJPEG on the chip, MSE still lit, no reason given
+	// anywhere, and a press of Main repainting the chip with the codec of the
+	// stream that had just failed.
+	group('at the end of the chain, with an MJPEG channel to fall back to');
+	{
+		const env = load('mse', { 'jpeg.enabled': true });
+		await tick();
+		const first = env.made[0];
+		// The chip is filled the way the real MSE player fills it: the codec
+		// arrives from the init message, and only then is the mime refused.
+		first.opts.onCodec('h265', 'hvc1.1.6.L120.90', 3840, 2160);
+		first.say('mjpeg', 'undecodable h265');
+
+		check('the fallback picture is up',
+			env.el('live-mjpeg').src === '/mjpeg', env.el('live-mjpeg').src);
+		check('the chip names it', env.el('mj-badge').textContent === 'MJPEG',
+			env.el('mj-badge').textContent);
+		check('the message says why, in words',
+			env.el('mj-served').hidden === false &&
+			/can.t decode/.test(env.el('mj-served-why').textContent),
+			env.el('mj-served-why').textContent);
+		check('and names the codec the browser refused',
+			/H265/.test(env.el('mj-served-why').textContent),
+			env.el('mj-served-why').textContent);
+		check('the note stays down — the fallback is the explanation now',
+			env.el('mj-note').style.display === 'none');
+
+		// The regression in the report: this repainted the chip from the
+		// failed stream's codec, over the MJPEG label, while MJPEG played.
+		const made = env.made.length;
+		env.el('mj-stream-0').fire('change');
+		check('picking a channel does not repaint the chip with a dead codec',
+			env.el('mj-badge').textContent !== 'H265 3840×2160',
+			env.el('mj-badge').textContent);
+		check('it retries the chain instead of doing nothing',
+			env.made.length === made + 1,
+			'made=' + env.made.length);
+		check('and the retried player is asked for that channel',
+			env.made[made].opts.stream === 0,
+			String(env.made[made].opts.stream));
+		check('the dead player was not reopened',
+			first.streamSet === null, 'streamSet=' + first.streamSet);
+	}
+
+	group('the transport the fallback came through can be pressed again');
+	{
+		const env = load('mse', { 'jpeg.enabled': true });
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');
+		check('nothing is lit, so a press is a real change',
+			env.el('mj-transport-m').checked === false);
+		// What a browser does when the label is clicked.
+		env.el('mj-transport-m').checked = true;
+		env.el('mj-transport-m').fire('change');
+		check('MSE was tried again', env.made.length === 2,
+			'made=' + env.made.length);
+		env.made[1].say('playing');
+		check('and once it works the fallback picture is gone',
+			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
+		check('with the message withdrawn', env.el('mj-served').hidden === true);
+		check('and the picker naming what is playing',
+			env.el('mj-transport-m').checked === true);
 	}
 
 	group('a cloned MSE element does not strand the swap');

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1070,6 +1070,24 @@ mark {
 	background: #0d0f14;
 }
 
+/* What the panel says when neither transport could play the camera. There is
+   no MJPEG fallback here and there is not going to be one, so this is the whole
+   of the account — centred on the empty picture rather than tucked under it,
+   because the empty picture is the thing being explained. Its own rule rather
+   than Bootstrap's .alert: the backdrop is the black stage, not the page. */
+.mj-live-alert {
+	position: absolute;
+	inset: auto 1.25rem;
+	top: 50%;
+	transform: translateY(-50%);
+	margin: 0;
+	z-index: 3;
+	text-align: center;
+	color: rgba(255, 255, 255, 0.85);
+	font-size: 0.9375rem;
+	line-height: 1.5;
+}
+
 /* On-picture chrome: black glass in both themes, because its background is the
    picture and not the page surface. */
 .mj-glass {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -936,6 +936,47 @@
 	// diverge is which transport to prefer and what to remember, and that is
 	// preview-transport.js.
 	function attachLivePreview(video) {
+		// True once both transports have been tried and nothing is attached.
+		// The stream picker reads it: with no player its clicks used to reach
+		// nothing at all, and a channel is still a request worth honouring —
+		// an H.264 substream plays in a browser that refused an H.265 main.
+		let exhausted = false;
+
+		// The reason codes preview.js emits, worded for this panel. The Live
+		// page has its own copy in preview-page.js, deliberately: it has an
+		// MJPEG picture to explain and this panel has an empty box, so the
+		// sentences differ past the first clause. A code neither of them
+		// knows still gets an honest general line. Keep the two in step when
+		// a code is added to preview.js.
+		function alertText(why) {
+			const bits = String(why || '').split(' ');
+			const ch = stream === 1 ? 'Sub' : 'Main';
+			if (bits[0] === 'undecodable') {
+				const codec = bits[1] ? bits[1].toUpperCase() : '';
+				return 'This browser can’t decode the ' + ch + ' stream' +
+					(codec ? '’s ' + codec + ' video' : '') +
+					', so there is no preview here.';
+			}
+			if (bits[0] === 'no-mse') {
+				return 'This browser has no Media Source Extensions, so it ' +
+					'cannot play the ' + ch + ' stream.';
+			}
+			if (bits[0] === 'unreachable') {
+				return 'The camera stopped sending the ' + ch + ' stream.';
+			}
+			return 'The ' + ch + ' stream could not be played in this browser.';
+		}
+		function showAlert(why) {
+			const a = document.getElementById('mj-live-alert');
+			if (!a) return;
+			a.textContent = alertText(why);
+			a.hidden = false;
+		}
+		function hideAlert() {
+			const a = document.getElementById('mj-live-alert');
+			if (a) a.hidden = true;
+		}
+
 		// This page's own remembered choice, defaulting to the substream. Not
 		// the Preview page's: the two are looked at for different reasons and
 		// can reasonably want different channels.
@@ -981,7 +1022,11 @@
 			// state.previewPlayer is what the tab teardown closes, so it has to
 			// name whatever is actually on screen — a stale handle there leaves
 			// a live socket behind on every visit.
-			onPromoted: () => { state.previewPlayer = swap.player(); },
+			onPromoted: () => {
+				state.previewPlayer = swap.player();
+				exhausted = false;
+				hideAlert();
+			},
 			onFailed: (kind, why, permanent) => {
 				// 'fallback' is durable and worth remembering; 'busy' says the
 				// camera is full, which it will not be for long.
@@ -990,14 +1035,35 @@
 				}
 			},
 			// Nothing on screen left to protect. MSE is the last thing to try;
-			// past that this panel simply has no preview, which is what its
-			// empty element already shows.
-			onExhausted: (kind) => {
+			// past that this panel has no preview at all — there is no MJPEG
+			// fallback here and there is not going to be one — so what it owes
+			// the viewer is the reason, which it used to withhold: an empty
+			// black box is indistinguishable from a camera that is off.
+			onExhausted: (kind, detail) => {
 				state.previewPlayer = null;
-				if (kind === 'webrtc') swap.start('mse');
+				if (kind === 'webrtc') { swap.start('mse'); return; }
+				exhausted = true;
+				showAlert(detail);
 			},
 			onLive: (st, d, kind) => {
-				if (kind !== 'webrtc') return;
+				if (kind !== 'webrtc') {
+					// MSE is the last thing to try, so its giving up ends the
+					// chain — and it says so on the live player's own channel
+					// rather than as a dropped trial whenever it was the first
+					// thing attached, which is the ordinary case here. Nothing
+					// read that state, so the panel sat black for ever with
+					// nothing said and no way back (#274).
+					if (st === 'mjpeg') {
+						// stop(), not retire(): a refused MSE player has not
+						// closed itself, and its socket's onclose restarts the
+						// reconnect ladder for a session already given up on.
+						swap.stop();
+						state.previewPlayer = null;
+						exhausted = true;
+						showAlert(d);
+					}
+					return;
+				}
 				if (st === 'fallback' || st === 'busy') {
 					if (st === 'fallback') window.MajesticTransport.demote();
 					// Its picture is frozen from here; the replacement is
@@ -1032,8 +1098,17 @@
 			// change event and is still an answer worth remembering.
 			elm.addEventListener('click', function () {
 				window.MajesticTransport.chooseStream('live', n);
-				if (n === stream) return;
+				// Not `if (n === stream) return` any more: with the chain out
+				// there is nothing on screen, and pressing the channel that is
+				// already selected is the only retry this panel offers.
+				if (n === stream && !exhausted) return;
 				stream = n;
+				if (exhausted) {
+					exhausted = false;
+					hideAlert();
+					swap.start(window.MajesticTransport.preferred());
+					return;
+				}
 				if (state.previewPlayer) state.previewPlayer.setStream(n);
 				// And the trial, if one is being judged: it keeps the stream it
 				// was opened with, so it would otherwise be promoted onto the
@@ -1095,6 +1170,10 @@
 		stage.innerHTML =
 			'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
 			'<video id="mj-live-video-b" autoplay muted playsinline class="mj-live-video" style="display:none"></video>' +
+			// When neither transport can play the camera, this panel has no
+			// MJPEG fallback to drop to and simply went black — the emptiest
+			// possible account of what happened (#274). It says so instead.
+			'<p class="mj-live-alert" id="mj-live-alert" hidden></p>' +
 			'<div class="mj-live-bar">' +
 			// The stream picker rides the picture, first in the bar, exactly
 			// where the Live page keeps it — and as the same component, not a

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -34,6 +34,14 @@
 	let jpegOn = false;
 	mjConfig().then(cfg => {
 		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
+		// The first attach does not wait for this fetch past CONFIG_WAIT_MS,
+		// and a player can refuse before it even starts — MSE reports 'no-mse'
+		// from inside attach(). Until this line runs, jpegOn is false because
+		// nothing is known, not because the channel is off, and a fallback
+		// decided on it would offer "Enable JPEG" for a camera that has JPEG
+		// enabled and would leave the picture it could have shown unshown.
+		// Re-decided here against the real answer; harmless when it agrees.
+		if (fellBack) showFallback(fellBack);
 		const subOk = mjGet(cfg, 'video1.enabled') === true;
 		subAvailable = subOk;
 		if (subOk) $('#mj-sub').hidden = false;
@@ -173,6 +181,11 @@
 	// picker, where a channel is still a request worth honouring: the Sub
 	// stream can be a codec this browser plays where the Main stream was not.
 	function retryFromFallback() {
+		// Guarded because one press can arrive twice: the click handler
+		// retries, and the change event that follows a radio that did move
+		// reaches goToStream(), which would otherwise restart the session
+		// that the click has just opened.
+		if (!fellBack) return;
 		fellBack = null;
 		hideStageMsg('fallback');
 		if (note) note.style.display = 'none';
@@ -1075,21 +1088,52 @@
 	// selected fires no change event and is still an answer — the one that has
 	// to be remembered, for someone whose video0 is cropped or whose substream
 	// is sized nothing like the preview box.
+	//
+	// That same silence is why the retry lives here too. Unlike the transport
+	// group, these radios keep their selection through a fallback — they say
+	// what was ASKED for, which is still true and is the channel the message
+	// names ("can't decode the Main stream's H265 video"), where the transport
+	// group says what is CARRYING the picture, which is nothing. So the
+	// channel a viewer wants to retry is usually the one already lit, no
+	// change event will ever come for it, and a retry that only hung off
+	// goToStream() could be reached solely by picking a channel they did not
+	// want. Auto has the same hole twice over: autoApply() returns before
+	// goToStream() whenever its pick equals the current stream.
+	//
+	// Click runs before the activation behaviour fires change, so when the
+	// radio does move the later goToStream() finds fellBack already cleared
+	// and does the ordinary thing to the player this just attached.
 	[s0, s1, autoCtl].forEach((el, n) => {
 		if (el) el.addEventListener('click', () => {
 			userPickedStream = true;
 			MajesticTransport.chooseStream('preview', n === 2 ? 'auto' : n);
+			if (!fellBack) return;
+			if (n === 2) {
+				autoOn = true;
+				lastAutoAt = 0;
+				const pick = autoPick();
+				if (pick !== null) stream = pick;
+				wantedCh = null;
+			} else {
+				autoOn = false;
+				stream = n;
+				wantedCh = n;
+			}
+			retryFromFallback();
 		});
 	});
 
-	// Dismissing the served-channel message. A click anywhere on it counts —
+	// Dismissing whatever is in the stage message slot. A click anywhere counts —
 	// the × is a real button for the keyboard, but a toast small enough to
 	// need aim is a toast that gets missed. stopPropagation for the same
 	// reason preview-adapt.js does it: a tap on the stage toggles the control
 	// bar, and dismissing a message should not also flip the chrome.
 	if (servedEl) servedEl.addEventListener('click', (ev) => {
 		if (ev && ev.stopPropagation) ev.stopPropagation();
-		hideServedMsg();
+		// Whatever is in the slot, not just a served message: the fallback
+		// borrows the same element and a dismissal that checked the owner
+		// would leave its sentence stuck on the picture for good.
+		hideStageMsg();
 	});
 
 	// Follow the size, debounced — a drag fires continuously, and the rate limit

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -29,6 +29,7 @@
 	const initial = $('#live-video');
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), img = $('#live-mjpeg'), note = $('#mj-note');
+	const noteWhy = $('#mj-note-why');
 	const servedEl = $('#mj-served'), servedWhy = $('#mj-served-why');
 	let jpegOn = false;
 	mjConfig().then(cfg => {
@@ -84,25 +85,122 @@
 	const cur = () => liveEl;
 
 	const BARS = '#000 url(/a/preview.svg)';
+	// Why the page is showing something other than a live player, or null while
+	// one is on screen. Everything that used to assume a player exists reads
+	// this: the chip must stop describing a session that ended, and the
+	// controls that retargeted that player have to restart the chain instead.
+	let fellBack = null;
 	function showVideo() {
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = '#000'; }
 		if (img) { img.style.display = 'none'; img.src = ''; }
 		if (note) note.style.display = 'none';
+		fellBack = null;
+		hideStageMsg('fallback');
 	}
 	function showNoSignal() {
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = BARS; }
 		if (img) { img.style.display = 'none'; img.src = ''; }
 		if (note) note.style.display = 'none';
+		fellBack = null;
+		hideStageMsg('fallback');
 		if (badge) badge.textContent = 'no signal';
 	}
-	function showFallback() {
+	// The end of the chain: both transports are gone and what is left is the
+	// camera's JPEG channel, or nothing at all. Saying so takes more than a
+	// word on the chip, which is the whole of #274 — the page arrived here and
+	// then went on describing the session it had lost:
+	//
+	//   - the reason was known and dropped. The player had just said why it
+	//     stopped and this function took no argument at all.
+	//   - the chip said MJPEG while `chipMedia` still held the failed stream's
+	//     codec, so the next setChip() — pressing Main, say — put `H265
+	//     3840x2160` back over the label, naming a stream nobody was watching.
+	//   - the one explanation the page owns was gated on jpeg.enabled being
+	//     OFF, i.e. shown only when there was no fallback to explain.
+	//   - MSE stayed lit on the picker although MSE was not carrying the
+	//     picture, and pressing it again fired no change event, so the
+	//     obvious retry was the one control on the bar that did nothing.
+	//   - the audio and talkback buttons stayed up for a player that had
+	//     stopped, and `player` still held it: a stream click would have
+	//     called setStream() on it and reopened its socket.
+	function showFallback(why) {
 		const v = cur();
 		if (v) v.style.display = 'none';
-		if (jpegOn && img) { img.src = '/mjpeg'; img.style.display = ''; if (note) note.style.display = 'none'; }
-		else if (note) note.style.display = '';
-		if (badge) badge.textContent = 'MJPEG';
+		fellBack = why || 'unknown';
+		// Destroyed, not merely retired. A refused MSE player has stopped its
+		// socket but not closed itself — only destroy() sets its `closed`
+		// flag, so the socket's own onclose starts the reconnect ladder again
+		// and the session it has already declared unusable goes on reporting
+		// 'connecting' from the grave. The swap still routes a retired live
+		// player's states to the page (dead marks the picture stale, not the
+		// handler), so those writes landed on the chip and replaced MJPEG with
+		// 'connecting…' seconds after the fallback appeared.
+		swap.stop();
+		player = null;
+		syncAudioCtl();
+		syncTalkCtl();
+		// Both describe the session that just ended.
+		chipMedia = null;
+		chipFps = 0;
+		if (window.MajesticAdapt) window.MajesticAdapt.reset();
+		if (window.MajesticStats) window.MajesticStats.reset();
+		const sentence = fallbackSentence(fellBack);
+		if (jpegOn && img) {
+			img.src = '/mjpeg';
+			img.style.display = '';
+			if (note) note.style.display = 'none';
+			if (badge) badge.textContent = 'MJPEG';
+			showStageMsg('fallback', sentence + ' Showing the MJPEG fallback.');
+		} else {
+			// No fallback to show, so the note carries the explanation and the
+			// remedy together and the toast would only repeat it. Nothing is
+			// playing, so the chip names no format either.
+			if (noteWhy) noteWhy.textContent = sentence;
+			if (note) note.style.display = '';
+			if (badge) badge.textContent = 'unavailable';
+			hideStageMsg('fallback');
+		}
+		// Neither transport is carrying the picture, so neither is lit. It is
+		// also what makes the retry work: with the group cleared, pressing the
+		// transport that just failed is a real change event again.
+		reflectTransport(null);
+	}
+
+	// Back to the top of the chain. The transport picker gets here on its own
+	// (nothing is checked, so any press is a change), so this is for the stream
+	// picker, where a channel is still a request worth honouring: the Sub
+	// stream can be a codec this browser plays where the Main stream was not.
+	function retryFromFallback() {
+		fellBack = null;
+		hideStageMsg('fallback');
+		if (note) note.style.display = 'none';
+		if (img) { img.style.display = 'none'; img.src = ''; }
+		if (badge) badge.textContent = 'connecting…';
+		attachPlayer(wantWebRTC());
+	}
+
+	// The player names the cause in a code and the page words it — the same
+	// division as the camera's `served` reply, including its rule for a code
+	// this version has never heard of: say something true and general rather
+	// than print an identifier at the viewer.
+	function fallbackSentence(why) {
+		const bits = String(why || '').split(' ');
+		const ch = streamName(stream ? 1 : 0);
+		if (bits[0] === 'undecodable') {
+			const codec = bits[1] ? bits[1].toUpperCase() : '';
+			return 'This browser can’t decode the ' + ch +
+				(codec ? '’s ' + codec + ' video' : '') + '.';
+		}
+		if (bits[0] === 'no-mse') {
+			return 'This browser has no Media Source Extensions, so it cannot ' +
+				'play the ' + ch + '.';
+		}
+		if (bits[0] === 'unreachable') {
+			return 'The camera stopped sending the ' + ch + '.';
+		}
+		return 'The ' + ch + ' could not be played in this browser.';
 	}
 
 	const mute = $('#mj-mute'), muteLbl = $('#mj-mute-lbl'), volCtl = $('#mj-vol');
@@ -119,6 +217,9 @@
 	// alternative deserves a name, and "unchecked" never said what it meant.
 	// The failure tooltip still lands on the WebRTC label (#mj-transport-lbl),
 	// which is where "why am I not on WebRTC?" gets asked.
+	//
+	// It has a third state, and it is the honest one at the end of the chain:
+	// null, nothing lit, because neither transport is carrying the picture.
 	const transportW = $('#mj-transport-w'), transportM = $('#mj-transport-m');
 	const transportGrp = $('#mj-transport-ctl');
 	const transportLbl = $('#mj-transport-lbl');
@@ -243,7 +344,11 @@
 	}
 
 	function setChip() {
-		if (!badge || !chipMedia) return;
+		// The fallback owns the chip until a player takes the stage back.
+		// chipMedia is cleared with it, so this is belt and braces — but the
+		// bug it guards, a control repainting the chip with the codec of the
+		// stream that failed, is exactly the one #274 photographed.
+		if (!badge || !chipMedia || fellBack) return;
 		const fps = usingWebRTC ? chipFps : cfgFps[stream ? 1 : 0];
 		badge.textContent = (chipMedia.codec || '').toUpperCase() + ' ' +
 			chipMedia.w + '×' + chipMedia.h +
@@ -258,16 +363,31 @@
 	// something (stream, transport) that makes it stale.
 	const streamName = (n) => n === 0 ? 'Main stream' : 'Sub stream';
 
-	function hideServedMsg() {
+	// One message slot, two authors. The served-channel mismatch and the
+	// fallback are both standing conditions rather than moments, and they
+	// cannot be true at once — a mismatch needs a session playing, the
+	// fallback means there is none — so they share the element. Who wrote it
+	// is tracked all the same, or "a player is back on screen" would wipe a
+	// served message belonging to that very player.
+	let msgOwner = null;
+	function showStageMsg(owner, text) {
+		if (!servedEl || !servedWhy) return;
+		msgOwner = owner;
+		servedWhy.textContent = text;
+		servedEl.hidden = false;
+	}
+	function hideStageMsg(owner) {
+		if (owner && msgOwner !== owner) return;
+		msgOwner = null;
 		if (servedEl) servedEl.hidden = true;
 	}
+	function hideServedMsg() { hideStageMsg('served'); }
 
 	function showServedMsg(info) {
-		if (!servedEl || !servedWhy) return;
 		const req = streamName(info.requested), got = streamName(info.channel);
 		// The page words the sentence; the camera only names the cause. An
 		// unknown code from a future daemon still gets an honest generic line.
-		servedWhy.textContent =
+		showStageMsg('served',
 			info.reason === 'unavailable'
 				? req + ' isn’t available right now — showing ' +
 					got + ' instead.'
@@ -275,8 +395,7 @@
 				? 'This browser’s WebRTC can’t decode the ' + req +
 					'’s format — showing ' + got + ' instead.'
 			: 'The camera couldn’t serve the ' + req +
-				' — showing ' + got + ' instead.';
-		servedEl.hidden = false;
+				' — showing ' + got + ' instead.');
 	}
 
 	// What a `served` reply from the camera does to this page: the chip, the
@@ -473,6 +592,11 @@
 			player = swap.player();
 			usingWebRTC = kind === 'webrtc';
 			liveEl = swap.element();
+			// From what is playing rather than from what was clicked: a retry
+			// out of the fallback starts the chain from the preferred
+			// transport without anyone having touched this group, and it was
+			// left with nothing lit.
+			reflectTransport(kind);
 			settle();
 			showVideo();
 		},
@@ -506,15 +630,15 @@
 		// WebRTC that means MSE, which plays what this browser's decoder takes
 		// rather than what its WebRTC stack will negotiate, a strictly larger
 		// set — and MJPEG if that already was the other transport.
-		onExhausted: (kind) => {
+		onExhausted: (kind, detail) => {
 			player = null;
 			if (kind === 'webrtc') attachPlayer(false);
-			else showFallback();
+			else showFallback(detail);
 		},
 		onLive: (s, d) => {
 			if (s === 'playing') showVideo();
 			else if (s === 'nosignal') showNoSignal();
-			else if (s === 'mjpeg') showFallback();
+			else if (s === 'mjpeg') showFallback(d);
 			else if (s === 'fallback' || s === 'busy') {
 				// The live player gave up mid-session. Staged like any other
 				// switch, so its last frame stays until the replacement has one
@@ -529,7 +653,7 @@
 					swap.retire();
 					attachPlayer(false);
 				} else {
-					showFallback();
+					showFallback(d);
 				}
 			}
 			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
@@ -913,6 +1037,14 @@
 		servedCh = null;
 		servedShownKey = '';
 		hideServedMsg();
+		// Nothing is attached: the chain ran out and the stage is showing the
+		// MJPEG fallback or the note. The pick is still a request worth
+		// honouring — an H.264 substream plays in a browser that refused an
+		// H.265 main, which is the camera in #274 — so it starts the chain
+		// again rather than doing nothing at all. Before this it did nothing
+		// visible and, on the fallback reached through onLive, called
+		// setStream() on a stopped player, reopening its socket.
+		if (fellBack) { retryFromFallback(); return; }
 		if (player) player.setStream(n);
 		const t = swap.trial();
 		if (t) t.setStream(n);

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -17,6 +17,15 @@ window.MajesticVideo = (function () {
 		}).join(',');
 	})();
 
+	// Why a session ended, as a code rather than a sentence — the same
+	// division the camera's `served` reply uses (#240): this file names the
+	// cause, the page words it for the viewer, and a code it does not know
+	// still gets an honest generic line. `undecodable` carries the codec
+	// after a space, because "which codec" is the one actionable part of it.
+	//
+	//   undecodable <codec>  the browser will not take this stream's mime
+	//   no-mse               no Media Source Extensions in this browser
+	//   unreachable          /ws/video would not stay open
 	function attach(video, opts) {
 		opts = opts || {};
 		const onState = opts.onState || function () {};
@@ -115,7 +124,7 @@ window.MajesticVideo = (function () {
 			if (wantAudio && !info.audioCodec) { wantAudio = false; video.muted = true; }
 			mime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
 			if (!mseOk || !MediaSource.isTypeSupported(mime)) {
-				onState('mjpeg', 'codec ' + info.codec + ' not playable here');
+				onState('mjpeg', 'undecodable ' + info.codec);
 				stop();
 				return;
 			}
@@ -125,7 +134,7 @@ window.MajesticVideo = (function () {
 			video.src = objUrl;
 			ms.addEventListener('sourceopen', function () {
 				try { sb = ms.addSourceBuffer(mime); }
-				catch (e) { onState('mjpeg', 'addSourceBuffer failed'); stop(); return; }
+				catch (e) { onState('mjpeg', 'undecodable ' + info.codec); stop(); return; }
 				try { sb.mode = 'segments'; } catch (e) {}
 				sb.addEventListener('updateend', pump);
 				started = true;
@@ -180,7 +189,7 @@ window.MajesticVideo = (function () {
 		function reconnect() {
 			teardownMse();
 			if (closed || reconnectTimer) return;
-			if (++failCount >= 6) { onState('mjpeg', 'live stream unavailable'); stop(); return; }
+			if (++failCount >= 6) { onState('mjpeg', 'unreachable'); stop(); return; }
 			reconnectTimer = setTimeout(function () {
 				reconnectTimer = null;
 				backoff = Math.min(backoff * 2, 8000);
@@ -271,7 +280,7 @@ window.MajesticVideo = (function () {
 		}
 
 		if (!mseOk) {
-			onState('mjpeg', 'MSE unavailable');
+			onState('mjpeg', 'no-mse');
 			return {
 				setStream: function () {}, requestIdr: function () {},
 				setAudio: function () {}, setVolume: function () {},

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -547,8 +547,15 @@ preview() {
 		<video id="live-video" class="mj-stage-media" autoplay muted playsinline></video>
 		<video id="live-video-b" class="mj-stage-media" autoplay muted playsinline style="display:none"></video>
 		<img id="live-mjpeg" class="mj-stage-media" alt="" style="display:none">
+		<!-- Shown only when there is no MJPEG fallback to show, so it carries
+		     both halves: why the stream could not be played (preview-page.js
+		     rewrites the span from the player's reason code) and the one thing
+		     that would give this browser a picture. With jpeg.enabled on, the
+		     picture arrives instead and the reason goes to the #mj-served
+		     toast — the explanation must not be the thing that disappears the
+		     moment the fallback works. -->
 		<p id="mj-note" class="alert alert-warning mj-stage-alert" style="display:none">
-			Your browser can't play the live H.264/H.265 stream.
+			<span id="mj-note-why">Your browser can't play the live video stream.</span>
 			<a href="mj-settings.cgi?tab=jpeg">Enable JPEG</a> for an MJPEG fallback.
 		</p>
 		<!-- The status chip. Same id as the badge it replaces, so every state


### PR DESCRIPTION
@usa- reported the Live page sitting on `Main` + `MSE` with **MJPEG** on the chip, both buttons still lit, and nothing anywhere saying why (#274). Reading the path turned up **six** ways the page went on describing the session it had lost — the report could only see two of them, and one of the other four was still doing damage in the background.

This PR is the bug half of #274 only. The feature half — MJPEG as a selectable source next to Main/Sub/Auto, and as an Auto candidate — is declined, so there is no closing trailer here; #274 gets closed by hand with that explanation.

## What was wrong

**The reason was known and thrown away.** The MSE player says exactly why it stopped and `showFallback()` took no argument at all. It does now, and the player reports a *code* rather than a sentence — the same division the camera's `served` reply uses (#240): `preview.js` names the cause (`undecodable <codec>`, `no-mse`, `unreachable`), the page words it, and a code a later release adds still degrades to an honest general line.

**The one explanation the page owned was shown only when it could not help.** `#mj-note` was gated on `jpeg.enabled` being **off** — displayed exactly when there was no fallback to explain, suppressed the moment the fallback worked. With a JPEG channel the reason now goes to the `#mj-served` toast over the picture; without one the note carries the reason and the remedy together.

**The chip named a stream nobody was watching.** `MJPEG` was written over a still-populated `chipMedia`, so the next `setChip()` — pressing **Main**, say — put `H265 3840×2160 · 25 fps` back over the label while MJPEG played. `chipMedia` is cleared with the session and `setChip()` is guarded. With no JPEG channel the chip reads `unavailable` rather than naming a format nothing is sending.

**The picker claimed a transport that was not carrying the picture**, and pressing it again fired no `change` event — so the obvious retry was the one control on the bar that did nothing. Neither radio is lit at the end of the chain: the honest state, and what makes any press a real retry. `onPromoted` reflects the transport that actually took the stage, so the group heals itself instead of tracking clicks.

**Main / Sub / Auto did nothing** — and on the fallback reached through `onLive`, worse than nothing: `player` still held the stopped MSE player, so a stream click called `setStream()` on it and reopened its socket. A channel is still a request worth honouring, so a pick now restarts the chain. An H.264 substream plays in a browser that refused an H.265 main, which is the reporter's camera exactly.

**The refused player was never destroyed.** Only `destroy()` sets `preview.js`'s `closed` flag, so after declaring itself unusable the socket's own `onclose` restarted the reconnect ladder — and the swap still routes a retired live player's states (`dead` marks the picture stale, not the handler). That is how `connecting…` landed on the chip seconds after MJPEG appeared. `swap.stop()` now, with the audio and talkback controls standing down with it.

**Live adjustments was worse.** Its `onLive` returned early for anything that was not WebRTC, so MSE giving up *as the first-attached player* — the ordinary case there — was swallowed whole: a black box, no message, no way back, for ever. It reports the reason now, in its own wording (it has an empty box to explain, not an MJPEG picture), and its Main/Sub picker is the retry, including a press of the channel already selected.

## What this is not

No MJPEG button, and no MJPEG candidate in Auto. It stays the last rung of `WebRTC → MSE → MJPEG → note`, for a browser that can decode nothing else — not a source the UI offers. `Main`/`Sub`/`Auto` picks an encoder channel and `WebRTC`/`MSE` picks a transport; `/mjpeg` is majestic's separate `jpeg` pipeline and is on neither axis.

## Verification

Lab `hi3516av300` with `video0` forced to H.265 (real Chrome via Playwright, which has no HEVC), so the failure is genuine rather than stubbed:

- the reported combination reproduces — chip `MJPEG`, message *"This browser can't decode the Main stream's H265 video. Showing the MJPEG fallback."*, neither transport lit;
- the chip **holds** `MJPEG` across 50 s where it used to flip to `connecting…`;
- pressing **Sub** from the fallback returns real video — `H264 640×360 · 15 fps`, MJPEG gone, message withdrawn, MSE lit as what is actually carrying it;
- with `jpeg.enabled` off: chip `unavailable`, note reading *"This browser can't decode the Main stream's H265 video."* above the Enable-JPEG link;
- Live adjustments: *"This browser can't decode the Main stream's H265 video, so there is no preview here."*, and **Sub** brings the preview back.

`npm test` passes — `tests/staging.test.js` grows a config-supplying loader so both halves of the fallback (with and without a JPEG channel) are exercised, plus the retry paths. `npm run build:dist` is clean and `bootstrap.min.css` is unchanged, so the purgecss gate stays green.
