### PR TITLE
Live: the page is the picture, and the picture covers the screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,11 +278,58 @@ The journal is the one write whose failure **stops** the actuation — it is wha
   exception is the PTZ pad — steering, not configuration — kept on the video
   until the multi-user split decides who may steer. Every setting belongs
   under `mj-settings.cgi` only.
-- **The Live page is a hero stage.** `preview()` emits `#mj-stage` — a
-  `position:relative` box that reserves the stream's aspect ratio (16:9 until
-  `onCodec` reports the real one), with everything overlaid on the video so
-  nothing ever displaces the picture: the status chip `#mj-badge` top-right
-  (`CODEC W×H · fps`; fps is live WebRTC stats via a loosened `onStats` gate,
+- **The Live page is the picture, and nothing else.** `preview.cgi` sets
+  `full_bleed=1`, which asks `p/header.cgi` and `p/footer.cgi` for a page with
+  no container, no card, no status strip and no footer: `body#page-preview` is
+  a `100dvh` flex column of navbar → banners → stage, so the stage takes
+  whatever is left and the page never scrolls. It is the only page that asks.
+  The strip went because all four of its readings — the two usage bars, the
+  signature, the clock, the SoC temperature — are on the Dashboard, and every
+  heartbeat writer already guards its `$('#…')`, so an absent strip and an
+  absent footer cost nothing. The `Stream URLs` link went for the same reason:
+  it is a menu item under Camera. Measured on a 2560×1440 monitor, an
+  ssc30kq's 4:3 sensor went from **1264 × 948** (32% of the screen, the sensor
+  drawn at 49%, 632px of empty page each side) to **2560 × 1920 at 1:1**.
+- **The stage is a viewport, and `preview-zoom.js` is the view rule.** Three
+  presets in the bar's `#mj-view-ctl` — `Fill` (`max(sw/fw, sh/fh)`, covers the
+  window, the long axis pans), `Fit` (`min(…)`, the whole frame, letterboxed),
+  `1:1` — plus drag/wheel pan, pinch and ctrl+wheel free zoom, and double-click
+  (pointer only) for Fit↔Fill. The chosen preset is `mj-view-pick` in
+  `localStorage`: one key, permanent, because nothing here demotes the view
+  behind the viewer's back the way a failed transport does. **Without the
+  module the page is still right** — the media keep the stylesheet's `inset: 0`
+  and `object-fit: contain`, which is exactly Fit, and the group stays
+  `hidden`. `preview-page.js` knows it only through two guarded calls
+  (`setFrame`, `scalePct`/`refresh`), because that file runs in a bare `vm` in
+  two of the tests. **The chip prints the scale** (`H264 2560×1920 · 25 fps ·
+  100%`): Fill covers the window by enlarging a stream smaller than the screen
+  — a 1080p main on a 1440p monitor is 133%, the 704×576 substream 364% — and a
+  soft picture with no number beside it reads as a soft camera.
+- **Two zooms, and they never share a control, a label or a gesture.** On a
+  Pelco camera the pad's `Zoom · Wide/Tele` drives a motor: it changes the
+  field of view for every viewer and for the recording, with no undo. The View
+  group scales pixels in one browser. So the pad owns the lens, the stage owns
+  the picture; View leads the bar and the pad sits hard against the right edge;
+  and **pinch never reaches the lens on any camera** — a reflex must not spin a
+  zoom motor. Arrows still steer where a pad exists (that contract predates
+  this) and `shift`+arrows pan there; with no pad the plain arrows pan.
+  `preview-hero.js`'s tap-to-toggle moved to `pointerup` with an 8px movement
+  threshold, or every drag would flash the bar at the start of it.
+- **What the chrome is anchored to.** The stage carries `--mj-pic-{top,left,
+  right}`, written by `preview-zoom.js` and read by the chrome that *annotates*
+  the picture — the chip, the stats panel, both toasts — so a letterboxed view
+  does not leave them floating in the black beside it. Fill makes the two the
+  same, so this is invisible in the ordinary case. The bar and the PTZ pad
+  deliberately do **not** read them: they are the player's furniture, and
+  furniture that jumps when you change zoom is worse than furniture on a band
+  (in Fit it also puts the pad in the gutter, covering nothing). One exception,
+  the chip's alone: a picture too small to carry the chrome without it
+  dominating — measured against the chip's own `offsetWidth`, not a constant —
+  hands the insets back to the stage. A 390 × 219 phone in Fit is that case;
+  1841 × 1381 with 359px of gutter is not, so it keeps its chip on the picture.
+- Everything is still overlaid on the video so nothing ever displaces the
+  picture: the status chip `#mj-badge` top-right
+  (`CODEC W×H · fps · scale`; fps is live WebRTC stats via a loosened `onStats` gate,
   or the configured `videoN.fps` on MSE, which measures nothing), the stats
   panel top-left as translucent glass, the adaptation toast `#mj-adapt`
   — **the stats panel is `preview-stats.js`**, the "network story": the CGI
@@ -339,26 +386,33 @@ The journal is the one write whose failure **stops** the actuation — it is wha
   `tests/auto-source.test.js` and `tests/staging.test.js` execute
   `preview-page.js` in a bare `vm` with a stubbed `$` over an `IDS` list: any
   new element preview-page.js touches must be `$`-guarded and, for coverage,
-  added to both `IDS` lists. Every group in the bar is black glass with a
-  micro-caps label and, where it has state, a lit indicator — the same
-  vocabulary the Live adjustments deck uses — but the markup is still
-  input-behind-a-label, because `preview-page.js` drives `.checked`/`.disabled`
-  on those inputs and they are what keeps the groups keyboard-reachable. The
-  bar stays overlaid at **every** width, since it lives inside `.mj-stage` and
-  that is what carries it into fullscreen; below `md` it scrolls sideways
-  rather than wrapping into rows over a 186px-tall picture, with the icon
+  added to both `IDS` lists. Every group in the bar is black glass and, where it
+  has state, a lit indicator with the word that names it — `Muted`, `Talk`,
+  `Stats`, because a lit dot alone does not say what is lit. A **segmented
+  picker carries no caption**: its options say what it is (`Main Sub Auto`,
+  `Fit Fill 1:1`, `WebRTC MSE`) and `aria-label` says it for a screen reader.
+  The markup is input-behind-a-label, because `preview-page.js` and
+  `preview-zoom.js` drive `.checked`/`.disabled` on those inputs and they are
+  what keeps the groups keyboard-reachable. The bar is one **centred** cluster,
+  not a row spanning the stage: left-aligned groups with the icons pushed to
+  the far edge were fine in a 1264px card and are half a metre of eye travel on
+  a 2560px one. It stays overlaid at **every** width, since it lives inside
+  `.mj-stage` and that is what carries it into fullscreen; below `md` it
+  scrolls sideways (back to `flex-start`, or the first group is off the
+  scrollport where no gesture reaches it) with the icon
   group `position: sticky; right: 0` so fullscreen is never what falls off the
   scrollport. PTZ is `p/motor.cgi` (markup only, hidden) +
   `preview-ptz.js`, which relocates the pad(s) into the stage's `#mj-ptz`
   mount: Pointer Events with capture for press-and-hold, arrow keys only
   while the stage itself has focus (the bar's slider and radios own them
-  otherwise), `apiFetch` to `j/ptz.cgi`. **The pad is the thing that moves off
-  the picture on a phone**, because unlike the bar it is always visible: below
-  `md` it sits under the stage (`top: 100%`), the stage reserves the room with
-  a `:has()`-conditional `margin-bottom`, and — since `.mj-stage` is
-  `overflow: hidden`, which is what rounds the picture's corners — that clip
-  moves onto `.mj-stage-media` and `.mj-bar` for the duration. `:fullscreen`
-  puts the pad back on the video, the one phone case with height to spare. **Four PTZ backends**, detected in
+  otherwise), `apiFetch` to `j/ptz.cgi`. **The pad is back on the picture at
+  every width.** It moved below the stage on a phone because that stage was
+  330×186 and a thumb-sized pad is 152px of it; the stage is now the window
+  less the navbar — 390×785 on the same phone, where the pad covers 6% — and
+  there is no page below it to move anything onto. The margin reservations, the
+  `:has()` guards and the corner-radius shuffle they needed went with it; what
+  stayed is the part that was about thumbs rather than space, a bigger grid
+  below `md`. **Four PTZ backends**, detected in
   `common.cgi:update_caminfo` into `ptz_backend` (cached in sysinfo like
   `ptz_support`). The switch is U-Boot `ptz_control` (#227): `gpio`
   (`gpio-motors` binary; pins in `ptz_gpio`, legacy `gpio_motors` accepted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,17 @@ The journal is the one write whose failure **stops** the actuation — it is wha
   dominating — measured against the chip's own `offsetWidth`, not a constant —
   hands the insets back to the stage. A 390 × 219 phone in Fit is that case;
   1841 × 1381 with 359px of gutter is not, so it keeps its chip on the picture.
+- **The two toasts are a stack, not two fixed offsets.** `#mj-toasts` is a flex
+  column hung under the chip at `--mj-chip-h`, the chip's *measured* height,
+  because that height is not a constant — "MJPEG" against "H265 3840×2160 · 25
+  fps · 36% · Sub stream", which wraps to two lines below ~300px — and at the
+  old hardcoded `top: 2.4rem` the adaptation toast started 2.6px **above** the
+  chip's bottom edge. A hidden toast takes no room, so the served message rises
+  into the adaptation toast's place when there is none. The chip also gained
+  `max-width: calc(100% - 1rem)`: right-anchored inside an `overflow: hidden`
+  stage, an uncapped long line ran off the *left* edge and lost its first
+  words. Wrapping is safe precisely because the stack measures rather than
+  assumes.
 - Everything is still overlaid on the video so nothing ever displaces the
   picture: the status chip `#mj-badge` top-right
   (`CODEC W×H · fps · scale`; fps is live WebRTC stats via a loosened `onStats` gate,

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2145,6 +2145,11 @@ mark {
 	top: calc(var(--mj-pic-top, 0px) + 0.5rem);
 	right: calc(var(--mj-pic-right, 0px) + 0.5rem);
 	z-index: 5;
+	/* It had no cap at all, and it is right-anchored with the stage clipping:
+	   a long line ("H265 3840×2160 · 25 fps · 36% · Sub stream") ran off the
+	   left edge and lost its first words rather than wrapping. Wrapping is
+	   fine here because the toasts below are hung off its MEASURED height. */
+	max-width: calc(100% - 1rem);
 	padding: 0.4rem 0.65rem;
 	border-radius: var(--bs-border-radius);
 	background: rgba(13, 15, 20, 0.72);
@@ -2313,15 +2318,39 @@ mark {
 
 /* The adaptation toast: under the chip, same glass. Hover pins it and click
    dismisses (preview-adapt.js), so unlike the chip it takes the pointer. */
-.mj-adapt-toast {
+/* The toast stack, hung under the chip rather than measured from the top of
+   the stage. --mj-chip-h is the chip's own rendered height (preview-zoom.js
+   measures it; the fallback is what it comes to at the default font size), so
+   a chip that grows a scale readout, or wraps to two lines on a phone, pushes
+   the toasts down instead of being crowded by them. A flex column, so a hidden
+   toast takes no room and the served message rises into the adaptation
+   toast's place when there is none. */
+.mj-toasts {
 	position: absolute;
-	top: calc(var(--mj-pic-top, 0px) + 2.4rem);
+	top: calc(var(--mj-pic-top, 0px) + var(--mj-chip-h, 1.75rem) + 1rem);
 	right: calc(var(--mj-pic-right, 0px) + 0.5rem);
 	z-index: 5;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 0.5rem;
+	max-width: min(75%, 22rem);
+	/* The stack is a container, not a surface: only the toasts in it take a
+	   click. Otherwise the gap between two of them would eat the tap that
+	   toggles the control bar. */
+	pointer-events: none;
+}
+
+.mj-toasts > * {
+	pointer-events: auto;
+}
+
+.mj-adapt-toast {
+	position: relative;
 	margin: 0;
 	/* Room on the right for the corner-anchored ×. */
 	padding: 0.3rem 1.5rem 0.3rem 0.6rem;
-	max-width: min(75%, 22rem);
+	max-width: 100%;
 	background: rgba(13, 15, 20, 0.72);
 	border: 1px solid rgba(255, 255, 255, 0.09);
 	color: rgba(255, 255, 255, 0.9);
@@ -2361,9 +2390,9 @@ mark {
 /* The served-channel message shares the toast's glass but its own slot,
    below the adaptation toast, so a fallback and a rate change can both be
    on screen without either covering the other. */
-.mj-served-toast {
-	top: calc(var(--mj-pic-top, 0px) + 5.2rem);
-}
+/* .mj-served-toast has nothing left to set — the stack spaces both toasts and
+   document order is what puts the served message below the adaptation one —
+   so the class stays on the markup as a label and carries no rule. */
 
 /* ── on-video chrome ────────────────────────────────────────────────────────
    The same vocabulary the Live adjustments deck uses — black glass, micro-caps

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2009,30 +2009,114 @@ mark {
 /* ---- Live View stage -------------------------------------------------------
    Everything below is on-video chrome: black glass over whatever the camera is
    showing, deliberately identical in both themes because its background is the
-   picture, not the page surface. The stage reserves 16:9 up front
-   (preview-page.js corrects the ratio from stream metadata) so nothing that
-   appears or disappears around the video can move it. */
+   picture, not the page surface.
+
+   The stage used to reserve the stream's shape inside the page's container and
+   size itself from the viewport HEIGHT less 12.5rem of chrome. Measured on a
+   2560x1440 monitor that gave a 4:3 sensor 1264 x 948 -- 32% of the screen,
+   the sensor drawn at 49% -- with 632px of empty page on each side and 254px
+   below the card, because .container (1320px) decided and the screen got no
+   vote. It is now a VIEWPORT: it takes the whole window under the navbar, and
+   preview-zoom.js sizes the picture inside it. Same window, same camera: 2560
+   x 1920 at 1:1.
+
+   These rules only ever apply to preview.cgi -- p/common.cgi's preview() is
+   the only thing that emits .mj-stage, and preview.cgi is its only caller.
+   mj-settings.cgi's Live section builds its own stage client-side out of
+   .mj-live-video, which is why none of this reaches it. */
 .mj-stage {
 	position: relative;
-	/* Fit the viewport, not just the column: at full container width a 16:9
-	   stage is ~710px tall and a laptop has to scroll to reach the bar and
-	   the device chips. The clamp sizes the stage from the viewport height
-	   (12.5rem ≈ navbar + status strip + card chrome + chips row), and the
-	   ratio keeps width and height honest together. preview-page.js rewrites
-	   it with the stream's real ratio; dvh where the browser has it, vh
-	   otherwise. Centered when narrower than the column. */
-	width: min(100%, calc((100vh - 12.5rem) * 1.77778));
-	width: min(100%, calc((100dvh - 12.5rem) * 1.77778));
-	margin-inline: auto;
-	aspect-ratio: 16 / 9;
 	background: #000;
 	overflow: hidden;
-	border-radius: var(--bs-border-radius);
+	/* The picture's gestures are this page's, not the browser's: a one-finger
+	   drag pans it and two fingers zoom it, and neither survives the browser
+	   deciding mid-gesture that it was a scroll. There is nothing to scroll
+	   here anyway — the page is exactly the viewport. The children that DO
+	   scroll take it back below. */
+	touch-action: none;
+	/* The insets of the picture inside the stage, written by preview-zoom.js
+	   and read by the chrome that annotates the picture. Declared here so that
+	   chrome is positioned correctly before -- and entirely without -- that
+	   module. */
+	--mj-pic-top: 0px;
+	--mj-pic-left: 0px;
+	--mj-pic-right: 0px;
 }
 
+/* The full-bleed page: body is the viewport, navbar and <main> are its rows,
+   and the stage takes what is left. No hardcoded navbar height anywhere -- the
+   column measures it -- so a wrapped nav on a narrow window shortens the
+   picture instead of pushing it off the bottom.
+
+   min-height: 0 on every flex item in the chain is the load-bearing half: a
+   flex item's default min-height is auto, so without it the stage refuses to
+   shrink below its content and the page scrolls after all. */
+#page-preview {
+	height: 100vh;
+	height: 100dvh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+#page-preview > .navbar {
+	flex: none;
+}
+
+#page-preview > main.mj-fullbleed {
+	flex: 1 1 auto;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	/* Banners are the pathological case: three of them on a short window can
+	   leave the stage nothing. They scroll rather than squeezing the picture
+	   to a sliver, and the stage keeps a floor. */
+	overflow-y: auto;
+}
+
+/* Nothing hides the banner container when the camera has raised no banners:
+   .container carries horizontal padding only, so with nothing in it it is 0px
+   tall on its own. (`:empty` would not have done it anyway — the whitespace
+   between the haserl conditionals is a text node, and `:empty` counts those.) */
+
+#page-preview .mj-player {
+	flex: 1 1 auto;
+	min-height: 0;
+	display: flex;
+}
+
+#page-preview .mj-stage {
+	flex: 1 1 auto;
+	min-width: 0;
+	min-height: 12rem;
+}
+
+/* The two overlays that scroll inside themselves — the bar sideways on a
+   phone, the stats panel down — take their gestures back from the stage. */
+.mj-bar,
+.mj-stats-overlay {
+	touch-action: auto;
+}
+
+/* Grab-to-pan, and only while there is something to pan to: a cursor that
+   promises movement over a picture that cannot move is a lie the pointer
+   tells before the hand does. preview-zoom.js owns the class. */
+.mj-stage.mj-pannable {
+	cursor: grab;
+}
+
+.mj-stage.mj-panning {
+	cursor: grabbing;
+}
 
 .mj-stage-media {
 	position: absolute;
+	/* The fallback, and it is a real one: with no preview-zoom.js the media
+	   fill the stage and object-fit letterboxes them, which is exactly Fit.
+	   The module overrides left/top/width/height with pixels; left+right+width
+	   over-constrained resolves in favour of left and width, so `inset` does
+	   not have to be unset for that to work -- but the module unsets it
+	   anyway, because relying on that is a detail of the writing mode. */
 	inset: 0;
 	width: 100%;
 	height: 100%;
@@ -2050,10 +2134,16 @@ mark {
 	z-index: 4;
 }
 
+/* Anchored to the PICTURE, not to the stage. Fill leaves the two the same, so
+   this changes nothing in the ordinary case; on a letterboxed view a chip at
+   the stage's corner floats in black, describing nothing. preview-zoom.js
+   zeroes the insets again when the picture is too small to carry the chrome
+   without it dominating -- a 390 x 219 phone in Fit -- so a band that exists
+   is not by itself a reason to use it. */
 .mj-chip {
 	position: absolute;
-	top: 0.5rem;
-	right: 0.5rem;
+	top: calc(var(--mj-pic-top, 0px) + 0.5rem);
+	right: calc(var(--mj-pic-right, 0px) + 0.5rem);
 	z-index: 5;
 	padding: 0.4rem 0.65rem;
 	border-radius: var(--bs-border-radius);
@@ -2069,8 +2159,8 @@ mark {
 
 .mj-stats-overlay {
 	position: absolute;
-	top: 0.5rem;
-	left: 0.5rem;
+	top: calc(var(--mj-pic-top, 0px) + 0.5rem);
+	left: calc(var(--mj-pic-left, 0px) + 0.5rem);
 	z-index: 5;
 	width: min(92%, 21rem);
 	/* Leave the bar's strip free below, and scroll rather than grow: on a
@@ -2225,8 +2315,8 @@ mark {
    dismisses (preview-adapt.js), so unlike the chip it takes the pointer. */
 .mj-adapt-toast {
 	position: absolute;
-	top: 2.4rem;
-	right: 0.5rem;
+	top: calc(var(--mj-pic-top, 0px) + 2.4rem);
+	right: calc(var(--mj-pic-right, 0px) + 0.5rem);
 	z-index: 5;
 	margin: 0;
 	/* Room on the right for the corner-anchored ×. */
@@ -2272,7 +2362,7 @@ mark {
    below the adaptation toast, so a fallback and a rate change can both be
    on screen without either covering the other. */
 .mj-served-toast {
-	top: 5.2rem;
+	top: calc(var(--mj-pic-top, 0px) + 5.2rem);
 }
 
 /* ── on-video chrome ────────────────────────────────────────────────────────
@@ -2487,6 +2577,12 @@ mark {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
+	/* One centred cluster rather than a row spanning the stage. Left-aligned
+	   groups with the icons pushed to the far edge was fine in a 1264px card;
+	   on a 2560px stage it is half a metre of eye travel between the stream
+	   picker and the fullscreen button, which is the complaint that closed
+	   #239 wearing different clothes. */
+	justify-content: center;
 	gap: 0.5rem;
 	padding: 2rem 0.75rem 0.5rem;
 	background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
@@ -2526,6 +2622,10 @@ mark {
 @media (max-width: 767.98px) {
 	.mj-bar {
 		flex-wrap: nowrap;
+		/* Back to the start edge: a centred flex row that overflows puts its
+		   first group off the left of the scrollport, where no scroll gesture
+		   reaches it. */
+		justify-content: flex-start;
 		overflow-x: auto;
 		padding-top: 1.25rem;
 		/* A default scrollbar draws a bright strip the width of the picture.
@@ -2686,76 +2786,18 @@ mark {
 	outline: var(--bs-focus-ring-width) solid var(--bs-focus-ring-color);
 }
 
-/* On a phone the pad comes off the picture and sits under it, side by side
-   with the zoom/focus cluster. At 390px the stage is 330×186, and steering
-   overlaid costs more than it is worth: a thumb-sized pad is 152px of a 186px
-   picture, and on a Pelco camera the cluster stacked above it needs another
-   130 that do not exist — it rendered over the top edge of the stage. Below
-   the picture there is room for both at full size, and the picture stays a
-   picture. The bar stays overlaid regardless: it is transient (tap to reveal),
-   the pad is not.
-
-   Reserving the space is the stage's margin, conditional on a pad that
-   preview-ptz.js actually mounted — no pad, no gap. A browser without :has()
-   simply keeps today's overlay geometry, which is why the margin and not the
-   positioning carries the condition.
-
-   These have to come AFTER the pad's own rules: same specificity, so it is
-   source order that decides. (A narrower block earlier in this file lost that
-   race silently and sized nothing.) */
+/* On a phone the pad and the stats panel used to come off the picture and sit
+   under it: at 390px the stage was 330x186, a thumb-sized pad is 152px of that
+   and the stats panel is taller than the whole stage, so overlaid they did not
+   annotate the picture, they replaced it. The stage is now the window less the
+   navbar -- 390x785 on that same phone -- so the pad covers 6% of it and the
+   panel has room, and there is no page below the stage to move anything onto.
+   Both are back on the picture at every width, and the margin reservations,
+   the :has() guards and the corner-radius shuffle they needed are gone with
+   them. What stays is the part that was about thumbs rather than about space:
+   a bigger grid on a touch screen. */
 @media (max-width: 767.98px) {
-	/* The stage clips, which is what rounds the picture's corners — so letting
-	   the pad out means moving that clip onto the media and the bar. */
-	.mj-stage {
-		overflow: visible;
-	}
-
-	.mj-stage-media,
-	.mj-bar {
-		border-bottom-left-radius: var(--bs-border-radius);
-		border-bottom-right-radius: var(--bs-border-radius);
-	}
-
-	.mj-stage-media {
-		border-top-left-radius: var(--bs-border-radius);
-		border-top-right-radius: var(--bs-border-radius);
-	}
-
-	/* Measured, not guessed: the pad is 152px with its gap, and a Pelco camera
-	   stacks the zoom/focus cluster beside it at 165. */
-	.mj-stage:has(> .mj-ptz:not([hidden])) {
-		margin-bottom: 10rem;
-	}
-
-	.mj-stage:has(> .mj-ptz .mj-ptz-fn:not([hidden])) {
-		margin-bottom: 11rem;
-	}
-
-	.mj-ptz {
-		top: 100%;
-		right: 0;
-		bottom: auto;
-		left: 0;
-		flex-direction: row;
-		align-items: flex-start;
-		justify-content: center;
-		gap: 0.5rem;
-		padding-top: 0.5rem;
-	}
-
-	/* Fullscreen is the one phone case with height to spare, and a pad below
-	   the picture there would be below the screen. Put it back on the video. */
-	.mj-stage:fullscreen .mj-ptz {
-		top: auto;
-		bottom: 3.25rem;
-		left: auto;
-		right: 0.5rem;
-		flex-direction: column;
-		align-items: flex-end;
-		padding-top: 0;
-	}
-
-	/* Off the picture, the pad can have the thumb-sized grid it wants. */
+	/* Off a mouse, the pad wants a thumb-sized grid. */
 	.mj-ptz-pad {
 		grid-template-columns: repeat(3, 2.75rem);
 		grid-auto-rows: 2.75rem;
@@ -2766,68 +2808,12 @@ mark {
 	}
 }
 
-/* The stats panel below md follows the pad off the picture, and for the same
-   arithmetic: it is taller than the whole 186px stage, so overlaid it would
-   not annotate the picture, it would replace it. Same mechanism as the pad —
-   absolute at top:100%, the stage reserving the room with a :has()-guarded
-   margin — and a fixed height so the reserved margin is a measurement, not a
-   guess; the story scrolls inside it. When the pad is out too, the pad keeps
-   the first slot (it is the always-visible one) and the panel stacks below
-   it. Fullscreen has height to spare and puts the panel back on the video. */
-@media (max-width: 767.98px) {
-	.mj-stats-overlay {
-		top: 100%;
-		left: 0;
-		right: 0;
-		width: auto;
-		height: 22rem;
-		max-height: none;
-	}
-
-	.mj-stage:has(> #mj-stats:not([hidden])) {
-		margin-bottom: 22.5rem;
-	}
-
-	.mj-stage:has(> .mj-ptz:not([hidden])) .mj-stats-overlay {
-		top: calc(100% + 10rem);
-	}
-
-	.mj-stage:has(> .mj-ptz:not([hidden])):has(> #mj-stats:not([hidden])) {
-		margin-bottom: 32.5rem;
-	}
-
-	.mj-stage:has(> .mj-ptz .mj-ptz-fn:not([hidden])) .mj-stats-overlay {
-		top: calc(100% + 11rem);
-	}
-
-	.mj-stage:has(> .mj-ptz .mj-ptz-fn:not([hidden])):has(> #mj-stats:not([hidden])) {
-		margin-bottom: 33.5rem;
-	}
-
-	.mj-stage:fullscreen .mj-stats-overlay {
-		top: 0.5rem;
-		left: 0.5rem;
-		right: auto;
-		width: min(92%, 21rem);
-		height: auto;
-		max-height: calc(100% - 5rem);
-	}
-}
-
-/* A Pelco camera puts two panels in that row, and at full size they need 284px
-   against a stage that is the viewport less ~56 — so from about 340px down
-   they hang over both edges of the picture (measured at 320: 284 into 264).
-   They stay side by side and give up 4px of grid instead of stacking, which
-   would put 315px of chrome under a 150px picture. 40px still clears WCAG
-   2.5.8 comfortably. Below 320 the page has other problems; Bootstrap's own
-   floor is 320 too. */
+/* A Pelco camera puts two panels in that column, and at full size they need
+   284px of height against a stage that is now the whole window -- so the
+   squeeze the narrowest phones used to face is gone. What is left is width:
+   below 320 the buttons themselves are what does not fit. 40px still clears
+   WCAG 2.5.8 comfortably. Bootstrap's own floor is 320 too. */
 @media (max-width: 359.98px) {
-	/* Only the pad got shorter here — the zoom/focus cluster is as tall as it
-	   was, so a Pelco camera keeps the 11rem the wider step reserved. */
-	.mj-stage:has(> .mj-ptz:not([hidden])) {
-		margin-bottom: 9.5rem;
-	}
-
 	.mj-ptz-pad {
 		grid-template-columns: repeat(3, 2.5rem);
 		grid-auto-rows: 2.5rem;
@@ -2843,11 +2829,13 @@ mark {
 	}
 }
 
+/* Fullscreen takes the stage out of the page's flex column, so it has to be
+   told its size again. The view rule then applies to the screen instead of to
+   the window, which is the whole reason the button is on the stage rather than
+   on the video: preview-zoom.js re-lays out on the resize this causes. */
 .mj-stage:fullscreen {
-	aspect-ratio: auto;
 	width: 100%;
 	height: 100%;
-	border-radius: 0;
 }
 
 .navbar-nav {

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -93,15 +93,25 @@
 	// come back up and fires only if it barely moved — on the pointerdown it
 	// flashed the bar at the start of every drag. 8px rather than 0 because a
 	// finger never lifts from exactly where it landed.
-	let tapId = null, tapX = 0, tapY = 0;
+	// A second finger cancels the tap outright, whatever the first one does. In
+	// a pinch the finger that is not driving the zoom can easily stay inside
+	// the 8px threshold, and lifting it would then toggle the bar as though
+	// nobody had zoomed at all. Counted here rather than asked of
+	// preview-zoom.js: the two hold their own pointer state, and a shared one
+	// is a third thing to keep in step.
+	let tapId = null, tapX = 0, tapY = 0, touching = 0;
 	stage.addEventListener('pointerdown', e => {
 		if (e.pointerType !== 'touch') return;
+		touching++;
+		if (touching > 1) tapId = null;
 		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-toasts')) return;
+		if (touching > 1) return;
 		tapId = e.pointerId;
 		tapX = e.clientX;
 		tapY = e.clientY;
 	});
 	stage.addEventListener('pointerup', e => {
+		if (e.pointerType === 'touch') touching = Math.max(0, touching - 1);
 		if (e.pointerId !== tapId) return;
 		tapId = null;
 		if (Math.abs(e.clientX - tapX) + Math.abs(e.clientY - tapY) > 8) return;
@@ -113,6 +123,7 @@
 		}
 	});
 	stage.addEventListener('pointercancel', e => {
+		if (e.pointerType === 'touch') touching = Math.max(0, touching - 1);
 		if (e.pointerId === tapId) tapId = null;
 	});
 

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -88,15 +88,32 @@
 	stage.addEventListener('pointermove', e => {
 		if (e.pointerType === 'mouse') show(2500);
 	});
+	// A pan is not a tap. Dragging the picture (preview-zoom.js) begins with a
+	// pointerdown on the stage as well, so the toggle waits for the pointer to
+	// come back up and fires only if it barely moved — on the pointerdown it
+	// flashed the bar at the start of every drag. 8px rather than 0 because a
+	// finger never lifts from exactly where it landed.
+	let tapId = null, tapX = 0, tapY = 0;
 	stage.addEventListener('pointerdown', e => {
 		if (e.pointerType !== 'touch') return;
 		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-adapt, #mj-served')) return;
+		tapId = e.pointerId;
+		tapX = e.clientX;
+		tapY = e.clientY;
+	});
+	stage.addEventListener('pointerup', e => {
+		if (e.pointerId !== tapId) return;
+		tapId = null;
+		if (Math.abs(e.clientX - tapX) + Math.abs(e.clientY - tapY) > 8) return;
 		if (stage.classList.contains('mj-show')) {
 			stage.classList.remove('mj-show');
 			clearTimeout(hideTimer);
 		} else {
 			show(4000);
 		}
+	});
+	stage.addEventListener('pointercancel', e => {
+		if (e.pointerId === tapId) tapId = null;
 	});
 
 	window.MajesticHero.wireFullscreen(stage, $('#mj-fs'));

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -96,7 +96,7 @@
 	let tapId = null, tapX = 0, tapY = 0;
 	stage.addEventListener('pointerdown', e => {
 		if (e.pointerType !== 'touch') return;
-		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-adapt, #mj-served')) return;
+		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-toasts')) return;
 		tapId = e.pointerId;
 		tapX = e.clientX;
 		tapY = e.clientY;

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -1421,6 +1421,13 @@
 		});
 	}
 
+	// The chip prints the scale, and the scale moves for reasons no player
+	// event reports: a preset, a pinch, a window resize. Over MSE the codec is
+	// reported once when the connection opens, so without this the percentage
+	// would be the one the session started with for as long as it lasted.
+	// (preview-zoom.js is loaded before this file so that it is here to ask.)
+	if (window.MajesticZoom) window.MajesticZoom.onScale(setChip);
+
 	if (statsBtn && statsBox) {
 		// Through the same helper the transport switch uses, so "is the panel
 		// showing" has one answer and not two that have to agree.

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -433,10 +433,21 @@
 		// chip claim 25 fps while the client managed 9, in exactly the case
 		// this exists to expose.
 		const fps = liveKind === 'mse' ? cfgFps[stream ? 1 : 0] : chipFps;
+		// The scale the picture is drawn at, because Fill covers the window by
+		// enlarging a stream smaller than the screen — a 1080p main on a 1440p
+		// monitor is 133%, the substream far more — and a soft picture with no
+		// number beside it reads as a soft camera. 1:1 is the one that never
+		// has to be explained. Absent where the module is (no zoom, no scale),
+		// which is also the bare-vm case the tests run.
+		const pct = window.MajesticZoom ? window.MajesticZoom.scalePct() : 0;
 		badge.textContent = (chipMedia.codec || '').toUpperCase() + ' ' +
 			chipMedia.w + '×' + chipMedia.h +
 			(fps ? ' · ' + Math.round(fps) + ' fps' : '') +
+			(pct ? ' · ' + pct + '%' : '') +
 			servedNote();
+		// Its width is what decides whether the chrome fits on the picture, and
+		// it has just changed.
+		if (window.MajesticZoom) window.MajesticZoom.refresh();
 	}
 
 	// The served-channel message: why the channel the viewer picked is not the
@@ -864,21 +875,18 @@
 	// The page's own callbacks, all of which belong to the player on screen: a
 	// trial has no badge, no audio control and no talkback button to report to.
 	// onState is the swap's, unchanged — it decides what a trial's states mean.
-	// What the codec callback reports, applied to the chip and the stage.
-	// Reserve the stream's true shape so the picture arriving (or a ratio
-	// change on a stream switch) never moves anything below the stage, and
-	// re-derive the viewport clamp from the same ratio — the CSS default
-	// assumes 16:9. The dvh write lands where the browser knows the unit and
-	// is ignored where it does not, leaving the vh version standing.
+	//
+	// What the codec callback reports, applied to the chip and to the view
+	// rule. The stage no longer reserves the stream's shape — it is the window
+	// under the navbar and its size is the page's, not the stream's — so the
+	// only thing the frame size decides here is how preview-zoom.js lays the
+	// picture out inside it. Guarded because this file is executed in a bare vm
+	// by two of the tests, and because the module is one <script> the page can
+	// be served without: with no module the media keep the stylesheet's
+	// `inset: 0` and letterbox, which is Fit.
 	function applyMedia(m) {
 		chipMedia = m;
-		const stage = $('#mj-stage');
-		if (stage && m.w && m.h) {
-			stage.style.aspectRatio = m.w + ' / ' + m.h;
-			const r = (m.w / m.h).toFixed(5);
-			stage.style.width = 'min(100%, calc((100vh - 12.5rem) * ' + r + '))';
-			stage.style.width = 'min(100%, calc((100dvh - 12.5rem) * ' + r + '))';
-		}
+		if (window.MajesticZoom) window.MajesticZoom.setFrame(m.w, m.h);
 		setChip();
 	}
 

--- a/www/a/preview-ptz.js
+++ b/www/a/preview-ptz.js
@@ -127,8 +127,11 @@
 		};
 		stage.addEventListener('keydown', e => {
 			// Only when the stage ITSELF is focused — focus on any control in
-			// the bar means the arrows are that control's.
-			if (e.target !== stage || !KEYS[e.key]) return;
+			// the bar means the arrows are that control's. Shift is not ours
+			// either: on a camera with a pad the plain arrows steer and shift
+			// asks preview-zoom.js for the picture instead, so the keyboard
+			// keeps both without either taking the other's keys.
+			if (e.target !== stage || e.shiftKey || !KEYS[e.key]) return;
 			e.preventDefault();
 			if (e.repeat) return;
 			const btn = pad.querySelector(KEYS[e.key]);

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -1,0 +1,344 @@
+// The Live page's view rule: how the stream's frame is fitted to a stage that
+// is now the whole window, and how you reach the part of it that does not fit.
+//
+// The page used to answer this with CSS alone -- the stage reserved the
+// stream's aspect ratio and `object-fit: contain` letterboxed inside it -- and
+// that is still what happens if this file fails to load. What it could not do
+// is cover the window: on a 2560x1440 monitor a 4:3 sensor was drawn at 1264 x
+// 948, a third of the screen, with the rest of it black or empty page. Three
+// presets and a pan replace the one behaviour:
+//
+//   Fill   scale = max(sw/fw, sh/fh)   covers the window; the long axis pans
+//   Fit    scale = min(sw/fw, sh/fh)   the whole frame, letterboxed
+//   1:1    scale = 1                   real pixels, for judging focus
+//
+// Deliberately a separate file from preview-page.js, for the same reason
+// preview-hero.js is one: that file is executed by tests/auto-source.test.js
+// and tests/staging.test.js in a bare vm with no document, so everything whose
+// whole job is to drive the DOM lives here, where the page is real. What
+// preview-page.js knows about this module is two guarded calls.
+//
+// `$` is a global from main.js.
+(function () {
+	const stage = $('#mj-stage');
+	if (!stage) return;
+
+	// The person's explicit choice, permanent -- the same contract as
+	// mj-transport-pick, and for the same reason it is a single key: nothing
+	// here demotes the view behind their back, so there is no second key
+	// carrying an expiry and no way for a fallback to be mistaken for a
+	// decision. A free zoom is not written: it is a gesture, not a choice.
+	const KEY = 'mj-view-pick';
+	const MODES = ['fit', 'fill', 'one'];
+	const RADIOS = { fit: '#mj-view-fit', fill: '#mj-view-fill', one: '#mj-view-one' };
+	// Where a press belongs to the control under it rather than to the picture.
+	const CHROME = '.mj-bar, .mj-ptz, #mj-stats, #mj-adapt, #mj-served';
+
+	function read(k) {
+		try { return localStorage.getItem(k); } catch (e) { return null; }
+	}
+	function write(k, v) {
+		try { localStorage.setItem(k, v); } catch (e) {}
+	}
+	function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+	let frame = null;      // {w, h} of the stream, once the codec is known
+	let mode = 'fill';     // 'fit' | 'fill' | 'one' | 'free'
+	let scale = 1;         // the scale in force
+	let ox = 0, oy = 0;    // the picture's left/top inside the stage
+	let placed = false;    // has a layout run against a known frame
+
+	const saved = read(KEY);
+	if (MODES.indexOf(saved) >= 0) mode = saved;
+
+	// ---- laying the picture out -------------------------------------------
+
+	// The media elements are re-queried every time rather than held: the MSE
+	// player replaces its <video> on every open and every reconnect, so a
+	// stored reference is a detached node within a session -- the same trap the
+	// transport swap hit.
+	function place(picW, picH) {
+		const els = stage.querySelectorAll('.mj-stage-media');
+		for (let i = 0; i < els.length; i++) {
+			const s = els[i].style;
+			// inset:0 from the stylesheet is the no-JS fallback; it has to go
+			// before pixels mean anything on all four sides.
+			s.inset = 'auto';
+			s.left = ox.toFixed(2) + 'px';
+			s.top = oy.toFixed(2) + 'px';
+			s.width = picW.toFixed(2) + 'px';
+			s.height = picH.toFixed(2) + 'px';
+		}
+	}
+
+	// Where the chrome that ANNOTATES the picture goes -- the chip, the stats
+	// panel, the two toasts -- as CSS custom properties the stylesheet adds to
+	// its own insets. Not the bar and not the PTZ pad: those are the player's
+	// furniture, and furniture that jumps when you change zoom is worse than
+	// furniture on a black band.
+	//
+	// Only called when the picture's SIZE changes, never on a pan: a picture
+	// small enough to leave a band cannot be panned in the first place, so
+	// panning never moves these.
+	function annotate(sw, sh, picW, picH) {
+		// Measured off the chip itself rather than guessed at, because its
+		// width is its text -- "H265 3840×2160 · 25 fps · 67%" against "MJPEG"
+		// -- and its height is the page's font size.
+		const badge = $('#mj-badge');
+		const cw = (badge && badge.offsetWidth) || 210;
+		const ch = (badge && badge.offsetHeight) || 30;
+		const visW = Math.min(sw, picW), visH = Math.min(sh, picH);
+		// A picture too small to carry the chip without the chip dominating it
+		// hands the chrome back to the stage: a 390 x 219 phone in Fit, where
+		// the chip is nearly half the width and there is 283px of band doing
+		// nothing. It is the picture being too small that moves it -- never the
+		// band merely existing, which is why 1841 x 1381 with 359px of gutter
+		// keeps its chip on the picture.
+		const roomy = visW >= cw * 3 && visH >= ch * 5;
+		const set = (name, px) => stage.style.setProperty(name, (roomy ? Math.max(0, px) : 0) + 'px');
+		set('--mj-pic-top', oy);
+		set('--mj-pic-left', ox);
+		set('--mj-pic-right', sw - (ox + picW));
+	}
+
+	function layout() {
+		const sw = stage.clientWidth, sh = stage.clientHeight;
+		if (!frame || !frame.w || !frame.h || !sw || !sh) return;
+
+		const kFit = Math.min(sw / frame.w, sh / frame.h);
+		const kFill = Math.max(sw / frame.w, sh / frame.h);
+
+		// What the middle of the window was looking at, in frame coordinates,
+		// so that changing the scale keeps the same part of the scene under it
+		// instead of throwing the view back to a corner.
+		let cx = 0.5, cy = 0.5;
+		if (placed && scale > 0) {
+			cx = (sw / 2 - ox) / (frame.w * scale);
+			cy = (sh / 2 - oy) / (frame.h * scale);
+		}
+
+		// Free zoom is bounded by what is worth looking at: no further out than
+		// the whole frame (or native, when the frame is smaller than the stage
+		// -- past that it is only black), no further in than 3x native. The
+		// presets are not clamped, because 1:1 means 1:1.
+		scale = mode === 'fit' ? kFit
+			: mode === 'one' ? 1
+			: mode === 'free' ? clamp(scale, Math.min(kFit, 1), Math.max(kFill, 1) * 3)
+			: kFill;
+
+		const picW = frame.w * scale, picH = frame.h * scale;
+		ox = picW <= sw ? (sw - picW) / 2 : clamp(sw / 2 - cx * picW, sw - picW, 0);
+		oy = picH <= sh ? (sh - picH) / 2 : clamp(sh / 2 - cy * picH, sh - picH, 0);
+		placed = true;
+
+		place(picW, picH);
+		annotate(sw, sh, picW, picH);
+		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+	}
+
+	function panBy(dx, dy) {
+		if (!frame || !placed) return;
+		const sw = stage.clientWidth, sh = stage.clientHeight;
+		const picW = frame.w * scale, picH = frame.h * scale;
+		if (picW > sw) ox = clamp(ox + dx, sw - picW, 0);
+		if (picH > sh) oy = clamp(oy + dy, sh - picH, 0);
+		place(picW, picH);
+	}
+
+	// Zoom about a point on the screen -- the pointer, or the midpoint between
+	// two fingers -- so what is under them stays under them.
+	function zoomAt(factor, clientX, clientY) {
+		if (!frame || !placed) return;
+		const sw = stage.clientWidth, sh = stage.clientHeight;
+		const r = stage.getBoundingClientRect();
+		const px = clientX - r.left, py = clientY - r.top;
+		const fx = (px - ox) / (frame.w * scale), fy = (py - oy) / (frame.h * scale);
+
+		const kFit = Math.min(sw / frame.w, sh / frame.h);
+		const kFill = Math.max(sw / frame.w, sh / frame.h);
+		const next = clamp(scale * factor, Math.min(kFit, 1), Math.max(kFill, 1) * 3);
+		if (next === scale) return;
+		scale = next;
+		mode = 'free';
+
+		const picW = frame.w * scale, picH = frame.h * scale;
+		ox = picW <= sw ? (sw - picW) / 2 : clamp(px - fx * picW, sw - picW, 0);
+		oy = picH <= sh ? (sh - picH) / 2 : clamp(py - fy * picH, sh - picH, 0);
+
+		place(picW, picH);
+		annotate(sw, sh, picW, picH);
+		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+		syncRadios();
+	}
+
+	// ---- the control -------------------------------------------------------
+
+	function syncRadios() {
+		MODES.forEach((m) => {
+			const el = $(RADIOS[m]);
+			// .checked directly, never a dispatched change: this reflects a
+			// decision already taken, and firing the event would re-enter
+			// setMode and write a choice nobody made.
+			if (el) el.checked = (m === mode);
+		});
+	}
+
+	function setMode(m) {
+		mode = m;
+		write(KEY, m);
+		syncRadios();
+		layout();
+	}
+
+	MODES.forEach((m) => {
+		const el = $(RADIOS[m]);
+		if (el) el.addEventListener('change', () => { if (el.checked) setMode(m); });
+	});
+
+	// Unhidden only now: without this file the group would be three radios that
+	// do nothing, and the page is correct (and Fit) without it.
+	const ctl = $('#mj-view-ctl');
+	if (ctl) ctl.hidden = false;
+	syncRadios();
+
+	// ---- gestures ----------------------------------------------------------
+
+	// Pointer bookkeeping, because pinch needs two of them and a drag needs to
+	// know it is alone. A press that lands on the bar, the pad or a panel is an
+	// interaction with that control and never enters here -- preview-ptz.js
+	// takes pointer capture on its buttons, but this listener is on the stage
+	// and would otherwise see the event on the way up.
+	const pts = new Map();
+	let pinchDist = 0, pinchX = 0, pinchY = 0;
+	let lastType = 'mouse';
+
+	stage.addEventListener('pointerdown', (e) => {
+		lastType = e.pointerType;
+		if (e.button != null && e.button > 0) return;
+		if (e.target.closest && e.target.closest(CHROME)) return;
+		pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
+		if (pts.size === 1 && stage.classList.contains('mj-pannable')) {
+			try { stage.setPointerCapture(e.pointerId); } catch (err) {}
+			stage.classList.add('mj-panning');
+		}
+		if (pts.size === 2) pinchDist = 0;
+	});
+
+	stage.addEventListener('pointermove', (e) => {
+		const p = pts.get(e.pointerId);
+		if (!p) return;
+		const dx = e.clientX - p.x, dy = e.clientY - p.y;
+		p.x = e.clientX; p.y = e.clientY;
+
+		if (pts.size >= 2) {
+			const it = pts.values(), a = it.next().value, b = it.next().value;
+			const d = Math.hypot(a.x - b.x, a.y - b.y);
+			const mx = (a.x + b.x) / 2, my = (a.y + b.y) / 2;
+			if (pinchDist > 0 && d > 0) {
+				zoomAt(d / pinchDist, mx, my);
+				panBy(mx - pinchX, my - pinchY);
+			}
+			pinchDist = d; pinchX = mx; pinchY = my;
+			return;
+		}
+		panBy(dx, dy);
+	});
+
+	function endPointer(e) {
+		pts.delete(e.pointerId);
+		if (pts.size < 2) pinchDist = 0;
+		if (!pts.size) {
+			stage.classList.remove('mj-panning');
+			try { stage.releasePointerCapture(e.pointerId); } catch (err) {}
+		}
+	}
+	stage.addEventListener('pointerup', endPointer);
+	stage.addEventListener('pointercancel', endPointer);
+
+	// Wheel pans; ctrl+wheel zooms, which is also what a trackpad pinch sends.
+	// preventDefault only where the gesture was actually taken, so a browser
+	// that would have done something useful with it still can.
+	stage.addEventListener('wheel', (e) => {
+		if (e.target.closest && e.target.closest(CHROME)) return;
+		if (e.ctrlKey) {
+			zoomAt(Math.exp(-e.deltaY / 300), e.clientX, e.clientY);
+			e.preventDefault();
+			return;
+		}
+		if (!stage.classList.contains('mj-pannable')) return;
+		panBy(-e.deltaX, -e.deltaY);
+		e.preventDefault();
+	}, { passive: false });
+
+	// The gesture people try first. Pointer only: on a touch screen the first
+	// of the two taps has already toggled the control bar, and a control that
+	// answers to half of somebody else's gesture is worse than one that does
+	// not answer at all. The View group is the touch answer.
+	stage.addEventListener('dblclick', (e) => {
+		if (lastType === 'touch') return;
+		if (e.target.closest && e.target.closest(CHROME)) return;
+		setMode(mode === 'fill' ? 'fit' : 'fill');
+	});
+
+	// Arrows steer on a camera that has a pad -- that contract predates this
+	// file and keeps the plain keys. Where there is no pad they are free, so
+	// they pan; on a PTZ camera shift is what asks for the picture instead.
+	// Asked at event time, not at load: the pad is mounted by preview-ptz.js.
+	const KEYS = { ArrowUp: [0, 1], ArrowDown: [0, -1], ArrowLeft: [1, 0], ArrowRight: [-1, 0] };
+	function hasPad() {
+		const m = $('#mj-ptz');
+		return !!(m && m.querySelector('.mj-ptz-pad'));
+	}
+	stage.addEventListener('keydown', (e) => {
+		if (e.target !== stage) return;
+		const d = KEYS[e.key];
+		if (!d) return;
+		if (hasPad() && !e.shiftKey) return;
+		if (!stage.classList.contains('mj-pannable')) return;
+		e.preventDefault();
+		panBy(d[0] * 80, d[1] * 80);
+	});
+
+	// ---- what the page tells this module -----------------------------------
+
+	window.MajesticZoom = {
+		// The stream's real pixel size, from the player's codec report. A
+		// change of channel lands here too, and it drops a free zoom back to
+		// the remembered preset: a scale chosen by pinching a 3840-wide frame
+		// means nothing against a 704-wide one.
+		setFrame: function (w, h) {
+			if (!w || !h) return;
+			const changed = !frame || frame.w !== w || frame.h !== h;
+			frame = { w: w, h: h };
+			if (changed && mode === 'free') {
+				mode = MODES.indexOf(saved) >= 0 ? saved : 'fill';
+				syncRadios();
+			}
+			layout();
+		},
+
+		// For the chip, which prints it: Fill covers the window by enlarging
+		// the picture when the stream is smaller than the screen -- a 1080p
+		// main on a 1440p monitor is drawn at 133% -- and nobody should be left
+		// to conclude the camera went soft. 0 means "no frame yet", which the
+		// caller renders as nothing rather than as 0%.
+		scalePct: function () { return frame && placed ? Math.round(scale * 100) : 0; },
+
+		// The chip's own width decides whether the chrome fits on the picture,
+		// so a repaint of the chip can change the answer.
+		refresh: function () {
+			const sw = stage.clientWidth, sh = stage.clientHeight;
+			if (frame && placed && sw && sh) annotate(sw, sh, frame.w * scale, frame.h * scale);
+		},
+	};
+
+	// The stage, not the window: fullscreen resizes it without the viewport
+	// moving, and so does a banner appearing above it.
+	if (typeof ResizeObserver === 'function') {
+		try { new ResizeObserver(layout).observe(stage); } catch (e) {
+			window.addEventListener('resize', layout);
+		}
+	} else {
+		window.addEventListener('resize', layout);
+	}
+})();

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -32,7 +32,7 @@
 	const MODES = ['fit', 'fill', 'one'];
 	const RADIOS = { fit: '#mj-view-fit', fill: '#mj-view-fill', one: '#mj-view-one' };
 	// Where a press belongs to the control under it rather than to the picture.
-	const CHROME = '.mj-bar, .mj-ptz, #mj-stats, #mj-adapt, #mj-served';
+	const CHROME = '.mj-bar, .mj-ptz, #mj-stats, #mj-toasts';
 
 	function read(k) {
 		try { return localStorage.getItem(k); } catch (e) { return null; }
@@ -87,6 +87,12 @@
 		const badge = $('#mj-badge');
 		const cw = (badge && badge.offsetWidth) || 210;
 		const ch = (badge && badge.offsetHeight) || 30;
+		// Published for the toast stack, which hangs under the chip: the chip's
+		// height is not a constant -- "MJPEG" against "H265 3840×2160 · 25 fps ·
+		// 36% · Sub stream", which wraps to two lines on a phone -- so a toast
+		// at a fixed offset from the top of the stage is either crowding it or
+		// sitting on it.
+		if (ch) stage.style.setProperty('--mj-chip-h', ch + 'px');
 		const visW = Math.min(sw, picW), visH = Math.min(sh, picH);
 		// A picture too small to carry the chip without the chip dominating it
 		// hands the chrome back to the stage: a 390 x 219 phone in Fit, where

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -47,9 +47,24 @@
 	let scale = 1;         // the scale in force
 	let ox = 0, oy = 0;    // the picture's left/top inside the stage
 	let placed = false;    // has a layout run against a known frame
+	let onScale = null;    // who to tell when the scale moves
 
 	const saved = read(KEY);
 	if (MODES.indexOf(saved) >= 0) mode = saved;
+	// The preset a free zoom falls back to. It has to track setMode(), not the
+	// value read at startup: pick Fit, pinch, then change channel, and the
+	// startup value would put you back on whatever you were using yesterday.
+	let lastPreset = mode;
+
+	// The chip prints the scale, and the scale moves without the player saying
+	// anything — a preset, a pinch, a window resize. Over MSE the codec is
+	// reported once when the connection opens, so a chip repainted only by
+	// player events would carry the opening percentage for the whole session.
+	function announce(prev) {
+		if (onScale && prev !== scale) {
+			try { onScale(); } catch (e) {}
+		}
+	}
 
 	// ---- laying the picture out -------------------------------------------
 
@@ -123,13 +138,10 @@
 			cy = (sh / 2 - oy) / (frame.h * scale);
 		}
 
-		// Free zoom is bounded by what is worth looking at: no further out than
-		// the whole frame (or native, when the frame is smaller than the stage
-		// -- past that it is only black), no further in than 3x native. The
-		// presets are not clamped, because 1:1 means 1:1.
+		const prev = scale;
 		scale = mode === 'fit' ? kFit
 			: mode === 'one' ? 1
-			: mode === 'free' ? clamp(scale, Math.min(kFit, 1), Math.max(kFill, 1) * 3)
+			: mode === 'free' ? clamp(scale, zoomFloor(kFit), zoomCeiling(kFill))
 			: kFill;
 
 		const picW = frame.w * scale, picH = frame.h * scale;
@@ -140,7 +152,18 @@
 		place(picW, picH);
 		annotate(sw, sh, picW, picH);
 		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+		announce(prev);
 	}
+
+	// Free zoom is bounded by what is worth looking at. Out: no further than
+	// the whole frame, or native when the frame is smaller than the stage --
+	// past either it is only black. In: 3x native, EXCEPT that Fill itself can
+	// need more than that (a 704x576 substream on a 1440p monitor is 364%), and
+	// a bound below the preset in force would drag the picture back the moment
+	// you touched it. Not `kFill * 3`: that read the enlargement Fill already
+	// needed as the thing to triple, and offered 1092% on that substream.
+	function zoomFloor(kFit) { return Math.min(kFit, 1); }
+	function zoomCeiling(kFill) { return Math.max(kFill, 3); }
 
 	function panBy(dx, dy) {
 		if (!frame || !placed) return;
@@ -162,8 +185,9 @@
 
 		const kFit = Math.min(sw / frame.w, sh / frame.h);
 		const kFill = Math.max(sw / frame.w, sh / frame.h);
-		const next = clamp(scale * factor, Math.min(kFit, 1), Math.max(kFill, 1) * 3);
+		const next = clamp(scale * factor, zoomFloor(kFit), zoomCeiling(kFill));
 		if (next === scale) return;
+		const prev = scale;
 		scale = next;
 		mode = 'free';
 
@@ -175,6 +199,7 @@
 		annotate(sw, sh, picW, picH);
 		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
 		syncRadios();
+		announce(prev);
 	}
 
 	// ---- the control -------------------------------------------------------
@@ -191,9 +216,40 @@
 
 	function setMode(m) {
 		mode = m;
+		lastPreset = m;
 		write(KEY, m);
 		syncRadios();
 		layout();
+	}
+
+	// The stream's real pixel size. A change of channel lands here too, and it
+	// drops a free zoom back to the preset chosen most recently: a scale
+	// arrived at by pinching a 3840-wide frame means nothing against a
+	// 704-wide one.
+	function setFrame(w, h) {
+		if (!w || !h) return;
+		const changed = !frame || frame.w !== w || frame.h !== h;
+		frame = { w: w, h: h };
+		if (changed && mode === 'free') {
+			mode = lastPreset;
+			syncRadios();
+		}
+		layout();
+	}
+
+	// The MJPEG fallback is a different picture with its own resolution --
+	// jpeg.size is configured separately from video0.size -- and place() sizes
+	// every media element from one frame. Without this the fallback inherits
+	// the box computed for the video stream that just failed, so Fill leaves
+	// black bars and panning reaches places the image does not occupy. The
+	// stream is multipart and fires load per frame in some browsers, hence the
+	// dimension guard; hidden means preview-page.js has taken the stage back.
+	const mjpeg = $('#live-mjpeg');
+	if (mjpeg) {
+		mjpeg.addEventListener('load', () => {
+			if (mjpeg.style.display === 'none') return;
+			setFrame(mjpeg.naturalWidth, mjpeg.naturalHeight);
+		});
 	}
 
 	MODES.forEach((m) => {
@@ -308,20 +364,13 @@
 	// ---- what the page tells this module -----------------------------------
 
 	window.MajesticZoom = {
-		// The stream's real pixel size, from the player's codec report. A
-		// change of channel lands here too, and it drops a free zoom back to
-		// the remembered preset: a scale chosen by pinching a 3840-wide frame
-		// means nothing against a 704-wide one.
-		setFrame: function (w, h) {
-			if (!w || !h) return;
-			const changed = !frame || frame.w !== w || frame.h !== h;
-			frame = { w: w, h: h };
-			if (changed && mode === 'free') {
-				mode = MODES.indexOf(saved) >= 0 ? saved : 'fill';
-				syncRadios();
-			}
-			layout();
-		},
+		// The stream's real pixel size, from the player's codec report.
+		setFrame: setFrame,
+
+		// Called whenever the scale moves for a reason the player does not know
+		// about — a preset, a pinch, a resize. preview-page.js repaints the
+		// chip from it.
+		onScale: function (fn) { onScale = fn; },
 
 		// For the chip, which prints it: Fill covers the window by enlarging
 		// the picture when the stream is smaller than the screen -- a 1080p

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -595,6 +595,15 @@ preview() {
 		     looking at the numbers does not displace the picture they
 		     describe. -->
 		<div id="mj-stats" class="mj-stats-overlay small" hidden></div>
+		<!-- The toast stack. A flex column rather than two boxes at hardcoded
+		     offsets under the chip: the chip's height is not a constant (its
+		     text is "MJPEG" on one camera and "H265 3840×2160 · 25 fps · 36% ·
+		     Sub stream" on another, which wraps on a phone), so anything
+		     measured from the top of the stage sat too close to it or on top of
+		     it. preview-zoom.js publishes the chip's measured height and the
+		     stack starts below it; a hidden toast takes no room, so the served
+		     message moves up when there is no adaptation toast above it. -->
+		<div class="mj-toasts" id="mj-toasts">
 		<!-- The adaptation toast (preview-adapt.js): the whole disclosure of
 		     WebRTC's shared-encoder bitrate adaptation, made at the moment it
 		     acts rather than as a standing sentence (the always-on note this
@@ -622,6 +631,7 @@ preview() {
 			<span id="mj-served-why"></span>
 			<button type="button" class="mj-adapt-close" aria-label="Dismiss">×</button>
 		</p>
+		</div>
 		<!-- PTZ mount. Empty and hidden on every camera; p/motor.cgi (included
 		     by preview.cgi only when the hardware exists) emits the pad after
 		     the player and preview-ptz.js relocates it in here. -->

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -530,13 +530,27 @@ pre() {
 preview() {
 	cat <<EOF
 <div class="mj-player" id="mj-player">
-	<!-- The stage: everything lives ON the video. The wrapper reserves 16:9
-	     (preview-page.js corrects it to the stream's real ratio once known),
-	     so neither loading nor the stats panel nor the control bar ever moves
-	     the picture — the old layout stacked all of those above the video and
-	     opening Stats pushed a 4K frame below the fold. tabindex makes the
-	     stage itself focusable: that focus is what scopes PTZ arrow keys away
-	     from the volume slider and the radio groups in the bar. -->
+	<!-- The stage: everything lives ON the video, and the stage is the page.
+	     It takes the whole window under the navbar — no container, no card, no
+	     footer — because the picture is what this page is for, and the frame
+	     around it was costing a 4:3 sensor two thirds of a 1440p screen.
+
+	     It is a VIEWPORT, not a box that reserves the stream's shape:
+	     preview-zoom.js sizes and positions the picture inside it (Fill covers
+	     the window, Fit shows the whole frame, 1:1 shows real pixels) and pans
+	     whatever does not fit. Without that module the media keep their CSS
+	     `inset: 0` and `object-fit: contain`, which is Fit.
+
+	     tabindex makes the stage itself focusable: that focus is what scopes
+	     the PTZ arrow keys away from the volume slider and the radio groups in
+	     the bar. -->
+	<!-- --mj-pic-*: the insets of the picture inside the stage, written by
+	     preview-zoom.js so the chrome that ANNOTATES the picture (the chip, the
+	     stats panel, the toasts) sits on it rather than floating in a
+	     letterbox band beside it. Zero here so the page is right before — and
+	     without — that module. The bar and the PTZ pad deliberately do not read
+	     them: they are the player's furniture, not annotation, and furniture
+	     that jumps when you change zoom is worse than furniture on black. -->
 	<div class="mj-stage" id="mj-stage" tabindex="0" aria-label="Live video">
 		<!-- Two, and only ever one of them visible. A transport switch attaches
 		     the new player to whichever is idle and leaves the other playing, so
@@ -633,6 +647,32 @@ preview() {
 		     fullscreen button in this very bar already won, when U+26F6 came
 		     out as a box on real hardware. -->
 	<div class="mj-bar" id="mj-bar">
+			<!-- How the frame is fitted to the window. First in the bar, and that
+			     is not arbitrary: on a camera with an optical zoom the page
+			     carries two zooms, and this one must not sit next to the pad's
+			     Wide/Tele. The pad owns the lens, the stage owns the picture.
+
+			     Hidden until preview-zoom.js takes it: without that module the
+			     media elements keep their CSS `inset: 0` and `object-fit:
+			     contain`, which is exactly Fit — a working page with one fewer
+			     control rather than a control that does nothing.
+
+			     No caption above the group, like Stream and Transport beside it:
+			     a segmented picker's options say what it is, and aria-label says
+			     it for a screen reader. Only the stateful toggles carry a word,
+			     because a lit dot alone does not say what is lit. -->
+			<span class="mj-hud mj-seg" role="group" aria-label="View" id="mj-view-ctl" hidden>
+				<input type="radio" class="mj-seg-in" name="mj-view" id="mj-view-fit" autocomplete="off">
+				<label class="mj-seg-lbl" for="mj-view-fit"
+					title="The whole frame. Letterboxed where its shape does not match the window's.">Fit</label>
+				<input type="radio" class="mj-seg-in" name="mj-view" id="mj-view-fill" autocomplete="off" checked>
+				<label class="mj-seg-lbl" for="mj-view-fill"
+					title="Cover the window: no part of the screen is spent on black. Whatever does not fit is one drag away.">Fill</label>
+				<input type="radio" class="mj-seg-in" name="mj-view" id="mj-view-one" autocomplete="off">
+				<label class="mj-seg-lbl" for="mj-view-one"
+					title="One stream pixel per screen pixel — what to judge focus on.">1:1</label>
+			</span>
+
 			<span class="mj-hud mj-seg" role="group" aria-label="Stream">
 				<input type="radio" class="mj-seg-in" name="mj-stream" id="mj-stream-0" autocomplete="off" checked>
 				<label class="mj-seg-lbl" for="mj-stream-0">Main</label>

--- a/www/cgi-bin/p/footer.cgi
+++ b/www/cgi-bin/p/footer.cgi
@@ -1,5 +1,8 @@
+<% if [ -z "$full_bleed" ]; then %>
 </div>
+<% fi %>
 </main>
+<% if [ -z "$full_bleed" ]; then %>
 <footer class="x-small">
 <div class="container pt-3">
 <div class="row">
@@ -12,5 +15,6 @@
 </div>
 </div>
 </footer>
+<% fi %>
 </body>
 </html>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -126,6 +126,17 @@ Pragma: no-cache
 		</div>
 	</nav>
 
+<% if [ -n "$full_bleed" ]; then %>
+	<!-- A page that IS its content (preview.cgi, and so far only it). <main> is
+	     a flex column: this container holds whatever banners the camera has to
+	     raise and collapses to nothing when it has none, and the page body
+	     below it takes the rest of the window. Every reading the status strip
+	     carries is on the Dashboard, so none of it is lost by leaving it out.
+	     The heartbeat writes each of those through a `$('#…')` guard, so an
+	     absent strip and an absent footer are already accounted for. -->
+	<main class="mj-fullbleed">
+		<div class="container">
+<% else %>
 	<main class="pb-4">
 		<div class="container" style="min-height: 85vh">
 			<div class="row mt-1 x-small">
@@ -150,6 +161,7 @@ Pragma: no-cache
 					<div class="text-secondary" id="soc-temp"></div>
 				</div>
 			</div>
+<% fi %>
 
 <% if [ -z "$network_gateway" ]; then %>
 <div class="alert alert-warning">
@@ -182,3 +194,9 @@ Pragma: no-cache
 
 <% if [ -z "$hide_title" ]; then %><h2><%= $page_title %></h2><% fi %>
 <% log_read %>
+<% if [ -n "$full_bleed" ]; then %>
+	<!-- Banners and flash messages end here; what follows is the page body,
+	     which on a full-bleed page is a sibling of this container rather than
+	     a child of it, and takes the height the banners did not. -->
+	</div>
+<% fi %>

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -1,32 +1,37 @@
 #!/usr/bin/haserl
 <%in p/common.cgi %>
 
-<% page_title="Live View"; hide_title=1 %>
+<%
+# full_bleed asks header.cgi and footer.cgi for a page that IS its content: no
+# container, no status strip, no footer, and a body that is exactly the
+# viewport with the stage taking whatever the navbar and any banner leave.
+#
+# The strip goes because all four of its readings -- the memory and overlay
+# bars, the signature, the clock, the SoC temperature -- are on the Dashboard,
+# which is where somebody goes to read them; here they were a band of small
+# text between the menu and the picture. Only this page asks for it: the same
+# argument applies to the other twenty, but that is a different change.
+page_title="Live View"; hide_title=1; full_bleed=1
+%>
 <%in p/header.cgi %>
-<!-- No page heading: the nav underlines "Live", and the row the <h2> occupied
-     is exactly the row the player needs to fit a laptop viewport without
-     scrolling.
+<!-- No page heading: the nav underlines "Live", and a heading here would be a
+     row taken off the picture.
 
      This page is deliberately settings-free: it is the page every user of a
      future multi-user system gets, read-only, so nothing on it changes the
-     camera. Every setting — including the night/IR/light toggles that used
-     to sit here — lives in mj-settings.cgi, whose Live section pairs the
+     camera. Every setting -- including the night/IR/light toggles that used
+     to sit here -- lives in mj-settings.cgi, whose Live section pairs the
      same preview with the real-time adjustments. The one exception is the
      PTZ pad, which steers rather than configures; it stays on the video
-     until the multi-user split decides who may steer. -->
+     until the multi-user split decides who may steer.
 
+     No "Stream URLs" link either: it is a menu item under Camera, and a
+     second copy under the picture was the only body text on the page. -->
 
-<div class="row g-4">
-	<div class="col-12">
-		<div class="card"><div class="card-body">
-			<% preview %>
-			<% if [ -n "$ptz_support" ]; then %>
-				<%in p/motor.cgi %>
-			<% fi %>
-			<p class="small mb-0 mt-2"><a href="mj-endpoints.cgi">Stream URLs</a></p>
-		</div></div>
-	</div>
-</div>
+<% preview %>
+<% if [ -n "$ptz_support" ]; then %>
+	<%in p/motor.cgi %>
+<% fi %>
 
 <script src="/a/preview.js"></script>
 <script src="/a/preview-webrtc.js"></script>
@@ -37,6 +42,7 @@
 <script src="/a/preview-adapt.js"></script>
 <script src="/a/preview-stats.js"></script>
 <script src="/a/preview-page.js"></script>
+<script src="/a/preview-zoom.js"></script>
 <script src="/a/preview-hero.js"></script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -41,8 +41,13 @@ page_title="Live View"; hide_title=1; full_bleed=1
 <script src="/a/charts.js"></script>
 <script src="/a/preview-adapt.js"></script>
 <script src="/a/preview-stats.js"></script>
-<script src="/a/preview-page.js"></script>
+<!-- preview-zoom.js before preview-page.js, and that order is load-bearing:
+     the page registers a chip repaint with the module, so the module has to
+     exist by the time the page runs. The dependency is one-way and guarded --
+     the module needs nothing from the page, and the page checks before it
+     asks -- so a build missing either file still works. -->
 <script src="/a/preview-zoom.js"></script>
+<script src="/a/preview-page.js"></script>
 <script src="/a/preview-hero.js"></script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
Redesign of `/cgi-bin/preview.cgi`. The page frame decided how big the video was and the screen got no vote: `.container` capped the stage at 1320 px and the stage reserved the stream's shape inside it. On a 2560 × 1440 monitor an ssc30kq's 4:3 sensor drew at **1264 × 948** — 32 % of the screen, the sensor at 49 %, with 632 px of empty page on each side and 254 px below the card. Same window, same camera, now: **2560 × 1920 at 1:1**.

### The subtraction

`preview.cgi` sets `full_bleed=1`, and `p/header.cgi` / `p/footer.cgi` answer it with no container, no card, no status strip and no footer. `body#page-preview` is a `100dvh` flex column of navbar → banners → stage, so the stage takes what is left and the page never scrolls.

- The **status strip** goes because all four of its readings — the two usage bars, the signature, the clock, the SoC temperature — are on the Dashboard, and every heartbeat writer already guards its `$('#…')`.
- The **Stream URLs** line goes because it is a menu item under Camera.
- Only this page asks for it. The same argument applies to the other twenty, but that is a different change.

### The addition

`www/a/preview-zoom.js` makes the stage a viewport:

| | rule | |
|---|---|---|
| **Fill** (default) | `max(sw/fw, sh/fh)` | covers the window; the long axis pans |
| **Fit** | `min(…)` | the whole frame, letterboxed |
| **1:1** | `1` | real pixels, for judging focus |

Plus drag/wheel panning, pinch and ctrl+wheel free zoom, and double-click for Fit↔Fill. The choice is `mj-view-pick` in `localStorage` — one key, permanent, because nothing here demotes the view behind the viewer's back the way a failed transport does.

**Without the module the page is still right**: the media keep the stylesheet's `inset: 0` and `object-fit: contain`, which is exactly Fit, and the group stays `hidden`. `preview-page.js` knows it through two guarded calls, because that file runs in a bare `vm` in two of the tests.

Sensor shape needs no breakpoint and no special case — it only decides how much there is to drag.

### The chip prints the scale

Fill covers the window by enlarging a stream smaller than the screen: a 1080p main on a 1440p monitor is **133 %**, the 704 × 576 substream **364 %**. A soft picture with no number beside it reads as a soft camera.

### Two zooms, never one control

On a Pelco camera the pad's `Zoom · Wide/Tele` drives a motor — it changes the field of view for every viewer and for the recording, with no undo. So the pad owns the lens and the stage owns the picture: View leads the bar, the pad stays hard against the right edge, and **pinch never reaches the lens on any camera**. Arrows still steer where a pad exists and `shift`+arrows pan there; with no pad the plain arrows pan. `preview-hero.js`'s tap-to-toggle moves to `pointerup` with an 8 px threshold, or every drag would flash the bar at the start of it.

### What the chrome is anchored to

Chrome that *annotates* the picture — chip, stats panel, both toasts — follows it through `--mj-pic-{top,left,right}`, so a letterboxed view does not leave them floating in the black beside it. The bar and the pad do not: they are the player's furniture, and furniture that jumps when you change zoom is worse than furniture on a band (in Fit it also puts the pad in the gutter, covering nothing).

One exception, the chip's alone: a picture too small to carry it without it dominating hands the insets back to the stage — measured against the chip's own `offsetWidth`, not a constant. A 390 × 219 phone in Fit is that case; 1841 × 1381 with 359 px of gutter is not.

The **PTZ pad is back on the picture at every width**. It moved below the stage on a phone because that stage was 330 × 186; it is 390 × 785 now, where the pad covers 6 %, and there is no page below it to move onto. The margin reservations, the `:has()` guards and the corner-radius shuffle they needed go with it.

### Second commit: the toasts

Reported against the deployed page — the chip and the bandwidth notification sit on top of each other. They did, literally: the chip ends at 41 px and `.mj-adapt-toast` was at a hardcoded `top: 2.4rem` = 38.4. `#mj-toasts` is now a flex column hung under the chip at its *measured* height, a hidden toast takes no room, and the chip gained `max-width` — right-anchored in an `overflow: hidden` stage, an uncapped long line ran off the **left** edge and lost its first words.

### Verified

Ten window/sensor/view combinations measured in a browser against the shipped CSS and this module: 2560 × 1381 4:3 gives 2560 × 1920 at 100 % (Fill) and 1841 × 1381 at 72 % with 359 px gutters (Fit); a 1440 × 900 stage with a 16:9 frame letterboxes 45 px and puts `--mj-pic-top` at 45; a 390 × 219 picture forces the insets to 0 and a 700 × 394 one does not. Toast gaps hold at 8 px from 2560 px down to 320, and at 280 the chip wraps and the stack follows.

Rendered on an ssc30kq (2560 × 1920), with the other pages checked for the `header.cgi` / `footer.cgi` change. `npm test` and `tools/lint-templates.sh` pass; `bootstrap.min.css` regenerates with no diff.

### Two calls left open

1. **The portrait phone.** Fill on a 390 × 844 phone showing a 16:9 sensor is a 3.6× crop — 28 % of the frame width. Shipped as Fill-everywhere-remembered: one rule, one tap to change. The alternative is to open portrait phones on Fit, which is a rule with an exception in it.
2. **How far the status strip goes.** Live only, behind `full_bleed`. The eye-travel argument from #239 applies to the other pages too, but that is a different change with a different reviewer.