### PR TITLE
Live adjustments: read the software-decoded canvas off the main thread

### DIFF
--- a/www/a/mj-luma.js
+++ b/www/a/mj-luma.js
@@ -171,19 +171,27 @@
 				if (v.tagName === 'CANVAS' && typeof createImageBitmap === 'function' &&
 					!bitmapBroken) {
 					busy = true;
+					// Capture what identifies the picture NOW, to compare after
+					// the async readback: the element, and a source token the
+					// caller may supply. The token exists because element
+					// identity is not enough — a same-codec channel switch
+					// reopens on the SAME canvas node, so the node stays live
+					// while the pixels under it change (see opts.token).
+					const tok = opts.token ? opts.token() : null;
+					const fresh = function () {
+						return !stopped && opts.video() === v &&
+							v.__mjPainted === true &&
+							(!opts.token || opts.token() === tok);
+					};
 					createImageBitmap(v, {
 						resizeWidth: SW, resizeHeight: SH, resizeQuality: 'low',
 					}).then(function (bmp) {
 						// Publish only if this is still the picture on screen. A
 						// channel or transport switch can land between the snapshot
-						// and here — the software player even swaps its canvas node
-						// — and a histogram of the frame that WAS is a wrong answer
-						// dressed as the current one, worse than one tick's gap. `v`
-						// is the superseded node after such a switch, so the
-						// identity check against the live element catches it.
-						if (!stopped && opts.video() === v && v.__mjPainted === true) {
-							sampleFrom(bmp);
-						}
+						// and here, and a histogram of the frame that WAS is a
+						// wrong answer dressed as the current one, worse than one
+						// tick's gap.
+						if (fresh()) sampleFrom(bmp);
 						bmp.close();
 						busy = false;
 					}).catch(function () {
@@ -193,9 +201,7 @@
 						// the stall is the lesser fault, and only where it is forced.
 						bitmapBroken = true;
 						busy = false;
-						if (!stopped && opts.video() === v && v.__mjPainted === true) {
-							sampleFrom(v);
-						}
+						if (fresh()) sampleFrom(v);
 					});
 				} else {
 					sampleFrom(v);

--- a/www/a/mj-luma.js
+++ b/www/a/mj-luma.js
@@ -18,8 +18,9 @@
 	// that the shape is readable in a 23rem panel.
 	const BINS = 64;
 	// The sample is a thumbnail, not the frame. A luma distribution is a
-	// statistic — 160x90 is 14,400 pixels, which is plenty for one, and small
-	// enough that the draw plus the readback stay far away from a frame budget.
+	// statistic — 160x90 is 14,400 pixels, which is plenty for one. The
+	// getImageData off this small target is cheap; what is NOT cheap is the
+	// draw that fills it from a large software-decoded canvas — see tick().
 	const SW = 160, SH = 90;
 
 	// Rec.709, because that is what an H.264 HD stream is: using the 601
@@ -100,6 +101,31 @@
 		const ctx = canvas.getContext('2d', { willReadFrequently: true });
 		let timer = null;
 		let stopped = false;
+		// One readback in flight at a time. The canvas path below is async, so
+		// without this a slow readback would pile the next tick's on top of it
+		// — the exact stall this guard exists to bound turned into a queue of
+		// them. A tick that finds one already running simply skips, which for a
+		// histogram sampled several times a second costs nothing.
+		let busy = false;
+
+		// Draw the (already thumbnail-sized) source into the sampling canvas and
+		// turn it into a histogram. `source` is either a bitmap the browser has
+		// already scaled to SWxSH off-thread, or a <video> the browser scales
+		// down for free as it draws — both leave getImageData reading 14,400
+		// pixels and nothing larger.
+		function sampleFrom(source) {
+			try {
+				ctx.drawImage(source, 0, 0, SW, SH);
+				const d = ctx.getImageData(0, 0, SW, SH).data;
+				const r = histogram(d, SW, SH);
+				r.path = path(r.bins);
+				opts.onData(r);
+			} catch (e) {
+				// A frame that cannot be drawn (mid-teardown, or a tainted
+				// canvas on some future cross-origin source) is not worth
+				// killing the loop over; the next tick may well work.
+			}
+		}
 
 		function tick() {
 			if (stopped) return;
@@ -123,17 +149,31 @@
 			const drawable = v && (v.tagName === 'CANVAS'
 				? v.__mjPainted === true
 				: (v.readyState >= 2 && v.videoWidth > 0));
-			if (!document.hidden && drawable) {
-				try {
-					ctx.drawImage(v, 0, 0, SW, SH);
-					const d = ctx.getImageData(0, 0, SW, SH).data;
-					const r = histogram(d, SW, SH);
-					r.path = path(r.bins);
-					opts.onData(r);
-				} catch (e) {
-					// A frame that cannot be drawn (mid-teardown, or a tainted
-					// canvas on some future cross-origin source) is not worth
-					// killing the loop over; the next tick may well work.
+			if (!document.hidden && drawable && !busy) {
+				// A <video> is cheap to sample: the browser scales it down as it
+				// draws, so the synchronous path stays well inside a frame.
+				//
+				// A software-decode CANVAS is not. drawImage() from a full-res
+				// WebGL surface forces a GPU->CPU readback of the WHOLE frame
+				// before the downscale, and on a weak client decoding a 2592x1520
+				// stream that measured ~570ms — four times a second, jamming the
+				// main thread and every transport switch riding on it (#288).
+				// createImageBitmap does the readback AND the downscale off the
+				// main thread and hands back a bitmap already sized SWxSH, so the
+				// draw above reads back nothing larger than the thumbnail. It
+				// snapshots the source at call time, exactly as drawImage would,
+				// so it captures the same frame from a preserveDrawingBuffer:false
+				// context rather than a blank one.
+				if (v.tagName === 'CANVAS' && typeof createImageBitmap === 'function') {
+					busy = true;
+					createImageBitmap(v, {
+						resizeWidth: SW, resizeHeight: SH, resizeQuality: 'low',
+					}).then(function (bmp) {
+						if (!stopped) sampleFrom(bmp);
+						bmp.close();
+					}).catch(function () {}).then(function () { busy = false; });
+				} else {
+					sampleFrom(v);
 				}
 			}
 			timer = setTimeout(tick, 1000 / (opts.hz || 4));

--- a/www/a/mj-luma.js
+++ b/www/a/mj-luma.js
@@ -107,6 +107,10 @@
 		// them. A tick that finds one already running simply skips, which for a
 		// histogram sampled several times a second costs nothing.
 		let busy = false;
+		// Set once if a browser exposes createImageBitmap but refuses this
+		// canvas source, so the loop stops asking it every tick and stays on the
+		// synchronous path — see the catch below.
+		let bitmapBroken = false;
 
 		// Draw the (already thumbnail-sized) source into the sampling canvas and
 		// turn it into a histogram. `source` is either a bitmap the browser has
@@ -164,14 +168,35 @@
 				// snapshots the source at call time, exactly as drawImage would,
 				// so it captures the same frame from a preserveDrawingBuffer:false
 				// context rather than a blank one.
-				if (v.tagName === 'CANVAS' && typeof createImageBitmap === 'function') {
+				if (v.tagName === 'CANVAS' && typeof createImageBitmap === 'function' &&
+					!bitmapBroken) {
 					busy = true;
 					createImageBitmap(v, {
 						resizeWidth: SW, resizeHeight: SH, resizeQuality: 'low',
 					}).then(function (bmp) {
-						if (!stopped) sampleFrom(bmp);
+						// Publish only if this is still the picture on screen. A
+						// channel or transport switch can land between the snapshot
+						// and here — the software player even swaps its canvas node
+						// — and a histogram of the frame that WAS is a wrong answer
+						// dressed as the current one, worse than one tick's gap. `v`
+						// is the superseded node after such a switch, so the
+						// identity check against the live element catches it.
+						if (!stopped && opts.video() === v && v.__mjPainted === true) {
+							sampleFrom(bmp);
+						}
 						bmp.close();
-					}).catch(function () {}).then(function () { busy = false; });
+						busy = false;
+					}).catch(function () {
+						// The browser has createImageBitmap but will not take this
+						// source. Stop asking it and fall back to the synchronous
+						// readback rather than leave the histogram blank for ever —
+						// the stall is the lesser fault, and only where it is forced.
+						bitmapBroken = true;
+						busy = false;
+						if (!stopped && opts.video() === v && v.__mjPainted === true) {
+							sampleFrom(v);
+						}
+					});
 				} else {
 					sampleFrom(v);
 				}

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -185,6 +185,15 @@ window.MajesticPreview = (function () {
 		// in a browser that refused an H.265 main.
 		let exhausted = false;
 		let frame = null;
+		// Bumped whenever the picture stops being what it was — a channel
+		// change, a dropped chain. An async consumer (the luma sampler reads a
+		// frame off the canvas off-thread) captures it before it starts and
+		// checks it before it publishes, so a readback that began on the stream
+		// just left cannot land as the current one. Element identity is not
+		// enough on its own: a same-codec channel switch reopens the socket on
+		// the SAME canvas node, so the node the sampler holds is still the live
+		// one while the pixels under it have moved.
+		let generation = 0;
 
 		// What the most recent attachment has reported about its picture, and
 		// which attachment that was. It is held rather than published because a
@@ -212,6 +221,9 @@ window.MajesticPreview = (function () {
 		// frame of a session, so it is a state they must handle anyway.
 		function forgetFrame() {
 			pending = null;
+			// Before the early return: a channel change with no frame yet still
+			// invalidates whatever an async consumer captured a moment ago.
+			generation++;
 			if (!frame) return;
 			frame = null;
 			if (opts.onFrame) opts.onFrame(null);
@@ -591,6 +603,12 @@ window.MajesticPreview = (function () {
 			// 300x150 while this already said 3840x2160. An overlay laid out
 			// from the element in that window is laid out from a default.
 			frame: function () { return frame; },
+
+			// A counter that changes when the picture's source does. An async
+			// consumer captures it before an off-thread readback and rechecks
+			// it after, to drop a result that no longer describes what is on
+			// screen — see the note where it is declared.
+			generation: function () { return generation; },
 
 			// The config has moved — re-read what it decides. Only the channel
 			// picker, because it is the only thing here settled once at mount:

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1346,6 +1346,9 @@
 			// player has marked it painted, so a histogram measures UNKNOWN
 			// rather than black while the picture is merely starting.
 			video: () => preview.media(),
+			// So an off-thread readback that began on the channel just left is
+			// dropped rather than published as the current one — see mj-luma.js.
+			token: () => preview.generation(),
 			onData: (r) => {
 				pathEl.setAttribute('d', r.path);
 				// One per cent is the threshold worth a warning: below it you


### PR DESCRIPTION
The luma histogram on the **Live adjustments** panel samples the preview by drawing it into a 160×90 canvas and reading that back. For a `<video>` that is cheap — the browser scales it down as it draws. For the **software-decode rung** it is not: the source is a full-resolution WebGL canvas, and `drawImage()` from it forces a GPU→CPU readback of the whole frame before the downscale.

On a weak client decoding a 2592×1520 H.265 stream, that readback measured **~570 ms**, four times a second — a main-thread stall that janks the UI and every transport switch riding on it. Reported on #288: the console floods with `[Violation] 'setTimeout' handler took 572ms` at `mj-luma.js:104`.

## Fix

`createImageBitmap` does the readback **and** the downscale off the main thread and returns a bitmap already sized 160×90, so the draw reads back nothing larger than the thumbnail.

- Measured at 6× CPU throttle: per-sample main-thread block **67 ms → ~1 ms**.
- It snapshots the source at call time exactly as `drawImage` would, so it captures the same frame from a `preserveDrawingBuffer: false` context rather than a blank one — **verified against a live 2592×1520 software-decoded main stream** (histogram populates and keeps updating).
- A one-in-flight guard skips a tick that arrives while a readback is still running, so a slow client can't queue stalls behind each other.
- The `<video>` path is unchanged.

Refs #288.