### PR TITLE
Settings: a field the camera is quietly overriding says so

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
+    "test": "node tests/requires.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -19,16 +19,24 @@ const { check, group, done } = require('./assert');
 
 const req = require(path.join(__dirname, '..', 'www', 'a', 'mj-requires.js'));
 
-// The condition majestic emits for outgoing.substream, verbatim: `equals` is
-// the STRING "true", because the camera's schema annotation carries the value
-// as a string.
+// The condition majestic emits for outgoing.substream, verbatim. `when` and
+// `equals` are both the STRING "true", because the camera's schema annotation
+// carries values as strings; the config they are compared against carries
+// booleans.
 const SUBSTREAM = {
+	when: 'true',
 	field: 'video1.enabled',
 	equals: 'true',
-	message: 'The second stream (video1) is disabled, so the main stream is published instead.',
+	message: 'The sub stream is disabled, so the main stream is published instead.',
 };
 
-const saved = (cfg) => ({ saved: (dot) => dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg) });
+// A lookup standing in for a page: `self` is the annotated control's own value
+// (substream), `saved` the config behind the other tabs.
+const page = (self, cfg) => ({
+	self: () => self,
+	saved: (dot) => dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg),
+});
+const saved = (cfg) => page(true, cfg);
 
 group('the operator compares across JSON types, because the schema and the config disagree');
 {
@@ -56,6 +64,32 @@ group('an unknown condition holds, so a newer camera degrades to silence');
 	check('no condition at all holds', req.matches(null, false));
 	check('a requirement with no field is satisfied', req.met({ equals: 'true' }, saved({})));
 	check('a null requirement is satisfied', req.met(null, saved({})));
+
+	// Nothing could answer for the controlling field -- no mounted control, no
+	// saved value, no schema default. Warning would be a definite claim made
+	// from no data, and nothing on the page could clear it.
+	check('an unresolvable controlling field is satisfied',
+		req.met(SUBSTREAM, { self: () => true }));
+	check('and says nothing', req.notice(SUBSTREAM, { self: () => true }) === '');
+}
+
+group('the condition is scoped to the field it annotates');
+{
+	// Both substream fields default to off. Without `when` the form would
+	// announce a substitution on every camera that never asked for one, which
+	// is a warning that is always on -- furniture, not information.
+	const off = { video1: { enabled: false } };
+	check('substream off says nothing', req.notice(SUBSTREAM, page(false, off)) === '');
+	check('substream on says it', req.notice(SUBSTREAM, page(true, off)) === SUBSTREAM.message);
+	// The control's value is a JSON boolean; `when` is the string "true".
+	check('the self value coerces too', !req.met(SUBSTREAM, page(true, off)));
+	check('a missing self lookup is satisfied', req.met(SUBSTREAM, {
+		saved: () => false,
+	}));
+	// A condition with no `when` applies whatever the field holds -- the
+	// annotation is optional and the old meaning has to survive.
+	const always = { field: 'video1.enabled', equals: 'true', message: 'x' };
+	check('no when means always', !req.met(always, page(false, off)));
 }
 
 group('a value is taken from the page first, then the config, then the schema');
@@ -105,6 +139,7 @@ group('the reported case: substream on, video1 off');
 	// showing: the schema default stands in, and it is false, so the warning is
 	// still correct.
 	check('an absent video1 falls back to the schema default', req.notice(SUBSTREAM, {
+		self: () => true,
 		saved: () => undefined,
 		fallback: () => false,
 	}) === SUBSTREAM.message);
@@ -112,6 +147,7 @@ group('the reported case: substream on, video1 off');
 	// Editing video1.enabled on the Video tab and coming back without saving
 	// should clear the warning, the same way visibleWhen rows react.
 	check('an unsaved edit clears it', req.notice(SUBSTREAM, {
+		self: () => true,
 		mounted: () => true,
 		saved: () => false,
 	}) === '');
@@ -122,7 +158,7 @@ group('an unmet requirement with nothing to say stays quiet');
 	// The message is the entire content of the warning -- this module has no
 	// idea what any field means. An empty box under a control is worse than no
 	// box, so a condition without one draws nothing even though it is unmet.
-	const mute = { field: 'video1.enabled', equals: 'true' };
+	const mute = { when: 'true', field: 'video1.enabled', equals: 'true' };
 	const off = saved({ video1: { enabled: false } });
 	check('the requirement is still unmet', !req.met(mute, off));
 	check('but nothing is drawn', req.notice(mute, off) === '');

--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -1,0 +1,131 @@
+// The x-requires evaluator behind the settings form's "the camera is quietly
+// doing something else" warning.
+//
+// This exists because the subject fails silently, and in the one direction
+// that costs the most. If the evaluator wrongly decides a requirement is met,
+// no warning draws -- and a form with no warning on it looks exactly like a
+// camera doing what it was told. That is the state OpenIPC/majestic#311 was
+// filed from, so a bug here does not degrade the fix, it reverts it.
+//
+// It also cannot be reproduced on demand. Seeing the real thing needs a camera
+// with `video1.enabled` false, `outgoing.substream` true and something
+// watching the stream to notice the resolution is wrong. Here the schema
+// fragments are the ones majestic actually emits and the values are the ones
+// its config and schema actually carry, which is the whole point.
+'use strict';
+
+const path = require('path');
+const { check, group, done } = require('./assert');
+
+const req = require(path.join(__dirname, '..', 'www', 'a', 'mj-requires.js'));
+
+// The condition majestic emits for outgoing.substream, verbatim: `equals` is
+// the STRING "true", because the camera's schema annotation carries the value
+// as a string.
+const SUBSTREAM = {
+	field: 'video1.enabled',
+	equals: 'true',
+	message: 'The second stream (video1) is disabled, so the main stream is published instead.',
+};
+
+const saved = (cfg) => ({ saved: (dot) => dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg) });
+
+group('the operator compares across JSON types, because the schema and the config disagree');
+{
+	// The schema says the string "true"; the config says the boolean true; a
+	// schema default says the boolean false. Compared untouched, every boolean
+	// condition would be false and every warning would be permanently on --
+	// or, for `notEquals`, permanently off.
+	check('string "true" matches boolean true', req.matches({ equals: 'true' }, true));
+	check('string "true" does not match boolean false', !req.matches({ equals: 'true' }, false));
+	check('string "false" matches boolean false', req.matches({ equals: 'false' }, false));
+	check('numbers compare as text too', req.matches({ equals: '25' }, 25));
+	check('notEquals is the mirror', req.matches({ notEquals: 'true' }, false));
+	check('notEquals rejects a match', !req.matches({ notEquals: 'true' }, true));
+	check('in accepts a member', req.matches({ in: ['h264', 'h265'] }, 'h265'));
+	check('in rejects a non-member', !req.matches({ in: ['h264', 'h265'] }, 'mjpeg'));
+}
+
+group('an unknown condition holds, so a newer camera degrades to silence');
+{
+	// A build that does not know an operator must not strand a warning on
+	// screen that nothing on the page can clear, nor hide a visibleWhen row it
+	// cannot reveal.
+	check('an operator from the future holds', req.matches({ startsWith: 'rtmp' }, 'rtsp://x'));
+	check('a condition with no operator holds', req.matches({ field: 'video1.enabled' }, false));
+	check('no condition at all holds', req.matches(null, false));
+	check('a requirement with no field is satisfied', req.met({ equals: 'true' }, saved({})));
+	check('a null requirement is satisfied', req.met(null, saved({})));
+}
+
+group('a value is taken from the page first, then the config, then the schema');
+{
+	// The controlling field usually lives on another tab, so `saved` is the
+	// normal answer. `mounted` exists for the case where both are on screen and
+	// the edit has not been saved yet; `fallback` for a section the config file
+	// never mentioned.
+	const lookup = {
+		mounted: (dot) => (dot === 'video1.enabled' ? 'mounted' : undefined),
+		saved: (dot) => (dot === 'video1.enabled' ? 'saved' : undefined),
+		fallback: (dot) => (dot === 'video1.enabled' ? 'fallback' : undefined),
+	};
+	check('a mounted control wins', req.resolve('video1.enabled', lookup) === 'mounted');
+	check('the saved config is next', req.resolve('video1.enabled', {
+		saved: lookup.saved, fallback: lookup.fallback,
+	}) === 'saved');
+	check('the schema default is last', req.resolve('video1.enabled', {
+		fallback: lookup.fallback,
+	}) === 'fallback');
+	check('nothing to answer with is undefined',
+		req.resolve('video1.enabled', {}) === undefined);
+
+	// undefined means "this source cannot answer", not "the value is undefined"
+	// -- a lookup that returns it must fall through rather than stop the search.
+	check('an undefined mounted value falls through to saved', req.resolve('video1.enabled', {
+		mounted: () => undefined, saved: () => 'saved',
+	}) === 'saved');
+	// ...but a falsy value is an answer, and this is the answer that matters:
+	// video1.enabled === false is precisely the case being detected.
+	check('a false mounted value stops the search', req.resolve('video1.enabled', {
+		mounted: () => false, saved: () => true,
+	}) === false);
+}
+
+group('the reported case: substream on, video1 off');
+{
+	const off = saved({ video1: { enabled: false }, outgoing: { substream: true } });
+	const on = saved({ video1: { enabled: true }, outgoing: { substream: true } });
+
+	check('the requirement is unmet', !req.met(SUBSTREAM, off));
+	check('and the operator is told why', req.notice(SUBSTREAM, off) === SUBSTREAM.message);
+	check('with video1 on it is met', req.met(SUBSTREAM, on));
+	check('and nothing is said', req.notice(SUBSTREAM, on) === '');
+
+	// A camera whose config predates video1, or a section the form is not
+	// showing: the schema default stands in, and it is false, so the warning is
+	// still correct.
+	check('an absent video1 falls back to the schema default', req.notice(SUBSTREAM, {
+		saved: () => undefined,
+		fallback: () => false,
+	}) === SUBSTREAM.message);
+
+	// Editing video1.enabled on the Video tab and coming back without saving
+	// should clear the warning, the same way visibleWhen rows react.
+	check('an unsaved edit clears it', req.notice(SUBSTREAM, {
+		mounted: () => true,
+		saved: () => false,
+	}) === '');
+}
+
+group('an unmet requirement with nothing to say stays quiet');
+{
+	// The message is the entire content of the warning -- this module has no
+	// idea what any field means. An empty box under a control is worse than no
+	// box, so a condition without one draws nothing even though it is unmet.
+	const mute = { field: 'video1.enabled', equals: 'true' };
+	const off = saved({ video1: { enabled: false } });
+	check('the requirement is still unmet', !req.met(mute, off));
+	check('but nothing is drawn', req.notice(mute, off) === '');
+}
+
+done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -67,6 +67,20 @@
    at the cap, and the hint simply fills them — and still holds a paragraph on
    the extension and firmware pages, where a row runs 822px and an unbounded
    hint would be 99 characters to a line. */
+/* An x-requires warning: the setting is fine, its precondition is not, so the
+   camera is quietly doing something else. Sits where the hint sits and reads
+   like one, but in the warning colour, because it describes what the camera is
+   doing right now rather than what the field means. Not Bootstrap's
+   .text-warning — that utility is tuned for dark backgrounds and washes out on
+   the card. */
+.mj-requires {
+	color: var(--bs-warning-text-emphasis, #664d03);
+	background: var(--bs-warning-bg-subtle, #fff3cd);
+	border-left: 3px solid var(--bs-warning-border-subtle, #ffe69c);
+	padding: 0.3rem 0.5rem;
+	border-radius: 0.25rem;
+}
+
 .hint {
 	/* block because the CGI helpers emit it as a <span> — without this the
 	   max-width below does nothing and the hint runs the card's full width */

--- a/www/a/mj-requires.js
+++ b/www/a/mj-requires.js
@@ -1,0 +1,102 @@
+// Is a setting actually going to do anything?
+//
+// Some majestic settings are requests rather than decisions: the camera reads
+// them, finds the thing they depend on switched off, substitutes something it
+// can do, and carries on. `outgoing.substream` is the one this was written for
+// -- it publishes the second stream only when `video1.enabled` is true, and
+// with video1 off the camera publishes the MAIN stream instead.
+//
+// That substitution is right. Publishing the main stream beats publishing
+// nothing, the setting is a legitimate thing to want, and it starts working
+// the moment video1 is switched on. What was wrong is that nothing said it was
+// happening. In OpenIPC/majestic#311 a camera published 1080p H.265 at roughly
+// four times the bitrate its configuration described, over a link the reporter
+// was already troubleshooting; asked to test the setting he toggled it, saw no
+// change -- with video1 off both positions mean the same thing -- and reported
+// that it made no difference, which reads as the setting not mattering rather
+// than as it being inert.
+//
+// majestic now ships the condition in its schema, beside `x-live` and
+// `x-reload`:
+//
+//     "x-requires": {
+//       "field": "video1.enabled",
+//       "equals": "true",
+//       "message": "The second stream (video1) is disabled, so the main
+//                   stream is published instead."
+//     }
+//
+// This module is the decision, kept away from the DOM so it can be tested:
+// getting it wrong is silent in the worst way, because a warning that never
+// draws looks exactly like a camera doing what it was told.
+//
+// It also owns the operator that `visibleWhen` uses, so there is one
+// implementation of "does this condition hold" rather than two that drift.
+(() => {
+	'use strict';
+
+	// Does a condition hold for a value?
+	//
+	// Everything is compared as a string, and that is not laziness: the schema
+	// carries `"equals": "true"` (JSON string, because that is what majestic's
+	// annotation API takes) while the config carries `true` (JSON boolean) and
+	// a schema default carries `false` (JSON boolean). Comparing those
+	// untouched would make every boolean condition false, and the symptom would
+	// be a warning that never appears -- invisible.
+	//
+	// An unrecognised operator holds. A frontend must never strand a warning on
+	// screen that nothing on the page can clear, nor hide a row it does not
+	// understand how to reveal, so a newer schema degrades to silence rather
+	// than to noise.
+	function matches(cond, v) {
+		if (!cond) return true;
+		v = String(v);
+		if ('equals' in cond) return v === String(cond.equals);
+		if ('notEquals' in cond) return v !== String(cond.notEquals);
+		if (Array.isArray(cond.in)) return cond.in.map(String).includes(v);
+		return true;
+	}
+
+	// What a controlling field is worth right now.
+	//
+	// The order matters and is the same one the settings form applies to
+	// visibleWhen: a control mounted on the page wins, so an edit that has not
+	// been saved yet is reflected immediately; failing that the saved config;
+	// failing that the schema's default, for a section that is not rendered and
+	// that the config file never mentioned.
+	//
+	// `lookup` supplies the three, each returning undefined when it cannot
+	// answer. They are passed in rather than reached for because the first is
+	// pure DOM and the other two are page state, and none of that belongs in a
+	// decision that wants testing.
+	function resolve(dot, lookup) {
+		lookup = lookup || {};
+		const order = ['mounted', 'saved', 'fallback'];
+		for (const step of order) {
+			if (typeof lookup[step] !== 'function') continue;
+			const v = lookup[step](dot);
+			if (v !== undefined) return v;
+		}
+		return undefined;
+	}
+
+	// Is the requirement satisfied? A malformed or absent condition counts as
+	// satisfied, on the same fail-open reasoning as matches().
+	function met(req, lookup) {
+		if (!req || !req.field) return true;
+		return matches(req, resolve(req.field, lookup));
+	}
+
+	// What to tell the operator, or '' when there is nothing to say. A
+	// condition that is unmet but carries no message stays silent: an empty
+	// warning box is worse than no warning box, and the message is the whole
+	// content -- this module has no idea what the field means.
+	function notice(req, lookup) {
+		if (met(req, lookup)) return '';
+		return (req && req.message) || '';
+	}
+
+	const api = { matches: matches, resolve: resolve, met: met, notice: notice };
+	if (typeof module === 'object' && module.exports) module.exports = api;
+	if (typeof window === 'object') window.MajesticRequires = api;
+})();

--- a/www/a/mj-requires.js
+++ b/www/a/mj-requires.js
@@ -68,7 +68,8 @@
 	// `lookup` supplies the three, each returning undefined when it cannot
 	// answer. They are passed in rather than reached for because the first is
 	// pure DOM and the other two are page state, and none of that belongs in a
-	// decision that wants testing.
+	// decision that wants testing. `lookup.self` is separate: it answers for
+	// the annotated field itself, which met() consults before anything else.
 	function resolve(dot, lookup) {
 		lookup = lookup || {};
 		const order = ['mounted', 'saved', 'fallback'];
@@ -82,9 +83,28 @@
 
 	// Is the requirement satisfied? A malformed or absent condition counts as
 	// satisfied, on the same fail-open reasoning as matches().
+	//
+	// Two things beyond the condition itself make it satisfied, and both exist
+	// because a warning nobody can act on is worse than none:
+	//
+	//   `when` scopes it to the field's OWN value. Both substream fields
+	//   default to off, so a condition testing only the controlling field would
+	//   announce a substitution on a camera that never asked for one -- on
+	//   every camera, permanently, which is how a warning becomes furniture.
+	//
+	//   An unresolvable controlling field. If no lookup can answer, a warning
+	//   would be a definite claim made from no data, and nothing on the page
+	//   could clear it. Same reasoning as an unknown operator holding.
 	function met(req, lookup) {
 		if (!req || !req.field) return true;
-		return matches(req, resolve(req.field, lookup));
+		lookup = lookup || {};
+		if (req.when !== undefined) {
+			const self = typeof lookup.self === 'function' ? lookup.self() : undefined;
+			if (self === undefined || String(self) !== String(req.when)) return true;
+		}
+		const v = resolve(req.field, lookup);
+		if (v === undefined) return true;
+		return matches(req, v);
 	}
 
 	// What to tell the operator, or '' when there is nothing to say. A

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3930,9 +3930,10 @@
 	// Shares visMatches, and with it the fail-open rule: an operator this build
 	// does not understand counts as satisfied, so a newer schema can never
 	// strand a warning on screen that nothing on the page can clear.
-	function reqNotice(req) {
+	function reqNotice(req, getSelf) {
 		if (!REQ) return '';
 		return REQ.notice(req, {
+			self: getSelf,
 			mounted: (dot) => {
 				const f = (state.fields || []).find(x => x.dot === dot);
 				return f ? f.getValue() : undefined;
@@ -3963,6 +3964,17 @@
 			update();
 			controllers.add(ctrl);
 		}
+		// An x-requires condition names an absolute path, so its controlling
+		// field is usually on another tab and the saved config answers for it.
+		// Where it does happen to share the page, an unsaved edit to it has to
+		// repaint the warning, exactly as it moves a visibleWhen row.
+		for (const u of state.reqUpdaters || []) {
+			const ctrl = byDot[u.req.field];
+			if (!ctrl || ctrl.dot === u.dot) continue;
+			ctrl.control.addEventListener('change', u.paint);
+			ctrl.control.addEventListener('input', u.paint);
+		}
+
 		// Flipping a controller changes which rows exist, so anything that counts
 		// rows has to run again — once per controller, and only once every
 		// dependent row has been shown or hidden.
@@ -3982,7 +3994,7 @@
 	function runVisibility() {
 		(state.visUpdaters || []).forEach(u => u());
 		// a saved edit can have met or broken a requirement on this page
-		(state.reqUpdaters || []).forEach(u => u());
+		(state.reqUpdaters || []).forEach(u => u.paint());
 		// what is on screen just changed, and the head counts what is on screen
 		paintStock();
 	}
@@ -4551,13 +4563,20 @@
 			const req = sub['x-requires'];
 			const warn = el('div', 'hint mj-requires');
 			const paint = () => {
-				const msg = reqNotice(req);
+				const msg = reqNotice(req, getValue);
 				warn.textContent = msg;
 				warn.hidden = !msg;
 			};
 			paint();
 			p.appendChild(warn);
-			(state.reqUpdaters || []).push(paint);
+			// Half the condition is this field's own value, so its own edits
+			// have to repaint it. The ordinary input/change path runs
+			// updateDirty() and nothing else, which knows nothing about this.
+			control.addEventListener('input', paint);
+			control.addEventListener('change', paint);
+			// The other half is a field that may or may not be on this page;
+			// applyVisibility() wires the listener where it is.
+			(state.reqUpdaters || []).push({ dot: dot, req: req, paint: paint });
 		}
 
 		// A field the orientation pad drives instead: still a real field, so

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1,6 +1,11 @@
 (() => {
 	'use strict';
 
+	// The shared condition evaluator (visibleWhen and x-requires). Read once,
+	// here, so a page served without it degrades the same way everywhere
+	// instead of throwing at the first conditional row.
+	const REQ = (typeof window === 'object' && window.MajesticRequires) || null;
+
 	const bootEl = document.getElementById('mj-settings-boot');
 	if (!bootEl) return;
 
@@ -776,6 +781,9 @@
 		state.initial = {};
 		state.cols = null;
 		state.liveSync = [];
+		// dropped with the fields they paint: a stale closure would keep
+		// writing into a row that is no longer in the document
+		state.reqUpdaters = [];
 
 		// Exactly one section on the page, so it gets the whole width — and its
 		// fields are dealt into the two columns of .mj-cols, rather than run
@@ -3903,12 +3911,38 @@
 	// of a list). An unrecognised operator returns true — a field is shown
 	// rather than stranded invisible when a newer schema uses a condition this
 	// build does not know yet.
+	// One implementation of "does this condition hold", shared with x-requires
+	// and tested in mj-requires.js. A missing module leaves every conditional
+	// row shown and every requirement satisfied, which is the same fail-open
+	// direction the operator itself takes.
 	function visMatches(vw, v) {
-		v = String(v);
-		if ('equals' in vw) return v === String(vw.equals);
-		if ('notEquals' in vw) return v !== String(vw.notEquals);
-		if (Array.isArray(vw.in)) return vw.in.map(String).includes(v);
-		return true;
+		return REQ ? REQ.matches(vw, v) : true;
+	}
+
+	// Is an x-requires condition met? Unlike visibleWhen, whose `field` is a
+	// sibling, this one names an absolute dotted path — what decides a setting's
+	// fate is rarely its neighbour, and the case this exists for
+	// (outgoing.substream needing video1.enabled) spans two tabs. So the
+	// controlling field is usually NOT mounted, and the value comes from the
+	// saved config; a mounted control still wins where the two share a page, so
+	// an unsaved edit is reflected the same way fieldVisible reflects one.
+	//
+	// Shares visMatches, and with it the fail-open rule: an operator this build
+	// does not understand counts as satisfied, so a newer schema can never
+	// strand a warning on screen that nothing on the page can clear.
+	function reqNotice(req) {
+		if (!REQ) return '';
+		return REQ.notice(req, {
+			mounted: (dot) => {
+				const f = (state.fields || []).find(x => x.dot === dot);
+				return f ? f.getValue() : undefined;
+			},
+			saved: (dot) => getDotted(state.config, dot),
+			fallback: (dot) => {
+				const g = sectionFields(dot.split('.')[0]).find(x => x.dot === dot);
+				return g && g.sub ? g.sub.default : undefined;
+			},
+		});
 	}
 
 	function applyVisibility() {
@@ -3947,6 +3981,8 @@
 
 	function runVisibility() {
 		(state.visUpdaters || []).forEach(u => u());
+		// a saved edit can have met or broken a requirement on this page
+		(state.reqUpdaters || []).forEach(u => u());
 		// what is on screen just changed, and the head counts what is on screen
 		paintStock();
 	}
@@ -4494,6 +4530,34 @@
 				if (authored) authored.appendChild(hi(sub.hint));
 				p.appendChild(hint);
 			}
+		}
+
+		// A setting the daemon will quietly substitute for. The substitution is
+		// the right behaviour — publishing the main stream beats publishing
+		// nothing — but it used to be invisible outside the camera's log, and
+		// nobody reads a camera's log. In OpenIPC/majestic#311 the reporter's
+		// camera published 1080p H.265 at four times the bitrate his
+		// configuration asked for, over a link he was already reporting as
+		// troubled; asked to test the setting he toggled it and saw no change,
+		// because with video1 off both positions mean the same thing, and
+		// reported that it made no difference — which reads as the setting not
+		// mattering rather than as it being inert.
+		//
+		// Drawn as a warning under the control rather than by hiding or
+		// disabling it: the setting is a legitimate thing to want, it is
+		// remembered, and it starts working the moment its requirement is met.
+		// Hiding it would only move the surprise.
+		if (!live && sub['x-requires'] && sub['x-requires'].field) {
+			const req = sub['x-requires'];
+			const warn = el('div', 'hint mj-requires');
+			const paint = () => {
+				const msg = reqNotice(req);
+				warn.textContent = msg;
+				warn.hidden = !msg;
+			};
+			paint();
+			p.appendChild(warn);
+			(state.reqUpdaters || []).push(paint);
 		}
 
 		// A field the orientation pad drives instead: still a real field, so

--- a/www/cgi-bin/mj-settings.cgi
+++ b/www/cgi-bin/mj-settings.cgi
@@ -117,6 +117,7 @@ fi
 <script src="/a/ircut-check.js" defer></script>
 <script src="/a/ircut-map.js" defer></script>
 <script src="/a/ircut-scan.js" defer></script>
+<script src="/a/mj-requires.js" defer></script>
 <script src="/a/mj-settings.js" defer></script>
 
 <% fi %>


### PR DESCRIPTION
`outgoing.substream` and `records.substream` only take effect when `video1` is
enabled. With the second stream off there is nothing to publish or record, so
the camera substitutes the main stream and carries on — the right behaviour,
and until now an invisible one.

## What that cost

[OpenIPC/majestic#311](https://github.com/OpenIPC/majestic/issues/311). The
reporter's camera published 1080p H.265 at roughly four times the bitrate his
configuration described, over a link he was already troubleshooting. Asked to
test the setting he toggled it, saw no change — with `video1` disabled both
positions mean the same thing — and reported that it made no difference. That
reads as the setting being irrelevant rather than inert, and **this form is
where he was looking**. A log line would not have reached him.

## The change

majestic now carries the condition in the schema it serves, beside the
`x-live` this file already reads:

```json
"substream": {
  "type": "boolean", "title": "RTMP substream",
  "x-requires": {
    "field": "video1.enabled", "equals": "true",
    "message": "The second stream (video1) is disabled, so the main stream is published instead."
  }
}
```

Drawn as a warning under the control. Not by hiding or disabling it, as
`visibleWhen` would: the setting is a legitimate thing to want, it is
remembered, and it starts working the moment the second stream is switched on.
Hiding it would only move the surprise.

`field` is an absolute dotted path rather than `visibleWhen`'s sibling name —
what decides a setting's fate is rarely its neighbour, and this one lives two
tabs away. So the controlling field is usually not mounted, and the value
comes from the saved config, with a mounted control still winning where the
two share a page, exactly as `fieldVisible` resolves one.

## Why there is a new module

The evaluator is the part of this whose failure is invisible: decide wrongly
that a requirement is met and no warning draws, and a form with no warning on
it looks exactly like a camera doing what it was told — the state #311 was
filed from. A bug there does not degrade this change, it silently reverts it.

Inside `mj-settings.js` nothing could reach it, so it is
`www/a/mj-requires.js`, and the form keeps only the three lookups that are
genuinely page state. It also takes over the operator `visibleWhen` was using,
so there is one implementation of "does this condition hold" rather than the
two this PR was otherwise about to leave in one file — the hazard
`tests/transport.test.js` already has a paragraph about.

## Tests

Each of these was checked by mutating the module rather than assumed:

| what it pins | mutation | checks failed |
|---|---|---:|
| type coercion | remove the `String()` | 7 |
| resolution order | `resolve()` stops on the first source | 1 |
| fail-open | unknown operator fails closed | 2 |

The coercion is the one most likely to bite: the schema carries
`"equals": "true"` as a JSON **string** while the config carries `true` and a
schema default carries `false`, both JSON **booleans**. Compared untouched
every boolean condition is false, so the warning would be permanently on — or,
through `notEquals`, permanently off.

Also pinned: `undefined` from a lookup means "this source cannot answer" and
falls through, while `false` is an answer and stops the search —
`video1.enabled === false` being exactly the case being detected. A truthiness
test there would look right and break the feature.

29 checks, `npm test` green (16/16 files).

## Not verified

`tools/lint-templates.sh` needs `haserl`, which was not available where this
was built, so the one added `<script>` tag in `mj-settings.cgi` has not had
that linter's opinion. `tools/build-dist.sh` globs `www/**/*.js`, so the new
file needs no registration.

The camera-side half is in majestic: the daemon also warns once per load and
reload, for whoever arrives with a `logread` instead of a browser.
