### PR TITLE
Live: a retry must not cost the viewer the picture they had

### DIFF
--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -334,6 +334,8 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		env.el('mj-transport-m').fire('change');
 		check('MSE was tried again', env.made.length === 2,
 			'made=' + env.made.length);
+		check('and the picture is held while it is judged',
+			env.el('live-mjpeg').src === '/mjpeg', env.el('live-mjpeg').src);
 		env.made[1].say('playing');
 		check('and once it works the fallback picture is gone',
 			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
@@ -358,8 +360,71 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			'made=' + env.made.length);
 		check('on the same channel', env.made[1].opts.stream === 0,
 			String(env.made[1].opts.stream));
-		check('and the fallback picture is gone',
+		check('and the picture is held for the attempt',
+			env.el('live-mjpeg').src === '/mjpeg', env.el('live-mjpeg').src);
+		env.made[1].say('playing');
+		check('handed over only once the replacement has one of its own',
 			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
+	}
+
+	// showFallback() stops the swap, so there is no live entry left for it to
+	// protect and the next attach is promoted the instant it is made. Without
+	// this the retry traded a working picture for a black stage and a
+	// negotiation that could still fail.
+	group('a retry does not cost the viewer the picture they had');
+	{
+		const env = load('mse', { 'jpeg.enabled': true });
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		// The transport group is unlit, so this is what a press looks like.
+		env.el('mj-transport-w').checked = true;
+		env.el('mj-transport-w').fire('change');
+		check('a player was made', env.made.length === 2);
+		check('the MJPEG picture is still up',
+			env.el('live-mjpeg').style.display === '',
+			env.el('live-mjpeg').style.display);
+		check('and the chip says so, and that it is trying',
+			env.el('mj-badge').textContent === 'MJPEG · retrying…',
+			env.el('mj-badge').textContent);
+		// Everything short of a picture must leave the stage alone.
+		env.made[1].say('connecting');
+		env.made[1].say('nosignal');
+		check('a connecting attempt does not take the picture',
+			env.el('live-mjpeg').style.display === '',
+			env.el('live-mjpeg').style.display);
+		check('nor rewrite the chip out from under it',
+			env.el('mj-badge').textContent === 'MJPEG · retrying…',
+			env.el('mj-badge').textContent);
+		// And when it fails, the fallback simply carries on.
+		env.made[1].say('fallback', 'no usable H.264 in the offer');
+		check('the MSE attempt that follows is made', env.made.length === 3);
+		env.made[2].say('mjpeg', 'undecodable h265');
+		check('the picture was never interrupted',
+			env.el('live-mjpeg').style.display === '',
+			env.el('live-mjpeg').style.display);
+		check('and the chip is back to naming it plainly',
+			env.el('mj-badge').textContent === 'MJPEG',
+			env.el('mj-badge').textContent);
+	}
+
+	// The served-channel answer belonged to the session that died. settle()
+	// only clears it on a promotion to MSE, so a retry that landed back on
+	// WebRTC used to inherit it.
+	group('the camera\u2019s served answer does not outlive its session');
+	{
+		const env = load('webrtc', { 'jpeg.enabled': true });
+		await tick();
+		const live = env.made[0];
+		live.say('playing');
+		env.el('mj-served').hidden = true;
+		live.opts.onServed({ channel: 1, requested: 0, reason: 'unavailable' });
+		check('the mismatch message is up', env.el('mj-served').hidden === false);
+		live.say('fallback', 'media stopped arriving');
+		env.made[1].say('mjpeg', 'undecodable h265');
+		check('and it is replaced, not left standing over the fallback',
+			env.el('mj-served').hidden === false &&
+			/can.t decode/.test(env.el('mj-served-why').textContent),
+			env.el('mj-served-why').textContent);
 	}
 
 	group('a channel that does move retries exactly once');

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -407,6 +407,44 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			env.el('mj-badge').textContent);
 	}
 
+	// Two ways an unproven promotion used to let a session with no picture
+	// speak for the stage: the chip and the served-channel answer.
+	group('a retry says nothing until it has a picture');
+	{
+		const env = load('webrtc', { 'jpeg.enabled': true });
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		env.el('mj-stream-0').fire('click');
+		const retry = env.made[1];
+		check('the retry is in flight', env.made.length === 2);
+
+		// The camera answers the offer before any media arrives, and says it
+		// is serving the other channel.
+		retry.opts.onServed({ channel: 1, requested: 0, reason: 'unavailable' });
+		check('the radios have not moved for a session with no picture',
+			env.el('mj-stream-0').checked === true &&
+			env.el('mj-stream-1').checked === false);
+		check('and the fallback still owns the message',
+			/can.t decode/.test(env.el('mj-served-why').textContent),
+			env.el('mj-served-why').textContent);
+
+		// MSE reports its codec once, from the init message, before playing.
+		retry.opts.onCodec('h264', 'avc1.640028', 640, 360);
+		check('the chip still describes the stage, not the attempt',
+			env.el('mj-badge').textContent === 'MJPEG · retrying…',
+			env.el('mj-badge').textContent);
+
+		// And now it plays: everything held is adopted at once.
+		retry.say('playing');
+		check('the picture is handed over',
+			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
+		check('the chip names what is actually playing',
+			/H264 640/.test(env.el('mj-badge').textContent),
+			env.el('mj-badge').textContent);
+		check('and the radios follow the camera now that there is a picture',
+			env.el('mj-stream-1').checked === true);
+	}
+
 	// The served-channel answer belonged to the session that died. settle()
 	// only clears it on a promotion to MSE, so a retry that landed back on
 	// WebRTC used to inherit it.

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -742,7 +742,22 @@
 	}
 
 	function handlersFor(id, onState) {
-		const isLive = () => swap.isLive(id);
+		// "Is this attachment the one the page is showing" — which is not the
+		// same question as "has the swap made it live". A retry out of the
+		// fallback is promoted unproven, because the swap had nothing of its
+		// own in the way, while the stage still holds the MJPEG picture from
+		// the session before it. Everything below belongs to whatever is on
+		// screen, so during that hold this attachment owns nothing yet: its
+		// codec and its served-channel answer are held exactly as a trial's
+		// are, and adopted by the onState handler at the moment showVideo()
+		// hands the stage over.
+		//
+		// Without the second clause a retry that never produced a frame could
+		// move the radios to the camera's served channel and replace the
+		// fallback's explanation with a mismatch toast, announcing a switch to
+		// a stream nobody was being shown — over an MJPEG picture belonging to
+		// a session that had already died.
+		const isLive = () => swap.isLive(id) && !holdingFallback;
 		// The MSE player reports its codec once, from the init message — which
 		// for a trial arrives BEFORE it is promoted, when isLive() is still
 		// false, and it never reports again. Held here and adopted the moment

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -98,15 +98,26 @@
 	// this: the chip must stop describing a session that ended, and the
 	// controls that retargeted that player have to restart the chain instead.
 	let fellBack = null;
+	// What the fallback has put on the stage — 'mjpeg', 'note', or null — as
+	// distinct from `fellBack`, which is cleared the moment a retry starts.
+	// They part company for the length of that retry, and that gap is the
+	// point: the picture stays until the replacement has one of its own.
+	let holdingFallback = null;
 	function showVideo() {
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = '#000'; }
 		if (img) { img.style.display = 'none'; img.src = ''; }
 		if (note) note.style.display = 'none';
 		fellBack = null;
+		holdingFallback = null;
 		hideStageMsg('fallback');
 	}
 	function showNoSignal() {
+		// 'no signal' is a stage of a retry, not its outcome. While the
+		// fallback picture is being held, taking it away for one would cost
+		// the viewer what they had in exchange for a session that may yet
+		// fail — and MSE reaches 'unreachable' only after six of these.
+		if (holdingFallback) return;
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = BARS; }
 		if (img) { img.style.display = 'none'; img.src = ''; }
@@ -154,12 +165,24 @@
 		chipFps = 0;
 		if (window.MajesticAdapt) window.MajesticAdapt.reset();
 		if (window.MajesticStats) window.MajesticStats.reset();
+		// The camera's served-channel answer belonged to the session that just
+		// died, and settle() only clears it on a promotion to MSE — so a retry
+		// that landed back on WebRTC used to inherit it, naming the wrong
+		// channel on the chip and handing the adaptation toast the wrong
+		// channel's configured bitrate, with no new `served` ever due on a
+		// daemon that does not send one. The message goes with it, whoever
+		// owns the slot: a mismatch toast standing over the fallback describes
+		// a session that no longer exists.
+		servedCh = null;
+		servedShownKey = '';
+		hideStageMsg();
 		const sentence = fallbackSentence(fellBack);
 		if (jpegOn && img) {
 			img.src = '/mjpeg';
 			img.style.display = '';
 			if (note) note.style.display = 'none';
 			if (badge) badge.textContent = 'MJPEG';
+			holdingFallback = 'mjpeg';
 			showStageMsg('fallback', sentence + ' Showing the MJPEG fallback.');
 		} else {
 			// No fallback to show, so the note carries the explanation and the
@@ -168,7 +191,7 @@
 			if (noteWhy) noteWhy.textContent = sentence;
 			if (note) note.style.display = '';
 			if (badge) badge.textContent = 'unavailable';
-			hideStageMsg('fallback');
+			holdingFallback = 'note';
 		}
 		// Neither transport is carrying the picture, so neither is lit. It is
 		// also what makes the retry work: with the group cleared, pressing the
@@ -176,22 +199,31 @@
 		reflectTransport(null);
 	}
 
-	// Back to the top of the chain. The transport picker gets here on its own
-	// (nothing is checked, so any press is a change), so this is for the stream
-	// picker, where a channel is still a request worth honouring: the Sub
-	// stream can be a codec this browser plays where the Main stream was not.
-	function retryFromFallback() {
+	// Back to the top of the chain, from either picker: `webrtc` is the
+	// transport group naming one, and undefined is the stream group leaving
+	// the choice to the stored preference.
+	//
+	// What it does NOT do is clear the stage. showFallback() stops the swap,
+	// so there is no live entry left for it to protect and the next attach is
+	// promoted the instant it is made — which meant a press of a transport
+	// button traded a working MJPEG picture for a black stage and a
+	// negotiation that could still fail, inverting the one rule
+	// preview-swap.js exists to enforce. The picture is the page's to hold
+	// now, and it is handed over in onPromoted, on a promotion that was
+	// earned by a picture rather than by there being nothing in the way.
+	function retryFromFallback(webrtc) {
 		// Guarded because one press can arrive twice: the click handler
 		// retries, and the change event that follows a radio that did move
 		// reaches goToStream(), which would otherwise restart the session
 		// that the click has just opened.
 		if (!fellBack) return;
 		fellBack = null;
-		hideStageMsg('fallback');
-		if (note) note.style.display = 'none';
-		if (img) { img.style.display = 'none'; img.src = ''; }
-		if (badge) badge.textContent = 'connecting…';
-		attachPlayer(wantWebRTC());
+		hideStageMsg();
+		if (badge) {
+			badge.textContent = holdingFallback === 'mjpeg'
+				? 'MJPEG · retrying…' : 'retrying…';
+		}
+		attachPlayer(webrtc === undefined ? wantWebRTC() : webrtc);
 	}
 
 	// The player names the cause in a code and the page words it — the same
@@ -361,7 +393,7 @@
 		// chipMedia is cleared with it, so this is belt and braces — but the
 		// bug it guards, a control repainting the chip with the codec of the
 		// stream that failed, is exactly the one #274 photographed.
-		if (!badge || !chipMedia || fellBack) return;
+		if (!badge || !chipMedia || fellBack || holdingFallback) return;
 		const fps = usingWebRTC ? chipFps : cfgFps[stream ? 1 : 0];
 		badge.textContent = (chipMedia.codec || '').toUpperCase() + ' ' +
 			chipMedia.w + '×' + chipMedia.h +
@@ -601,7 +633,7 @@
 				{ stream: stream, iceServers: () => ice,
 					audio: audioOn, volume: vol },
 				handlersFor(id, onState))),
-		onPromoted: (kind) => {
+		onPromoted: (kind, proven) => {
 			player = swap.player();
 			usingWebRTC = kind === 'webrtc';
 			liveEl = swap.element();
@@ -611,7 +643,11 @@
 			// left with nothing lit.
 			reflectTransport(kind);
 			settle();
-			showVideo();
+			// Only when this promotion means a picture. Holding the fallback,
+			// an unproven one is just the swap saying it had nothing of its
+			// own in the way — and showing the empty video element for it
+			// would take away the picture the viewer still has.
+			if (proven || !holdingFallback) showVideo();
 		},
 		// A trial was dropped and the screen is untouched. All that changes is
 		// the toggle, which has to come back up carrying the reason.
@@ -669,7 +705,11 @@
 					showFallback(d);
 				}
 			}
-			else if (badge) badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+			// Not while the fallback picture is being held: these describe the
+			// attempt, and the chip has to go on describing the stage.
+			else if (badge && !holdingFallback) {
+				badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+			}
 		},
 	});
 
@@ -1006,14 +1046,20 @@
 		// From the preference rather than from usingWebRTC, which the deferred
 		// attach above has not set yet.
 		reflectTransport(wantWebRTC() ? 'webrtc' : 'mse');
+		// Out of a fallback these go through the retry, so the picture that is
+		// on the stage is held for the attempt exactly as it is for a channel
+		// press. Playing, they are an ordinary transport switch and the swap
+		// protects the picture itself.
 		transportW.addEventListener('change', () => {
 			if (!transportW.checked) return;
 			rememberTransport('webrtc');
+			if (fellBack) { retryFromFallback(true); return; }
 			attachPlayer(true);
 		});
 		transportM.addEventListener('change', () => {
 			if (!transportM.checked) return;
 			rememberTransport('mse');
+			if (fellBack) { retryFromFallback(false); return; }
 			attachPlayer(false);
 		});
 	}

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -62,7 +62,13 @@ window.MajesticSwap = function (opts) {
 		if (entry && entry.p) { try { entry.p.destroy(); } catch (e) {} }
 	}
 
-	function promote() {
+	// `proven` says whether this promotion was earned by a picture. A trial
+	// is promoted because it reported 'playing', so the answer is yes; a first
+	// attach is promoted because there was nothing to protect, which is not
+	// the same claim at all. Callers that have something of their own on the
+	// stage — the Preview page holds an MJPEG fallback the swap knows nothing
+	// about — need to tell the two apart before they tear it down.
+	function promote(proven) {
 		const s = staging;
 		staging = null;
 		if (live) {
@@ -71,7 +77,7 @@ window.MajesticSwap = function (opts) {
 		}
 		live = s;
 		show(s.slot, true);
-		opts.onPromoted(s.kind);
+		opts.onPromoted(s.kind, proven === true);
 	}
 
 	// The trial failed. Leave the screen exactly as it was — unless what is on
@@ -110,7 +116,7 @@ window.MajesticSwap = function (opts) {
 				// connecting, no signal, reconnecting — is exactly what must
 				// not reach the page, because the point is that trying costs
 				// the viewer nothing until it succeeds.
-				if (state === 'playing') promote();
+				if (state === 'playing') promote(true);
 				else if (state === 'fallback' || state === 'busy' ||
 					state === 'mjpeg') {
 					drop(detail, state === 'fallback');
@@ -133,9 +139,10 @@ window.MajesticSwap = function (opts) {
 		}
 		staging.p = p;
 
-		// Nothing on screen to protect: this is the first attach, so the trial
-		// is the live player and the caller hears about it immediately.
-		if (!live) promote();
+		// Nothing the SWAP is protecting: this is the first attach, so the trial
+		// is the live player and the caller hears about it immediately — but
+		// unproven, because nothing has reported a picture yet.
+		if (!live) promote(false);
 	}
 
 	// The player on screen has given up. Its picture is a frozen frame from

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -26,6 +26,14 @@ window.MajesticVideo = (function () {
 	//   undecodable <codec>  the browser will not take this stream's mime
 	//   no-mse               no Media Source Extensions in this browser
 	//   unreachable          /ws/video would not stay open
+	//   mse-error            MediaSource refused a mime it said it supported
+	//
+	// The last one is deliberately vague, because so is the fact: it is only
+	// reached AFTER isTypeSupported() returned true, so the throw is a source
+	// buffer limit, a MediaSource that is no longer open, quota — anything but
+	// the decoder. Reporting it as `undecodable` would have the page state
+	// something false about the browser, which is the failure this whole
+	// vocabulary exists to prevent.
 	function attach(video, opts) {
 		opts = opts || {};
 		const onState = opts.onState || function () {};
@@ -134,7 +142,7 @@ window.MajesticVideo = (function () {
 			video.src = objUrl;
 			ms.addEventListener('sourceopen', function () {
 				try { sb = ms.addSourceBuffer(mime); }
-				catch (e) { onState('mjpeg', 'undecodable ' + info.codec); stop(); return; }
+				catch (e) { onState('mjpeg', 'mse-error'); stop(); return; }
 				try { sb.mode = 'segments'; } catch (e) {}
 				sb.addEventListener('updateend', pump);
 				started = true;


### PR DESCRIPTION
Four findings from a second review pass over #279. **One is a regression that PR introduced**, and it is the reason this follow-up is not a nice-to-have.

## The retry threw away a working picture

`showFallback()` destroys the refused player through `swap.stop()` — necessary, because a refused MSE player has stopped its socket without closing itself and would otherwise reconnect from the grave. But it leaves **no live entry for the swap to protect**, so the next attach is promoted the instant it is made (`start()`'s `if (!live) promote()`), and `onPromoted`'s `showVideo()` took the MJPEG picture down for a negotiation that had proved nothing and might still fail.

Concretely: press **WebRTC** while watching the MJPEG fallback and you got a black stage — with the chip still reading `MJPEG` — for up to the WebRTC no-signal timeout, paid for with a picture that was working. That inverts the one rule `preview-swap.js` exists to enforce:

> nothing on screen changes until the replacement is known to work

…and #279 suspended it exactly where it had just become load-bearing.

The picture is the page's to hold, because the swap cannot know about it:

- `holdingFallback` tracks what is actually on the stage (`'mjpeg'` or `'note'`) and **outlives `fellBack`**, which a retry clears immediately. The two parting company for the length of the attempt is the whole mechanism.
- `promote()` now reports whether it was **earned** — a trial that said `playing` — or merely unopposed, and the page hands the stage over only on the former.
- `no signal` and `connecting` leave both the picture and the chip alone while a retry is in flight. The chip reads `MJPEG · retrying…`, so the press is still acknowledged.
- Both transport buttons route through the same retry as the stream picker instead of calling `attachPlayer()` directly, so the two paths cannot drift again.

## The served-channel answer outlived its session

`showFallback()` cleared `chipMedia`, the player and both panels — but not `servedCh`, and `settle()` clears it only on a promotion to MSE. So a retry landing back on WebRTC inherited the dead session's channel: `servedStream()` returned the old one, the chip named the wrong channel, and `preview-adapt` took the wrong channel's configured bitrate as its baseline — with no new `served` ever due on a daemon that does not send one. Cleared with the rest of the session.

## A mismatch toast could stand over the fallback

The no-JPEG branch cleared the message slot only if the fallback owned it. A served mismatch left up by a dying WebRTC session therefore stayed on screen beside the "no Media Source Extensions" note, describing a session that no longer existed. Reachable on **iPhone Safari**, which has no MSE at all, so the trial answers from inside `attach()`. The slot is cleared unconditionally now.

## `addSourceBuffer` failures were reported as an undecodable codec

That catch is reached **only after** `isTypeSupported()` returned true, so the throw is a source-buffer limit, a `MediaSource` no longer open, quota — anything but the decoder. Wording it as "This browser can't decode the Main stream's H265 video" states something false about the browser, which is the exact failure the reason-code vocabulary was introduced to prevent. It gets its own code, `mse-error`, falling through to the general line.

## Verification

`npm test` passes; `npm run build:dist` clean; `bootstrap.min.css` unchanged.

Three new/updated groups in `tests/staging.test.js` pin the rule directly: a retry keeps the picture, `connecting`/`nosignal` do not take it or rewrite the chip, a failed retry leaves the fallback exactly as it was, the picture is handed over only on a proven promotion, and a served mismatch is replaced rather than left standing.

On the lab `hi3516av300` with `video0` on H.265 and real Chrome: pressing **MSE** from the fallback re-runs the chain, fails, and the MJPEG picture is never interrupted — where before the same press blanked the stage. Pressing **WebRTC** succeeds (the camera serves Sub) and the handover happens only when the picture arrives.

Follow-up to #279; same reporter thread, #274.
