### PR TITLE
Live: zoom into a rectangle you draw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,19 @@ The journal is the one write whose failure **stops** the actuation — it is wha
   100%`): Fill covers the window by enlarging a stream smaller than the screen
   — a 1080p main on a 1440p monitor is 133%, the 704×576 substream 364% — and a
   soft picture with no number beside it reads as a soft camera.
-- **Zoom to an area is the discoverable zoom-in.** `#mj-area` arms one drag;
+- **A drag always does something, and which thing is decided by whether
+  anything is hidden.** `setAffordance()` sets `.mj-pannable` and
+  `.mj-drawable` — mutually exclusive by construction, since a picture with
+  nothing off-screen has nothing to pan. The stylesheet reads them for the
+  cursor (`grab` / `crosshair`) and the pointer handler reads them for the
+  gesture. So in **Fit** a drag draws a zoom rectangle with no control to visit
+  first, which is what makes Fit the state you can react from: see something
+  happen, drag a box round it, you are on it. Zooming in makes the picture
+  pannable, so the next drag moves it — the cursor changes at the same moment,
+  which is the disclosure.
+- **Zoom to an area is the discoverable zoom-in.** `#mj-area` arms one drag,
+  and is the way to draw a rectangle while the picture *is* pannable (where a
+  bare drag would move it instead);
   the rubber band is `#mj-marquee` (a single element — its 9999px box-shadow
   spread is what dims everything outside it), and on release `zoomToRect()`
   converts the rectangle to *frame* coordinates before changing the scale,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,31 @@ The journal is the one write whose failure **stops** the actuation — it is wha
   100%`): Fill covers the window by enlarging a stream smaller than the screen
   — a 1080p main on a 1440p monitor is 133%, the 704×576 substream 364% — and a
   soft picture with no number beside it reads as a soft camera.
+- **Zoom to an area is the discoverable zoom-in.** `#mj-area` arms one drag;
+  the rubber band is `#mj-marquee` (a single element — its 9999px box-shadow
+  spread is what dims everything outside it), and on release `zoomToRect()`
+  converts the rectangle to *frame* coordinates before changing the scale,
+  because stage pixels mean nothing across the change that is about to happen.
+  The scale falls out of the rectangle (`min(sw/fw, sh/fh)` with 8% padding,
+  through the same floor and ceiling as every other zoom), and the selection's
+  middle goes to the middle of the stage before the ordinary pan clamp pulls it
+  back — so a rectangle drawn in a corner lands in that corner. A drag under
+  `max(16px, 2% of the stage)` in either dimension is a slip, not a request, and
+  zooms nothing. It disarms after one drag: a mode you can forget you are in is
+  the wrong thing to leave over a picture that also steers a camera. Borrowed
+  from the QA video comparison in the sibling `rnd-player` (`docs/quality-compare.md`),
+  which draws the same rectangle for the same reason; the spotlight and the
+  persistent highlight are not, since this picture is live rather than paused.
+- **The wheel zooms, and used to pan.** Panning the overflowing axis is what a
+  Mac trackpad's two fingers want, but a mouse wheel is the only zoom a Windows
+  or Linux viewer has without knowing `ctrl`+wheel exists — and one input cannot
+  mean pan on a picture that overflows and zoom on one that does not without
+  changing meaning under the hand mid-gesture. Panning is the drag, on every
+  platform and on touch. `ctrl`+wheel is kept because that is what a trackpad
+  pinch sends. **Esc** is the way back out: armed, it disarms; free-zoomed, it
+  returns to the preset in force. Document-level, so it works wherever the
+  pointer went after the button was pressed; in fullscreen the browser takes it
+  first, which is the right precedence.
 - **Two zooms, and they never share a control, a label or a gesture.** On a
   Pelco camera the pad's `Zoom · Wide/Tele` drives a motor: it changes the
   field of view for every viewer and for the recording, with no undo. The View

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2109,6 +2109,28 @@ mark {
 	cursor: grabbing;
 }
 
+/* Zoom to an area. Armed, the whole stage is a crosshair — including where the
+   picture is pannable, because while the rectangle is being drawn that is what
+   the drag means. */
+.mj-stage.mj-armed,
+.mj-stage.mj-armed .mj-stage-media {
+	cursor: crosshair;
+}
+
+/* The rubber band. The 9999px shadow spread dims everything outside the
+   rectangle in one element rather than four, and the stage's overflow is what
+   trims it. pointer-events: none because the drag belongs to the stage — the
+   band is drawn under the pointer and must never become its target. */
+.mj-marquee {
+	position: absolute;
+	z-index: 6;
+	border: 1px dashed rgba(255, 255, 255, 0.9);
+	border-radius: 2px;
+	background: rgba(255, 255, 255, 0.06);
+	box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.45);
+	pointer-events: none;
+}
+
 .mj-stage-media {
 	position: absolute;
 	/* The fallback, and it is a real one: with no preview-zoom.js the media

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2109,11 +2109,15 @@ mark {
 	cursor: grabbing;
 }
 
-/* Zoom to an area. Armed, the whole stage is a crosshair — including where the
-   picture is pannable, because while the rectangle is being drawn that is what
-   the drag means. */
+/* Zoom to an area: a crosshair while the Area button is armed, and also
+   wherever the picture has nothing to pan — Fit, and Fill on a camera whose
+   shape matches the window. A drag there was doing nothing at all, which is
+   the one state where the picture is whole and the thing you want next is to
+   get closer to part of it. */
 .mj-stage.mj-armed,
-.mj-stage.mj-armed .mj-stage-media {
+.mj-stage.mj-armed .mj-stage-media,
+.mj-stage.mj-drawable,
+.mj-stage.mj-drawable .mj-stage-media {
 	cursor: crosshair;
 }
 

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -174,6 +174,46 @@
 		place(picW, picH);
 	}
 
+	// Zoom to a rectangle drawn on the picture. The scale falls out of the
+	// rectangle rather than being chosen, which is the point: a pinch is a
+	// trackpad gesture and a mouse has no equivalent, and neither of them lets
+	// you say WHICH part of the scene you meant.
+	//
+	// The rectangle is converted to frame coordinates first. Stage pixels mean
+	// nothing across a scale change, and the scale is about to change.
+	function zoomToRect(rx, ry, rw, rh) {
+		if (!frame || !placed || rw <= 0 || rh <= 0) return;
+		const sw = stage.clientWidth, sh = stage.clientHeight;
+		const fx = (rx - ox) / scale, fy = (ry - oy) / scale;
+		const fw = rw / scale, fh = rh / scale;
+
+		const kFit = Math.min(sw / frame.w, sh / frame.h);
+		const kFill = Math.max(sw / frame.w, sh / frame.h);
+		// A little room around the selection, so what was asked for is not
+		// flush against the edges of the window. Not much: drawing a rectangle
+		// is a request for that rectangle, and the sibling project's 20% puts
+		// a fifth of the screen back into context nobody asked to see.
+		const PAD = 1.08;
+		const prev = scale;
+		scale = clamp(Math.min(sw / (fw * PAD), sh / (fh * PAD)),
+			zoomFloor(kFit), zoomCeiling(kFill));
+		mode = 'free';
+
+		const picW = frame.w * scale, picH = frame.h * scale;
+		// The selection's middle goes to the middle of the stage, then the
+		// ordinary clamp pulls it back if that would show black. A rectangle
+		// drawn in a corner therefore lands in that corner, not off the edge.
+		const mx = fx + fw / 2, my = fy + fh / 2;
+		ox = picW <= sw ? (sw - picW) / 2 : clamp(sw / 2 - mx * scale, sw - picW, 0);
+		oy = picH <= sh ? (sh - picH) / 2 : clamp(sh / 2 - my * scale, sh - picH, 0);
+
+		place(picW, picH);
+		annotate(sw, sh, picW, picH);
+		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+		syncRadios();
+		announce(prev);
+	}
+
 	// Zoom about a point on the screen -- the pointer, or the midpoint between
 	// two fingers -- so what is under them stays under them.
 	function zoomAt(factor, clientX, clientY) {
@@ -261,6 +301,8 @@
 	// do nothing, and the page is correct (and Fit) without it.
 	const ctl = $('#mj-view-ctl');
 	if (ctl) ctl.hidden = false;
+	const areaCtl = $('#mj-area-ctl');
+	if (areaCtl) areaCtl.hidden = false;
 	syncRadios();
 
 	// ---- gestures ----------------------------------------------------------
@@ -274,10 +316,43 @@
 	let pinchDist = 0, pinchX = 0, pinchY = 0;
 	let lastType = 'mouse';
 
+	// Zoom-to-area. `armed` is the button's state; `band` is the drag in
+	// progress, in stage coordinates.
+	const areaBtn = $('#mj-area'), band = $('#mj-marquee');
+	let armed = false, drawing = null;
+
+	function setArmed(on) {
+		armed = !!on && !!band;
+		drawing = null;
+		if (band) band.hidden = true;
+		stage.classList.toggle('mj-armed', armed);
+		// The checkbox is the control's state, so it is written rather than
+		// asked -- Esc and the end of a drag both disarm without touching it.
+		if (areaBtn && areaBtn.checked !== armed) areaBtn.checked = armed;
+	}
+	if (areaBtn) areaBtn.addEventListener('change', () => setArmed(areaBtn.checked));
+
+	function bandRect(e) {
+		const r = stage.getBoundingClientRect();
+		const x = clamp(e.clientX - r.left, 0, r.width), y = clamp(e.clientY - r.top, 0, r.height);
+		return {
+			x: Math.min(drawing.x, x), y: Math.min(drawing.y, y),
+			w: Math.abs(x - drawing.x), h: Math.abs(y - drawing.y),
+		};
+	}
+
 	stage.addEventListener('pointerdown', (e) => {
 		lastType = e.pointerType;
 		if (e.button != null && e.button > 0) return;
 		if (e.target.closest && e.target.closest(CHROME)) return;
+
+		if (armed) {
+			const r = stage.getBoundingClientRect();
+			drawing = { x: e.clientX - r.left, y: e.clientY - r.top };
+			try { stage.setPointerCapture(e.pointerId); } catch (err) {}
+			return;
+		}
+
 		pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
 		if (pts.size === 1 && stage.classList.contains('mj-pannable')) {
 			try { stage.setPointerCapture(e.pointerId); } catch (err) {}
@@ -287,6 +362,15 @@
 	});
 
 	stage.addEventListener('pointermove', (e) => {
+		if (drawing) {
+			const b = bandRect(e);
+			band.hidden = false;
+			band.style.left = b.x + 'px';
+			band.style.top = b.y + 'px';
+			band.style.width = b.w + 'px';
+			band.style.height = b.h + 'px';
+			return;
+		}
 		const p = pts.get(e.pointerId);
 		if (!p) return;
 		const dx = e.clientX - p.x, dy = e.clientY - p.y;
@@ -307,6 +391,23 @@
 	});
 
 	function endPointer(e) {
+		if (drawing) {
+			const b = bandRect(e);
+			try { stage.releasePointerCapture(e.pointerId); } catch (err) {}
+			// A rectangle has to be deliberate. Below this it is a slip or a
+			// click, and zooming 40x into a stray 3px drag is the worst
+			// possible answer to one. The floor is a share of the stage with
+			// an absolute minimum, so it means the same thing on a 2560px
+			// monitor and a 390px phone.
+			const minW = Math.max(16, stage.clientWidth * 0.02);
+			const minH = Math.max(16, stage.clientHeight * 0.02);
+			if (b.w >= minW && b.h >= minH) zoomToRect(b.x, b.y, b.w, b.h);
+			// One drag, then it disarms itself: a mode you can forget you are
+			// in is the wrong thing to leave over a picture that also steers a
+			// camera.
+			setArmed(false);
+			return;
+		}
 		pts.delete(e.pointerId);
 		if (pts.size < 2) pinchDist = 0;
 		if (!pts.size) {
@@ -317,18 +418,16 @@
 	stage.addEventListener('pointerup', endPointer);
 	stage.addEventListener('pointercancel', endPointer);
 
-	// Wheel pans; ctrl+wheel zooms, which is also what a trackpad pinch sends.
-	// preventDefault only where the gesture was actually taken, so a browser
-	// that would have done something useful with it still can.
+	// The wheel zooms, about the pointer. It used to pan the overflowing axis,
+	// which is what a Mac trackpad's two fingers want -- but a mouse wheel is
+	// the only zoom a Windows or Linux viewer has without knowing that
+	// ctrl+wheel is a thing, and the same input cannot mean pan on a picture
+	// that overflows and zoom on one that does not without changing meaning
+	// under the hand mid-gesture. Panning is the drag, on every platform and on
+	// touch. ctrl+wheel is kept because that is what a trackpad pinch sends.
 	stage.addEventListener('wheel', (e) => {
 		if (e.target.closest && e.target.closest(CHROME)) return;
-		if (e.ctrlKey) {
-			zoomAt(Math.exp(-e.deltaY / 300), e.clientX, e.clientY);
-			e.preventDefault();
-			return;
-		}
-		if (!stage.classList.contains('mj-pannable')) return;
-		panBy(-e.deltaX, -e.deltaY);
+		zoomAt(Math.exp(-e.deltaY / (e.ctrlKey ? 300 : 500)), e.clientX, e.clientY);
 		e.preventDefault();
 	}, { passive: false });
 
@@ -359,6 +458,19 @@
 		if (!stage.classList.contains('mj-pannable')) return;
 		e.preventDefault();
 		panBy(d[0] * 80, d[1] * 80);
+	});
+
+	// Escape is the way back out, and it is on the document rather than the
+	// stage because arming is the closest thing this page has to a mode: it has
+	// to be cancellable from wherever the pointer went after the button was
+	// pressed. Armed, it disarms; free-zoomed, it returns to the preset in
+	// force -- which is what the View group would do, one key instead of aiming
+	// at a control that auto-hides. In fullscreen the browser takes the key
+	// first and this never runs, which is the right precedence.
+	document.addEventListener('keydown', (e) => {
+		if (e.key !== 'Escape') return;
+		if (armed) { setArmed(false); return; }
+		if (mode === 'free') setMode(lastPreset);
 	});
 
 	// ---- what the page tells this module -----------------------------------

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -347,12 +347,33 @@
 	}
 	if (areaBtn) areaBtn.addEventListener('change', () => setArmed(areaBtn.checked));
 
-	function bandRect(e) {
-		const r = stage.getBoundingClientRect();
-		const x = clamp(e.clientX - r.left, 0, r.width), y = clamp(e.clientY - r.top, 0, r.height);
+	// The visible picture, in stage coordinates. Under Fit — and under 1:1 on a
+	// frame smaller than the window — the rest of the stage is black, and a
+	// rectangle drawn on black is not a rectangle on the picture: converted to
+	// frame coordinates it comes out negative or past the far edge, and the
+	// clamp then lands the view on some edge as though that had been asked for.
+	// Where the picture overflows this is the whole stage and clamping to it
+	// does nothing.
+	function picRect() {
+		const sw = stage.clientWidth, sh = stage.clientHeight;
+		if (!frame || !placed) return { x: 0, y: 0, r: sw, b: sh };
 		return {
-			x: Math.min(drawing.x, x), y: Math.min(drawing.y, y),
-			w: Math.abs(x - drawing.x), h: Math.abs(y - drawing.y),
+			x: Math.max(0, ox), y: Math.max(0, oy),
+			r: Math.min(sw, ox + frame.w * scale),
+			b: Math.min(sh, oy + frame.h * scale),
+		};
+	}
+
+	// Both ends held inside the picture, so the band shows exactly what will be
+	// selected — and a drag that never leaves the letterbox collapses to
+	// nothing, which the minimum-size test then throws away.
+	function bandRect(e) {
+		const s = stage.getBoundingClientRect(), p = picRect();
+		const x = clamp(e.clientX - s.left, p.x, p.r), y = clamp(e.clientY - s.top, p.y, p.b);
+		const x0 = clamp(drawing.x, p.x, p.r), y0 = clamp(drawing.y, p.y, p.b);
+		return {
+			x: Math.min(x0, x), y: Math.min(y0, y),
+			w: Math.abs(x - x0), h: Math.abs(y - y0),
 		};
 	}
 
@@ -360,11 +381,15 @@
 		lastType = e.pointerType;
 		if (e.button != null && e.button > 0) return;
 		if (e.target.closest && e.target.closest(CHROME)) return;
+		// A rectangle belongs to the pointer that began it. A second finger
+		// arriving mid-drag is not a new origin, and it must not start a pan
+		// either.
+		if (drawing) return;
 
 		// Armed, or simply nothing to pan: either way the drag draws.
 		if (armed || stage.classList.contains('mj-drawable')) {
 			const r = stage.getBoundingClientRect();
-			drawing = { x: e.clientX - r.left, y: e.clientY - r.top };
+			drawing = { id: e.pointerId, x: e.clientX - r.left, y: e.clientY - r.top };
 			try { stage.setPointerCapture(e.pointerId); } catch (err) {}
 			return;
 		}
@@ -379,6 +404,7 @@
 
 	stage.addEventListener('pointermove', (e) => {
 		if (drawing) {
+			if (e.pointerId !== drawing.id) return;
 			const b = bandRect(e);
 			band.hidden = false;
 			band.style.left = b.x + 'px';
@@ -406,10 +432,16 @@
 		panBy(dx, dy);
 	});
 
-	function endPointer(e) {
-		if (drawing) {
-			const b = bandRect(e);
-			try { stage.releasePointerCapture(e.pointerId); } catch (err) {}
+	// `commit` is false for pointercancel: the browser took the gesture away —
+	// a system edge swipe, a device rotation, another element capturing the
+	// pointer — and a gesture that was interrupted is not a gesture that was
+	// completed. It cleans up and zooms nothing.
+	function finishDraw(e, commit) {
+		if (!drawing || e.pointerId !== drawing.id) return false;
+		const b = commit ? bandRect(e) : null;
+		try { stage.releasePointerCapture(e.pointerId); } catch (err) {}
+		drawing = null;
+		if (b) {
 			// A rectangle has to be deliberate. Below this it is a slip or a
 			// click, and zooming 40x into a stray 3px drag is the worst
 			// possible answer to one. The floor is a share of the stage with
@@ -418,12 +450,14 @@
 			const minW = Math.max(16, stage.clientWidth * 0.02);
 			const minH = Math.max(16, stage.clientHeight * 0.02);
 			if (b.w >= minW && b.h >= minH) zoomToRect(b.x, b.y, b.w, b.h);
-			// One drag, then it disarms itself: a mode you can forget you are
-			// in is the wrong thing to leave over a picture that also steers a
-			// camera.
-			setArmed(false);
-			return;
 		}
+		// One drag, then it disarms itself: a mode you can forget you are in is
+		// the wrong thing to leave over a picture that also steers a camera.
+		setArmed(false);
+		return true;
+	}
+
+	function endPointer(e) {
 		pts.delete(e.pointerId);
 		if (pts.size < 2) pinchDist = 0;
 		if (!pts.size) {
@@ -431,8 +465,8 @@
 			try { stage.releasePointerCapture(e.pointerId); } catch (err) {}
 		}
 	}
-	stage.addEventListener('pointerup', endPointer);
-	stage.addEventListener('pointercancel', endPointer);
+	stage.addEventListener('pointerup', (e) => { if (!finishDraw(e, true)) endPointer(e); });
+	stage.addEventListener('pointercancel', (e) => { if (!finishDraw(e, false)) endPointer(e); });
 
 	// The wheel zooms, about the pointer. It used to pan the overflowing axis,
 	// which is what a Mac trackpad's two fingers want -- but a mouse wheel is

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -122,6 +122,21 @@
 		set('--mj-pic-right', sw - (ox + picW));
 	}
 
+	// What a drag on the picture means, as two classes: the stylesheet reads
+	// them for the cursor and the pointer handler reads them for the gesture.
+	// They are mutually exclusive by construction, which is the whole idea --
+	// a picture with nothing hidden has nothing to pan, so the drag is free,
+	// and the useful thing to do with it is draw a rectangle to zoom into.
+	// That is what makes Fit the state you can react from: see something
+	// happen, drag a box round it, and you are on it, no control to visit
+	// first. Where the picture DOES overflow the drag is the pan, and the Area
+	// button is how you ask for a rectangle instead.
+	function setAffordance(sw, sh, picW, picH) {
+		const pannable = picW > sw + 1 || picH > sh + 1;
+		stage.classList.toggle('mj-pannable', pannable);
+		stage.classList.toggle('mj-drawable', placed && !pannable);
+	}
+
 	function layout() {
 		const sw = stage.clientWidth, sh = stage.clientHeight;
 		if (!frame || !frame.w || !frame.h || !sw || !sh) return;
@@ -151,7 +166,7 @@
 
 		place(picW, picH);
 		annotate(sw, sh, picW, picH);
-		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+		setAffordance(sw, sh, picW, picH);
 		announce(prev);
 	}
 
@@ -209,7 +224,7 @@
 
 		place(picW, picH);
 		annotate(sw, sh, picW, picH);
-		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+		setAffordance(sw, sh, picW, picH);
 		syncRadios();
 		announce(prev);
 	}
@@ -237,7 +252,7 @@
 
 		place(picW, picH);
 		annotate(sw, sh, picW, picH);
-		stage.classList.toggle('mj-pannable', picW > sw + 1 || picH > sh + 1);
+		setAffordance(sw, sh, picW, picH);
 		syncRadios();
 		announce(prev);
 	}
@@ -346,7 +361,8 @@
 		if (e.button != null && e.button > 0) return;
 		if (e.target.closest && e.target.closest(CHROME)) return;
 
-		if (armed) {
+		// Armed, or simply nothing to pan: either way the drag draws.
+		if (armed || stage.classList.contains('mj-drawable')) {
 			const r = stage.getBoundingClientRect();
 			drawing = { x: e.clientX - r.left, y: e.clientY - r.top };
 			try { stage.setPointerCapture(e.pointerId); } catch (err) {}

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -700,7 +700,7 @@ preview() {
 			<span class="mj-hud mj-tog-wrap" id="mj-area-ctl" hidden>
 				<input type="checkbox" class="mj-tog-in" id="mj-area" autocomplete="off">
 				<label class="mj-tog" for="mj-area" id="mj-area-lbl"
-					title="Draw a rectangle on the picture to enlarge that part of it. Esc cancels; Fit or Fill comes back out.">
+					title="Draw a rectangle on the picture to enlarge that part of it. Where nothing is hidden — Fit, mostly — you can just drag; this is for when the picture is already zoomed in and a drag would move it instead. Esc cancels; Fit or Fill comes back out.">
 					<span class="mj-led"></span>
 					<svg viewBox="0 0 20 20" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 						<rect x="3" y="4.4" width="14" height="11.2" rx="1.2" stroke-dasharray="3 2.2"></rect>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -632,6 +632,10 @@ preview() {
 			<button type="button" class="mj-adapt-close" aria-label="Dismiss">×</button>
 		</p>
 		</div>
+		<!-- The rubber band, while a zoom-to-area rectangle is being drawn.
+		     Its huge box-shadow spread is what dims everything outside it --
+		     one element instead of four, clipped by the stage. -->
+		<div id="mj-marquee" class="mj-marquee" hidden></div>
 		<!-- PTZ mount. Empty and hidden on every camera; p/motor.cgi (included
 		     by preview.cgi only when the hardware exists) emits the pad after
 		     the player and preview-ptz.js relocates it in here. -->
@@ -681,6 +685,29 @@ preview() {
 				<input type="radio" class="mj-seg-in" name="mj-view" id="mj-view-one" autocomplete="off">
 				<label class="mj-seg-lbl" for="mj-view-one"
 					title="One stream pixel per screen pixel — what to judge focus on.">1:1</label>
+			</span>
+
+			<!-- Zoom to an area you draw. The View presets and pinch already zoom,
+			     but pinch is a trackpad gesture and a mouse has nothing like it:
+			     ctrl+wheel works everywhere and is discoverable by nobody. This
+			     is the control that says out loud that the picture can be
+			     enlarged, and it is more precise than either -- you say which
+			     part, and the scale falls out of the rectangle.
+
+			     Armed rather than modal: one drag, then it disarms itself.
+			     A mode you can forget you are in is the wrong thing to put
+			     over a live picture that also steers a camera. -->
+			<span class="mj-hud mj-tog-wrap" id="mj-area-ctl" hidden>
+				<input type="checkbox" class="mj-tog-in" id="mj-area" autocomplete="off">
+				<label class="mj-tog" for="mj-area" id="mj-area-lbl"
+					title="Draw a rectangle on the picture to enlarge that part of it. Esc cancels; Fit or Fill comes back out.">
+					<span class="mj-led"></span>
+					<svg viewBox="0 0 20 20" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<rect x="3" y="4.4" width="14" height="11.2" rx="1.2" stroke-dasharray="3 2.2"></rect>
+						<path d="M10 7.6v4.8M7.6 10h4.8"></path>
+					</svg>
+					<span class="mj-tog-t">Area</span>
+				</label>
 			</span>
 
 			<span class="mj-hud mj-seg" role="group" aria-label="Stream">


### PR DESCRIPTION
Follow-up to #289.

The page could already zoom **out** — Fit is a button — and zoom **in** only by pinching, which is a trackpad gesture. A mouse has no equivalent: `ctrl`+wheel works in every browser and is discoverable by nobody. So a viewer on Windows or Linux had a picture that could be enlarged and no way to find out.

### Area

A new toggle in the player bar arms one drag. Draw a rectangle on the picture, release, and that part of it fills the window. It is more precise than either gesture, because the scale is not chosen at all — it falls out of the rectangle — and because you say *which* part of the scene you meant.

- The rectangle is converted to **frame coordinates** before anything moves: stage pixels mean nothing across a scale change, and the scale is about to change.
- Scale is `min(sw/fw, sh/fh)` with 8 % padding, through the same floor and ceiling as every other zoom here — so a tiny selection stops at 3× native rather than magnifying blur.
- The selection's middle goes to the middle of the stage and the ordinary pan clamp then pulls it back. That is what makes a rectangle drawn in a corner land in that corner instead of off the edge.
- A drag under `max(16px, 2% of the stage)` in either dimension is a slip, not a request, and zooms nothing. 40× into a stray 3 px drag is the worst possible reading of one.
- It **disarms after a single drag**. A mode you can forget you are in is the wrong thing to leave over a live picture that also steers a camera.

Borrowed from the QA video comparison in the sibling `rnd-player` (`docs/quality-compare.md`), which draws the same rectangle for the same reason. Its spotlight and persistent highlight are deliberately *not* borrowed: that picture is paused and this one is live, so dimming the rest of the scene past the end of the gesture would hide the thing being watched.

### The wheel now zooms

It used to pan the overflowing axis. That is what a Mac trackpad's two fingers want — but the wheel is the only zoom a mouse has, and one input cannot mean pan on a picture that overflows and zoom on one that does not without changing meaning under the hand mid-gesture. **Panning is the drag**, on every platform and on touch. `ctrl`+wheel stays, since that is what a trackpad pinch sends.

### Esc

Armed, it disarms. Free-zoomed, it returns to the preset in force — what the View group would do, without aiming at a control that auto-hides. On the document rather than the stage, because arming is the nearest thing this page has to a mode and has to be cancellable from wherever the pointer went. In fullscreen the browser takes the key first, which is the right precedence.

### Verified

In a browser against the real module — 800 × 600 frame in a 1000 × 500 stage:

| | result |
|---|---|
| selection of frame rect 200 × 150 | lands **600 × 450**, centred exactly on the stage centre |
| its scale | **300 %** — the ceiling, from a requested 309 % |
| on release | band hidden, button unchecked, disarmed |
| 3 px drag | geometry unchanged, still disarms |
| wheel from Fit (83 %) | 277 %, then **Esc → 83 %** with Fit still lit |

`npm test` and the template lint pass, `bootstrap.min.css` regenerates with no diff, and the page renders on the ssc30kq lab camera.