### PR TITLE
Live: the caption stops deciding where the chip goes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,10 +368,21 @@ The journal is the one write whose failure **stops** the actuation — it is wha
   deliberately do **not** read them: they are the player's furniture, and
   furniture that jumps when you change zoom is worse than furniture on a band
   (in Fit it also puts the pad in the gutter, covering nothing). One exception,
-  the chip's alone: a picture too small to carry the chrome without it
-  dominating — measured against the chip's own `offsetWidth`, not a constant —
-  hands the insets back to the stage. A 390 × 219 phone in Fit is that case;
-  1841 × 1381 with 359px of gutter is not, so it keeps its chip on the picture.
+  and it is **`--mj-pic-top` alone**: a picture too small to carry the chrome
+  without it dominating, *and* with a band above deep enough to actually clear
+  the chip, hands that one inset back to the stage. A 390 × 219 phone in Fit is
+  that case; 1841 × 1381 with 359px of gutter is not, so it keeps its chip on
+  the picture. The horizontal pair is **never** surrendered — sideways there is
+  no band deep enough to clear a chip, so the move covers exactly as much
+  picture as before and cuts the chip loose from the corner it describes. Both
+  halves of that rule are #302: the gate used to be measured against the chip's
+  own `offsetWidth`, so pressing **Auto** — which always appends the served
+  channel's name — grew the chip by 42%, tripped the gate, and threw every
+  annotation out to the screen's edges with the picture not moving a pixel. A
+  threshold that decides where a widget is drawn must never be measured against
+  what that widget happens to say, so it takes nominals (`CHIP_W`/`CHIP_H`);
+  `--mj-chip-h`, which describes the chip on screen rather than placing it,
+  stays measured.
 - **The two toasts are a stack, not two fixed offsets.** `#mj-toasts` is a flex
   column hung under the chip at `--mj-chip-h`, the chip's *measured* height,
   because that height is not a constant — "MJPEG" against "H265 3840×2160 · 25

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2454,9 +2454,12 @@ mark {
 /* Anchored to the PICTURE, not to the stage. Fill leaves the two the same, so
    this changes nothing in the ordinary case; on a letterboxed view a chip at
    the stage's corner floats in black, describing nothing. preview-zoom.js
-   zeroes the insets again when the picture is too small to carry the chrome
-   without it dominating -- a 390 x 219 phone in Fit -- so a band that exists
-   is not by itself a reason to use it. */
+   zeroes --mj-pic-top again when the picture is too small to carry the chrome
+   without it dominating AND the band above is deep enough to take it -- a
+   390 x 219 phone in Fit -- so a band that exists is not by itself a reason to
+   use it. The horizontal pair is never zeroed: sideways there is no band deep
+   enough to clear a chip, so the move only cuts it loose from what it
+   describes (#302). */
 .mj-chip {
 	position: absolute;
 	top: calc(var(--mj-pic-top, 0px) + 0.5rem);

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -445,8 +445,9 @@
 			(fps ? ' · ' + Math.round(fps) + ' fps' : '') +
 			(pct ? ' · ' + pct + '%' : '') +
 			servedNote();
-		// Its width is what decides whether the chrome fits on the picture, and
-		// it has just changed.
+		// Its height is what the toast stack hangs off, and a caption that wraps
+		// to a second line has just changed it. Its WIDTH decides nothing about
+		// placement any more (#302).
 		if (window.MajesticZoom) window.MajesticZoom.refresh();
 	}
 

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -599,8 +599,13 @@
 		// caller renders as nothing rather than as 0%.
 		scalePct: function () { return frame && placed ? Math.round(scale * 100) : 0; },
 
-		// The chip's own width decides whether the chrome fits on the picture,
-		// so a repaint of the chip can change the answer.
+		// A repaint of the chip, which is the toast stack's problem: the stack
+		// hangs off `--mj-chip-h`, the chip's MEASURED height, and a caption
+		// that wraps to a second line is taller than the one it replaced. It no
+		// longer moves the annotations themselves -- the chip's WIDTH deciding
+		// where the chip is drawn is the whole of #302, and the gate takes
+		// nominals now -- so nothing here should be read as a licence to
+		// reintroduce that.
 		refresh: function () {
 			const sw = stage.clientWidth, sh = stage.clientHeight;
 			if (frame && placed && sw && sh) annotate(sw, sh, frame.w * scale, frame.h * scale);

--- a/www/a/preview-zoom.js
+++ b/www/a/preview-zoom.js
@@ -34,6 +34,18 @@
 	// Where a press belongs to the control under it rather than to the picture.
 	const CHROME = '.mj-bar, .mj-ptz, #mj-stats, #mj-toasts';
 
+	// The status chip's footprint, as NOMINALS rather than as its measured
+	// size, and that distinction is the whole of #302. The chip's width is its
+	// text -- "MJPEG" against "H265 3840×2160 · 25 fps · 36% · Sub stream" --
+	// so a gate that decides WHERE the chip is drawn from what the chip
+	// currently SAYS is a widget deciding its own position: the served-channel
+	// label Auto always carries grew the chip by 42%, tripped the gate, and
+	// flung every annotation off the picture and out to the screen's edges
+	// while the picture did not move at all. Measure the picture, not the
+	// caption. 210 x 30 is a chip of about thirty monospace characters at
+	// 0.75rem with its padding and border, which is the ordinary line.
+	const CHIP_W = 210, CHIP_H = 30;
+
 	function read(k) {
 		try { return localStorage.getItem(k); } catch (e) { return null; }
 	}
@@ -96,28 +108,42 @@
 	// small enough to leave a band cannot be panned in the first place, so
 	// panning never moves these.
 	function annotate(sw, sh, picW, picH) {
-		// Measured off the chip itself rather than guessed at, because its
-		// width is its text -- "H265 3840×2160 · 25 fps · 67%" against "MJPEG"
-		// -- and its height is the page's font size.
 		const badge = $('#mj-badge');
-		const cw = (badge && badge.offsetWidth) || 210;
-		const ch = (badge && badge.offsetHeight) || 30;
+		const ch = (badge && badge.offsetHeight) || CHIP_H;
 		// Published for the toast stack, which hangs under the chip: the chip's
 		// height is not a constant -- "MJPEG" against "H265 3840×2160 · 25 fps ·
 		// 36% · Sub stream", which wraps to two lines on a phone -- so a toast
 		// at a fixed offset from the top of the stage is either crowding it or
-		// sitting on it.
+		// sitting on it. MEASURED, because it is describing the chip that is on
+		// screen; the gate below is a different question and takes nominals.
 		if (ch) stage.style.setProperty('--mj-chip-h', ch + 'px');
 		const visW = Math.min(sw, picW), visH = Math.min(sh, picH);
-		// A picture too small to carry the chip without the chip dominating it
-		// hands the chrome back to the stage: a 390 x 219 phone in Fit, where
-		// the chip is nearly half the width and there is 283px of band doing
-		// nothing. It is the picture being too small that moves it -- never the
-		// band merely existing, which is why 1841 x 1381 with 359px of gutter
-		// keeps its chip on the picture.
-		const roomy = visW >= cw * 3 && visH >= ch * 5;
-		const set = (name, px) => stage.style.setProperty(name, (roomy ? Math.max(0, px) : 0) + 'px');
-		set('--mj-pic-top', oy);
+		// A picture too small to carry the chrome without the chrome dominating
+		// it hands the chip back to the stage: the 390 x 219 phone in Fit this
+		// hatch was written for, where the chip is nearly half the picture's
+		// width and there is 283px of band above it doing nothing. It is the
+		// picture being too small that moves it -- never the band merely
+		// existing, which is why 1841 x 1381 with 359px of gutter keeps its
+		// chip on the picture.
+		const cramped = visW < CHIP_W * 3 || visH < CHIP_H * 5;
+		// Handing the chip back is only worth anything if the band above can
+		// actually take it. Where it cannot, the move is a few pixels that
+		// leave the chip on the picture anyway, having cut it loose from the
+		// picture's corner for nothing.
+		const clears = oy >= CHIP_H * 2;
+		const set = (name, px) => stage.style.setProperty(name, Math.max(0, px) + 'px');
+		set('--mj-pic-top', cramped && clears ? 0 : oy);
+		// The horizontal insets are never surrendered, whatever the gate says.
+		// Moving the chip sideways cannot get it off the picture: in every case
+		// cramped enough to ask, the chip is WIDER than the pillar it would
+		// move into, so it covers exactly as much picture as before and now
+		// hangs off into black as well. And in the case the hatch exists for --
+		// a portrait phone, where the picture is as wide as the stage -- these
+		// are zero already, so surrendering them was never what helped. What it
+		// did instead was flip on a word: the gate used to be measured against
+		// the chip's own offsetWidth, so pressing Auto appended " · Sub stream",
+		// the chip grew 42%, and every annotation jumped from the picture's
+		// corner to the screen's with the picture not moving a pixel (#302).
 		set('--mj-pic-left', ox);
 		set('--mj-pic-right', sw - (ox + picW));
 	}


### PR DESCRIPTION
On a 4:3 sensor in **Fit** the picture is pillarboxed, and the chip, the stats panel and the toasts are anchored to the *picture* rather than to the stage so they do not float in the black beside it. Pressing **Auto** threw all of them out to the screen's edges — with the picture not moving a pixel.

## What was wrong

Two defects, in the same four lines.

**1. The gate measured the chip, so the chip decided where the chip went.**

`annotate()` publishes `--mj-pic-{top,left,right}` and has an escape hatch: a picture too small to carry the chrome hands the insets back. It was gated on

```js
const cw = (badge && badge.offsetWidth) || 210;
const roomy = visW >= cw * 3 && visH >= ch * 5;
```

`cw` is the chip's *rendered* width — i.e. its text. In Auto the chip always names the served channel (#184), so `setChip()` appends `" · Sub stream"` and then calls `MajesticZoom.refresh()`. Measured on the reporter's viewport, 1411×707 in Fit, picture 793×649 with 309px pillars:

| | caption | chip | gate `793 ≥ cw×3` | `--mj-pic-left` | chip lands at |
|---|---|---|---|---|---|
| manual | `H264 704×576 · 30 fps · 113%` | 224px | 793 ≥ 672 ✔ | 308.9px | x 870–1094, on the picture |
| **Auto** | `… · 113% · Sub stream` | 318px | 793 < 954 ✘ | **0px** | x 1085–1403, on the black band |

The `<video>` box is byte-identical in both (309..1102). Only a word changed. The same flip is available from a served-channel mismatch note appearing, or from the scale reading going 99% → 100%.

**2. The hatch fired on the wrong axis.**

It was calibrated on a phone in Fit — 390 × 219 of picture with 283px of band **above** it — where surrendering `--mj-pic-top` lifts the chip into empty space directly above the picture. One boolean drove all three insets, so a *width* test surrendered the horizontal pair as well and threw the chrome sideways into the pillars: precisely what `bootstrap.override.css`'s own comment forbids — *"a chip at the stage's corner floats in black, describing nothing."*

## The fix

- **Nominals, not measurement.** `CHIP_W = 210, CHIP_H = 30` — about thirty monospace characters at 0.75rem with padding and border. A threshold that decides where a widget is drawn must not be measured against what that widget happens to say. `--mj-chip-h` stays measured, because it *describes* the chip on screen rather than placing it, and the toast stack needs the real height; the two questions are now visibly separate in the code.
- **`--mj-pic-top` alone is surrendered**, and only when the band above is at least two chip-heights deep. Where it is not, the "escape" moves the chip a few pixels and leaves it on the picture anyway, having cut it loose from the corner it describes for nothing.
- **The horizontal pair is never surrendered.** Sideways there is no band deep enough to clear a chip: in every case cramped enough to ask, the chip is *wider* than the pillar it would move into, so it covers the same picture as before and hangs off into black as well. And on the portrait phone this hatch was written for, the horizontal insets are zero anyway — so surrendering them was never what helped.

## Verification

A harness against a real camera that changes **only the chip's caption** — `MJPEG` → `H264 2560×1920 · 30 fps · 34%` → `… · Main stream`, then `MajesticZoom.refresh()`, stream untouched — and asserts (a) the insets do not move and (b) the horizontal pair equals the picture's real offsets:

| layout | master | this branch |
|---|---|---|
| reporter 1411×707, Fit | defect 1 + 2 | clean |
| 2560×1440, Fit | clean¹ | clean |
| phone 390×785, Fit | defect 1 | clean, top still surrendered |
| landscape phone 785×390, Fit | defect 1 + 2 | clean |
| 1411×707, Fill | clean | clean |

¹ that picture is 1689px wide, so master's gate happens not to trip there; at 1920×707 the picture is 865px and it does.

Master fails five assertions, this passes all of them, and the phone still hands its chip up into the band above the picture. `npm test` passes.

Fixes #302
