### PR TITLE
Live adjustments: the software H.265 rung, and the three things it needed

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -103,6 +103,14 @@ function load(cfg) {
 			choose() {}, demote() {},
 			impl: (k) => (k === 'webrtc' ? impls.webrtc : impls.mse),
 			iceServers: () => [],
+			// The real rule lives in preview-transport.js and is tested there;
+			// this mirrors it so the page's chain can be driven here.
+			softwareRungFor: (d) => {
+				const bits = String(d || '').split(' ');
+				const w = win.MajesticWasm;
+				return bits[0] === 'undecodable' &&
+					!!(w && w.available && w.handles && w.handles(bits[1]));
+			},
 			chosenStream: () => (cfg.picked === undefined ? null : cfg.picked),
 			chooseStream(where, n) { env.stored = n; },
 		},

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -124,6 +124,14 @@ function load(pickedTransport, cfg, cfgDelay, wasmOk) {
 			choose(k) { env.chosen = k; }, demote() { env.demoted = true; },
 			impl: (k) => (k === 'webrtc' ? impls.webrtc : impls.mse),
 			iceServers: () => [],
+			// The real rule lives in preview-transport.js and is tested there;
+			// this mirrors it so the page's chain can be driven here.
+			softwareRungFor: (d) => {
+				const bits = String(d || '').split(' ');
+				const w = win.MajesticWasm;
+				return bits[0] === 'undecodable' &&
+					!!(w && w.available && w.handles && w.handles(bits[1]));
+			},
 			chosenStream: () => null, chooseStream() {},
 		},
 	};

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -24,7 +24,14 @@ const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-transport.js');
 // browser state and not a hypothetical one.
 function load(withStorage, seed, refuseWrites) {
 	const store = Object.assign({}, seed || {});
-	const ctx = { window: {}, console: console };
+	// The three players the module dispatches between. Named objects rather
+	// than stubs with behaviour: impl() is a lookup, and what is asserted is
+	// which one comes back.
+	const ctx = { window: {
+		MajesticWebRTC: { name: 'webrtc' },
+		MajesticVideo: { name: 'mse' },
+		MajesticWasm: { name: 'wasm' },
+	}, console: console };
 	if (withStorage) {
 		ctx.localStorage = {
 			getItem: (k) => (k in store ? store[k] : null),
@@ -48,6 +55,23 @@ function load(withStorage, seed, refuseWrites) {
 const iceServers = load(false).iceServers;
 
 const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+// impl() had no coverage at all, and it is the one line that decides what BOTH
+// pages can attach — the Live page has its own copy of the lookup, but the
+// settings panel goes through this one.
+group('impl() maps a kind to a player');
+{
+	const t = load(true);
+	check('webrtc', t.impl('webrtc').name === 'webrtc', t.impl('webrtc').name);
+	check('mse', t.impl('mse').name === 'mse', t.impl('mse').name);
+	check('wasm', t.impl('wasm').name === 'wasm', t.impl('wasm').name);
+	// MSE is the floor on purpose: it plays whatever the browser can decode,
+	// so an unrecognised kind lands somewhere that works rather than on
+	// undefined.
+	check('anything else falls to MSE', t.impl('nonsense').name === 'mse',
+		t.impl('nonsense').name);
+	check('and so does nothing at all', t.impl().name === 'mse');
+}
 const is = (name, got, want) =>
 	check(name, eq(got, want), 'got ' + JSON.stringify(got));
 

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -49,6 +49,7 @@ function load(withStorage, seed, refuseWrites) {
 	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
 	const mod = ctx.window.MajesticTransport;
 	mod.store = store;   // for asserting what survived
+	mod.__ctx = ctx;     // for varying the globals the module reads
 	return mod;
 }
 
@@ -59,6 +60,45 @@ const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 // impl() had no coverage at all, and it is the one line that decides what BOTH
 // pages can attach — the Live page has its own copy of the lookup, but the
 // settings panel goes through this one.
+// The gate that decides whether the software rung is worth a network round
+// trip. It moved here from the two pages precisely so it could be tested once
+// instead of drifting in two copies.
+group('softwareRungFor() gates the software rung');
+{
+	const t = load(true);
+	const setWasm = (w) => { t.__ctx.window.MajesticWasm = w; };
+	const h265 = { available: true, handles: (c) => /^h265$|^hevc$/i.test(c || '') };
+
+	setWasm(h265);
+	check('a refused H.265 stream opens it',
+		t.softwareRungFor('undecodable h265') === true);
+	check('so does hevc spelled out',
+		t.softwareRungFor('undecodable hevc') === true);
+	// A browser refusing H.264 High 10 reports the same code; sending that to
+	// an H.265 decoder would be a slower way to fail.
+	check('a refused H.264 stream does not',
+		t.softwareRungFor('undecodable h264') === false);
+	// These are not decoding problems at all.
+	check('an unreachable camera does not',
+		t.softwareRungFor('unreachable') === false);
+	check('a browser without MSE does not',
+		t.softwareRungFor('no-mse') === false);
+	check('a source-buffer failure does not',
+		t.softwareRungFor('mse-error') === false);
+	check('and neither does nothing at all',
+		t.softwareRungFor() === false);
+
+	// The common case: no decoder module in the page at all, which is every
+	// camera whose browser never loaded one.
+	setWasm(undefined);
+	check('with no decoder present it is never worth trying',
+		t.softwareRungFor('undecodable h265') === false);
+
+	setWasm({ available: false, handles: () => true });
+	check('nor when the browser cannot run one',
+		t.softwareRungFor('undecodable h265') === false);
+}
+
 group('impl() maps a kind to a player');
 {
 	const t = load(true);

--- a/www/a/mj-luma.js
+++ b/www/a/mj-luma.js
@@ -107,13 +107,22 @@
 			// Nothing to read: the tab is hidden, the player has not attached
 			// yet, or the stream dropped. Say nothing rather than draw a lie —
 			// an empty histogram would read as "the picture is black".
-			// A canvas is as good a drawImage source as a video and has
-			// neither readyState nor videoWidth, so the guard asks each what it
-			// can answer. Without this the sampler no-ops for ever against the
+			// A canvas is as good a drawImage source as a video and has neither
+			// readyState nor videoWidth, so the guard asks each what it can
+			// answer. Without it the sampler no-ops for ever against the
 			// software-decode rung, and an empty histogram reads as "the
 			// picture is black" rather than as "nothing is being measured".
+			//
+			// But a canvas's SIZE is not the answer: one is 300x150 from the
+			// moment it exists, so width alone would accept a surface nothing
+			// has been decoded into yet and publish black as a measurement.
+			// Only whoever paints it knows, so it must say so — `__mjPainted`,
+			// an expando rather than an attribute because cloneNode copies
+			// attributes and a replaced canvas would inherit a claim it has
+			// not earned. Unmarked means unknown, and unknown means silent.
 			const drawable = v && (v.tagName === 'CANVAS'
-				? v.width > 0 : (v.readyState >= 2 && v.videoWidth > 0));
+				? v.__mjPainted === true
+				: (v.readyState >= 2 && v.videoWidth > 0));
 			if (!document.hidden && drawable) {
 				try {
 					ctx.drawImage(v, 0, 0, SW, SH);

--- a/www/a/mj-luma.js
+++ b/www/a/mj-luma.js
@@ -107,7 +107,14 @@
 			// Nothing to read: the tab is hidden, the player has not attached
 			// yet, or the stream dropped. Say nothing rather than draw a lie —
 			// an empty histogram would read as "the picture is black".
-			if (!document.hidden && v && v.readyState >= 2 && v.videoWidth > 0) {
+			// A canvas is as good a drawImage source as a video and has
+			// neither readyState nor videoWidth, so the guard asks each what it
+			// can answer. Without this the sampler no-ops for ever against the
+			// software-decode rung, and an empty histogram reads as "the
+			// picture is black" rather than as "nothing is being measured".
+			const drawable = v && (v.tagName === 'CANVAS'
+				? v.width > 0 : (v.readyState >= 2 && v.videoWidth > 0));
+			if (!document.hidden && drawable) {
 				try {
 					ctx.drawImage(v, 0, 0, SW, SH);
 					const d = ctx.getImageData(0, 0, SW, SH).data;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -965,6 +965,11 @@
 			if (bits[0] === 'unreachable') {
 				return 'The camera stopped sending the ' + ch + ' stream.';
 			}
+			if (bits[0] === 'decoder-unavailable' || bits[0] === 'no-offscreen') {
+				return 'This browser can’t decode the ' + ch + ' stream, and ' +
+					'the software decoder could not be loaded, so there is no ' +
+					'preview here.';
+			}
 			return 'The ' + ch + ' stream could not be played in this browser.';
 		}
 		function showAlert(why) {
@@ -976,6 +981,37 @@
 		function hideAlert() {
 			const a = document.getElementById('mj-live-alert');
 			if (a) a.hidden = true;
+		}
+
+		// The same walk the Live page makes, for the same reasons — see
+		// preview-page.js:nextRung. Kept as its own dozen lines rather than
+		// shared, on the standing division in this file: what the two pages DO
+		// about an outcome differs (one has an MJPEG picture to fall to, this
+		// one has an empty box and a sentence), while the rules about which
+		// transport to prefer live in preview-transport.js.
+		function nextRung(kind, detail) {
+			// A channel change can change the codec, and the failure that put
+			// us on the software rung was about the channel we left. Ask the
+			// whole chain again rather than giving up: an H.264 substream
+			// plays natively, and this panel exists to be looked at.
+			if (String(detail || '').split(' ')[0] === 'codec-changed') {
+				swap.start(window.MajesticTransport.preferred());
+				return;
+			}
+			if (kind === 'webrtc') { swap.start('mse'); return; }
+			if (kind === 'mse' && wasmRungFor(detail)) { swap.start('wasm'); return; }
+			exhausted = true;
+			showAlert(detail);
+		}
+
+		// Only when the browser refused the codec, and only for a codec the
+		// decoder handles — an unreachable camera is not a decoding problem,
+		// and an H.264 refusal must not spend a round trip on an H.265 decoder.
+		function wasmRungFor(detail) {
+			const bits = String(detail || '').split(' ');
+			return bits[0] === 'undecodable' &&
+				!!(window.MajesticWasm && window.MajesticWasm.available &&
+					window.MajesticWasm.handles(bits[1]));
 		}
 
 		// This page's own remembered choice, defaulting to the substream. Not
@@ -998,8 +1034,10 @@
 			// captured node is detached within a session and every show or hide
 			// afterwards writes to something nobody can see.
 			elements: [
-				() => document.getElementById('mj-live-video'),
-				() => document.getElementById('mj-live-video-b'),
+				(kind) => document.getElementById(
+					kind === 'wasm' ? 'mj-live-canvas' : 'mj-live-video'),
+				(kind) => document.getElementById(
+					kind === 'wasm' ? 'mj-live-canvas-b' : 'mj-live-video-b'),
 			],
 			open: (kind, el, id, onState) => {
 				const impl = window.MajesticTransport.impl(kind);
@@ -1023,10 +1061,20 @@
 			// state.previewPlayer is what the tab teardown closes, so it has to
 			// name whatever is actually on screen — a stale handle there leaves
 			// a live socket behind on every visit.
-			onPromoted: () => {
+			onPromoted: (kind) => {
 				state.previewPlayer = swap.player();
 				exhausted = false;
 				hideAlert();
+				// The idle pair of the other kind is hidden by nobody — the
+				// swap only touches the slot it is using — so an empty <video>
+				// would sit visible under a painting canvas.
+				(kind === 'wasm'
+					? ['mj-live-video', 'mj-live-video-b']
+					: ['mj-live-canvas', 'mj-live-canvas-b']
+				).forEach((id) => {
+					const e = document.getElementById(id);
+					if (e) e.style.display = 'none';
+				});
 			},
 			onFailed: (kind, why, permanent) => {
 				// 'fallback' is durable and worth remembering; 'busy' says the
@@ -1042,9 +1090,7 @@
 			// black box is indistinguishable from a camera that is off.
 			onExhausted: (kind, detail) => {
 				state.previewPlayer = null;
-				if (kind === 'webrtc') { swap.start('mse'); return; }
-				exhausted = true;
-				showAlert(detail);
+				nextRung(kind, detail);
 			},
 			onLive: (st, d, kind) => {
 				if (kind !== 'webrtc') {
@@ -1060,8 +1106,7 @@
 						// reconnect ladder for a session already given up on.
 						swap.stop();
 						state.previewPlayer = null;
-						exhausted = true;
-						showAlert(d);
+						nextRung(kind, d);
 					}
 					return;
 				}
@@ -1171,6 +1216,13 @@
 		stage.innerHTML =
 			'<video id="mj-live-video" autoplay muted playsinline class="mj-live-video"></video>' +
 			'<video id="mj-live-video-b" autoplay muted playsinline class="mj-live-video" style="display:none"></video>' +
+			// The software-decode rung paints a canvas rather than a video, so
+			// the panel needs its own pair the way the Live page does. Without
+			// them `impl()` knowing the kind would be worse than useless: it
+			// would attach a canvas painter to a <video> and paint nothing,
+			// with no error anywhere.
+			'<canvas id="mj-live-canvas" class="mj-live-video" style="display:none"></canvas>' +
+			'<canvas id="mj-live-canvas-b" class="mj-live-video" style="display:none"></canvas>' +
 			// When neither transport can play the camera, this panel has no
 			// MJPEG fallback to drop to and simply went black — the emptiest
 			// possible account of what happened (#274). It says so instead.
@@ -1642,11 +1694,17 @@
 			video: () => {
 				// Whichever element the swap currently has on screen; the MSE
 				// player replaces its node on every reconnect.
-				const a = document.getElementById('mj-live-video');
-				const b = document.getElementById('mj-live-video-b');
-				if (a && a.style.display !== 'none' && a.readyState >= 2) return a;
-				if (b && b.style.display !== 'none' && b.readyState >= 2) return b;
-				return a || b;
+				// Four candidates now, not two: the software rung paints a
+				// canvas. Filtering on readyState alone would have skipped
+				// both canvases for ever — they do not have one — and the
+				// histogram would simply have stopped on an H.265 camera,
+				// silently, which is the failure this panel can least afford.
+				const ready = (e) => e && e.style.display !== 'none' &&
+					(e.tagName === 'CANVAS' ? e.width > 0 : e.readyState >= 2);
+				const els = ['mj-live-video', 'mj-live-video-b',
+					'mj-live-canvas', 'mj-live-canvas-b']
+					.map((id) => document.getElementById(id));
+				return els.find(ready) || els[0] || els[1];
 			},
 			onData: (r) => {
 				pathEl.setAttribute('d', r.path);

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1005,6 +1005,15 @@
 				return;
 			}
 			exhausted = true;
+			// A canvas that has stopped being painted keeps its last frame and
+			// nothing hides it, so the luma sampler would go on reporting a
+			// frozen picture as the current one — a stale measurement dressed
+			// as a live one, which is worse than none. Withdrawing the claim
+			// is what makes the histogram fall silent.
+			['mj-live-canvas', 'mj-live-canvas-b'].forEach((id) => {
+				const e = document.getElementById(id);
+				if (e) e.__mjPainted = false;
+			});
 			showAlert(detail);
 		}
 

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -999,20 +999,15 @@
 				return;
 			}
 			if (kind === 'webrtc') { swap.start('mse'); return; }
-			if (kind === 'mse' && wasmRungFor(detail)) { swap.start('wasm'); return; }
+			if (kind === 'mse' &&
+				window.MajesticTransport.softwareRungFor(detail)) {
+				swap.start('wasm');
+				return;
+			}
 			exhausted = true;
 			showAlert(detail);
 		}
 
-		// Only when the browser refused the codec, and only for a codec the
-		// decoder handles — an unreachable camera is not a decoding problem,
-		// and an H.264 refusal must not spend a round trip on an H.265 decoder.
-		function wasmRungFor(detail) {
-			const bits = String(detail || '').split(' ');
-			return bits[0] === 'undecodable' &&
-				!!(window.MajesticWasm && window.MajesticWasm.available &&
-					window.MajesticWasm.handles(bits[1]));
-		}
 
 		// This page's own remembered choice, defaulting to the substream. Not
 		// the Preview page's: the two are looked at for different reasons and
@@ -1041,7 +1036,26 @@
 			],
 			open: (kind, el, id, onState) => {
 				const impl = window.MajesticTransport.impl(kind);
+				// A canvas is 300x150 the moment it exists and reports a size
+				// before anything has been decoded into it, so its dimensions
+				// prove nothing — sampling one would publish a black histogram
+				// for a preview that is merely starting, and "the picture is
+				// black" is the exact lie the sampler's guard exists to
+				// prevent. A frame is the only proof of a frame.
+				//
+				// The mark is an expando, not a data attribute, and resolved
+				// through swap.element() rather than through `el`. Both matter:
+				// the software player REPLACES its canvas on attach (the handle
+				// from transferControlToOffscreen is spent once posted), so `el`
+				// is a detached node by the time a frame arrives — and
+				// cloneNode copies attributes, so a data-* mark would be
+				// inherited by the fresh canvas and declare it painted before
+				// it was. An expando is copied by neither.
 				return impl.attach(el, {
+					onCodec: () => {
+						const live = swap.element();
+						if (live) live.__mjPainted = true;
+					},
 					stream: stream,
 					// Opened with the volume it should have rather than given
 					// it afterwards; see preview-swap.js on why applying
@@ -1699,8 +1713,15 @@
 				// both canvases for ever — they do not have one — and the
 				// histogram would simply have stopped on an H.265 camera,
 				// silently, which is the failure this panel can least afford.
+				// Videos know their own readiness; a canvas does not, so the
+				// player marks it when it has actually decoded a frame. Until
+				// then this returns a video that will fail the sampler's own
+				// guard, which keeps the measurement UNKNOWN rather than
+				// reporting black.
 				const ready = (e) => e && e.style.display !== 'none' &&
-					(e.tagName === 'CANVAS' ? e.width > 0 : e.readyState >= 2);
+					(e.tagName === 'CANVAS'
+						? e.__mjPainted === true
+						: e.readyState >= 2);
 				const els = ['mj-live-video', 'mj-live-video-b',
 					'mj-live-canvas', 'mj-live-canvas-b']
 					.map((id) => document.getElementById(id));

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -285,6 +285,13 @@
 	const transportW = $('#mj-transport-w'), transportM = $('#mj-transport-m');
 	const transportGrp = $('#mj-transport-ctl');
 	const transportLbl = $('#mj-transport-lbl');
+	function hideOtherKind(kind) {
+		(kind === 'wasm'
+			? ['#live-video', '#live-video-b']
+			: ['#live-canvas', '#live-canvas-b']
+		).forEach((sel) => { const e = $(sel); if (e) e.style.display = 'none'; });
+	}
+
 	function reflectTransport(kind) {
 		if (transportW) transportW.checked = kind === 'webrtc';
 		if (transportM) transportM.checked = kind === 'mse';
@@ -717,6 +724,12 @@
 			// transport carrying anything — and would make a press of either
 			// radio tear down a working session.
 			reflectTransport(kind === 'wasm' ? 'mse' : kind);
+			// The idle pair belonging to the OTHER kind is hidden by nobody:
+			// the swap only ever touches the slot it is using, so an empty
+			// <video> sits visible underneath a canvas that is painting over
+			// it. That is harmless only because the canvas is opaque and later
+			// in DOM order, which is not a thing to rely on.
+			hideOtherKind(kind);
 			settle();
 			// Only when this promotion means a picture. Holding the fallback,
 			// an unproven one is just the swap saying it had nothing of its

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -853,25 +853,13 @@
 			return;
 		}
 		if (kind === 'webrtc') { attachPlayer('mse'); return; }
-		if (kind === 'mse' && wasmRungFor(detail)) { attachPlayer('wasm'); return; }
+		if (kind === 'mse' && MajesticTransport.softwareRungFor(detail)) {
+			attachPlayer('wasm');
+			return;
+		}
 		showFallback(detail);
 	}
 
-	// Entered only when the BROWSER refused the codec, and only for a codec the
-	// decoder can actually take. `unreachable` and `no-mse` are not decoding
-	// problems, and an H.264 High 10 refusal reports `undecodable` too — sending
-	// it to an H.265 decoder would be a slower way to fail, after a network
-	// round trip for the module.
-	//
-	// `detail` here is the PLAYER's reason code (preview.js). The camera's
-	// served-channel reply also has a reason spelled `undecodable`, meaning
-	// something else entirely; the two vocabularies must not be crossed.
-	function wasmRungFor(detail) {
-		const bits = String(detail || '').split(' ');
-		return bits[0] === 'undecodable' &&
-			!!(window.MajesticWasm && window.MajesticWasm.available &&
-				window.MajesticWasm.handles(bits[1]));
-	}
 
 	// The page's own callbacks, all of which belong to the player on screen: a
 	// trial has no badge, no audio control and no talkback button to report to.

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -119,8 +119,15 @@ window.MajesticTransport = (function () {
 	}
 
 	// The implementation behind a name, for a caller doing its own attaching.
+	// MSE stays the else-branch, because it is the floor: `preferred()` and
+	// `choose()` only ever name a transport, and the software rung is not one —
+	// it is reached by the chain, never remembered, never picked. So a caller
+	// asking for 'wasm' has decided already, and an unknown string still lands
+	// on the player that plays anything the browser can decode.
 	function impl(kind) {
-		return kind === 'webrtc' ? window.MajesticWebRTC : window.MajesticVideo;
+		return kind === 'webrtc' ? window.MajesticWebRTC
+			: kind === 'wasm' ? window.MajesticWasm
+			: window.MajesticVideo;
 	}
 
 	// Which encoder channel the person last picked, or null if they never have.

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -124,6 +124,23 @@ window.MajesticTransport = (function () {
 	// it is reached by the chain, never remembered, never picked. So a caller
 	// asking for 'wasm' has decided already, and an unknown string still lands
 	// on the player that plays anything the browser can decode.
+	// Whether the software-decode rung is worth trying for a given failure.
+	// Here rather than in either page because it is a RULE, which is what this
+	// module is for — and because two copies of it would drift: the Live page
+	// and the settings panel differ in what they do about the outcome, not in
+	// what makes the attempt worth a network round trip.
+	//
+	// `detail` is the player's reason code. Only a codec the browser refused,
+	// and only one this decoder speaks: an unreachable camera is not a decoding
+	// problem, and an H.264 High 10 refusal reports the same code, where
+	// launching an H.265 decoder would be a slower way to fail.
+	function softwareRungFor(detail) {
+		const bits = String(detail || '').split(' ');
+		const w = window.MajesticWasm;
+		return bits[0] === 'undecodable' &&
+			!!(w && w.available && w.handles && w.handles(bits[1]));
+	}
+
 	function impl(kind) {
 		return kind === 'webrtc' ? window.MajesticWebRTC
 			: kind === 'wasm' ? window.MajesticWasm
@@ -249,6 +266,7 @@ window.MajesticTransport = (function () {
 		choose: choose,
 		demote: demote,
 		impl: impl,
+		softwareRungFor: softwareRungFor,
 		iceServers: iceServers,
 		chosenStream: chosenStream,
 		chooseStream: chooseStream,

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -93,6 +93,7 @@ fi
 <script src="/a/preview.js"></script>
 <script src="/a/preview-webrtc.js"></script>
 <script src="/a/preview-swap.js"></script>
+<script src="/a/preview-wasm.js"></script>
 <script src="/a/preview-transport.js"></script>
 <%
 # preview-hero.js publishes window.MajesticHero (fullscreen + snapshot) before


### PR DESCRIPTION
#286 landed software H.265 decode on the Live page and **deliberately withheld it here**. `MajesticTransport.impl()` knowing the kind would have been worse than useless: this panel had no canvas elements, so it would have attached a canvas painter to a `<video>` and painted nothing — no picture, no error, nothing said. That was billed as a second integration rather than a line. This is it.

## Canvases of its own

Two, hidden, beside the two videos, with the panel's swap getters resolving each slot through **that slot's kind** — the same shape the Live page uses and for the same reason: `promote()` hides the outgoing slot *before* it swaps `live`, so a single latched kind hides the wrong element.

## The chain, not a pair of tests

`nextRung()` walks `WebRTC → MSE → software decode → the panel's own sentence`, entered on `undecodable` and only for a codec the decoder handles, and treating `codec-changed` as a **restart** rather than an ending — an H.264 substream plays natively, and this panel exists to be looked at.

Kept as its own dozen lines rather than shared with `preview-page.js`, on the division this file already states: what the two pages *do* about an outcome differs — one has an MJPEG picture to fall to, this one has an empty box and a sentence — while the rules about which transport to prefer stay in `preview-transport.js`.

## The luma histogram, which was the quiet one

Its guard was `readyState >= 2 && videoWidth > 0`. **A canvas has neither**, so on an H.265 camera the sampler would have no-opped for ever — and an empty histogram reads as *"the picture is black"* rather than *"nothing is being measured"*, on the one panel whose job is judging exposure by eye.

Both halves were broken, not one: `mj-luma.js`'s guard, **and** the getter in `mj-settings.js`, which filtered on `readyState` and only ever considered the two videos. The sampler now asks each source what it can answer, and the getter offers four candidates.

## And one found by looking at the result

The idle pair belonging to the *other* kind is hidden by nobody — the swap only ever touches the slot it is using. An empty `<video>` was sitting visible underneath a canvas painting over it. Harmless today only because the canvas is opaque and later in DOM order, which is not a thing to rely on. Fixed on **both** pages.

## `impl()` gains its first test

It had none, and it is the single line that decides what this panel can attach. Covered now including the else-branch: MSE is the floor on purpose, so an unrecognised kind lands on the player that plays whatever the browser can decode rather than on `undefined`.

## Verification

Lab `hi3516av300`, `video0.codec h265`, real Chrome (no HEVC). The panel shows the picture, the control bar works, and the luma histogram is populated **from the canvas** — real path data, not an empty box. The idle `<video>` is hidden. `npm test` passes, `npm run build:dist` clean, `bootstrap.min.css` unchanged.
