### PR TITLE
Settings: one width for every page (#239)

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -256,22 +256,33 @@ body > main > .container > h2 {
 	line-height: 1.3;
 }
 
-/* Only this page widens, and only because of the one thing on it that can use a
-   bigger monitor. Bootstrap's shared 1320px cap meant the Live preview was
-   exactly 966x543 on a 1080p screen and on a 1440p one alike — the container was
-   what stopped it, not the window (#239). Every other page keeps the cap; a
-   ceiling stays, because a settings form whose rows run the width of a 4K
-   monitor is not a form anyone can read. */
+/* This page is capped at the same 1320px as every other page, and the cap is
+   written out rather than left to Bootstrap's `.container` — that is a five-step
+   ladder (540/720/960/1140/1320), and its step below 1400px is 1140, so simply
+   deleting this rule would leave a 1340px window NARROWER than it is today
+   (434px columns down to 361). `min()` keeps the 96vw floor that made the page
+   fit small windows and puts the ceiling back where the rest of the UI has it.
+
+   The ceiling had been lifted to 2400px so the Live preview could use a big
+   monitor (#239). Measured on a hi3516av300 at 2560x1440, that bought the form
+   nothing: the same seventeen rows, the same 1068px of page — and it hung 540px
+   past the navbar and the footer, which are 1320px on every page including this
+   one. It bought the picture 2056x1157 instead of 976x549, at the price of the
+   panel it belongs to: the stage below sizes itself from the window's HEIGHT and
+   reserves room for the Tone strip and nothing else, so the wider the picture
+   the further Scene/Luma/Orientation fall past the bottom — about 240px at every
+   window size. Stop the picture at 976 and the whole panel is on one screen for
+   the first time: 8px to spare at 1080p, 368px at 1440p. Below 1375px, where
+   96vw already wins, nothing about this changes. */
 #page-mj-settings > main > .container {
-	max-width: min(96vw, 2400px);
+	max-width: min(96vw, 1320px);
 }
 
-/* Once the container is free to grow, a quarter-width rail is 437px of mostly
-   nothing on a 1080p screen — a column of one-word labels, sized as a fraction
-   of a page whose width now comes from the monitor. So the rail takes what the
-   tree needs and the form column takes the rest, which on that screen hands the
-   picture another 60px of width. Below md the two stack and the percentages
-   never applied anyway, hence the same breakpoint Bootstrap uses. */
+/* A quarter-width rail is a fraction of a page, and this page's width is now a
+   constant — so make the rail one too. It takes what the tree needs (a column of
+   one-word labels) and the form column takes the rest, which is 976px at the cap
+   against the 966px a col-md-3 would leave. Below md the two stack and the
+   percentages never applied anyway, hence the same breakpoint Bootstrap uses. */
 @media (min-width: 768px) {
 	#page-mj-settings .row > .col-md-3 {
 		width: 20rem;

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -57,12 +57,21 @@
 
 /* Hints sit under the control they explain and are held to a readable measure:
    full-column-width help set at nearly the size of the label above it competes
-   with the field rather than supporting it. */
+   with the field rather than supporting it.
+
+   The measure is in characters, because that is what a measure is. It used to be
+   22rem, and a pixel guess cannot know what it is guessing at: 352px is 42
+   characters of this type, which held the sentence well short of its own column
+   and read as a hard-wrapped poem next to the empty two thirds of a wide one
+   (#239). 66ch never binds inside a settings column — those are 451 and 472px
+   at the cap, and the hint simply fills them — and still holds a paragraph on
+   the extension and firmware pages, where a row runs 822px and an unbounded
+   hint would be 99 characters to a line. */
 .hint {
 	/* block because the CGI helpers emit it as a <span> — without this the
 	   max-width below does nothing and the hint runs the card's full width */
 	display: block;
-	max-width: 22rem;
+	max-width: 66ch;
 	margin-top: 0.35rem;
 	margin-bottom: 0;
 	font-size: 0.78125rem;


### PR DESCRIPTION
Follow-up to #263, from @usa-'s two closing comments on #239: on a large monitor the lifted container cap gives *"no additional information … just more empty space, which makes you move your eyes farther"*, and the field descriptions break into very short lines because of `.hint { max-width: 22rem }`.

Two one-line CSS changes. Every number below was measured on a hi3516av300 in **Camera → Settings**, before and after.

### 1 · The page goes back to 1320px

`#page-mj-settings > main > .container` had its own 2400px ceiling so the Live preview could use a big monitor. The form got nothing out of it — at 2560 × 1440 the Main stream section is seventeen rows and 1068px of page **either way**, only dealt into 991px columns instead of 451px ones. And it hung **540px past the navbar and the footer on each side**, which are 1320px on this page as on every other.

Not done by deleting the rule. Bootstrap's `.container` is a five-step ladder (540/720/960/1140/1320) and its step below 1400px is **1140**, so a plain revert would leave the reporter's own 1340px window *narrower* than it is today — 434px columns down to 361. The rule stays and states the cap, keeping the `96vw` floor, so nothing below 1375px changes at all.

| window | picture before | after | form column before | after | whole Live panel on one screen |
|---|---|---|---|---|---|
| **1340 × 708** — the reporter's | 758 × 426 | **758 × 426** | 434 px | **434 px** | no, either way |
| 1600 × 900 | 1099 × 618 | 976 × 549 | 559 px | 451 px | no, either way |
| 1920 × 1080 | 1419 × 798 | 976 × 549 | 712 px | 451 px | **only after — by 8 px** |
| 2560 × 1440 | 2056 × 1157 | 976 × 549 | 991 px | 451 px | **only after — 368 px clear** |

What it costs is the picture. What it buys is the panel that picture belongs to: the stage sizes itself from the window's *height* and reserves room for the Tone strip and nothing else, so a wider picture is a taller one and Scene / Luma / Orientation end up with their top edge at the fold and 240px of themselves below it — at 1340 × 708, 1920 × 1080 and 2560 × 1440 alike. Capped, the whole panel is on one screen for the first time.

At the window this was reported from, the picture is unchanged: it is bound there by the window's height, not by the container, so the 2.9× that window gained in #263 is untouched.

### 2 · A description is measured in characters, not pixels

`22rem` is 352px, and 352px is 42 characters of the type it is set in — short of the 451px column it lives in even with the page capped, and comically short of the 991px one, where it read as a hard-wrapped poem beside 631px of nothing. `66ch` never binds inside a settings column, so the description fills it; on the extension and firmware pages, where a row runs 822px, it still binds, which is what the original cap existed to do.

### What is not here

A third commit moved the per-field `↺` off the column's right edge to sit beside its control, on the strength of it being 890px from a switch at 2560 × 1440. It has been dropped: that distance was a symptom of the 2400px page, and the first commit fixes it. The rail placement is deliberate and documented in `.mj-ctl` — a reset that hugs the end of its control lands at six different x-positions down one ISP column, because a number stops at 10rem, a select at 16, an array at 20 and a switch at its own width. Inside a 451px column the 378px separation is what that rail was designed to cost, so the older decision stands.

### Verification

Deployed to a hi3516av300 and re-measured through the browser: container 1320, columns 451/472, hint 441px (the long WebRTC-bitrate one drops 6 lines → 5), stage 976 × 549 at both 1080p and 1440p, 758 × 426 at 1340 × 708, and the Live deck 368px clear of the bottom at 1440p / 8px at 1080p. `npm test` passes; `lint-templates.sh` and the PurgeCSS regeneration are both clean (no markup changed).