### PR TITLE
Live: a retired player is not a transport the viewer chose

### DIFF
--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -112,7 +112,7 @@ function load(pickedTransport, cfg, cfgDelay) {
 		MajesticTransport: {
 			available: () => true,
 			preferred: () => pickedTransport || 'mse',
-			choose() {}, demote() { env.demoted = true; },
+			choose(k) { env.chosen = k; }, demote() { env.demoted = true; },
 			impl: (k) => (k === 'webrtc' ? impls.webrtc : impls.mse),
 			iceServers: () => [],
 			chosenStream: () => null, chooseStream() {},
@@ -275,6 +275,17 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		check('neither transport is lit any more',
 			env.el('mj-transport-w').checked === false &&
 			env.el('mj-transport-m').checked === false);
+		// #269: what the page REMEMBERS about this browser, which nothing on
+		// screen can correct. The MSE failure arrives after WebRTC has been
+		// retired, and onFailed used to read that retired entry as "WebRTC is
+		// still playing" — writing the permanent choice key from a failure
+		// path and wiping the six-hour demotion recorded moments before. The
+		// browser then re-ran the whole failing negotiation on every load, for
+		// ever, because a stored choice outranks a demotion and demote() will
+		// not overwrite one.
+		check('the refusal is still what is remembered', env.demoted === true);
+		check('and nothing was recorded as the viewer’s own choice',
+			env.chosen === undefined, String(env.chosen));
 	}
 
 	// #274: the page reached the end of the chain and went on describing the

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -657,8 +657,18 @@
 			// — including when the failure was MSE and WebRTC is still playing,
 			// where leaving it unchecked would report the opposite of the truth
 			// and make the stored preference retry the failure next load.
+			//
+			// playing(), not kind(): the question is whether WebRTC is still
+			// carrying the picture, and a retired player occupies the live
+			// slot with a frozen frame while carrying nothing. Asked the wider
+			// question, an MSE failure arriving after WebRTC had already given
+			// up took this branch on the way to the end of the chain — and
+			// wrote the viewer's PERMANENT choice from a failure path,
+			// erasing the demotion the WebRTC refusal had recorded a moment
+			// earlier. showFallback() unlights both radios straight after, so
+			// nothing on screen said so; the storage was wrong for good (#269).
 			if (kind !== 'webrtc') {
-				if (swap.kind() === 'webrtc') {
+				if (swap.playing() === 'webrtc') {
 					reflectTransport('webrtc');
 					rememberTransport('webrtc');
 				}

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -163,7 +163,15 @@ window.MajesticSwap = function (opts) {
 		player: function () { return live && live.p; },
 		// Resolved now, not remembered: see the note on opts.elements.
 		element: function () { return live && node(live.slot); },
-		kind: function () { return live && live.kind; },
+		// The transport on screen AND still moving, which is the only form of
+		// this question with a safe answer. Its predecessor `kind()` reported
+		// the live slot's transport whether or not it had been retired, and a
+		// retired player is a frozen frame carrying nothing — so every caller
+		// that used it to name the transport in use was wrong exactly when
+		// something had gone wrong. There is deliberately no accessor for the
+		// wider question: player() and element() already serve the cases that
+		// are about the picture rather than the transport.
+		playing: function () { return live && !live.dead ? live.kind : null; },
 		// The trial, for a caller that has to keep it in step with a control
 		// the viewer moved while it was being judged — a stream change applied
 		// only to the visible player would be promoted away a moment later.


### PR DESCRIPTION
Part of #269. #279 landed while this was being investigated and fixed everything the end of the chain **shows**; this is the half it **records**, which nothing on screen can correct afterwards.

### The path

H.265 on the main stream of a camera whose sub stream is off — the factory default, so this is what a reset camera does the moment someone picks H.265. WebRTC has nothing it can offer (RFC 7798 has no level asymmetry, and there is no second channel to fall back to), MSE cannot decode what it gets, and the chain ends at MJPEG.

The WebRTC refusal calls `rememberDemotion()`. Then the MSE failure arrives, and `onFailed` asks `swap.kind() === 'webrtc'` to mean *"WebRTC is still playing, so put the toggle back on it"*. `kind()` answers for whatever occupies the live slot, **retired or not** — right for the picture, since a retired player's last frame is still what the viewer is looking at, and wrong for naming the transport in use. So the branch fired, and `rememberTransport()` — `MajesticTransport.choose`, the **permanent explicit-choice** key — was written from a failure path, clearing the six-hour demotion recorded moments earlier.

### Why nothing showed it

`showFallback()` unlights both radios immediately afterwards, so the screen was already correct. Only `localStorage` was wrong, and it stayed wrong: `preferred()` reads a stored choice ahead of everything, and `demote()` refuses to overwrite one. That browser then re-ran the full failing negotiation — ICE, DTLS, the no-signal timeout, three attempts — before falling to MSE and then MJPEG, on **every** load of the page, for ever. The expiry that exists precisely so a camera which cannot serve WebRTC stops being retried had been switched off by the failure it was recorded for.

### The change

`preview-swap.js` grows `playing()` — the transport on screen *and* still moving — and `onFailed` asks that instead. Two accessors, because a slot that keeps a dead entry has two questions to answer and the callers want different ones.

### Measured

hi3516ev300, `video0.codec: h265`, `video1.enabled: false`, real Chrome via Playwright (no HEVC decoder, so the same dead end):

| | before | after |
| --- | --- | --- |
| `localStorage` | `mj-transport-pick: webrtc` | `mj-transport-auto: <ts>` |
| `MajesticTransport.preferred()` | `webrtc` | `mse` |

Everything #279 put on the screen is unchanged — chip `MJPEG`, neither radio lit, *"This browser can't decode the Main stream's H265 video. Showing the MJPEG fallback."*

The staging test's end-of-chain group grew two assertions; the second fails without this change.

### Not closing #269

The reporter's other symptom — the jerky picture — is still with them: I have asked which the chip says, since `MJPEG` means it is the 5 fps snapshot fallback (explained by the above plus #279) and `H265 …` means Safari decoded it and the judder is a separate, codec-independent frame-rate question. Measured on the lab camera, the fragment cadence is three at 41.9 ms then one gap of 83.8 ms — about 19 fps against a configured 20 — **identically on H.264 and H.265**.

Also separate, and raised as OpenIPC/majestic#309: `videoN.profile` is a no-op for H.265 on HiSilicon, so the "High Profile" in the report's title never reached the encoder.
