### PR TITLE
Live: one MSE session per player, however the reconnect got there

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
+    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -1,0 +1,200 @@
+// The MSE player's socket lifecycle: exactly one /ws/video session per player,
+// no matter which door the reconnect came through.
+//
+// This one is here because the failure is invisible from the browser. A socket
+// nobody closes goes on being served: the camera keeps encoding for it, keeps
+// sending to it, and keeps counting it among the viewers it has. The tab shows
+// a picture the whole time — the *new* session's picture — so the only place
+// the damage is visible is the camera's own client count, and by the time
+// anyone reads that, the link is carrying five copies of the stream and the
+// blinking that started it has become self-inflicted (majestic-webui#298: ten
+// sessions for one viewer, one per blink).
+//
+// Neither path below can be reproduced on demand in a browser. One needs the
+// decoder to raise an error, which needs a stream damaged in transit; the
+// other needs a close handshake slower than 300 ms, which needs a bad link.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'preview.js');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A socket that records what was done to it. `closed` and the handler slots
+// are the whole subject: a discarded socket must be shut AND silenced.
+function makeSockets(env) {
+	return function WebSocketStub(url) {
+		const s = {
+			url: url, readyState: 1, closed: false, binaryType: '',
+			onopen: null, onmessage: null, onclose: null, onerror: null,
+			close() { this.closed = true; this.readyState = 3; },
+			// Deliver an event the way the browser would: through whatever
+			// handler is attached *now*. A silenced socket has none, which is
+			// exactly what the second group is checking.
+			fire(ev, arg) { const h = this['on' + ev]; if (h) h(arg); },
+			silent() {
+				return !this.onopen && !this.onmessage &&
+					!this.onclose && !this.onerror;
+			},
+		};
+		env.sockets.push(s);
+		return s;
+	};
+}
+
+// The element the player owns. freshVideo() clones and replaces it on every
+// (re)connect, so the test has to follow the current node the same way the DOM
+// does — anything holding the first one is holding a detached node.
+function makeVideo(env) {
+	function node() {
+		const v = {
+			muted: false, volume: 1, src: '', paused: false,
+			videoWidth: 1280, videoHeight: 720,
+			buffered: { length: 0 },
+			handlers: {},
+			addEventListener(ev, fn) { (this.handlers[ev] = this.handlers[ev] || []).push(fn); },
+			removeEventListener(ev, fn) {
+				this.handlers[ev] = (this.handlers[ev] || []).filter((f) => f !== fn);
+			},
+			removeAttribute() { this.src = ''; },
+			load() {}, play() { return Promise.resolve(); },
+			cloneNode() { return node(); },
+			getVideoPlaybackQuality() { return { totalVideoFrames: 0, droppedVideoFrames: 0 }; },
+			fire(ev) {
+				(this.handlers[ev] || []).slice().forEach((f) => f({ target: this }));
+			},
+		};
+		v.parentNode = {
+			replaceChild(fresh) { env.video = fresh; },
+		};
+		return v;
+	}
+	env.video = node();
+	return env.video;
+}
+
+function load() {
+	const env = { sockets: [], states: [] };
+	const video = makeVideo(env);
+
+	const MediaSourceStub = function () {
+		const ms = {
+			readyState: 'open',
+			listeners: {},
+			addEventListener(ev, fn) { ms.listeners[ev] = fn; },
+			addSourceBuffer() {
+				return {
+					updating: false, mode: '', buffered: { length: 0 },
+					addEventListener() {}, appendBuffer() {}, remove() {}, abort() {},
+				};
+			},
+			removeSourceBuffer() {}, endOfStream() {},
+		};
+		env.ms = ms;
+		return ms;
+	};
+	MediaSourceStub.isTypeSupported = () => true;
+
+	const win = { MediaSource: MediaSourceStub };
+	const ctx = {
+		window: win,
+		MediaSource: MediaSourceStub,
+		WebSocket: makeSockets(env),
+		URL: { createObjectURL: () => 'blob:stub', revokeObjectURL() {} },
+		location: { protocol: 'http:', host: 'camera' },
+		console: console, JSON: JSON, Promise: Promise,
+		setTimeout, clearTimeout, setInterval, clearInterval,
+	};
+	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+
+	env.player = win.MajesticVideo.attach(video, {
+		onState: (s, d) => env.states.push(d ? s + ' ' + d : s),
+	});
+	// The socket is live and the camera has sent its init frame: from here the
+	// player is playing, which is the state every one of these starts from.
+	env.play = () => {
+		const s = env.sockets[env.sockets.length - 1];
+		s.fire('open');
+		s.fire('message', { data: JSON.stringify({ type: 'init', codec: 'h264', codecString: 'avc1.4d001f' }) });
+		if (env.ms && env.ms.listeners.sourceopen) env.ms.listeners.sourceopen();
+	};
+	env.live = () => env.sockets.filter((s) => !s.closed);
+	return env;
+}
+
+(async () => {
+	group('a video error replaces the session rather than adding to it');
+	{
+		const env = load();
+		env.play();
+		check('one session to start with', env.sockets.length === 1, env.sockets.length + '');
+
+		// What a decode error looks like from here: the element says it has
+		// stopped, and the player rebuilds. The socket it was reading is the
+		// thing that must not survive that.
+		env.video.fire('error');
+		check('the failed session was closed at once', env.sockets[0].closed);
+		check('and silenced, so its own close cannot answer for the player',
+			env.sockets[0].silent());
+
+		await sleep(1300); // the first backoff
+		check('a replacement was opened', env.sockets.length === 2, env.sockets.length + '');
+		check('and it is the only one the camera is serving',
+			env.live().length === 1, env.live().length + ' live');
+		env.player.destroy();
+	}
+
+	group('a late close cannot take the live session down with it');
+	{
+		const env = load();
+		env.play();
+		const first = env.sockets[0];
+
+		// Main/Sub, or unmute: stop, then reopen 300 ms later. On a link where
+		// the close handshake takes longer than that, the browser fires the
+		// first socket's close event when the second one is already carrying
+		// the picture.
+		env.player.setStream(1);
+		await sleep(500);
+		check('the second session is open', env.sockets.length === 2, env.sockets.length + '');
+		env.play();
+
+		check('the first was closed and silenced', first.closed && first.silent());
+		first.fire('close');   // it lands now — too late to mean anything
+		await sleep(1300);     // longer than a backoff: a reconnect would show
+		check('no third session was opened', env.sockets.length === 2, env.sockets.length + '');
+		check('and the live one is still the live one',
+			env.live().length === 1 && !env.sockets[1].closed);
+		env.player.destroy();
+	}
+
+	group('the camera closing a session still brings the player back');
+	{
+		const env = load();
+		env.play();
+		env.sockets[0].close();      // as the reaper does: shut, then the event
+		env.sockets[0].fire('close');
+		await sleep(1300);
+		check('it reconnected', env.sockets.length === 2, env.sockets.length + '');
+		check('with one live session', env.live().length === 1, env.live().length + ' live');
+		env.player.destroy();
+	}
+
+	group('destroy leaves nothing behind');
+	{
+		const env = load();
+		env.play();
+		env.player.destroy();
+		check('the socket is closed', env.sockets[0].closed);
+		check('and silenced, so the ladder does not restart from the grave',
+			env.sockets[0].silent());
+		await sleep(1300);
+		check('nothing reconnected', env.sockets.length === 1, env.sockets.length + '');
+	}
+
+	done();
+})();

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -93,6 +93,33 @@ window.MajesticVideo = (function () {
 			if (objUrl) { try { URL.revokeObjectURL(objUrl); } catch (e) {} objUrl = null; }
 		}
 
+		// Give up a socket, for good. Both halves of this matter, and for
+		// different reasons.
+		//
+		// Closing it is what stops the camera serving it. An abandoned
+		// /ws/video session is a live subscription: the camera goes on
+		// encoding for it and sending to it for as long as the tab is open,
+		// and counts it among the viewers it is serving. That is #298 — ten
+		// sessions, one per blink, on a link that could not carry two, each
+		// new one competing with the ones it was meant to replace.
+		//
+		// Dropping the handlers is what stops a socket speaking for the player
+		// after it has been replaced. They close over `ws`, the slot, and not
+		// over the socket they belong to, so a close event that lands after
+		// the slot has moved on nulls the socket now carrying the picture and
+		// starts a reconnect on top of it — orphaning that one in turn. On a
+		// LAN the close lands well inside reopen()'s 300 ms gap and nothing
+		// shows; add a second of latency and pressing Main/Sub leaks a session
+		// every other press.
+		function discard(sock) {
+			if (!sock) return;
+			sock.onopen = null;
+			sock.onmessage = null;
+			sock.onclose = null;
+			sock.onerror = null;
+			try { sock.close(); } catch (e) {}
+		}
+
 		function onVideoError(e) {
 			if (!closed && e.target === video) reconnect();
 		}
@@ -173,16 +200,23 @@ window.MajesticVideo = (function () {
 
 		function open() {
 			if (closed) return;
+			// One socket per player, held where the sockets are made rather
+			// than trusted of every caller that leads here.
+			discard(ws);
 			freshVideo();
 			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
 			onState('connecting');
 			let url = proto + '://' + location.host + '/ws/video?stream=' + stream;
 			if (wantAudio && audioPrefs) url += '&audio=' + audioPrefs;
-			ws = new WebSocket(url);
-			ws.binaryType = 'arraybuffer';
+			// Each handler is bound to its own socket, so an error late in a
+			// session's life closes the session that raised it and not
+			// whichever one happens to be in the slot by then.
+			const sock = new WebSocket(url);
+			ws = sock;
+			sock.binaryType = 'arraybuffer';
 			gotSignal = false;
-			ws.onopen = function () { backoff = 1000; armSignalTimer(); };
-			ws.onmessage = function (e) {
+			sock.onopen = function () { backoff = 1000; armSignalTimer(); };
+			sock.onmessage = function (e) {
 				if (typeof e.data === 'string') {
 					let info; try { info = JSON.parse(e.data); } catch (_) { return; }
 					if (info && info.type === 'init') onInit(info);
@@ -190,11 +224,17 @@ window.MajesticVideo = (function () {
 				}
 				onBinary(e.data);
 			};
-			ws.onclose = function () { ws = null; if (!closed) reconnect(); };
-			ws.onerror = function () { try { ws.close(); } catch (e) {} };
+			sock.onclose = function () { ws = null; if (!closed) reconnect(); };
+			sock.onerror = function () { try { sock.close(); } catch (e) {} };
 		}
 
 		function reconnect() {
+			// Before the backoff rather than after it: until this socket is
+			// closed the camera is still encoding and sending for it, and the
+			// reconnect is about to ask for a second one. The video element
+			// raising an error is the path that used to skip this.
+			discard(ws);
+			ws = null;
 			teardownMse();
 			if (closed || reconnectTimer) return;
 			if (++failCount >= 6) { onState('mjpeg', 'unreachable'); stop(); return; }
@@ -207,7 +247,8 @@ window.MajesticVideo = (function () {
 
 		function stop() {
 			clearTimeout(signalTimer);
-			if (ws) { try { ws.close(); } catch (e) {} ws = null; }
+			discard(ws);
+			ws = null;
 			teardownMse();
 		}
 


### PR DESCRIPTION
Fixes #298.

## What the reporter sees

`Browser (MSE) × 10` in the Stats panel, for one open tab, and the count goes up by one on every blink.

## What it is

A blink is the MSE player rebuilding itself. Two paths get it there, and both leave the socket it was reading open.

**The video element raising an error.** `reconnect()` tore down the MediaSource and, after a backoff, opened a second socket — without closing the first. Nothing closes it afterwards either: the camera goes on encoding for it and sending to it for as long as the tab lives, and counts it among the viewers it is serving. On a link where the camera has to drop frames to keep up, the decoder error that starts this is exactly what a congested link produces, so it repeats.

**A close that lands late.** The socket handlers close over `ws`, the slot, rather than over their own socket. `reopen()` — Main/Sub, unmute — closes and reopens 300 ms later, and a link that does not finish a close handshake inside that window fires the *first* socket's close event when the *second* is already carrying the picture: the live socket's reference is dropped and a reconnect starts on top of it, orphaning it in turn.

Either way the browser shows a picture that looks right, so the only place the damage is visible is the camera's client count — and it compounds, because each orphan is another copy of the stream on a link that was already struggling.

## The change

A socket is given up in one place, and giving it up means both things: **closed**, so the camera stops serving it, and **silenced**, so it cannot answer for a player that has moved on. Every path that opens one goes through it — the video-error reconnect (before the backoff, not after: until it is closed the camera is still sending to it), `stop()`, and `open()` itself, which is where "one socket per player" can be an invariant rather than a property of its callers. Handlers now bind to their own socket, so an error late in a session's life closes the session that raised it rather than whichever one is in the slot by then.

## Measured

On a lab ev300 with this WebUI, reading the camera's own client count:

| | before | after |
|---|---|---|
| four reconnects after a video error | 1 → 5, all five still being served | stays 1 |
| five Main/Sub presses, 1.5 s one-way delay | 1 → 3 | does not move |

## Tests

`tests/preview-socket.test.js` (new, in `npm test`) drives the player against socket stubs: a video error must replace the session rather than add to it, a late close must not take the live session down with it, and the two things the fix must not break — a camera-side close still brings the player back, `destroy()` still leaves nothing behind. Reverting `preview.js` fails five of its checks.