### PR TITLE
Land on the picture, and hand the viewer on when there isn't one

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-stats.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
+    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/video-check.test.js
+++ b/tests/video-check.test.js
@@ -140,6 +140,15 @@ group('what it does say');
 		hold(st, sample({ venc_empty_frames_run: 40 }), 2), null);
 	check('a stalled encoder is a finding', !!stall && stall.code === 'stall');
 	check('and it offers a restart', !!stall && /fw-restart/.test(stall.act.href));
+	// The banner this replaced carried .confirm + data-confirm, which main.js
+	// wires at load — and the anchor it lands on now is written at runtime, so
+	// that wiring would never see it. The prompt travels with the action
+	// instead, or one click restarts the camera.
+	check('and restarting asks first',
+		!!stall && typeof stall.act.confirm === 'string' &&
+		/Restart the camera/.test(stall.act.confirm));
+	check('while a settings link does not ask',
+		!!off && !off.act.confirm);
 
 	const tr = vc.tracker();
 	const blind = vc.diagnose(BOTH_ON, sample(BLIND), hold(tr, sample(BLIND), 12), null);
@@ -166,7 +175,13 @@ group('what it does say');
 		{ blackS: 12 });
 	check('with both signals the sentence says both',
 		!!both && /picture is completely black/.test(both.detail) &&
-		/maximum\s+exposure and gain/.test(both.detail));
+		/longest\s+exposure/.test(both.detail));
+	// The predicate never looks at isp_again — the gain scale is vendor
+	// specific and has no portable ceiling — so no sentence may claim it.
+	// Stating an observation the code did not make is the same failure as
+	// convicting on a test that could not look.
+	check('and neither sentence claims anything about gain',
+		!!both && !/gain/.test(both.detail) && !!blind && !/gain/.test(blind.detail));
 }
 
 group('the picture alone, where the camera cannot say');

--- a/tests/video-check.test.js
+++ b/tests/video-check.test.js
@@ -1,0 +1,246 @@
+// "Is the camera seeing anything?" — the decision table.
+//
+// This exists for the reason ircut-check.test.js does: every branch renders a
+// confident sentence, so a wrong branch reads exactly like a right one, and
+// nothing here can be checked by looking at the page. Reaching the branches
+// that matter needs a camera booted on the wrong sensor driver — which is how
+// the numbers below were obtained, on a hi3516av300 flashed for an imx415 and
+// booted on imx335: isp_avelum 0 against 40, isp_again 32381 against 1024,
+// isp_exposureismax 1 against 0, and a stream that PLAYED, perfectly, in black.
+//
+// The stakes are not symmetric and the tests are weighted accordingly. A missed
+// finding leaves somebody looking at a black rectangle, which is where they
+// already were. A false one moves them off the page they asked for and tells
+// them their camera is broken when it is working — so most of what follows is
+// about the cases this must stay silent on.
+'use strict';
+
+const path = require('path');
+const { check, group, done } = require('./assert');
+
+const vc = require(path.join(__dirname, '..', 'www', 'a', 'video-check.js'));
+
+// A heartbeat sample as main.js publishes it, with only the keys diagnose()
+// reads. `up` defaults past the boot grace so a test has to opt into booting.
+function sample(v, opts) {
+	const o = opts || {};
+	return {
+		ok: o.ok === undefined ? true : o.ok,
+		fails: o.fails || 0,
+		mjUptimeS: o.up === undefined ? 600 : o.up,
+		night: o.night === undefined ? 0 : o.night,
+		m: { v: v || {} },
+	};
+}
+
+const BLIND = { isp_avelum: 0, isp_exposureismax: 1, isp_again: 32381 };
+const LIT = { isp_avelum: 40, isp_exposureismax: 0, isp_again: 1024 };
+const BOTH_ON = { video0: { enabled: true }, video1: { enabled: false } };
+
+// Drive the tracker for `secs` seconds of the same sample, one push a second,
+// and return the last push result.
+function hold(tr, s, secs, t0) {
+	let r = null;
+	for (let i = 0; i <= secs; i++) r = tr.push(s, (t0 || 0) + i);
+	return r;
+}
+function holdPic(tr, look, secs, t0) {
+	let r = 0;
+	for (let i = 0; i <= secs; i++) r = tr.picture(look, (t0 || 0) + i);
+	return r;
+}
+
+group('the picture statistic');
+{
+	check('a solid black frame reads black',
+		vc.look({ total: 14400, mean: 0, low: 1 }) === 'black');
+	check('an ordinary frame reads lit',
+		vc.look({ total: 14400, mean: 61, low: 0.02 }) === 'lit');
+	// Both halves are needed, and each rules out a different innocent frame.
+	check('a very dark scene with a spread of tones is not black',
+		vc.look({ total: 14400, mean: 1.4, low: 0.6 }) === 'lit',
+		'a low mean alone is a night scene');
+	check('a black frame with one bright lamp in it is not black',
+		vc.look({ total: 14400, mean: 9, low: 0.997 }) === 'lit',
+		'a high dark-bucket share alone is a lamp at night');
+	// null is not "lit". Nothing was measured, and the run length has to break
+	// rather than count it as disagreement.
+	check('a frame nothing could be measured from reads null',
+		vc.look({ total: 0, mean: 0, low: 0 }) === null);
+	check('no histogram at all reads null', vc.look(null) === null);
+}
+
+group("the camera's own opinion");
+{
+	check('wide open and metering nothing is blind', vc.ispBlind(BLIND) === true);
+	check('metering light is not blind', vc.ispBlind(LIT) === false);
+	// The one that matters for cross-vendor honesty: SigmaStar publishes no
+	// isp_avelum, and a camera that cannot answer must not be read as
+	// answering no.
+	check('a camera that does not publish isp_avelum answers null',
+		vc.ispBlind({ isp_exposureismax: 1 }) === null);
+	check('a camera that does not publish isp_exposureismax answers null',
+		vc.ispBlind({ isp_avelum: 0 }) === null);
+	check('no metrics at all answers null', vc.ispBlind({}) === null);
+}
+
+group('what it refuses to say');
+{
+	const tr = vc.tracker();
+	check('an unreachable camera produces no finding',
+		vc.diagnose(BOTH_ON, sample(BLIND, { ok: false }), { blindS: 99, blind: true }, null) === null);
+
+	const boot = vc.tracker();
+	const bootTrack = hold(boot, sample(BLIND, { up: 5 }), 20);
+	check('a camera that is still starting is never convicted',
+		vc.diagnose(BOTH_ON, sample(BLIND, { up: 5 }), bootTrack, null) === null,
+		'the ISP reads nothing while it converges');
+
+	// The whole false-positive class, in one line: the camera says it is
+	// metering light, so a dark-looking frame is a night scene and none of this
+	// code's business.
+	const lit = vc.tracker();
+	check('a camera that is metering light is left alone, black picture or not',
+		vc.diagnose(BOTH_ON, sample(LIT), hold(lit, sample(LIT), 60), { blackS: 999 }) === null);
+
+	const brief = vc.tracker();
+	check('a couple of seconds of darkness is not a finding',
+		vc.diagnose(BOTH_ON, sample(BLIND), hold(brief, sample(BLIND), 3), null) === null,
+		'BLIND_S is ' + vc.BLIND_S + 's');
+
+	// mjConfig() resolves {} when the fetch failed. An absent key must decline
+	// to answer, not read as a disabled channel.
+	check('a config that never arrived does not report the channels off',
+		vc.diagnose({}, sample(LIT), { blindS: 0, blind: false }, null) === null);
+	check('one channel on is not both channels off',
+		vc.diagnose({ video0: { enabled: false }, video1: { enabled: true } },
+			sample(LIT), { blindS: 0, blind: false }, null) === null);
+}
+
+group('what it does say');
+{
+	const off = vc.diagnose({ video0: { enabled: false }, video1: { enabled: false } },
+		sample(LIT), { blindS: 0, blind: false }, null);
+	check('both channels off is a finding', !!off && off.code === 'off');
+	check('and it is a configuration fault, not a hardware one',
+		!!off && off.where === 'config');
+	check('and it acts on the video settings',
+		!!off && /tab=video0/.test(off.act.href));
+	// A switch being off is not something to go and read a log about.
+	check('and it does not send anybody to the logs',
+		!!off && !off.help);
+	// True from the first sample: nothing about it needs time to establish, and
+	// it holds even on a camera that has only just booted.
+	const offBooting = vc.diagnose({ video0: { enabled: false }, video1: { enabled: false } },
+		sample(LIT, { up: 2 }), { blindS: 0, blind: false }, null);
+	check('and the boot grace does not delay it', !!offBooting && offBooting.code === 'off');
+
+	const st = vc.tracker();
+	const stall = vc.diagnose(BOTH_ON, sample({ venc_empty_frames_run: 40 }),
+		hold(st, sample({ venc_empty_frames_run: 40 }), 2), null);
+	check('a stalled encoder is a finding', !!stall && stall.code === 'stall');
+	check('and it offers a restart', !!stall && /fw-restart/.test(stall.act.href));
+
+	const tr = vc.tracker();
+	const blind = vc.diagnose(BOTH_ON, sample(BLIND), hold(tr, sample(BLIND), 12), null);
+	check('a camera reading no light is a finding', !!blind && blind.code === 'blind');
+	check('and it is a camera fault', !!blind && blind.where === 'camera');
+	check('and it names the wrong sensor driver first',
+		!!blind && /wrong sensor driver/.test(blind.detail),
+		'this page is reached minutes after somebody flashed a camera');
+	check('and it never states a cause it cannot prove',
+		!!blind && /lens cap/.test(blind.detail) && /no light in it/.test(blind.detail));
+	// The camera is not something its owner can repair from a settings page,
+	// so the finding also points at the one artefact worth screenshotting for
+	// whoever sold it to them.
+	check('and a hardware fault offers the logs',
+		!!blind && !!blind.help && /info-logs/.test(blind.help.href));
+	check('the stalled encoder offers them too',
+		!!stall && !!stall.help && /info-logs/.test(stall.help.href));
+
+	// Both signals agreeing gets its own sentence, because it is a stronger
+	// claim than either alone.
+	const tr2 = vc.tracker();
+	holdPic(tr2, 'black', 12);
+	const both = vc.diagnose(BOTH_ON, sample(BLIND), hold(tr2, sample(BLIND), 12),
+		{ blackS: 12 });
+	check('with both signals the sentence says both',
+		!!both && /picture is completely black/.test(both.detail) &&
+		/maximum\s+exposure and gain/.test(both.detail));
+}
+
+group('the picture alone, where the camera cannot say');
+{
+	// A SigmaStar-shaped camera: no isp_avelum, so ispBlind() is null and only
+	// the decoded frame is left.
+	const tr = vc.tracker();
+	const t = hold(tr, sample({ venc0_rcvd_bytes: 5 }), 12);
+	const f = vc.diagnose(BOTH_ON, sample({ venc0_rcvd_bytes: 5 }), t, { blackS: 12 });
+	check('a black picture alone is still a finding', !!f && f.code === 'blind');
+	check('but the sentence admits the cause is not certain',
+		!!f && /not certain/.test(f.detail));
+	// The strongest action is not taken on the weaker evidence.
+	check('and it is not conclusive, so nobody is moved off the page',
+		!!f && f.conclusive === false);
+}
+
+group('what may move somebody off the Live page');
+{
+	const tr = vc.tracker();
+	const day = vc.diagnose(BOTH_ON, sample(BLIND), hold(tr, sample(BLIND), 12), null);
+	check('a blind camera in daylight is conclusive', !!day && day.conclusive === true);
+
+	// A night camera with no illuminator is genuinely dark and genuinely fine,
+	// and it fixes itself at dawn.
+	const tn = vc.tracker();
+	const night = vc.diagnose(BOTH_ON, sample(BLIND, { night: 1 }),
+		hold(tn, sample(BLIND, { night: 1 }), 12), null);
+	check('the same camera at night is reported but not acted on',
+		!!night && night.code === 'blind' && night.conclusive === false);
+
+	// "An absent reading is not a zero" — a camera that does not publish
+	// night_enabled has not told us it is day.
+	const tu = vc.tracker();
+	const unknown = vc.diagnose(BOTH_ON, sample(BLIND, { night: null }),
+		hold(tu, sample(BLIND, { night: null }), 12), null);
+	check('a camera that does not report day or night is not acted on either',
+		!!unknown && unknown.code === 'blind' && unknown.conclusive === false);
+}
+
+group('runs are broken by gaps, not carried across them');
+{
+	// The bug this shape exists to prevent: an unreachable camera billing the
+	// whole offline stretch as darkness nobody was watching.
+	const tr = vc.tracker();
+	hold(tr, sample(BLIND), 8, 0);
+	tr.push(sample(BLIND, { ok: false }), 9);
+	const after = tr.push(sample(BLIND), 100);
+	check('an unreachable sample restarts the blind run',
+		after.blindS === 0, 'got ' + after.blindS);
+
+	const lit = vc.tracker();
+	hold(lit, sample(BLIND), 8, 0);
+	lit.push(sample(LIT), 9);
+	const back = lit.push(sample(BLIND), 10);
+	check('a camera that meters light again restarts the run',
+		back.blindS === 0, 'got ' + back.blindS);
+
+	// The picture sampler stops while the tab is hidden and says so by not
+	// calling. The next frame after that must not bill the gap.
+	const pic = vc.tracker();
+	holdPic(pic, 'black', 8, 0);
+	const resumed = pic.picture('black', 8 + vc.PIC_GAP_S + 5);
+	check('a gap in the picture samples restarts the black run',
+		resumed === 0, 'got ' + resumed);
+	const contiguous = pic.picture('black', 8 + vc.PIC_GAP_S + 6);
+	check('and it starts counting again from the frame that resumed it',
+		contiguous === 1, 'got ' + contiguous);
+
+	const unk = vc.tracker();
+	holdPic(unk, 'black', 8, 0);
+	const broke = unk.picture(null, 9);
+	check('a frame nothing could be measured from breaks the run',
+		broke === 0, 'a picture that stopped agreeing is not one that still agrees a bit');
+}
+
+done();

--- a/www/a/preview-health.js
+++ b/www/a/preview-health.js
@@ -109,6 +109,12 @@
 		if (alertAct) {
 			alertAct.textContent = f.act.label + ' →';
 			alertAct.href = f.act.href;
+			// Assigned rather than added, so a repaint replaces the prompt
+			// instead of stacking another one. See the same line in status.js:
+			// main.js wires `.confirm` at load and this link is written later.
+			alertAct.onclick = f.act.confirm
+				? (ev) => { if (!confirm(f.act.confirm)) ev.preventDefault(); }
+				: null;
 		}
 		if (alertHelp) {
 			alertHelp.hidden = !f.help;

--- a/www/a/preview-health.js
+++ b/www/a/preview-health.js
@@ -1,0 +1,145 @@
+// The Live page's answer to a camera that has nothing to show.
+//
+// This page is where a newly claimed camera now lands, which means it is where
+// a camera that came up wrong is first met -- and the commonest way that
+// happens is invisible to every part of the player: majestic runs, the stream
+// negotiates, the picture plays, and the picture is black (video-check.js
+// carries the measurements). Nothing in the fallback chain fires, because
+// nothing failed. So the disclosure cannot come from the player; it has to come
+// from looking at what the player is showing.
+//
+// Both signals are already on the wire. The camera's own exposure gauges ride
+// the /metrics heartbeat main.js polls every 2s on every page, and the picture
+// is decoded in the <video> element, where mj-luma.js reads a 160x90 thumbnail
+// off a canvas -- the same trick the Live adjustments histogram uses, for the
+// same reason: it costs the camera nothing and there is no endpoint to add.
+// Nothing here polls anything of its own.
+//
+// A separate file from preview-page.js because that file is executed in a bare
+// `vm` by tests/auto-source.test.js and tests/staging.test.js, and everything
+// below touches `location`, `sessionStorage` and the heartbeat. It needs
+// nothing from preview-page.js in return: the visible media element is found
+// on the stage, so the two never speak.
+(function () {
+	'use strict';
+
+	const stage = document.getElementById('mj-stage');
+	const VC = window.MajesticVideoCheck;
+	if (!stage || !VC) return;
+
+	// Where a hand-off is remembered. Per tab, and the reason it exists is the
+	// Back button: without it, Back from the Dashboard lands here, finds the
+	// same fault, and bounces straight off again -- a viewer could never reach
+	// the Live page of a camera with a dark picture. Spent once, this page
+	// states the finding and stays put.
+	const ONCE = 'mj-novideo';
+	function seen() {
+		try { return sessionStorage.getItem(ONCE) !== null; } catch (e) { return false; }
+	}
+	function mark(code) {
+		try { sessionStorage.setItem(ONCE, code); } catch (e) {}
+	}
+
+	const alertEl = document.getElementById('mj-blind');
+	const alertWhy = document.getElementById('mj-blind-why');
+	const alertAct = document.getElementById('mj-blind-act');
+	const alertHelp = document.getElementById('mj-blind-help');
+
+	let cfg = {};
+	if (typeof mjConfig === 'function') {
+		mjConfig().then((c) => { cfg = c || {}; }).catch(() => {});
+	}
+
+	const track = VC.tracker();
+	let trackNow = { blindS: 0, blind: null };
+	let picNow = null;
+	let shown = null;
+	// Declared with everything else it is read beside, not next to the
+	// subscription below: MajesticLuma.start() samples once synchronously, so
+	// decide() can run before the bottom of this file has been evaluated, and a
+	// `let` down there would still be in its dead zone when it did.
+	let lastSample = null;
+
+	function now() { return performance.now() / 1000; }
+
+	// The media elements come and go -- the MSE player replaces its <video> on
+	// every reconnect and the transport swap keeps two slots -- so the visible
+	// one is re-queried rather than held, exactly as preview-zoom.js does. A
+	// held reference is a detached node within a session, and a detached node
+	// samples black for ever.
+	function visibleMedia() {
+		const els = stage.querySelectorAll('.mj-stage-media');
+		for (let i = 0; i < els.length; i++) {
+			const e = els[i];
+			if (e.tagName === 'IMG') continue; // the MJPEG fallback is jpeg.size, not the stream
+			if (getComputedStyle(e).display !== 'none') return e;
+		}
+		return null;
+	}
+
+	if (window.MajesticLuma) {
+		// 1 Hz. The run this feeds is ten seconds long, so ten samples decide
+		// it; four a second would buy nothing but readbacks.
+		window.MajesticLuma.start({
+			video: visibleMedia,
+			hz: 1,
+			onData: function (h) {
+				picNow = { blackS: track.picture(VC.look(h), now()) };
+				decide();
+			},
+		});
+	}
+
+	function render(f) {
+		// Toggled rather than rebuilt: the sentence is long, and re-writing it
+		// every two seconds would restart a screen reader part-way through
+		// reading it out. Keyed on the WORDS and not on the finding's code,
+		// because one code has several sentences — the exposure gauges reach a
+		// verdict before the picture run does, so a `blind` finding that starts
+		// as "the sensor reports no light" becomes "the picture is black AND
+		// the sensor reports no light" a few seconds later. Keyed on the code
+		// alone that upgrade never landed, and the page went on stating the
+		// weaker half of what it knew.
+		const key = f && (f.code + f.detail);
+		if (shown === key) return;
+		shown = key;
+		if (!alertEl) return;
+		if (!f) { alertEl.style.display = 'none'; return; }
+		if (alertWhy) alertWhy.textContent = f.title + ' — ' + f.detail;
+		if (alertAct) {
+			alertAct.textContent = f.act.label + ' →';
+			alertAct.href = f.act.href;
+		}
+		if (alertHelp) {
+			alertHelp.hidden = !f.help;
+			if (f.help) {
+				alertHelp.textContent = f.help.label + ' →';
+				alertHelp.href = f.help.href;
+			}
+		}
+		alertEl.style.display = '';
+	}
+
+	function decide() {
+		const f = VC.diagnose(cfg, lastSample, trackNow, picNow);
+		render(f);
+		if (!f || !f.conclusive || seen()) return;
+		// Not while nobody is looking. A background tab that navigates itself
+		// is a tab whose Back history the viewer never agreed to, and the
+		// finding will still be here -- and still true -- when they return.
+		if (document.hidden) return;
+		mark(f.code);
+		// replace(), not assign(): this page would decide the same thing again
+		// on the way back, and leaving it in history as an entry that
+		// re-triggers is the trap the one-shot above exists to close.
+		location.replace('status.cgi?novideo=' + encodeURIComponent(f.code));
+	}
+
+	if (typeof mjMetricsSubscribe === 'function') {
+		mjMetricsSubscribe(function (s) {
+			lastSample = s;
+			trackNow = track.push(s, now());
+			decide();
+		});
+	}
+})();

--- a/www/a/preview-wasm.js
+++ b/www/a/preview-wasm.js
@@ -94,6 +94,11 @@ window.MajesticWasm = (function () {
 			dead = true;
 			if (statsTimer) { clearInterval(statsTimer); statsTimer = null; }
 			if (worker) { try { worker.terminate(); } catch (e) {} worker = null; }
+			// The worker is gone but its last frame stays on the canvas, and a
+			// frozen frame is not a measurement of anything current. Withdraw
+			// the claim rather than leave whatever is sampling it reading a
+			// still picture as live evidence.
+			try { el.__mjPainted = false; } catch (e) {}
 			if (reason) onState('mjpeg', reason);
 		}
 
@@ -128,7 +133,24 @@ window.MajesticWasm = (function () {
 				const m = e.data;
 				if (m.type === 'state') {
 					if (m.state === 'mjpeg') die(m.detail || 'decoder-error');
-					else onState(m.state, m.detail);
+					else {
+						// Whoever paints a canvas is the only one who can say
+						// it has been painted, and here that is a worker
+						// holding an OffscreenCanvas: the main thread never
+						// sees a frame land, and the placeholder element is
+						// 300x150 and blank-looking from the moment it exists.
+						// mj-luma.js reads this expando before it will measure
+						// a canvas, and without it anything sampling the
+						// software-decode rung silently measures nothing --
+						// which for the black-picture check is the difference
+						// between "no fault" and "never looked".
+						//
+						// 'playing' is the claim, because that is already what
+						// this contract means by it: the swap puts the canvas
+						// on screen on the strength of the same message.
+						if (m.state === 'playing') el.__mjPainted = true;
+						onState(m.state, m.detail);
+					}
 				} else if (m.type === 'codec') {
 					onCodec('h265', '', m.width, m.height);
 				} else if (m.type === 'stats' && onStats) {

--- a/www/a/status.js
+++ b/www/a/status.js
@@ -96,7 +96,18 @@
 			const a = $('#st-alert-novideo-a');
 			if (t) t.textContent = f.title;
 			if (d) d.textContent = f.detail;
-			if (a) { a.textContent = f.act.label + ' →'; a.href = f.act.href; }
+			if (a) {
+				a.textContent = f.act.label + ' →';
+				a.href = f.act.href;
+				// Assigned, not added: this anchor is rewritten on every
+				// finding and addEventListener would stack a prompt per
+				// repaint. main.js cannot help here — it wires `.confirm` once
+				// at load and this link does not exist in its final form until
+				// long after.
+				a.onclick = f.act.confirm
+					? (ev) => { if (!confirm(f.act.confirm)) ev.preventDefault(); }
+					: null;
+			}
 			const h = $('#st-alert-novideo-h');
 			if (h) {
 				h.hidden = !f.help;
@@ -461,15 +472,23 @@
 
 	function onSample(s) {
 		if (!s.ok) {
+			// Tracking consumes EVERY sample, failures included, and is not
+			// inside the two-failure gate below. The blind run is a duration
+			// measured from when it started, so a poll that is merely skipped
+			// leaves the clock running: one failed heartbeat in the middle of a
+			// dark stretch would have had the next good sample bill the whole
+			// outage as blindness nobody watched, and ten seconds of that is a
+			// finding. An unreachable camera is not a camera reporting
+			// darkness — the same reasoning as the IR-cut tracker's.
+			if (vidTrack) vidTrackNow = vidTrack.push(s, performance.now() / 1000);
+			// What is DISPLAYED still waits for the second failure, so a single
+			// dropped poll does not flap a banner off and on again.
+			//
 			// With no current data there is no evidence the condition alerts
 			// still hold — clear them rather than presenting the last good
 			// sample's warnings as current next to "not responding".
 			if (s.fails >= 2) {
 				setAlert('#st-alert-exp', false);
-				// Same reasoning as the IR-cut line below: an unreachable
-				// camera is not a camera reporting darkness, so the run is
-				// broken rather than carried across the gap.
-				if (vidTrack) vidTrackNow = vidTrack.push(s, performance.now() / 1000);
 				renderNoVideo(s);
 				// Not cleared, narrowed: an unset irCutPin1 is still unset
 				// while the camera is unreachable, but a day/night

--- a/www/a/status.js
+++ b/www/a/status.js
@@ -51,8 +51,72 @@
 		const el = $(id);
 		if (el) el.hidden = !on;
 		const box = $('#st-alerts');
-		if (box) box.hidden = !['#st-alert-stale', '#st-alert-exp', '#st-alert-stall', '#st-alert-ircut']
+		if (box) box.hidden = !['#st-alert-stale', '#st-alert-exp', '#st-alert-novideo',
+			'#st-alert-wasnovideo', '#st-alert-ircut']
 			.some(a => { const e = $(a); return e && !e.hidden; });
+	}
+
+	// ── nothing to see ──────────────────────────────────────────────────────
+	// The verdict is in /a/video-check.js; this only decides what the dashboard
+	// says out loud, the same split as the IR-cut banner below. No picture is
+	// measured here — the Dashboard has no decoded frame, only a snapshot in a
+	// tile — so the finding rests on the camera's own exposure gauges alone,
+	// and on a camera that does not publish them there is simply no finding.
+	// That is the honest answer rather than a gap: it is the Live page, which
+	// has the frame, that can still tell.
+	const VC = window.MajesticVideoCheck;
+	const vidTrack = VC ? VC.tracker() : null;
+	let vidTrackNow = { blindS: 0, blind: null };
+	// Set by the Live page's hand-off. Cleared the moment a finding renders —
+	// the banner then IS the explanation and two of them would be one too many.
+	let cameFromLive = false;
+	try {
+		cameFromLive = new URLSearchParams(location.search).has('novideo');
+	} catch (e) {}
+	// Its own copy rather than a read of nmCfg: that one is narrowed to
+	// .nightMode, and diagnose() asks about the video channels. {} is the right
+	// starting value — every test in there is `=== false`, so an unfetched
+	// config declines to answer instead of reporting both channels off.
+	let cfgNow = {};
+	// When this page first heard from the camera, so the all-clear above can
+	// tell "checked and found nothing" from "has not looked yet".
+	let vidFirstS = null;
+	if (VC && typeof mjConfig === 'function') {
+		mjConfig().then(c => {
+			if (c && Object.keys(c).length) cfgNow = c;
+		}).catch(() => {});
+	}
+
+	function renderNoVideo(s) {
+		if (!VC) return;
+		const f = VC.diagnose(cfgNow, s, vidTrackNow, null);
+		if (f) {
+			cameFromLive = false;
+			const t = $('#st-alert-novideo-t'), d = $('#st-alert-novideo-d');
+			const a = $('#st-alert-novideo-a');
+			if (t) t.textContent = f.title;
+			if (d) d.textContent = f.detail;
+			if (a) { a.textContent = f.act.label + ' →'; a.href = f.act.href; }
+			const h = $('#st-alert-novideo-h');
+			if (h) {
+				h.hidden = !f.help;
+				if (f.help) { h.textContent = f.help.label + ' →'; h.href = f.help.href; }
+			}
+		}
+		setAlert('#st-alert-novideo', !!f);
+		// Only once the camera has actually been heard from. Saying anything
+		// about the hand-off off an unanswered poll would be a claim made from
+		// nothing.
+		const heard = !!s && s.ok;
+		if (heard && vidFirstS === null) vidFirstS = performance.now() / 1000;
+		// The all-clear is earned, not assumed: this page's own blind run has
+		// to have had time to fire and not fired. Before that the banner states
+		// the hand-off and stops there.
+		const settled = vidFirstS !== null &&
+			performance.now() / 1000 - vidFirstS >= (VC ? VC.BLIND_S : 10);
+		const ok = $('#st-alert-wasnovideo-ok');
+		if (ok) ok.textContent = settled ? ' It looks fine now.' : '';
+		setAlert('#st-alert-wasnovideo', cameFromLive && heard);
 	}
 
 	// ── IR-cut ──────────────────────────────────────────────────────────────
@@ -402,7 +466,11 @@
 			// sample's warnings as current next to "not responding".
 			if (s.fails >= 2) {
 				setAlert('#st-alert-exp', false);
-				setAlert('#st-alert-stall', false);
+				// Same reasoning as the IR-cut line below: an unreachable
+				// camera is not a camera reporting darkness, so the run is
+				// broken rather than carried across the gap.
+				if (vidTrack) vidTrackNow = vidTrack.push(s, performance.now() / 1000);
+				renderNoVideo(s);
 				// Not cleared, narrowed: an unset irCutPin1 is still unset
 				// while the camera is unreachable, but a day/night
 				// disagreement is a claim about right now, and there is no
@@ -470,7 +538,12 @@
 		if (encTile) encTile.hidden = !encHas;
 		if (encPanel) encPanel.hidden = !encHas;
 
-		setAlert('#st-alert-stall', v.venc_empty_frames_run > 25);
+		if (vidTrack) vidTrackNow = vidTrack.push(s, performance.now() / 1000);
+		renderNoVideo(s);
+		// Kept alongside, and it is not the same statement. This one says the
+		// scene is darker than the sensor can compensate for, which is a true
+		// and ordinary thing at dusk; the banner above only speaks when the
+		// metered luminance is zero as well, which no scene produces.
 		setAlert('#st-alert-exp', v.isp_exposureismax > 0);
 		const lum = $('#st-alert-exp-lum');
 		if (lum) lum.textContent = ('isp_avelum' in v) ? ' Scene luminance ' + v.isp_avelum + ' of 255.' : '';

--- a/www/a/video-check.js
+++ b/www/a/video-check.js
@@ -1,0 +1,226 @@
+// Is the camera seeing anything?
+//
+// The Live page is where a newly claimed camera lands, so it is where a camera
+// that came up wrong is first met. The obvious guess about what that looks like
+// is wrong, and it was measured rather than assumed: booting a hi3516av300
+// board on the wrong sensor driver (imx335 on an imx415 board) does NOT stop
+// the camera. majestic stays up, serves the whole WebUI, and the Live page
+// plays the stream perfectly -- readyState 4, time advancing, a real frame
+// size. The picture is simply black.
+//
+// So every signal about the pipeline MOVING is useless here. venc0_rcvd_bytes
+// goes on climbing, at about one per cent of the healthy rate, because a black
+// frame compresses to almost nothing -- and a rate that low is not something
+// this can convict on either, since a static dark scene at night is allowed to
+// look like that. The fault is in what the sensor reports and in the picture:
+//
+//                     healthy          wrong driver
+//   isp_avelum          40                  0
+//   isp_again         1024               32381   (pinned at maximum)
+//   isp_exposureismax    0                   1
+//   /image.jpg       392 KB               62 KB, solid black
+//
+// Two independent signals, and they answer different halves. The camera's own
+// gauges say it is straining -- exposure and gain wide open -- and reading
+// nothing. The decoded picture says the frame that came out the far end is
+// black. Either alone has an innocent explanation; together they do not.
+//
+// A separate file, and tested, for the same reason ircut-check.js is: this
+// renders a confident sentence whichever branch it takes, a wrong branch reads
+// exactly like a right one, and reaching half the branches needs a camera
+// booted on the wrong sensor.
+(function () {
+	'use strict';
+
+	// How long majestic must have been up before anything here convicts it. A
+	// camera that is starting is not a camera that is broken: the ISP converges
+	// over the first seconds and reads nothing at all while it does.
+	const BOOT_GRACE_S = 30;
+	// How long "seeing nothing" has to hold. Timed from when it started rather
+	// than counted in samples, because the heartbeat backs off and skips ticks
+	// on a busy camera and a sample count is then not a duration.
+	const BLIND_S = 10;
+	// A gap in the picture samples is not agreement continuing through it --
+	// the sampler stops while the tab is hidden and while the player is between
+	// elements. Longer than one sampling interval, short enough that a real
+	// pause resets the run.
+	const PIC_GAP_S = 4;
+
+	// The picture, from an mj-luma histogram. `mean` is the frame's average
+	// luma over 0..255 and `low` the fraction of pixels in the darkest of its
+	// 64 buckets. Both, because either alone is reachable innocently: a very
+	// dark scene has a low mean with a spread of tones, and a mostly-black
+	// frame with one bright lamp in it has a high `low` and is a picture.
+	const BLACK_MEAN = 2;
+	const BLACK_LOW = 0.995;
+
+	// 'black', 'lit', or null for a frame nothing could be measured from.
+	// null is not 'lit': it is the absence of an answer, and the run-length
+	// below has to treat it as a break rather than as disagreement.
+	function look(h) {
+		if (!h || !h.total) return null;
+		return (h.mean <= BLACK_MEAN && h.low >= BLACK_LOW) ? 'black' : 'lit';
+	}
+
+	// The camera's own opinion: exposure at its ceiling and the metered scene
+	// luminance at zero. true / false / null, and null is load-bearing --
+	// isp_avelum is not published by every vendor (SigmaStar reports none), so
+	// a camera that cannot answer must not be read as answering no.
+	function ispBlind(v) {
+		if (!v || !('isp_avelum' in v) || !('isp_exposureismax' in v)) return null;
+		return v.isp_avelum === 0 && v.isp_exposureismax > 0;
+	}
+
+	// Dotted lookup, local rather than main.js's mjGet: this file is required
+	// directly by its test, where no page globals exist.
+	function get(cfg, dot) {
+		return dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg);
+	}
+
+	// Run lengths for both signals. Held here rather than recomputed per sample
+	// because "how long has this been true" is the whole question -- one black
+	// frame is a shutter, ten seconds of them is a fault.
+	function tracker() {
+		let ispAt = null, picAt = null, picSeen = null;
+		return {
+			// Consecutive seconds the decoded picture has looked black.
+			// Anything that is not 'black' resets the run, null included: a
+			// frame nothing could be measured from is not a frame that still
+			// agrees a bit.
+			picture: function (l, nowS) {
+				// The sampler stops when the tab is hidden or the player is
+				// between elements, and it says so by not calling. Without
+				// this, the next frame after a gap bills the whole gap as
+				// blackness nobody watched.
+				if (picSeen !== null && nowS - picSeen > PIC_GAP_S) picAt = null;
+				picSeen = nowS;
+				if (l === 'black') { if (picAt === null) picAt = nowS; }
+				else picAt = null;
+				return picAt === null ? 0 : nowS - picAt;
+			},
+			push: function (s, nowS) {
+				// An unreachable camera is not a camera reporting darkness.
+				if (!s || !s.ok) {
+					ispAt = null;
+					return { blindS: 0, blind: null };
+				}
+				const b = ispBlind(s.m && s.m.v);
+				if (b === true) { if (ispAt === null) ispAt = nowS; }
+				else ispAt = null;
+				return { blindS: ispAt === null ? 0 : nowS - ispAt, blind: b };
+			},
+		};
+	}
+
+	// Where a finding about the hardware sends somebody who cannot fix it
+	// themselves. Everything in this file is what the WebUI can work out from
+	// two gauges and a thumbnail; the log is where majestic says what actually
+	// happened when it brought the sensor up, and it is the one thing an owner
+	// can screenshot and hand to whoever sold them the camera. Named once so
+	// the findings that carry it cannot drift apart.
+	const HELP = { href: 'info-logs.cgi', label: 'View logs' };
+
+	// What the camera cannot show, and why.
+	//
+	//   cfg   majestic's config, or {} when the fetch failed -- which is why
+	//         every test below is `=== false` and never falsy: an absent key
+	//         from a failed fetch must not read as a disabled channel.
+	//   s     a heartbeat sample (main.js), carrying s.m.v and s.mjUptimeS.
+	//   tr    the last tracker().push() result.
+	//   pic   { blackS } from tracker().picture(), or null where no picture is
+	//         being measured -- the Dashboard has no decoded frame to read.
+	//
+	// Returns a finding, or null for "nothing to say", which includes every
+	// case where the answer is not knowable. Silence here is never a clean bill
+	// of health; it is the absence of a claim.
+	//
+	// A finding about the hardware also carries `help` (above). The
+	// configuration finding does not: nothing went wrong there, a switch is
+	// off, and sending somebody to a log to read about it would be a wild goose
+	// chase dressed up as support.
+	function diagnose(cfg, s, tr, pic) {
+		if (!s || !s.ok) return null;
+		const v = (s.m && s.m.v) || {};
+
+		// Nothing is being encoded at all. A fact about the configuration
+		// rather than the hardware, true from the first sample, and the one
+		// finding here that names a thing the owner can simply switch on.
+		if (get(cfg, 'video0.enabled') === false &&
+			get(cfg, 'video1.enabled') === false) {
+			return {
+				code: 'off', where: 'config', conclusive: true,
+				title: 'No video channel is turned on',
+				detail: 'Neither the main nor the sub stream is enabled, so the ' +
+					'camera is not encoding a picture for anything to show.',
+				act: { href: 'mj-settings.cgi?tab=video0', label: 'Open Video settings' },
+			};
+		}
+
+		if (s.mjUptimeS != null && s.mjUptimeS < BOOT_GRACE_S) return null;
+
+		// The encoder is awake and being handed nothing. Only SigmaStar
+		// publishes this, and it is the one fault where the pipeline really has
+		// stopped rather than gone dark.
+		if (v.venc_empty_frames_run > 25) {
+			return {
+				code: 'stall', where: 'camera', conclusive: true,
+				title: 'The encoder has stopped',
+				detail: 'The camera is running, but the encoder has stopped ' +
+					'producing frames while everything else looks alive.',
+				act: { href: 'fw-restart.cgi', label: 'Restart camera' },
+				help: HELP,
+			};
+		}
+
+		const ispSays = tr ? tr.blind : null;
+		const ispHeld = (tr ? tr.blindS : 0) >= BLIND_S;
+		const picHeld = (pic ? pic.blackS : 0) >= BLIND_S;
+
+		// The camera says it is metering light. Believe it over a dark-looking
+		// frame: that is a night scene, a covered lens or a picture this code
+		// has no business having an opinion about.
+		if (ispSays === false) return null;
+		if (!(ispSays === true && ispHeld) && !picHeld) return null;
+
+		// Which evidence actually arrived decides the sentence. Naming the
+		// wrong-driver case first is not a guess about probability in general
+		// -- it is the case this page is reached in, minutes after somebody
+		// flashed a camera and set its first password.
+		const cause = ' On a newly flashed camera this is usually the wrong ' +
+			'sensor driver for the board; it can also be a lens cap, or a ' +
+			'scene with no light in it at all.';
+		const both = ispSays === true && ispHeld && picHeld;
+		const detail = both
+			? 'The picture is completely black, and the sensor is at maximum ' +
+				'exposure and gain while still reading no light.' + cause
+			: ispSays === true
+				? 'The sensor is at maximum exposure and gain and reporting no ' +
+					'light at all.' + cause
+				: 'Every frame is completely black. This camera does not report ' +
+					'its own exposure, so the cause is not certain.' + cause;
+
+		return {
+			code: 'blind', where: 'camera',
+			// The strongest action this feature takes is moving somebody off
+			// the page they asked for, so it is spent only on the reading that
+			// cannot be explained by the scene: the camera's own gauges saying
+			// it is wide open and blind, in a camera that has decided it is
+			// DAY. A night camera with no illuminator is genuinely dark and
+			// genuinely fine, and it fixes itself at dawn. `s.night` is null on
+			// a camera that does not publish it, and an unknown is not a day.
+			conclusive: ispSays === true && ispHeld && s.night === 0,
+			title: 'The camera is not seeing anything',
+			detail: detail,
+			act: { href: 'mj-settings.cgi?tab=isp', label: 'Open Image settings' },
+			help: HELP,
+		};
+	}
+
+	const api = {
+		diagnose: diagnose, tracker: tracker, look: look, ispBlind: ispBlind,
+		BOOT_GRACE_S: BOOT_GRACE_S, BLIND_S: BLIND_S, PIC_GAP_S: PIC_GAP_S,
+		BLACK_MEAN: BLACK_MEAN, BLACK_LOW: BLACK_LOW,
+	};
+	if (typeof module === 'object' && module.exports) module.exports = api;
+	if (typeof window === 'object') window.MajesticVideoCheck = api;
+})();

--- a/www/a/video-check.js
+++ b/www/a/video-check.js
@@ -20,9 +20,17 @@
 //   isp_exposureismax    0                   1
 //   /image.jpg       392 KB               62 KB, solid black
 //
+// Only two of those are tested. isp_again moved further than anything else and
+// is deliberately not in the predicate: the scale is vendor-specific -- the
+// same idle state reads 1024 on HiSilicon, 126 on Ingenic and 20855 on
+// SigmaStar -- so there is no portable way to ask whether a gain is at its
+// ceiling, and a threshold picked from one board would fire on another camera
+// doing nothing wrong. It is recorded here because it is what the fault looked
+// like, not because anything reads it.
+//
 // Two independent signals, and they answer different halves. The camera's own
-// gauges say it is straining -- exposure and gain wide open -- and reading
-// nothing. The decoded picture says the frame that came out the far end is
+// gauges say it is holding the shutter open as long as it can and still
+// reading nothing. The decoded picture says the frame that came out the far end is
 // black. Either alone has an innocent explanation; together they do not.
 //
 // A separate file, and tested, for the same reason ircut-check.js is: this
@@ -167,7 +175,18 @@
 				title: 'The encoder has stopped',
 				detail: 'The camera is running, but the encoder has stopped ' +
 					'producing frames while everything else looks alive.',
-				act: { href: 'fw-restart.cgi', label: 'Restart camera' },
+				// The confirmation travels WITH the action, because the anchor
+				// it lands on is written at runtime and main.js wired
+				// `.confirm` once at load — so the class the banner this
+				// replaced carried would never have been seen, and the link
+				// restarted the camera on one click. Whoever renders a finding
+				// is responsible for asking; both consumers do.
+				act: {
+					href: 'fw-restart.cgi', label: 'Restart camera',
+					confirm: 'Restart the camera now?\n\nSettings are kept. ' +
+						'Video and recording stop for about half a minute ' +
+						'while it comes back.',
+				},
 				help: HELP,
 			};
 		}
@@ -189,12 +208,20 @@
 		const cause = ' On a newly flashed camera this is usually the wrong ' +
 			'sensor driver for the board; it can also be a lens cap, or a ' +
 			'scene with no light in it at all.';
+		// Only what the predicate actually tested. The measured signature had
+		// gain pinned at maximum too (32381 against a healthy 1024), and the
+		// first draft of these sentences said so -- but ispBlind() never looks
+		// at isp_again, and it cannot: the gain scale is vendor-specific, the
+		// same idle state reads 1024 on HiSilicon, 126 on Ingenic and 20855 on
+		// SigmaStar, and there is no portable "is this its ceiling" test. A
+		// sentence that states an observation the code did not make is the
+		// same failure as a finding reached from a test that could not look.
 		const both = ispSays === true && ispHeld && picHeld;
 		const detail = both
-			? 'The picture is completely black, and the sensor is at maximum ' +
-				'exposure and gain while still reading no light.' + cause
+			? 'The picture is completely black, and the sensor is at its ' +
+				'longest exposure and still reading no light.' + cause
 			: ispSays === true
-				? 'The sensor is at maximum exposure and gain and reporting no ' +
+				? 'The sensor is at its longest exposure and reporting no ' +
 					'light at all.' + cause
 				: 'Every frame is completely black. This camera does not report ' +
 					'its own exposure, so the cause is not certain.' + cause;

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -581,6 +581,23 @@ preview() {
 			<span id="mj-note-why">Your browser can't play the live video stream.</span>
 			<a href="mj-settings.cgi?tab=jpeg">Enable JPEG</a> for an MJPEG fallback.
 		</p>
+		<!-- The other half of "there is nothing to see", and the one #mj-note
+		     cannot reach: a camera on the wrong sensor driver PLAYS, so the
+		     player never fails and never writes the note. preview-health.js
+		     owns this one and writes both the sentence and the link from the
+		     finding, because one banner covers a black picture, a stopped
+		     encoder and a camera with no channel enabled, and each of those
+		     wants its own words and its own destination. Usually the viewer has
+		     already been handed to the Dashboard by the time it renders; this
+		     is what the page says when that hand-off has been spent. -->
+		<p id="mj-blind" class="alert alert-warning mj-stage-alert" style="display:none">
+			<span id="mj-blind-why"></span>
+			<a id="mj-blind-act" href="mj-settings.cgi?tab=isp"></a>
+			<!-- Hidden until a finding says it applies: a hardware fault is the
+			     one an owner cannot fix from a settings page, and the log is
+			     what they can screenshot for whoever sold them the camera. -->
+			<a id="mj-blind-help" href="info-logs.cgi" hidden></a>
+		</p>
 		<!-- The status chip. Same id as the badge it replaces, so every state
 		     write (connecting… / no signal / MJPEG / reconnecting…) keeps
 		     landing; live it reads "H264 3840×2160 · 25 fps". The transport is

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -49,5 +49,15 @@ page_title="Live View"; hide_title=1; full_bleed=1
 <script src="/a/preview-zoom.js"></script>
 <script src="/a/preview-page.js"></script>
 <script src="/a/preview-hero.js"></script>
+<!-- Is the camera seeing anything? Nothing the player can answer — a camera on
+     the wrong sensor driver plays perfectly and plays black — so this reads the
+     exposure gauges off the heartbeat and the picture off the decoded frame,
+     and hands the viewer to the Dashboard when neither has anything in it.
+     mj-luma.js is the histogram it measures the frame with, the same one the
+     Live adjustments panel uses; video-check.js is the verdict. Both before it,
+     and both guarded, so a build missing either leaves the page as it was. -->
+<script src="/a/mj-luma.js"></script>
+<script src="/a/video-check.js"></script>
+<script src="/a/preview-health.js"></script>
 
 <%in p/footer.cgi %>

--- a/www/cgi-bin/status.cgi
+++ b/www/cgi-bin/status.cgi
@@ -56,11 +56,37 @@ done) %>
 		<a class="small ms-auto" href="mj-settings.cgi?tab=nightMode">Open Day / Night &rarr;</a>
 		<button type="button" class="btn btn-link btn-sm small p-0 ms-3" id="st-alert-ircut-no" hidden>No filter here</button>
 	</div>
-	<div class="st-alert" id="st-alert-stall" hidden>
+	<!-- Nothing to see, and the wording is written by status.js from the finding
+	     (video-check.js), because one banner covers three of them: a camera
+	     reading no light at all, an encoder that has stopped, and a camera with
+	     no channel enabled. This replaced a fixed "Encoder stalled" banner that
+	     could only ever fire on SigmaStar, and that said nothing about the
+	     fault a newly flashed camera actually has — the wrong sensor driver,
+	     which streams perfectly and streams black. -->
+	<div class="st-alert" id="st-alert-novideo" hidden>
 		<span class="st-alert-ico" aria-hidden="true">&#9888;</span>
-		<span class="small"><b>Encoder stalled</b> — the encoder has stopped producing frames while everything else looks alive.</span>
-		<a class="small ms-auto confirm" href="fw-restart.cgi"
-			data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera &rarr;</a>
+		<span class="small"><b id="st-alert-novideo-t"></b> &mdash; <span id="st-alert-novideo-d"></span></span>
+		<a class="small ms-auto" id="st-alert-novideo-a" href="mj-settings.cgi?tab=isp"></a>
+		<!-- Only on a hardware finding. What this page can say is worked out
+		     from two gauges; the log is where majestic says what happened when
+		     it brought the sensor up, and it is what an owner can screenshot
+		     for whoever sold them the camera. -->
+		<a class="small ms-3" id="st-alert-novideo-h" href="info-logs.cgi" hidden></a>
+	</div>
+	<!-- Why you are here, when the Live page sent you and the fault has since
+	     cleared. Being moved to another page for no visible reason is worse
+	     than the fault it was moving you away from. -->
+	<div class="st-alert" id="st-alert-wasnovideo" hidden>
+		<span class="st-alert-ico" aria-hidden="true">&#8505;</span>
+		<!-- Two states, because this page needs its own ten seconds to reach a
+		     verdict and during them it knows nothing. Saying "it looks fine
+		     now" on arrival would be a reassurance issued before anything had
+		     been measured — and on the camera this feature exists for, it would
+		     be contradicted by the banner above a few seconds later. So the
+		     sentence starts as the bare fact of the hand-off and only earns its
+		     second half (status.js) once the check has run and found nothing. -->
+		<span class="small">Live video was not available a moment ago, so you were brought here.<span id="st-alert-wasnovideo-ok"></span></span>
+		<a class="small ms-auto" href="preview.cgi">Open Live &rarr;</a>
 	</div>
 </div>
 
@@ -240,6 +266,7 @@ done) %>
 
 <script src="/a/charts.js" defer></script>
 <script src="/a/ircut-check.js" defer></script>
+<script src="/a/video-check.js" defer></script>
 <script src="/a/status.js" defer></script>
 
 <%in p/footer.cgi %>

--- a/www/index.html
+++ b/www/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<meta content="0; url=/cgi-bin/status.cgi" http-equiv="refresh">
+		<!-- The bare hostname means "show me the camera", so it lands on the
+		     picture. Everything else follows from this one line: majestic turns
+		     an unauthenticated navigation here into login.html?next=…, so the
+		     sign-in flow lands on the picture too. The Dashboard is one nav
+		     click away, and the Live page hands the viewer to it by itself when
+		     there is nothing to look at (preview-health.js). -->
+		<meta content="0; url=/cgi-bin/preview.cgi" http-equiv="refresh">
 		<meta content="no-store" name="cache-control">
 		<title>OpenIPC</title>
 	</head>

--- a/www/login.html
+++ b/www/login.html
@@ -130,15 +130,15 @@
 			// which would turn ?next= into an open redirect.
 			function safeNext() {
 				var raw = new URLSearchParams(location.search).get('next');
-				if (!raw) return '/cgi-bin/status.cgi';
+				if (!raw) return '/cgi-bin/preview.cgi';
 				if (raw.charAt(0) !== '/' || raw.charAt(1) === '/' || raw.indexOf('\\') !== -1) {
-					return '/cgi-bin/status.cgi';
+					return '/cgi-bin/preview.cgi';
 				}
 				// Never point back at this page. The already-signed-in check below
 				// acts on it, so a ?next= aimed here would spin: probe says OK,
 				// replace() lands here again, probe says OK…
 				if (raw.split(/[?#]/)[0] === location.pathname) {
-					return '/cgi-bin/status.cgi';
+					return '/cgi-bin/preview.cgi';
 				}
 				return raw;
 			}

--- a/www/setup.html
+++ b/www/setup.html
@@ -921,7 +921,7 @@
 				if (!ev.persisted) return;
 				fetch('/setup.html', { method: 'HEAD', credentials: 'same-origin' })
 					.then(function (r) {
-						if (!r.ok) location.replace('/cgi-bin/status.cgi');
+						if (!r.ok) location.replace('/cgi-bin/preview.cgi');
 					})
 					.catch(function () { /* camera unreachable: leave the form */ });
 			});
@@ -988,13 +988,16 @@
 								return;
 							}
 							// Signed in already — /setup minted the session on its
-							// way out, so the status page opens without a second
-							// sign-in. replace(), not href: this page no longer
+							// way out, so the Live page opens without a second
+							// sign-in. The picture is what somebody who has just
+							// claimed a camera came for; if there is nothing to
+							// see, that page hands them on to the Dashboard with
+							// the reason. replace(), not href: this page no longer
 							// exists on the camera, and leaving it in history
 							// means Back lands on a 404.
-							location.replace('/cgi-bin/status.cgi');
+							location.replace('/cgi-bin/preview.cgi');
 						}).catch(function () {
-							location.replace('/cgi-bin/status.cgi');
+							location.replace('/cgi-bin/preview.cgi');
 						});
 					}
 					// The endpoint answers in plain text and says something useful


### PR DESCRIPTION
Somebody who has just set the first password on a camera, or who types the bare
hostname, wants to see their camera. Every path landed them on the Dashboard:
`index.html` refreshed to `status.cgi`, `setup.html` replaced to it three times,
`login.html` defaulted `?next=` to it. They land on Live now — the one line in
`index.html` carries the sign-in flow too, since majestic turns a navigation
there into `login.html?next=…`.

That is only safe if a camera with nothing to show says so.

## What a camera with no picture actually looks like

Measured rather than assumed, and the assumption was wrong. Booting the lab
hi3516av300 on the wrong sensor driver — `fw_setenv sensor imx335` on an imx415
board, which is the newcomer's fault — does **not** stop the camera. majestic
stays up, serves the whole WebUI, and the Live page plays the stream perfectly:
`readyState 4`, `currentTime` advancing, 2592×1520 at 62%. The picture is
simply black.

So every signal about the pipeline *moving* is useless here. `venc0_rcvd_bytes`
goes on climbing, at about 1% of the healthy rate, because a black frame
compresses to almost nothing — and a rate that low is not something to convict
on either, since a static night scene is allowed to look like that. Nothing in
the fallback chain fires, because nothing failed.

The fault is in what the sensor reports, and in the picture:

|                     | healthy | wrong driver |
|---|---|---|
| `isp_avelum`        | 40      | **0** |
| `isp_again`         | 1024    | **32381** (pinned at maximum) |
| `isp_exposureismax` | 0       | **1** |
| `/image.jpg`        | 392 KB  | 62 KB, solid black |

(A second fault class was measured and is deliberately **not** handled: a bad
`isp.sensorConfig` leaves the majestic process alive but serving no HTTP at all,
so the WebUI is down with the camera and no browser-side check can reach it.)

## The design

`www/a/video-check.js` is a verdict on the **picture**, not on the pipeline, and
it reads two independent signals that answer different halves. The camera's own
gauges say it is wide open and metering nothing. `mj-luma.js` — already written,
already tested, already used by the Live adjustments histogram — says the frame
that came out the far end is black. Either alone has an innocent explanation: a
low mean is a night scene, a high dark-bucket share is one lamp in the dark.
Together they do not.

**Nothing polls anything new.** The gauges ride the `/metrics` heartbeat
`main.js` already runs on every page; the picture is decoded in the `<video>`
element already. The healthy camera pays nothing, which was the constraint.

`www/a/preview-health.js` hands the viewer to the Dashboard, and the guards are
the feature rather than trimming around it:

- **30 s of majestic uptime.** A camera that is starting is not a camera that is
  broken — the ISP reads nothing at all while it converges.
- **The reading holds 10 s**, timed rather than counted in samples, because the
  heartbeat backs off and skips ticks on a busy camera.
- **It must be day.** A night camera with no illuminator is genuinely dark and
  genuinely fine, and it fixes itself at dawn. `night_enabled` absent is not a
  day either — the finding still shows, it just does not move anybody.
- **A background tab never navigates itself.**
- **One hand-off per tab**, in `sessionStorage`. Without it, Back from the
  Dashboard lands on Live, finds the same fault and bounces straight off again,
  and a viewer could never reach the Live page of a camera with a dark picture.
  Spent, the page states the finding and stays put.

On the Dashboard the finding replaces the fixed **Encoder stalled** banner,
which could only ever fire on SigmaStar and said nothing about the fault a newly
flashed camera actually has. Its all-clear is earned rather than assumed: that
page needs its own ten seconds, and "it looks fine now" issued on arrival would
be contradicted by the banner landing a moment later — so the sentence starts as
the bare fact of the hand-off and only earns its second half once the check has
run and found nothing.

Both **hardware** findings offer the log page. What this code can work out comes
from two gauges and a thumbnail; the log is where majestic says what actually
happened bringing the sensor up, and it is the one artefact an owner can
screenshot for whoever sold them the camera. The configuration finding does not
offer it — nothing went wrong there, a switch is off.

`preview-page.js` is untouched: the visible media element is found on the stage,
so the new file and the player never speak, and the two `vm` tests need nothing.

## Verified on hardware

The lab av300, broken and restored three times:

- **healthy** — `/` lands on Live, 50 s with nothing firing and no hand-off.
  This is the regression that matters most; a false hand-off is worse than the
  bug.
- **broken** — `/` → Live at 1.6 s, black stream plays at 5 s, hand-off to
  `status.cgi?novideo=blind` at **16 s**, neutral banner at 18.6 s, full finding
  with both links at 29 s. No moment where the page contradicts itself.
- **second visit** — no redirect, finding rendered in place with
  *Open Image settings →* and *View logs →*.
- **both signals** — the sentence upgrades from "the sensor is at maximum…" to
  "the picture is completely black, and the sensor is at maximum…" at 16.4 s,
  which is how the browser-side half was confirmed working rather than assumed.

`tests/video-check.test.js` covers the table, weighted toward what it must stay
silent on. `npm test` and `tools/lint-templates.sh` pass; `bootstrap.min.css`
regenerates byte-identical.
