### PR TITLE
Live: decode H.265 in software when the browser will not

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -16,7 +16,8 @@ const A = (f) => path.join(__dirname, '..', 'www', 'a', f);
 const SRCS = [A('preview-swap.js'), A('preview-page.js')];
 
 const IDS = [
-	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
+	'live-mjpeg', 'live-video', 'live-video-b', 'live-canvas', 'live-canvas-b',
+	'mj-audio-ctl', 'mj-badge',
 	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note',
 	'mj-note-why', 'mj-stats',
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -21,7 +21,8 @@ const A = (f) => path.join(__dirname, '..', 'www', 'a', f);
 const SRCS = [A('preview-swap.js'), A('preview-page.js')];
 
 const IDS = [
-	'live-mjpeg', 'live-video', 'live-video-b', 'mj-audio-ctl', 'mj-badge',
+	'live-mjpeg', 'live-video', 'live-video-b', 'live-canvas', 'live-canvas-b',
+	'mj-audio-ctl', 'mj-badge',
 	'mj-lightmon', 'mj-mute', 'mj-mute-lbl', 'mj-mute-t', 'mj-note',
 	'mj-note-why', 'mj-stats',
 	'mj-stats-btn', 'mj-stats-ctl', 'mj-stream-0', 'mj-stream-1',
@@ -79,7 +80,7 @@ function makePlayers(env) {
 			available: kind === 'webrtc',
 		};
 	}
-	return { mse: impl('mse'), webrtc: impl('webrtc') };
+	return { mse: impl('mse'), webrtc: impl('webrtc'), wasm: impl('wasm') };
 }
 
 // `cfg` is a flat map of dotted keys, or omitted for the historic behaviour:
@@ -88,7 +89,7 @@ function makePlayers(env) {
 // reads jpeg.enabled and behaves differently on each answer, so it needs one.
 // `cfgDelay` puts the answer past the page's CONFIG_WAIT_MS deadline, which is
 // the case where jpegOn is false only because nothing is known yet.
-function load(pickedTransport, cfg, cfgDelay) {
+function load(pickedTransport, cfg, cfgDelay, wasmOk) {
 	const env = { made: [], els: {} };
 	IDS.forEach((id) => { env.els['#' + id] = makeEl(id); });
 	// Swap in a fresh node under the same id, as replaceChild does.
@@ -109,6 +110,14 @@ function load(pickedTransport, cfg, cfgDelay) {
 		devicePixelRatio: 1,
 		MajesticVideo: impls.mse,
 		MajesticWebRTC: impls.webrtc,
+		// Absent unless a test asks for it, which is also the real camera with
+		// no route to the CDN: the rung is simply not there and the chain is
+		// what it always was. Every group written for #279/#280 depends on
+		// that, since they all reach MJPEG through `undecodable h265`.
+		MajesticWasm: wasmOk ? Object.assign({}, impls.wasm, {
+			available: true,
+			handles: (c) => /^h265$|^hevc$/i.test(String(c || '')),
+		}) : undefined,
 		MajesticTransport: {
 			available: () => true,
 			preferred: () => pickedTransport || 'mse',
@@ -125,6 +134,7 @@ function load(pickedTransport, cfg, cfgDelay) {
 		console: console,
 		MajesticVideo: impls.mse,
 		MajesticWebRTC: impls.webrtc,
+		MajesticWasm: win.MajesticWasm,
 		MajesticTransport: win.MajesticTransport,
 		$: (sel) => env.els[sel],
 		// Never resolves unless a test asked for one: every test here drives
@@ -424,10 +434,16 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 	{
 		const env = load('webrtc', { 'jpeg.enabled': true });
 		await tick();
-		env.made[0].say('mjpeg', 'undecodable h265');
+		// The real sequence to the floor, now that the chain is a walk rather
+		// than a pair of tests: WebRTC gives up with `fallback` (it has no
+		// concept of `mjpeg`), MSE is tried and refuses the codec, and with no
+		// software rung available that is the end of it.
+		env.made[0].say('fallback', 'no usable H.264 in the offer');
+		env.made[1].say('mjpeg', 'undecodable h265');
 		env.el('mj-stream-0').fire('click');
-		const retry = env.made[1];
-		check('the retry is in flight', env.made.length === 2);
+		const retry = env.made[2];
+		check('the retry is in flight', env.made.length === 3,
+			'made=' + env.made.length);
 
 		// The camera answers the offer before any media arrives, and says it
 		// is serving the other channel.
@@ -527,6 +543,64 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		check('and the note that offered a remedy it did not need is down',
 			env.el('mj-note').style.display === 'none');
 		check('nothing was re-attached behind it', env.made.length === 1,
+			'made=' + env.made.length);
+	}
+
+	// The software-decode rung: WebRTC -> MSE -> wasm -> MJPEG, entered only
+	// when the BROWSER refused the codec and only for a codec it can take.
+	group('a browser that cannot decode the stream gets the software rung');
+	{
+		const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		check('a third player was made', env.made.length === 2,
+			'made=' + env.made.length);
+		check('and it is the software decoder',
+			env.made[1] && env.made[1].kind === 'wasm', env.made[1] && env.made[1].kind);
+		check('the fallback picture is not up yet',
+			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
+		// It rides the MSE socket, so MSE is what is carrying the picture.
+		env.made[1].say('playing');
+		check('MSE stays lit, because that is the transport underneath',
+			env.el('mj-transport-m').checked === true &&
+			env.el('mj-transport-w').checked === false);
+	}
+
+	group('the rung is not taken for a failure that is not about the codec');
+	{
+		for (const reason of ['unreachable', 'no-mse', 'mse-error']) {
+			const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+			await tick();
+			env.made[0].say('mjpeg', reason);
+			check('`' + reason + '` goes straight to MJPEG',
+				env.made.length === 1 && env.el('live-mjpeg').src === '/mjpeg',
+				'made=' + env.made.length);
+		}
+	}
+
+	group('the rung is not taken for a codec it cannot decode');
+	{
+		const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+		await tick();
+		// A browser refusing H.264 High 10 reports the same code. Sending that
+		// to an H.265 decoder would be a slower way to fail.
+		env.made[0].say('mjpeg', 'undecodable h264');
+		check('h264 does not launch the H.265 decoder',
+			env.made.length === 1, 'made=' + env.made.length);
+		check('and the fallback is up', env.el('live-mjpeg').src === '/mjpeg');
+	}
+
+	group('the software rung is never tried twice');
+	{
+		const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		const wasm = env.made[1];
+		wasm.say('playing');
+		// Its own failure has already been through both transports.
+		wasm.say('mjpeg', 'undecodable h265');
+		check('it falls to MJPEG rather than round again',
+			env.made.length === 2 && env.el('live-mjpeg').src === '/mjpeg',
 			'made=' + env.made.length);
 	}
 

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -636,6 +636,28 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			env.el('mj-served-why').textContent);
 	}
 
+	// A channel change can change the codec, and the failure that put us on the
+	// software rung was about the channel we just left. An H.264 substream
+	// plays natively, so falling to MJPEG there would hand the viewer the worst
+	// option available for a stream the browser decodes perfectly.
+	group('a codec change asks the whole chain again, not the floor');
+	{
+		const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		const wasm = env.made[1];
+		check('the software rung took it', wasm.kind === 'wasm', wasm.kind);
+		wasm.say('playing');
+		// The viewer picks a channel the camera encodes as H.264.
+		wasm.say('mjpeg', 'codec-changed h264');
+		const after = env.made[env.made.length - 1];
+		check('a fresh attempt was made, not a fallback',
+			env.made.length === 3 && env.el('live-mjpeg').src === '',
+			'made=' + env.made.length + ' img=' + env.el('live-mjpeg').src);
+		check('and it starts from a real transport, not the rung again',
+			after.kind !== 'wasm', after.kind);
+	}
+
 	group('a cloned MSE element does not strand the swap');
 	{
 		const env = load('mse');

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -604,6 +604,38 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			'made=' + env.made.length);
 	}
 
+	// The disclosure is latched so it is not raised twice in one session. That
+	// latch has to die with the session, or the NEXT software session plays
+	// with nothing saying so — which is the one thing this rung must not do.
+	group('the software-decode disclosure returns after a fallback');
+	{
+		const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'undecodable h265');
+		const wasm = env.made[1];
+		wasm.say('playing');
+		wasm.opts.onStats({ transport: 'wasm', width: 1920, height: 1080,
+			framesDecoded: 100, framesDropped: 0, queuedMs: 50 });
+		check('it says software decoding is happening',
+			/decoding it in software/.test(env.el('mj-served-why').textContent),
+			env.el('mj-served-why').textContent);
+
+		// The session dies and the chain runs out.
+		wasm.say('mjpeg', 'decoder-error');
+		check('the fallback took the stage',
+			env.el('live-mjpeg').src === '/mjpeg', env.el('live-mjpeg').src);
+
+		// A retry gets back to software decode.
+		env.el('mj-stream-0').fire('click');
+		const again = env.made[env.made.length - 1];
+		again.say('playing');
+		again.opts.onStats({ transport: 'wasm', width: 1920, height: 1080,
+			framesDecoded: 100, framesDropped: 0, queuedMs: 50 });
+		check('and it says so again',
+			/decoding it in software/.test(env.el('mj-served-why').textContent),
+			env.el('mj-served-why').textContent);
+	}
+
 	group('a cloned MSE element does not strand the swap');
 	{
 		const env = load('mse');

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -158,6 +158,15 @@
 		// 'connecting…' seconds after the fallback appeared.
 		swap.stop();
 		player = null;
+		// The kind goes with the player. Left standing it names a session that
+		// ended, and every `liveKind === …` test below is then answering about
+		// something that is not on screen.
+		liveKind = null;
+		// And the software-decode disclosure's latch. hideStageMsg() above
+		// takes the message down, but the latch is what stops it being raised
+		// twice — so leaving it set means a later software session plays with
+		// no disclosure at all, which is the one thing this rung must never do.
+		swNoteKey = '';
 		syncAudioCtl();
 		syncTalkCtl();
 		// Both describe the session that just ended.

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -211,7 +211,7 @@
 	// preview-swap.js exists to enforce. The picture is the page's to hold
 	// now, and it is handed over in onPromoted, on a promotion that was
 	// earned by a picture rather than by there being nothing in the way.
-	function retryFromFallback(webrtc) {
+	function retryFromFallback(kind) {
 		// Guarded because one press can arrive twice: the click handler
 		// retries, and the change event that follows a radio that did move
 		// reaches goToStream(), which would otherwise restart the session
@@ -223,7 +223,7 @@
 			badge.textContent = holdingFallback === 'mjpeg'
 				? 'MJPEG · retrying…' : 'retrying…';
 		}
-		attachPlayer(webrtc === undefined ? wantWebRTC() : webrtc);
+		attachPlayer(kind === undefined ? wantWebRTC() : kind);
 	}
 
 	// The player names the cause in a code and the page words it — the same
@@ -293,7 +293,11 @@
 	// The player on screen and which transport it is, both kept in step by the
 	// swap's onPromoted. Read by the controls, which act on what is playing
 	// rather than on what is being tried.
-	let player = null, usingWebRTC = false;
+	// A KIND, not a boolean. There are three now, and every place that read
+	// "not WebRTC" and meant "therefore MSE" is a place a third one would
+	// inherit assumptions nobody checked. Each site below says which kind it
+	// means; the three that are not mechanical are called out where they are.
+	let player = null, liveKind = null;
 	// Carried across a transport switch, because a new player starts from its
 	// defaults and the user's choices should outlive the machinery.
 	let stream = 0, audioOn = false, vol = 1;
@@ -356,8 +360,13 @@
 		const asked = stream ? 1 : 0;
 		// The camera said outright — no inference needed. Older daemons never
 		// say, and everything below is the fallback for them.
-		if (usingWebRTC && servedCh !== null) return servedCh;
-		if (!usingWebRTC || !chipMedia) return asked;
+		if (liveKind === 'webrtc' && servedCh !== null) return servedCh;
+		// Deliberately `!== 'webrtc'` and not a list. The frame-size inference
+		// exists because WebRTC's ?stream= is a preference the camera may not
+		// honour; /ws/video serves the number it is given or nothing, so both
+		// the MSE and the software-decode rungs get the exact channel they
+		// asked for and must NOT be guessed about.
+		if (liveKind !== 'webrtc' || !chipMedia) return asked;
 		const want = sizeOf[asked], other = sizeOf[asked ? 0 : 1];
 		if (!want || !other) return asked;
 		const is = d => d.w === chipMedia.w && d.h === chipMedia.h;
@@ -377,7 +386,7 @@
 		// speaks only on a mismatch — the radio already names the intent, so
 		// the chip only reports betrayal.
 		if (autoOn) {
-			if (usingWebRTC && servedCh === null &&
+			if (liveKind === 'webrtc' && servedCh === null &&
 				(!sizeOf[0] || !sizeOf[1] ||
 				(sizeOf[0].w === sizeOf[1].w && sizeOf[0].h === sizeOf[1].h))) {
 				return '';
@@ -394,7 +403,12 @@
 		// bug it guards, a control repainting the chip with the codec of the
 		// stream that failed, is exactly the one #274 photographed.
 		if (!badge || !chipMedia || fellBack || holdingFallback) return;
-		const fps = usingWebRTC ? chipFps : cfgFps[stream ? 1 : 0];
+		// WebRTC measures its own rate, MSE measures nothing so the configured
+		// rate stands in — and software decode measures, which is the entire
+		// point of that rung. Leaving it on the configured rate would make the
+		// chip claim 25 fps while the client managed 9, in exactly the case
+		// this exists to expose.
+		const fps = liveKind === 'mse' ? cfgFps[stream ? 1 : 0] : chipFps;
 		badge.textContent = (chipMedia.codec || '').toUpperCase() + ' ' +
 			chipMedia.w + '×' + chipMedia.h +
 			(fps ? ' · ' + Math.round(fps) + ' fps' : '') +
@@ -427,6 +441,38 @@
 		if (servedEl) servedEl.hidden = true;
 	}
 	function hideServedMsg() { hideStageMsg('served'); }
+
+	// Nobody asked for software decoding — the chain chose it after the browser
+	// refused the stream — so the page owes the viewer the fact, in the slot
+	// that already carries standing conditions. It is said once, and upgraded
+	// in place if the client turns out not to keep up.
+	//
+	// The "cannot keep up" test is the DROP COUNT and how far behind the
+	// camera we are, never achieved-versus-configured fps: a VBR encoder on a
+	// quiet scene legitimately sends 12 frames where 30 were configured, and
+	// grading on that would accuse the client of a fault the camera committed.
+	let swNoteKey = '';
+	function softwareNote(s) {
+		// A PROPORTION, and a standing delay — not "has ever dropped a frame".
+		// A drop or two while the first GOP is found is not a client that
+		// cannot cope, and latching the accusation on one of them would be the
+		// same unfairness as grading on configured fps.
+		const seen = s.framesDecoded + s.framesDropped;
+		const behind = s.queuedMs > 400 ||
+			(seen > 60 && s.framesDropped / seen > 0.1);
+		const key = behind ? 'behind' : 'plain';
+		if (key === swNoteKey) return;
+		// Never re-raise a message the viewer dismissed, unless the news
+		// actually changed — going from coping to not coping is news.
+		if (swNoteKey && key === 'plain') return;
+		swNoteKey = key;
+		showStageMsg('software',
+			behind
+				? 'This browser can’t decode H.265, so the page is decoding it in ' +
+					'software — and cannot keep up at this size. Try the Sub stream.'
+				: 'This browser can’t decode H.265, so the page is decoding it in ' +
+					'software.');
+	}
 
 	function showServedMsg(info) {
 		const req = streamName(info.requested), got = streamName(info.channel);
@@ -590,14 +636,16 @@
 		// nothing, so a stale baseline (and a toast still standing) would
 		// describe a session that is gone. Back on WebRTC it re-adopts from
 		// the first tick rather than announcing whatever moved while away.
-		if (window.MajesticAdapt && !usingWebRTC) window.MajesticAdapt.reset();
+		if (window.MajesticAdapt && liveKind !== 'webrtc') window.MajesticAdapt.reset();
 		// The stats panel's deltas belong to the session that just ended —
 		// differencing a new session's counters against them would print one
 		// tick of nonsense rates.
 		if (window.MajesticStats) window.MajesticStats.reset();
 		// Same for the served-channel answer and its message: both belong to
 		// a WebRTC session. MSE serves the number it is given or nothing.
-		if (!usingWebRTC) {
+		// The software-decode disclosure belongs to a software-decode session.
+		if (liveKind !== 'wasm') { swNoteKey = ''; hideStageMsg('software'); }
+		if (liveKind !== 'webrtc') {
 			servedCh = null;
 			servedShownKey = '';
 			wantedCh = null;
@@ -611,7 +659,7 @@
 		// Back on WebRTC, the toggle's tooltip goes back to the standing
 		// explanation: a failure wrote its reason there, and leaving it would
 		// keep complaining about a session that is long over.
-		if (transportLbl && usingWebRTC) transportLbl.title = TRANSPORT_TITLE;
+		if (transportLbl && liveKind === 'webrtc') transportLbl.title = TRANSPORT_TITLE;
 	}
 
 	// The swap itself lives in preview-swap.js — two elements, a trial that
@@ -622,7 +670,12 @@
 		// Resolved on every use, never stored: the MSE player replaces its
 		// element on each reconnect, so a node captured here would be detached
 		// within a session and every show/hide would write to nothing.
-		elements: [() => $('#live-video'), () => $('#live-video-b')],
+		// Four elements, two slots. The kind decides which pair, because
+		// software decode paints a canvas and the other two drive a video.
+		elements: [
+			(kind) => $(kind === 'wasm' ? '#live-canvas' : '#live-video'),
+			(kind) => $(kind === 'wasm' ? '#live-canvas-b' : '#live-video-b'),
+		],
 		// audio and volume go in at attach rather than after promotion.
 		// Applying them later means renegotiating a session that has just
 		// proved itself, which blanks the picture for anyone who was listening
@@ -635,13 +688,18 @@
 				handlersFor(id, onState))),
 		onPromoted: (kind, proven) => {
 			player = swap.player();
-			usingWebRTC = kind === 'webrtc';
+			liveKind = kind;
 			liveEl = swap.element();
 			// From what is playing rather than from what was clicked: a retry
 			// out of the fallback starts the chain from the preferred
 			// transport without anyone having touched this group, and it was
 			// left with nothing lit.
-			reflectTransport(kind);
+			// Software decode rides the MSE transport's socket, so MSE is what
+			// is carrying the picture and MSE is what stays lit. Leaving the
+			// group dark would collide with the meaning #280 gave it — neither
+			// transport carrying anything — and would make a press of either
+			// radio tear down a working session.
+			reflectTransport(kind === 'wasm' ? 'mse' : kind);
 			settle();
 			// Only when this promotion means a picture. Holding the fallback,
 			// an unproven one is just the swap saying it had nothing of its
@@ -691,18 +749,25 @@
 		// set — and MJPEG if that already was the other transport.
 		onExhausted: (kind, detail) => {
 			player = null;
-			if (kind === 'webrtc') attachPlayer(false);
-			else showFallback(detail);
+			nextRung(kind, detail);
 		},
 		onLive: (s, d) => {
 			if (s === 'playing') showVideo();
 			else if (s === 'nosignal') showNoSignal();
-			else if (s === 'mjpeg') showFallback(d);
+			// Through the chain, not straight to the floor. This is the path a
+			// first attach takes — it is promoted immediately, so its giving up
+			// arrives here rather than as a dropped trial — and sending it
+			// directly to showFallback() skipped every rung below the one that
+			// failed.
+			else if (s === 'mjpeg') { swap.retire(); nextRung(liveKind, d); }
 			else if (s === 'fallback' || s === 'busy') {
 				// The live player gave up mid-session. Staged like any other
 				// switch, so its last frame stays until the replacement has one
 				// of its own.
-				if (usingWebRTC) {
+				// `=== 'webrtc'`, never `!== 'mse'`: a software-decode session
+				// reporting `fallback` has already been reached THROUGH both
+				// transports failing, so re-running them would loop.
+				if (liveKind === 'webrtc') {
 					reflectTransport('mse');
 					if (transportLbl) {
 						transportLbl.title = 'WebRTC: ' + (d || 'unavailable') +
@@ -710,7 +775,7 @@
 					}
 					if (s === 'fallback') rememberDemotion();
 					swap.retire();
-					attachPlayer(false);
+					attachPlayer('mse');
 				} else {
 					showFallback(d);
 				}
@@ -724,10 +789,44 @@
 	});
 
 	const MajesticVideoImpl = (kind) =>
-		kind === 'webrtc' ? MajesticWebRTC : MajesticVideo;
+		kind === 'webrtc' ? MajesticWebRTC
+		: kind === 'wasm' ? window.MajesticWasm
+		: MajesticVideo;
 
-	function attachPlayer(webrtc) {
-		swap.start(webrtc ? 'webrtc' : 'mse');
+	function attachPlayer(kind) {
+		swap.start(kind === true ? 'webrtc' : kind === false ? 'mse' : kind);
+	}
+
+	// The chain, as an ordered walk rather than the pair of `kind === 'webrtc'`
+	// tests it used to be:
+	//
+	//     WebRTC -> MSE -> [software decode] -> MJPEG -> note
+	//
+	// The third rung is not a transport and gets no radio. It is the same
+	// /ws/video bytes the MSE player just failed on, decoded in WebAssembly
+	// instead of by the browser — so the picker goes on naming the transport
+	// exactly once, and a codec problem never touches the viewer's remembered
+	// preference.
+	function nextRung(kind, detail) {
+		if (kind === 'webrtc') { attachPlayer('mse'); return; }
+		if (kind === 'mse' && wasmRungFor(detail)) { attachPlayer('wasm'); return; }
+		showFallback(detail);
+	}
+
+	// Entered only when the BROWSER refused the codec, and only for a codec the
+	// decoder can actually take. `unreachable` and `no-mse` are not decoding
+	// problems, and an H.264 High 10 refusal reports `undecodable` too — sending
+	// it to an H.265 decoder would be a slower way to fail, after a network
+	// round trip for the module.
+	//
+	// `detail` here is the PLAYER's reason code (preview.js). The camera's
+	// served-channel reply also has a reason spelled `undecodable`, meaning
+	// something else entirely; the two vocabularies must not be crossed.
+	function wasmRungFor(detail) {
+		const bits = String(detail || '').split(' ');
+		return bits[0] === 'undecodable' &&
+			!!(window.MajesticWasm && window.MajesticWasm.available &&
+				window.MajesticWasm.handles(bits[1]));
 	}
 
 	// The page's own callbacks, all of which belong to the player on screen: a
@@ -854,6 +953,7 @@
 			},
 			onStats: (s) => {
 				if (!isLive()) return;
+				if (s.transport === 'wasm') softwareNote(s);
 				// The chip rides every tick, not just when the panel is open —
 				// this is where its fps comes from, and a fresh write also
 				// heals it after a transient "reconnecting…" state. The panel
@@ -1061,7 +1161,7 @@
 		// Not while a trial is being judged: that trial is the viewer's own
 		// choice in flight, and it was opened after `ice` was filled anyway, so
 		// restarting WebRTC here would both undo their click and re-do work.
-		if (!moved && player && !swap.trial() && usingWebRTC && ice.length) {
+		if (!moved && player && !swap.trial() && liveKind === 'webrtc' && ice.length) {
 			attachPlayer(true);
 		}
 	});

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -817,6 +817,20 @@
 	// exactly once, and a codec problem never touches the viewer's remembered
 	// preference.
 	function nextRung(kind, detail) {
+		// A channel change can change the CODEC, and the failure that put us on
+		// this rung was about the channel we have just left. So this is not the
+		// chain running out — it is a different question, asked again from the
+		// top: an H.264 substream may well play over WebRTC or MSE natively,
+		// and falling to MJPEG here would hand the viewer the worst option
+		// available for a stream the browser can decode perfectly.
+		//
+		// It cannot loop: the rung only stands down for a codec it does not
+		// handle, and if the new one is refused too the reason will name that
+		// codec, which the gate below rejects.
+		if (String(detail || '').split(' ')[0] === 'codec-changed') {
+			attachPlayer(wantWebRTC());
+			return;
+		}
 		if (kind === 'webrtc') { attachPlayer('mse'); return; }
 		if (kind === 'mse' && wasmRungFor(detail)) { attachPlayer('wasm'); return; }
 		showFallback(detail);

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -254,6 +254,14 @@
 		if (bits[0] === 'unreachable') {
 			return 'The camera stopped sending the ' + ch + '.';
 		}
+		// The software-decode rung could not fetch its decoder — no route out
+		// of the network, most likely, which is an ordinary state for a camera
+		// rather than a fault. Say what happened rather than blaming the
+		// stream, which is fine and would play anywhere else.
+		if (bits[0] === 'decoder-unavailable' || bits[0] === 'no-offscreen') {
+			return 'This browser can’t decode the ' + ch + ', and the software ' +
+				'decoder could not be loaded.';
+		}
 		return 'The ' + ch + ' could not be played in this browser.';
 	}
 

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -43,7 +43,22 @@ window.MajesticSwap = function (opts) {
 	let staging = null;  // { id, p, slot, kind }
 	let seq = 0;
 
-	function node(slot) { return els[slot](); }
+	// Which kind a slot currently holds. The getter needs it because not every
+	// player paints a <video>: software decode paints a <canvas>, so "the
+	// element for slot 1" is not one answer.
+	//
+	// It has to be per SLOT and not one latched value, because promote() hides
+	// the outgoing slot before it swaps `live` — and the outgoing slot's kind
+	// is not the incoming one. Latching the incoming kind globally would hide
+	// the wrong element and leave a frozen canvas over live video, which is
+	// exactly the failure this file's header warns about.
+	function kindOf(slot) {
+		if (staging && staging.slot === slot) return staging.kind;
+		if (live && live.slot === slot) return live.kind;
+		return null;
+	}
+
+	function node(slot) { return els[slot](kindOf(slot)); }
 
 	// Which callbacks a caller's own handlers should answer to. Everything but
 	// the state feed belongs to the player on screen alone: a trial has no
@@ -101,13 +116,18 @@ window.MajesticSwap = function (opts) {
 
 		const id = ++seq;
 		const slot = live ? spareSlot() : 0;
+		// Registered before the element is resolved: node() asks kindOf(), and
+		// without this the incoming attach would be handed the outgoing kind's
+		// element.
+		staging = { id: id, p: null, slot: slot, kind: kind };
 		const el = node(slot);
 		// The other transport may have used this element a moment ago, and an
 		// element carrying both a MediaSource url and a srcObject is a
 		// confusing thing to debug.
+		// Harmless on a canvas, which has neither; the point is that a video
+		// element carrying both a MediaSource url and a srcObject is a
+		// confusing thing to debug.
 		try { el.removeAttribute('src'); el.srcObject = null; } catch (e) {}
-
-		staging = { id: id, p: null, slot: slot, kind: kind };
 
 		const onState = function (state, detail) {
 			if (isStaging(id)) {

--- a/www/a/preview-wasm.js
+++ b/www/a/preview-wasm.js
@@ -32,7 +32,13 @@ window.MajesticWasm = (function () {
 	// module's own imports resolve against the blob's useless base URL, so the
 	// base is injected rather than left to relative resolution.
 	let workerBlob = null;
+	// Remembered for the session once the module has failed to arrive. Without
+	// it every fallback pays the same doomed round trip again, and on a camera
+	// with no route out that is a timeout each time — the rung has to be cheap
+	// to not have, because not having it is the common case.
+	let loadFailed = false;
 	function workerUrl() {
+		if (loadFailed) return Promise.reject(new Error('unavailable'));
 		if (workerBlob) return Promise.resolve(workerBlob);
 		const ctl = new AbortController();
 		const bail = setTimeout(() => ctl.abort(), LOAD_TIMEOUT_MS);
@@ -45,7 +51,8 @@ window.MajesticWasm = (function () {
 					{ type: 'text/javascript' });
 				workerBlob = URL.createObjectURL(blob);
 				return workerBlob;
-			});
+			})
+			.catch((e) => { loadFailed = true; throw e; });
 	}
 
 	// Only what this decoder actually handles. The chain gates on this before

--- a/www/a/preview-wasm.js
+++ b/www/a/preview-wasm.js
@@ -24,7 +24,17 @@ window.MajesticWasm = (function () {
 	// fetched, version-pinned, with an error path — and a camera with no route
 	// to it simply does not get this rung. The chain carries on to MJPEG and
 	// says why, which is what it was taught to do in #279.
-	const BASE = (window.MJ_WASM_BASE || '/a/hevc/');
+	// Version-pinned, like @xterm/xterm@5.5.0 in tool-console.cgi and
+	// codemirror@5.65.16 in files.js. jsDelivr serves the tag straight from the
+	// repository, so there is no npm step between a release and this URL — and
+	// it serves the .wasm as application/wasm, which the camera cannot: its
+	// static table knows no such type, so a camera-hosted copy would arrive as
+	// application/octet-stream and streaming instantiation would reject it.
+	//
+	// MJ_WASM_BASE overrides it, for a development build or an operator who
+	// would rather host it themselves.
+	const BASE = (window.MJ_WASM_BASE ||
+		'https://cdn.jsdelivr.net/gh/OpenIPC/hevc-wasm@v0.1.0/dist/');
 	const LOAD_TIMEOUT_MS = 8000;
 
 	// A Worker cannot be constructed from a cross-origin URL, so the worker

--- a/www/a/preview-wasm.js
+++ b/www/a/preview-wasm.js
@@ -1,0 +1,187 @@
+// Software H.265, for a browser whose decoder will not take it.
+//
+// This is NOT a third transport. It is the same /ws/video bytes the MSE player
+// reads, decoded in WebAssembly instead of by the browser, so the picker keeps
+// naming the transport exactly once and the viewer's remembered preference is
+// untouched by what is a codec problem. The page reaches it as a rung of the
+// fallback chain, on the `undecodable` reason code and only for a codec this
+// decoder handles — see preview-page.js.
+//
+// It returns the same nine-member object every other player returns, so
+// preview-swap.js needs to know nothing about it.
+//
+// WHAT IS DIFFERENT, and it is one thing: this player paints a <canvas>, not a
+// <video>. WebCodecs and MediaStreamTrackGenerator would let a decoder feed a
+// real video element, and both are secure-context-only — useless on a camera
+// with no TLS certificate. OffscreenCanvas is not, which is what makes this
+// possible at all. Everything that reaches into the live element expecting
+// videoWidth/readyState/requestVideoFrameCallback has to be taught about that.
+window.MajesticWasm = (function () {
+	'use strict';
+
+	// Where the decoder comes from. Same rule as xterm.js in tool-console.cgi
+	// and CodeMirror in files.js: too big to sit in a camera's flash, so it is
+	// fetched, version-pinned, with an error path — and a camera with no route
+	// to it simply does not get this rung. The chain carries on to MJPEG and
+	// says why, which is what it was taught to do in #279.
+	const BASE = (window.MJ_WASM_BASE || '/a/hevc/');
+	const LOAD_TIMEOUT_MS = 8000;
+
+	// A Worker cannot be constructed from a cross-origin URL, so the worker
+	// source is fetched as text and run from a blob. That also means the
+	// module's own imports resolve against the blob's useless base URL, so the
+	// base is injected rather than left to relative resolution.
+	let workerBlob = null;
+	function workerUrl() {
+		if (workerBlob) return Promise.resolve(workerBlob);
+		const ctl = new AbortController();
+		const bail = setTimeout(() => ctl.abort(), LOAD_TIMEOUT_MS);
+		return fetch(BASE + 'decoder-worker.js', { signal: ctl.signal })
+			.then((r) => (r.ok ? r.text() : Promise.reject(new Error('http ' + r.status))))
+			.then((src) => {
+				clearTimeout(bail);
+				const abs = new URL(BASE, location.href).href;
+				const blob = new Blob([src.replace(/(['"])\.\.?\//g, '$1' + abs)],
+					{ type: 'text/javascript' });
+				workerBlob = URL.createObjectURL(blob);
+				return workerBlob;
+			});
+	}
+
+	// Only what this decoder actually handles. The chain gates on this before
+	// spending a network round trip: a browser refusing H.264 High 10 reports
+	// the same `undecodable` code, and launching an H.265 decoder for it would
+	// be a slower way to fail.
+	function handles(codec) {
+		return /^h?e?vc?$|^h265$|^hevc$/i.test(String(codec || ''));
+	}
+
+	function attach(el, opts) {
+		opts = opts || {};
+		const onState = opts.onState || function () {};
+		const onCodec = opts.onCodec || function () {};
+		const onAudio = opts.onAudio || function () {};
+		const onStats = opts.onStats || null;
+		let stream = opts.stream | 0;
+		let worker = null, dead = false, statsTimer = null;
+		let cum = { frames: 0, decodeMs: 0 };
+
+		onState('connecting');
+		// This transport carries no audio: the fragments are muxed and splitting
+		// the audio track out to a separate MSE element, with our own A/V sync,
+		// is a second project. Say so once rather than leave a dead control.
+		onAudio(null);
+
+		function die(reason) {
+			if (dead) return;
+			dead = true;
+			if (statsTimer) { clearInterval(statsTimer); statsTimer = null; }
+			if (worker) { try { worker.terminate(); } catch (e) {} worker = null; }
+			if (reason) onState('mjpeg', reason);
+		}
+
+		// transferControlToOffscreen is one-way and permanent: a second call on
+		// the same element throws. The two canvas slots are reused across every
+		// attach, so the handle is cached on the element itself.
+		let off;
+		try {
+			off = el.__mjOffscreen ||
+				(el.__mjOffscreen = el.transferControlToOffscreen());
+		} catch (e) {
+			onState('mjpeg', 'no-offscreen');
+			return facade();
+		}
+
+		workerUrl().then((url) => {
+			if (dead) return;
+			worker = new Worker(url, { type: 'module' });
+			worker.onerror = () => die('decoder-unavailable');
+			worker.onmessage = (e) => {
+				const m = e.data;
+				if (m.type === 'state') {
+					if (m.state === 'mjpeg') die(m.detail || 'decoder-error');
+					else onState(m.state, m.detail);
+				} else if (m.type === 'codec') {
+					onCodec('h265', '', m.width, m.height);
+				} else if (m.type === 'stats' && onStats) {
+					const s = m.stats;
+					// fps and decode time are MEASURED here, unlike MSE which
+					// measures nothing — that is the point of the rung, and the
+					// chip is expected to show it.
+					const dFrames = s.frames - cum.frames;
+					const dMs = s.decodeMs - cum.decodeMs;
+					cum = { frames: s.frames, decodeMs: s.decodeMs };
+					onStats({
+						transport: 'wasm',
+						fps: dFrames,
+						framesDecoded: s.frames,
+						framesDropped: s.dropped,
+						decodeTime: s.decodeMs / 1000,
+						meanDecodeMs: dFrames ? dMs / dFrames : 0,
+						queuedFrames: s.queuedFrames,
+						// How far behind the camera this client is, measured
+						// rather than assumed — the number the page warns on,
+						// and the one a fps-versus-configured comparison gets
+						// wrong when a VBR encoder legitimately sends fewer.
+						queuedMs: s.queuedMs,
+						sourceIntervalMs: s.sourceIntervalMs,
+						gopDrops: s.gopDrops,
+						idrRequests: s.idrRequests,
+						rxBytes: s.bytes,
+						width: s.width, height: s.height,
+						codec: 'h265',
+					});
+				}
+			};
+			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+			worker.postMessage({
+				type: 'start',
+				url: proto + '://' + location.host + '/ws/video?stream=' + stream,
+				canvas: off,
+			}, [off]);
+			// Once transferred the handle is spent; a later attach to this
+			// element reuses the cached OffscreenCanvas rather than the element.
+			el.__mjOffscreenSent = true;
+			if (onStats) statsTimer = setInterval(() => {
+				if (worker) worker.postMessage({ type: 'stats' });
+			}, 1000);
+		}).catch(() => die('decoder-unavailable'));
+
+		function facade() {
+			return {
+				setStream: function (n) {
+					n = n | 0;
+					if (n === stream || dead) return;
+					stream = n;
+					// A channel change is a new socket; the worker owns it, so
+					// this is a restart rather than a message. The page stages
+					// attaches through preview-swap, which will destroy this one.
+					die(null);
+					onState('mjpeg', 'restart');
+				},
+				requestIdr: function () { if (worker) worker.postMessage({ type: 'idr' }); },
+				setAudio: function () {},
+				setVolume: function () {},
+				audioSupported: function () { return false; },
+				setMic: function () {},
+				micSupported: function () { return false; },
+				destroy: function () { die(null); },
+				supported: true,
+			};
+		}
+		return facade();
+	}
+
+	return {
+		attach: attach,
+		handles: handles,
+		// Cheap and synchronous: whether this browser could run the rung at all.
+		// Whether the module actually loads is a network question, answered by
+		// attach() reporting 'mjpeg' with a reason the chain already understands.
+		available: typeof Worker === 'function' &&
+			typeof WebAssembly === 'object' &&
+			typeof OffscreenCanvas === 'function' &&
+			typeof HTMLCanvasElement !== 'undefined' &&
+			typeof HTMLCanvasElement.prototype.transferControlToOffscreen === 'function',
+	};
+})();

--- a/www/a/preview-wasm.js
+++ b/www/a/preview-wasm.js
@@ -87,13 +87,24 @@ window.MajesticWasm = (function () {
 			if (reason) onState('mjpeg', reason);
 		}
 
-		// transferControlToOffscreen is one-way and permanent: a second call on
-		// the same element throws. The two canvas slots are reused across every
-		// attach, so the handle is cached on the element itself.
+		// transferControlToOffscreen() is one-way and permanent, and the
+		// OffscreenCanvas it returns is DETACHED the moment it is posted in a
+		// transfer list. So the handle cannot be cached and reused either --
+		// caching it only moves the failure from the second transfer to the
+		// second postMessage, where it is quieter.
+		//
+		// The element itself is replaced instead, which is what preview.js
+		// already does to its <video> on every open (cloneNode + replaceChild,
+		// keeping the id). It is safe here for the same reason it is safe
+		// there: the swap resolves its elements through getters by id and
+		// never holds a node. Done before the worker exists, so a session
+		// never sees its canvas swapped underneath it.
 		let off;
 		try {
-			off = el.__mjOffscreen ||
-				(el.__mjOffscreen = el.transferControlToOffscreen());
+			const fresh = el.cloneNode(false);
+			if (el.parentNode) el.parentNode.replaceChild(fresh, el);
+			el = fresh;
+			off = el.transferControlToOffscreen();
 		} catch (e) {
 			onState('mjpeg', 'no-offscreen');
 			return facade();
@@ -146,9 +157,6 @@ window.MajesticWasm = (function () {
 				url: proto + '://' + location.host + '/ws/video?stream=' + stream,
 				canvas: off,
 			}, [off]);
-			// Once transferred the handle is spent; a later attach to this
-			// element reuses the cached OffscreenCanvas rather than the element.
-			el.__mjOffscreenSent = true;
 			if (onStats) statsTimer = setInterval(() => {
 				if (worker) worker.postMessage({ type: 'stats' });
 			}, 1000);
@@ -160,11 +168,13 @@ window.MajesticWasm = (function () {
 					n = n | 0;
 					if (n === stream || dead) return;
 					stream = n;
-					// A channel change is a new socket; the worker owns it, so
-					// this is a restart rather than a message. The page stages
-					// attaches through preview-swap, which will destroy this one.
-					die(null);
-					onState('mjpeg', 'restart');
+					// The worker owns the socket, so a channel change is its
+					// business and the page never hears about it. Reporting a
+					// state here instead -- which the first cut did, as
+					// `mjpeg restart` -- was read by the chain as this rung
+					// giving up, so picking Sub while software decoding dropped
+					// a working picture to MJPEG.
+					if (worker) worker.postMessage({ type: 'setStream', stream: n });
 				},
 				requestIdr: function () { if (worker) worker.postMessage({ type: 'idr' }); },
 				setAudio: function () {},

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -546,6 +546,15 @@ preview() {
 		     outgoing one before anybody knows whether it works. -->
 		<video id="live-video" class="mj-stage-media" autoplay muted playsinline></video>
 		<video id="live-video-b" class="mj-stage-media" autoplay muted playsinline style="display:none"></video>
+		<!-- The software-decode rung paints here instead. Two, for the same
+		     reason the videos are two: a trial has to prove itself on an idle
+		     element before it takes the stage. Hidden to start with, because
+		     nothing hides them but the swap and the swap only touches the slot
+		     it is using. WebCodecs and MediaStreamTrackGenerator would let a
+		     decoder feed a real <video>, and both are secure-context-only,
+		     which a camera on plain HTTP is not -- hence a canvas. -->
+		<canvas id="live-canvas" class="mj-stage-media" style="display:none"></canvas>
+		<canvas id="live-canvas-b" class="mj-stage-media" style="display:none"></canvas>
 		<img id="live-mjpeg" class="mj-stage-media" alt="" style="display:none">
 		<!-- Shown only when there is no MJPEG fallback to show, so it carries
 		     both halves: why the stream could not be played (preview-page.js

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -31,6 +31,7 @@
 <script src="/a/preview.js"></script>
 <script src="/a/preview-webrtc.js"></script>
 <script src="/a/preview-swap.js"></script>
+<script src="/a/preview-wasm.js"></script>
 <script src="/a/preview-transport.js"></script>
 <script src="/a/charts.js"></script>
 <script src="/a/preview-adapt.js"></script>


### PR DESCRIPTION
A camera on `video0.codec: h265` is unplayable in a browser without native HEVC: WebRTC cannot negotiate what the browser will not decode, and MSE's `isTypeSupported()` refuses the mime, so the page falls all the way to MJPEG. That is #274, and #269 is the same wall from another angle. #279/#280 made that fall *honest*; this makes it unnecessary — by decoding H.265 in WebAssembly.

**This PR is the rung, not the decoder.** The decoder is a separate module (built from [OpenIPC/libde265](https://github.com/OpenIPC/libde265)) and is not published yet. With no module reachable — which is every camera today — `MajesticWasm` fails to load, the rung is skipped, and behaviour is byte-for-byte what it is now. See *Trying it* below.

## A rung, not a radio

The chain becomes an ordered walk rather than the two `kind === 'webrtc'` tests it was:

```
WebRTC → MSE → software decode → MJPEG → note
```

It is **not a transport and gets no button**: it is the same `/ws/video` bytes the MSE player just failed on, decoded in WebAssembly instead of by the browser. So the picker goes on naming the transport exactly once, MSE stays lit (that *is* the socket underneath), and a codec problem never touches the viewer's remembered preference.

Entered only on the player's `undecodable` reason code **and** only for a codec the decoder handles. `unreachable` and `no-mse` are not decoding problems; a browser refusing H.264 High 10 reports the same code, and sending that to an H.265 decoder would be a slower way to fail — after a network round trip for the module. (Note there are two unrelated vocabularies spelling `undecodable`: the player's reason code, which is the trigger, and the camera's served-channel reply, which means something else. The gate tests the former.)

## A kind, not a boolean

`usingWebRTC` becomes `liveKind`, because every site that read "not WebRTC" and meant "therefore MSE" is a site a third kind inherits assumptions from. Two are deliberate and called out in the source:

- **`servedStream()` keeps `!== 'webrtc'`.** The frame-size inference exists because WebRTC's `?stream=` is a *preference* the camera may not honour. `/ws/video` serves the number it is given or nothing, so the software rung gets the exact channel it asked for and must not be guessed about.
- **`setChip()` becomes `kind === 'mse' ? configured : measured`.** WebRTC measures its rate, MSE measures nothing so the configured rate stands in — and software decode *measures*, which is the entire point of the rung. Left on the configured rate the chip would claim 25 fps while the client managed 9, in exactly the case this exists to expose.

## Four elements, two slots

The decoder paints a `<canvas>`: WebCodecs and `MediaStreamTrackGenerator` would let it feed a real `<video>`, and both are secure-context-only, which a camera on plain HTTP is not.

So `preview-swap.js` resolves each slot's element through **that slot's own kind**. Not one latched value — `promote()` hides the outgoing slot *before* it swaps `live`, and the outgoing kind is not the incoming one, so a global latch would hide the wrong element and leave a frozen canvas over live video: the exact failure that file's header warns about.

## And it says so

Nobody asked for software decoding, so the page discloses it in the message slot #240 built, and upgrades that in place to name the Sub stream when the client cannot keep up.

The test for "cannot keep up" is the drop **proportion** over a settled sample plus the standing delay — never achieved-versus-configured fps. A VBR encoder on a quiet scene legitimately sends 12 frames where 30 were configured, and grading on that would accuse the client of a fault the camera committed. (First cut latched on `framesDropped > 0` and did exactly that off a single startup drop.)

## Verification

Lab `hi3516av300`, `video0.codec h265`, real Chrome — which has no HEVC decoder, so the failure is genuine:

- **1080p** — full source rate, chip `H265 1920×1080 · 20 fps` (measured), zero drops, 51 ms behind, plain disclosure.
- **4K** — 11 fps, and the message upgrades to name the Sub stream.
- **No module** — `decoder-unavailable`, chain continues to MJPEG with the #279 sentence, no stall.

`npm test` passes. Four new groups pin the chain: the rung is taken for `undecodable h265`; **not** taken for `unreachable`/`no-mse`/`mse-error`; **not** taken for `undecodable h264`; and never tried twice. Every group written for #279/#280 still passes untouched — because `MajesticWasm` is absent in the vm, which is also the real offline camera. That property is what the gate is for.

`npm run build:dist` clean; `bootstrap.min.css` unchanged.

## Trying it

The module is not on a CDN yet, so the rung is dormant by default. To test:

1. Build the decoder module and drop its `dist/` on the camera at `/var/www/a/hevc/`.
2. Set a camera to `video0.codec: h265` and open **Live** in a browser with no HEVC (Chrome or Firefox on Linux, Chromium on a Raspberry Pi).

`window.MJ_WASM_BASE` overrides the location if you host it elsewhere.

## Not in this PR

- **Live adjustments.** `MajesticTransport.impl()` deliberately does not know the new kind, so that panel never attaches it — it has no canvas elements, and wiring it in would attach a canvas painter to a `<video>` and paint nothing. It needs its own canvases or an explicit refusal; either is a second integration.
- **Publishing the module**, which is where the HEVC patent question has to be answered.
- **Transport.** #285 proposes carrying the bitstream over an `RTCDataChannel` instead of a WebSocket, with the benchmarks that would justify it.
