### PR TITLE
Live and Dashboard: the picture is the size it will be, from the first frame

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3567,6 +3567,14 @@ dialog.mj-modal::backdrop {
 	align-items: baseline;
 	gap: 0.75rem;
 	margin-bottom: 0.4rem;
+	/* The live readout beside the caption is empty until the first sample, and
+	   its line box is the taller of the two -- 0.8125rem monospace against the
+	   caption's 11px, both at 1.5 -- so the head grew 3px the moment a number
+	   landed in it, and the whole hero row with it. That was the last thing on
+	   the Dashboard still moving after the page had opened. Reserved from the
+	   readout's own size rather than from a measurement, so it tracks the rule
+	   below instead of recording what that rule produced one afternoon. */
+	min-height: calc(0.8125rem * 1.5);
 }
 
 .st-chart-head .st-now {
@@ -3605,10 +3613,24 @@ dialog.mj-modal::backdrop {
 }
 
 /* The camera itself. A fixed-ratio box: the snapshot may lag or be disabled,
-   and the row must not reflow around it either way. */
+   and the row must not reflow around it either way.
+
+   align-self is what makes that true, and it is not a tidy-up. A flex row's
+   default `align-items: stretch` gives its items a DEFINITE cross size, and a
+   definite cross size overrides `aspect-ratio` outright -- so the ratio
+   declared above held only for as long as this tile happened to be the tallest
+   thing on the row. Its rowmate is a chart that draws nothing until the
+   heartbeat has fed it a sample; when it arrived the row grew to 224px and
+   took the tile with it, and the camera picture changed shape a few seconds
+   after the page opened, from 16:9 to 1.64:1 with `object-fit: cover`
+   re-cropping it. Reserving the chart's height (charts.js) stops the row
+   moving, but only this stops the ratio being something the neighbours get a
+   vote on. The row is a picture beside a graph: the picture's shape is a fact
+   about the camera, and the graph is the elastic one. */
 .st-prev {
 	position: relative;
 	flex: 0 0 23rem;
+	align-self: start;
 	aspect-ratio: 16 / 9;
 	display: block;
 	border-radius: var(--bs-border-radius-lg);
@@ -3710,6 +3732,10 @@ dialog.mj-modal::backdrop {
 	.st-prev {
 		flex: 1 1 auto;
 		width: 100%;
+		/* Stacked, the row is a column and the cross axis is the horizontal
+		   one, where start would shrink the tile to its content. The width
+		   above already prevents that; this says so. */
+		align-self: stretch;
 	}
 }
 

--- a/www/a/charts.js
+++ b/www/a/charts.js
@@ -77,9 +77,27 @@ window.MjCharts = (function () {
 	// window is drawn as if it were recent.
 	const CHART_WINDOW = 120; // seconds of history on screen ("-2 min")
 	const CHART_GAP = 8;      // a hole longer than this breaks the line
+	// The plot's vertical furniture, hoisted out of renderChart so that the
+	// height a chart is GOING to draw at can be known before it has any samples
+	// to draw. Everything horizontal stays in there: it depends on the host's
+	// measured width, which is not knowable this early.
+	const PAD_T = 5;  // headroom above the top gridline
+	const X_BAND = 14; // the "-2 min / now" strip below the plot
+	function chartHeight(cfg) { return PAD_T + cfg.h + X_BAND; }
 	function makeChart(sel, cfg) {
 		const host = typeof sel === 'string' ? $(sel) : sel;
 		if (!host) return null;
+		// Reserve the height now. A chart draws nothing until it has been
+		// pushed a sample, which on the dashboard is one heartbeat away, so its
+		// box was 0px tall through the first seconds of the page and then
+		// sprang to its full height -- taking everything below it down the page
+		// and, on the Dashboard's hero row, stretching the camera tile out of
+		// the 16:9 it declares (a flex row's default `align-items: stretch`
+		// gives an item a definite cross size, which overrides `aspect-ratio`;
+		// the tile went 368x207 to 368x224 about four seconds in). The number
+		// is not a guess or a duplicate: it is the same arithmetic the render
+		// uses, so the reservation cannot drift from what lands in it.
+		host.style.minHeight = chartHeight(cfg) + 'px';
 		const ch = { host: host, cfg: cfg, pts: [] };
 		charts.push(ch);
 		return ch;
@@ -96,7 +114,7 @@ window.MjCharts = (function () {
 		const W = ch.host.clientWidth;
 		if (!W) return;
 		const cfg = ch.cfg;
-		const padL = 30, padR = 6, padT = 5, H = cfg.h, XB = 14;
+		const padL = 30, padR = 6, padT = PAD_T, H = cfg.h, XB = X_BAND;
 		const plotW = W - padL - padR;
 		const lo = cfg.lo;
 		let hi = cfg.hi;

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -307,6 +307,38 @@
 		});
 	}
 
+	// And the same thing for video, which is where it actually mattered. The
+	// size used to arrive only through preview-page.js's onCodec, and on the
+	// WebRTC path that is fed by the once-a-second getStats() poll -- so the
+	// picture was already on screen, in the stylesheet's inset:0/contain
+	// fallback, for up to a poll interval before anything laid it out.
+	// Measured on an av300 at 1600x900: loadedmetadata, resize and playing all
+	// at t=4752ms with videoWidth already 3840x2160, and the placement at
+	// t=5500ms -- 748ms of picture drawn as Fit and then jumping to Fill. (The
+	// MSE path never showed it: preview.js reports the codec from the init
+	// segment, before a frame exists.) The element knows its own size the
+	// moment it has one, so ask it instead of waiting to be told.
+	//
+	// Capture, because neither event bubbles -- but both pass through the
+	// stage on the way down -- and delegated rather than bound, because the
+	// media elements come and go: the MSE player replaces its <video> on every
+	// reconnect and the transport swap has two slots.
+	//
+	// The display guard is the swap's invariant, not tidiness: a trial attaches
+	// to the hidden slot and reports metadata there, and resizing the live
+	// picture to a channel nobody has agreed to yet is exactly what "nothing on
+	// screen changes until the replacement is known to work" forbids. The
+	// promotion carries its own report -- the stats tick that says `playing`
+	// is the one that names the size -- so nothing is lost by ignoring this.
+	function fromMedia(e) {
+		const el = e.target;
+		if (!el || !el.videoWidth) return;
+		if (getComputedStyle(el).display === 'none') return;
+		setFrame(el.videoWidth, el.videoHeight);
+	}
+	stage.addEventListener('loadedmetadata', fromMedia, true);
+	stage.addEventListener('resize', fromMedia, true);
+
 	MODES.forEach((m) => {
 		const el = $(RADIOS[m]);
 		if (el) el.addEventListener('change', () => { if (el.checked) setMode(m); });


### PR DESCRIPTION
Both the Dashboard and the Live page showed the camera at one size and changed
it a second or two later. Same symptom, two unrelated causes. Measured on a
hi3516av300 at 1600x900, 3840x2160 h264 main.

## Live — the size arrived a poll interval late

`preview-zoom.js` learned the frame size only through `preview-page.js`'s
`onCodec`, and on the **WebRTC** path that is fed by the once-a-second
`getStats()` poll (`inbound-rtp.frameWidth/frameHeight`). So the picture was
already on screen — drawn in the stylesheet's `inset: 0` / `object-fit: contain`
no-JS fallback, which is Fit — for up to a full poll interval before anything
laid it out:

```
t=4752ms  loadedmetadata + resize + playing   videoWidth already 3840x2160
t=5500ms  MajesticZoom places the picture     scale 42%
```

748 ms of picture at 1341x754 with letterbox bars, then a jump to 1600x900
filling the window. The MSE path never showed it: `preview.js` reports the
codec from the init-segment parse, so placement happens at `readyState 1` with
`currentTime` still 0, before a frame exists.

The element knows its own size the moment it has one, so ask it instead of
waiting to be told — a **capture-phase** `loadedmetadata`/`resize` listener on
the stage. Capture because neither event bubbles; delegated rather than bound
because the media elements come and go (the MSE player replaces its `<video>`
on every reconnect, and the transport swap has two slots).

The `display` guard is the swap's invariant rather than tidiness: a trial
attaches to the hidden slot and reports metadata there, and resizing the live
picture for a replacement nobody has agreed to yet is exactly what *nothing on
screen changes until the replacement is known to work* forbids. The promotion
carries its own report — the stats tick that says `playing` is the one that
names the size — so nothing is lost by ignoring it. It mirrors the `heldMedia`
gate `preview-page.js` already applies to the same report.

**After:** metadata at 4996 ms, placement at **4997 ms**.

## Dashboard — a flex row was overruling a declared ratio

`.st-prev` declares `aspect-ratio: 16 / 9`, and its comment states the intent:
*"A fixed-ratio box: the snapshot may lag or be disabled, and the row must not
reflow around it either way."* It did reflow. A flex row's default
`align-items: stretch` gives its items a **definite** cross size, and a
definite cross size overrides `aspect-ratio` outright — so the ratio held only
for as long as the tile happened to be the tallest thing on the row.

Its rowmate is a chart that draws nothing until the heartbeat has fed it a
sample. When it arrived the row grew to 224px and took the tile with it:
368x207 (1.778) to 368x224 (1.642), with `object-fit: cover` re-cropping the
snapshot. Confirmed by counterfactual in the live page — `align-items:
flex-start` on the row holds the tile at 207 while the panel alone grows.

Three changes:

- **`align-self: start` on `.st-prev`** — the declared ratio becomes the tile's
  own business rather than something its neighbours get a vote on. The tile now
  measures 368x207 at every sample from first paint onward.
- **`charts.js` reserves each host's height at `makeChart`** — every chart on
  the page was 0px tall until its first sample and then sprang to full height,
  taking everything below it down the page. The number is `PAD_T + cfg.h +
  X_BAND`, hoisted out of `renderChart`, so the reservation is the same
  arithmetic the render uses and cannot drift from what lands in it.
- **`min-height` on `.st-chart-head`** — the last 3px. The live readout beside
  the caption is empty until the first sample and its line box is the taller of
  the two (0.8125rem monospace against 11px, both at 1.5), so the head grew the
  moment a number landed in it.

## One deliberate trade

With `align-self: start` the tile is 17px shorter than the chart panel beside
it — a visible step at the bottom of the hero row. Letting it stretch keeps the
row flush but reintroduces a load-time shape change whenever the deferred
scripts execute after first paint, and a picture's shape should not be decided
by the graph next to it. Happy to swap it the other way if the step reads worse
than it measures.

Not closed here: the hero row still grows once when the deferred scripts run
after first paint on a slow camera. That is the ordinary `defer` race every
JS-filled panel on that page shares, and it no longer reaches the tile.

## Verification

On the lab av300, driving the real pages through CDP with a session cookie:

- Live, WebRTC: metadata 4996 ms, placement 4997 ms (was 748 ms apart). The
  first sample carrying a decoded frame already reads `box=1600x900 scale=42`.
- Live, MSE: unchanged — placed at `readyState 1`, `currentTime` 0, before any
  frame.
- A live WebRTC to MSE swap: scale holds at 42% across the promotion, the
  hidden trial moves nothing.
- Dashboard: `.st-prev` is 368.0x207.0 at every sample of a 14 s trace; the
  hero row reaches its height once and never moves again.
- `npm test` and `tools/lint-templates.sh` pass.
