### PR TITLE
Day / Night: the dismissal sticks, the sweep can find the pad it is on

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -360,6 +360,41 @@ function runRest() {
 			/closing coil/.test(half[0].detail), half[0].detail);
 	}
 
+	group('wired: only a filter the camera can drive contradicts "there is none"');
+	{
+		// The dashboard drops the owner's "no filter here" claim the moment
+		// this says yes, so it has to ask the same question the banner does.
+		check('nothing assigned is not wired', ic.wired({}) === false);
+		check('the closing coil alone is', ic.wired({ irCutPin1: 11 }) === true);
+		// It used to be EITHER coil, which made Dismiss unusable on the very
+		// camera that was showing the banner: pressing it recorded the claim,
+		// and the next load read the opening coil, called it a contradiction
+		// and deleted it again — dismiss, reload, banner (#273).
+		check('the opening coil alone is not, because majestic moves nothing with it',
+			ic.wired({ irCutPin2: 10 }) === false);
+		check('and that is exactly the camera the banner is raised on',
+			ic.diagnose({ irCutPin2: 10 }, null, null)[0].id === 'no-pins');
+		check('pin 0 is a pin here too', ic.wired({ irCutPin1: 0 }) === true);
+	}
+
+	group('diagnose: a switch that is doing nothing says so');
+	{
+		const both = ic.diagnose(
+			{ irCutPin1: 11, irCutPin2: 10, irCutSingleInvert: true }, null, null);
+		const f = both.filter(x => x.id === 'invert-inert')[0];
+		check('the invert switch is called out when both coils are assigned',
+			!!f, JSON.stringify(both.map(x => x.id)));
+		check('as an observation, not a fault', f && f.level === 'info');
+		check('and it names the coil a single-pad filter goes on',
+			f && /closing coil/.test(f.detail));
+		check('one coil assigned IS the mode, so nothing is inert',
+			!ic.diagnose({ irCutPin1: 11, irCutSingleInvert: true }, null, null)
+				.some(x => x.id === 'invert-inert'));
+		check('and with the switch off there is nothing to say',
+			!ic.diagnose({ irCutPin1: 11, irCutPin2: 10 }, null, null)
+				.some(x => x.id === 'invert-inert'));
+	}
+
 	group('diagnose: the light monitor');
 	{
 		const blind = ic.diagnose({ irCutPin1: 11, lightMonitor: true }, null, null);

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -238,7 +238,25 @@ group('run: it finds the pair, and only the pair');
 					return scan.run(brakeOpen.io, [[11, 10]], { settleMs: 0 }).then((r4) => {
 						check('and a brake-held one found the same way is still brake-held',
 							r4.pins.brakeHeld === true, String(r4.pins.brakeHeld));
-						return eighth();
+						// A pad majestic already holds on a coil is braked and
+						// kept exported rather than floated, so the filter is
+						// never let go of and the classification cannot be made.
+						// null, not false: "it holds its position on its own"
+						// would be a claim about a pad nothing released (#273).
+						const held = camera(11, 10);
+						const heldIo = Object.assign({}, held.io, {
+							release: (a, b) => held.io.release(a, b)
+								.then(() => ({ done: true, floated: false })),
+						});
+						return scan.run(heldIo, [[11, 10]], { settleMs: 0 }).then((r5) => {
+							check('a release that did not float reports no classification',
+								r5.pins.brakeHeld === null, String(r5.pins.brakeHeld));
+							check('and the pair itself is still reported',
+								r5.pins.irCutPin1 === 11 && r5.pins.irCutPin2 === 10);
+							check('and the run still settles',
+								r5.pins.settled === true);
+							return eighth();
+						});
 					});
 				});
 			});

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -102,6 +102,24 @@ group('pairs: the pad list is the SoC\'s, never a constant');
 	}));
 	check('a driver-held line is in no pair', !h.some((x) => x.indexOf(3) >= 0));
 	check('a sysfs export stays a candidate', h.some((x) => x.indexOf(1) >= 0));
+
+	// The two coils are what this sweep is FOR. Skipping a pad already on one
+	// of them made a camera with one coil assigned unable to find the pair
+	// containing it: every pair that could have been the answer was absent from
+	// the list, the sweep ran to the end, and it reported nothing (#273).
+	const half = scan.pairs(Object.assign({}, B10, {
+		assigned: [{ pin: 11, role: 'irCutPin1' }, { pin: 52, role: 'backlightPin' },
+			{ pin: 66, role: 'lightSensorPin' }],
+	}));
+	check('a pad already on a coil is still a candidate',
+		half.some((x) => x.indexOf(11) >= 0));
+	check('and the pair it belongs to is still tried first',
+		half[0][0] === 11 && half[0][1] === 10, JSON.stringify(half[0]));
+	// Not a blanket un-skip: these two are deliberate assignments to another
+	// function, and driving the lamp mid-sweep would change the very picture
+	// the scan reads its answer off.
+	check('the illuminator is not a candidate', !half.some((x) => x.indexOf(52) >= 0));
+	check('nor is the daylight sensor', !half.some((x) => x.indexOf(66) >= 0));
 }
 
 // ---------------------------------------------------------------------------

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -52,14 +52,21 @@
 	// has to be dropped the moment the answer becomes yes — a claim that the
 	// camera has no filter cannot outlive someone configuring one.
 	function wired(nm) {
-		// EITHER coil. The filter is an H-bridge across two pads and the map
-		// assigns them independently, so a camera with only the opening coil
-		// set is half-configured, not unfitted — and it is exactly the camera
-		// that needs the missing-pin banner rather than a claim that there is
-		// no filter here. diagnose() still decides separately whether the
-		// wiring can actually drive anything.
+		// The same question the missing-pin finding asks, and it has to be the
+		// same question. It used to be EITHER coil, on the reasoning that a
+		// half-configured camera is not an unfitted one — true, but it made the
+		// dismissal impossible to use on exactly the camera that was showing
+		// the banner. With only the opening coil assigned majestic still moves
+		// nothing, so the banner stands and offers Dismiss; pressing it
+		// recorded the claim, and the next load read a coil, called it a
+		// contradiction, and deleted it again. Dismiss, reload, banner (#273).
+		//
+		// A claim is only contradicted by a filter this camera can actually
+		// drive. A pad assigned to a coil that majestic never reaches is not
+		// one, and someone pressing Dismiss under that banner is answering
+		// about the state they are looking at.
 		const n = nm || {};
-		return has(n.irCutPin1) || has(n.irCutPin2);
+		return has(n.irCutPin1);
 	}
 	// majestic writes booleans as booleans, but a hand-edited majestic.yaml can
 	// leave "true" as a string and yaml-cli does not normalise it.
@@ -194,6 +201,27 @@
 					'coil as well: on its own, one coil of a pair is left ' +
 					'carrying current for as long as the camera stays in that ' +
 					'position.',
+				fix: 'nightMode',
+			});
+		}
+
+		// The switch that only means something in the mode above. Someone who
+		// turns it on with both coils assigned has changed nothing and has no
+		// way to find that out — the field carries no description on a majestic
+		// that predates one, and even with it a settings page cannot say
+		// whether THIS camera is in the mode. Reported here, where it can, and
+		// it is where the reporter's own question gets its answer: the pad that
+		// drives a single-pad filter goes on the closing coil (#273).
+		if (on(nm.irCutSingleInvert) && driveable && !single) {
+			out.push({
+				id: 'invert-inert', level: 'info',
+				title: '"Single IRcut is inverted" is doing nothing here',
+				detail: 'That switch only applies where one pad drives the ' +
+					'filter, and both coils are assigned, so majestic pulses ' +
+					'the pair and never reads it. To drive the filter from one ' +
+					'pad, leave the opening coil unassigned \u2014 the closing ' +
+					'coil is the one majestic drives, and this switch then ' +
+					'chooses which level means night.',
 				fix: 'nightMode',
 			});
 		}

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -66,7 +66,7 @@
 		// care what is on the end of it, and plenty of boards carry a white
 		// LED ring instead of an IR one. Naming the pad after one of the two
 		// tells the owner of the other that this row is not theirs (#273).
-		{ key: 'backlightPin', label: 'Night illuminator', hint: 'the LED ring, infrared or white', color: '#c96a2e' },
+		{ key: 'backlightPin', label: 'Night illuminator', hint: 'the light, infrared or white', color: '#c96a2e' },
 		{ key: 'lightSensorPin', label: 'Daylight sensor', hint: 'photocell that says when it is dark', color: '#8a5cd8' },
 	];
 	const byKey = {};

--- a/www/a/ircut-scan.js
+++ b/www/a/ircut-scan.js
@@ -252,16 +252,27 @@
 		return ensureClosed()
 			.then(() => io.look())
 			.then((closed) => io.release(closeHigh, otherPad)
-				.then(() => io.wait(settle))
-				.then(() => io.look())
-				.then((floated) => {
-					// Floating releases the brake. A filter that moves was being
-					// held there and its pads must stay driven; one that does
-					// not is latching and can be let go.
-					out.brakeHeld = classify(closed.gmin, floated.gmin) !== null;
-					// Put it back where daylight wants it either way.
-					return io.drive(closeHigh, otherPad);
-				}))
+				.then((rel) => io.wait(settle)
+					.then(() => io.look())
+					.then((floated) => {
+						// Floating releases the brake. A filter that moves was
+						// being held there and its pads must stay driven; one
+						// that does not is latching and can be let go.
+						//
+						// Unless the release did not float. A pad majestic
+						// already holds on a coil is braked and kept exported
+						// instead — floating it would spring a brake-held
+						// filter open and unexporting it would take away the
+						// path majestic writes through — and the endpoint says
+						// so. That is null, never false: "it holds its position
+						// on its own" is a claim, and it would be made here
+						// from a pad that was never let go of.
+						out.brakeHeld = (rel && rel.floated === false)
+							? null
+							: classify(closed.gmin, floated.gmin) !== null;
+						// Put it back where daylight wants it either way.
+						return io.drive(closeHigh, otherPad);
+					})))
 			.then(() => { out.settled = true; return out; })
 			.catch(() => out);
 	}

--- a/www/a/ircut-scan.js
+++ b/www/a/ircut-scan.js
@@ -69,7 +69,19 @@
 	function pairs(info, opts) {
 		opts = opts || {};
 		const skip = {};
-		(info.assigned || []).forEach((a) => { skip[a.pin] = 1; });
+		// Pads with a job that is not this one. The two IR-cut coils are the
+		// EXCEPTION and stay candidates: they are what this sweep is looking
+		// for, so skipping them made a camera with one coil already assigned
+		// unable to find the pair that includes it — every pair containing that
+		// pad was simply absent from the list, the sweep ran to the end and
+		// reported nothing (#273). The illuminator and the daylight sensor stay
+		// skipped: those are deliberate assignments to a different function,
+		// and driving the lamp mid-sweep would change the very picture the scan
+		// is reading. A pad whose role the camera did not name is skipped as
+		// before — an unnamed job is still a job.
+		(info.assigned || []).forEach((a) => {
+			if (a.role !== 'irCutPin1' && a.role !== 'irCutPin2') skip[a.pin] = 1;
+		});
 		(opts.exclude || []).forEach((p) => { skip[p] = 1; });
 		// A line a kernel DRIVER holds is wired to something deliberate and is
 		// the class of pad that resets a PHY or drops a rail. "sysfs" is only an

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3807,12 +3807,22 @@
 				// The pair itself was watched moving the picture, so it is
 				// reported either way; what may be missing is the classification
 				// and the guarantee that the filter was left closed.
-				const tail = found.settled
-					? (found.brakeHeld
-						? 'It springs open when the pins are released, so they have to stay driven.'
-						: 'It holds its position on its own.')
-					: 'The checks after that did not finish, so the filter may not have ' +
-					'been left closed &mdash; look at the picture before trusting it.';
+				// brakeHeld is three-valued. null is a test that did not run:
+				// one of these pads is already majestic's, so it was braked
+				// rather than let go of, and there is no way to see whether the
+				// filter would have sprung open. Saying "it holds its position
+				// on its own" from that would be a claim made about a pad
+				// nothing released (#273).
+				const tail = !found.settled
+					? 'The checks after that did not finish, so the filter may not have ' +
+						'been left closed &mdash; look at the picture before trusting it.'
+					: found.brakeHeld === null
+						? 'Whether it holds its position on its own was not tested: ' +
+							'majestic is already driving one of these pads, and letting ' +
+							'go of it here would have moved the filter.'
+						: found.brakeHeld
+							? 'It springs open when the pins are released, so they have to stay driven.'
+							: 'It holds its position on its own.';
 				host.innerHTML = '<div class="mj-live-grp-head">' +
 					'<span class="mj-cap">Find the pins</span>' +
 					'<span class="mj-live-rule"></span></div>' +
@@ -4896,10 +4906,17 @@
 				flashToolbar(
 					'Saved and applied. The video streams were not interrupted.');
 		} catch (e) {
+			// Accepted, not verified. The POST answering ok means majestic
+			// took every leaf and saved once — but the page's own confirmation
+			// of what the camera now holds is the step that just threw, and on
+			// an older daemon a cleared pin comes back 202 and is ignored. So
+			// this says what is known and hands the reader the way to find out
+			// the rest, rather than swapping one confident wrong answer for
+			// another.
 			showError(landed
-				? 'Saved \u2014 the camera has the change \u2014 but the page ' +
-					'could not finish updating: ' + e.message + '. Reload to ' +
-					'see what the camera is holding now.'
+				? 'The camera accepted the change, but the page could not ' +
+					'read back what it is holding now: ' + e.message +
+					'. Reload the page before changing anything else.'
 				: 'Save failed: ' + e.message);
 		} finally {
 			liveSaving--;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3787,7 +3787,21 @@
 						'<div class="alert alert-secondary py-2 px-3 mb-0 small">' +
 						'<b>Nothing moved the picture.</b> Either the filter is on a pair this ' +
 						'scan did not reach, or there is not enough light to see it move. ' +
-						'Try again in daylight, or set the pins by hand.</div>';
+						'Try again in daylight, or set the pins by hand.' +
+						// Named because it is a real class of camera the sweep
+						// cannot reach, rather than a gap in the pad list. A
+						// single-pad filter is moved by HOLDING one pad at a
+						// level, and holding a pad is the thing this scan may
+						// not do: on a two-coil board it would leave a winding
+						// carrying current, which is why every actuation here
+						// is a brief pulse across a pair. So that wiring is
+						// found by hand and confirmed by the test (#273).
+						'<br><br>A filter driven from a single pad is not something ' +
+						'this sweep can find: it works by pulsing pairs, and a ' +
+						'single-pad filter is moved by holding one pad at a level, ' +
+						'which is not safe to do to a pad whose job is unknown. ' +
+						'If yours is wired that way, put the pad on the closing coil ' +
+						'yourself and press <b>Test the filter</b>.</div>';
 					return;
 				}
 				// The pair itself was watched moving the picture, so it is
@@ -4638,6 +4652,10 @@
 			if (d) n++;
 		}
 		state.dirtyN = n;
+		// A new edit outranks the last save's confirmation. renderToolbar leaves
+		// the label alone while a message is set, so leaving the flash up would
+		// print "Saved and applied" beside a Save button that has work to do.
+		if (n && state.flashPending) setToolbarMsg('');
 		renderToolbar();
 		paintStock();
 		// Every edit funnels through here — the map, a save, a per-row reset,
@@ -4686,11 +4704,45 @@
 	// is gone).
 	function setToolbarMsg(text, cls) {
 		state.toolbarMsg = text || '';
+		// Clearing the message also ends a flash. A flash IS a message with a
+		// timer on it, and leaving flashPending set would hold the bar open
+		// around nothing.
+		if (!text) {
+			if (state.flashTimer) clearTimeout(state.flashTimer);
+			state.flashTimer = null;
+			state.flashPending = false;
+		}
 		const lbl = document.getElementById('mj-dirty-count');
 		if (!lbl) return;
 		if (!text) { renderToolbar(); return; }
 		lbl.className = 'me-auto small ' + (cls || 'text-danger');
 		lbl.textContent = text;
+	}
+
+	// How long a save's confirmation stays up. It is the only thing holding the
+	// bar open, so it has to go away on its own.
+	const FLASH_MS = 6000;
+
+	// What a successful save says when it leaves nothing pending. An in-place
+	// change is carried by the save itself — no reload, no blink — so without
+	// this the bar vanishes the instant Save is pressed and the operator is
+	// left to guess whether anything happened. `flashPending` is the third
+	// reason for the bar to exist, beside dirty changes and a due reload, and
+	// renderToolbar already knows it.
+	//
+	// It did not exist. The call site shipped without it, inside onSubmit's
+	// try, so a save that had SUCCEEDED threw a ReferenceError on its way out
+	// and the catch reported "Save failed: Can't find variable: flashToolbar"
+	// over a change the camera had already taken (#273).
+	function flashToolbar(text) {
+		if (state.flashTimer) clearTimeout(state.flashTimer);
+		setToolbarMsg(text, 'text-secondary');
+		state.flashPending = true;
+		renderToolbar();
+		state.flashTimer = setTimeout(() => {
+			state.flashTimer = null;
+			setToolbarMsg('');
+		}, FLASH_MS);
 	}
 
 	// What a change costs, as the camera itself declares it, reduced to the
@@ -4790,6 +4842,15 @@
 		setToolbarMsg('');
 		clearError();
 		liveSaving++;
+		// Whether the camera has already taken the change. Everything after the
+		// POST answers ok is the PAGE catching up — re-reading the config,
+		// re-baselining, dressing the toolbar — and a throw in any of it is not
+		// a save that failed. Reported as one, it tells the operator to redo a
+		// change the camera is already holding, and hides a real page bug
+		// behind a plausible sentence about the camera. That is what happened
+		// when the toolbar's confirmation helper turned out never to have been
+		// defined: the save landed and the page said "Save failed" (#273).
+		let landed = false;
 		try {
 			if (dirty.length) {
 				const res = await apiFetch('/api/v1/config', {
@@ -4804,6 +4865,7 @@
 					return;
 				}
 			}
+			landed = true;
 			// The camera now holds these, so the snapshot the revert is built
 			// from has to say so before anything can read it again. refresh()
 			// sets the same values a moment later from the config itself — but
@@ -4834,7 +4896,11 @@
 				flashToolbar(
 					'Saved and applied. The video streams were not interrupted.');
 		} catch (e) {
-			showError('Save failed: ' + e.message);
+			showError(landed
+				? 'Saved \u2014 the camera has the change \u2014 but the page ' +
+					'could not finish updating: ' + e.message + '. Reload to ' +
+					'see what the camera is holding now.'
+				: 'Save failed: ' + e.message);
 		} finally {
 			liveSaving--;
 			btn.disabled = false;

--- a/www/cgi-bin/j/gpio.cgi
+++ b/www/cgi-bin/j/gpio.cgi
@@ -154,6 +154,24 @@ assigned() {
 	done
 }
 
+# The pads majestic has on the IR-cut coils, out of everything `assigned`
+# reports. They are the one class of assigned pad a scan may drive, because they
+# are what a scan is FOR: refusing them left a camera with one coil already set
+# unable to find the pair containing it, and the sweep reported nothing after
+# trying every pair that could not be the answer (#273).
+#
+# They are also the one class it may not hand back the ordinary way. That export
+# is majestic's, and low is where majestic leaves the pad to hold the filter for
+# daylight — so unexporting one floats a brake-held filter open and leaves
+# majestic writing to a path that is no longer there. mode=float therefore
+# BRAKES a coil pad and keeps it exported, and says so in `floated` rather than
+# letting the caller assume a measurement that did not happen.
+coil_pads() {
+	assigned | while read -r v k; do
+		case "$k" in irCutPin1|irCutPin2) echo "$v" ;; esac
+	done
+}
+
 # ── the journal ─────────────────────────────────────────────────────────────
 # Written BEFORE a pad is driven and synced, because the whole point is to
 # survive the pad that stops the camera answering. On the next boot the WebUI
@@ -204,10 +222,20 @@ if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
 				deny "pad $pad is held by the kernel driver \\\"$own\\\""
 			fi
 		done
-		for v in $(assigned | cut -d' ' -f1); do
-			[ "$v" = "$pad" ] && deny "pad $pad is already assigned"
+		# The IR-cut coils are exempt (see coil_pads). Everything else the
+		# camera has been told about — the illuminator, the daylight sensor, a
+		# PTZ line — is an answer rather than a candidate and stays refused.
+		for line in $(assigned | sed 's/ /:/'); do
+			pv="${line%%:*}"; role="${line#*:}"
+			case "$role" in irCutPin1|irCutPin2) continue ;; esac
+			if [ "$pv" = "$pad" ]; then deny "pad $pad is already assigned"; fi
 		done
 	done
+	COILS=$(coil_pads)
+	is_coil() {
+		for c in $COILS; do [ "$c" = "$1" ] && return 0; done
+		return 1
+	}
 
 	# One actuation at a time, camera-wide. Two overlapping requests could
 	# energise two windings at once, or the same one twice with no gap — and a
@@ -299,18 +327,31 @@ if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
 		# successful close, and a filter that opens is brake-held while one that
 		# stays is latching. It also returns a ruled-out pad to the state the
 		# scan found it in.
+		# Unexport what this gives back, and unconditionally — not just what
+		# this request exported. float is a caller SAYING "give these back",
+		# and by the time it arrives the pads are exported from the actuation
+		# that preceded it, a separate request, so they look like somebody
+		# else's; judging by who exported them leaves a sysfs entry behind for
+		# every pair a scan rules out.
+		#
+		# A coil pad is the exception and is neither floated nor unexported.
+		# It is majestic's, and braked is where majestic leaves it: floating it
+		# springs a brake-held filter open, and taking the export away leaves
+		# majestic writing to a path that has gone. FLOATED goes back to the
+		# caller so a classification that did not happen is not read as one
+		# that did.
+		FLOATED=true
 		for pad in "$DRIVE" "$LOWPAD"; do
 			[ -d "/sys/class/gpio/gpio$pad" ] || continue
+			if is_coil "$pad"; then
+				FLOATED=false
+				echo out > "/sys/class/gpio/gpio$pad/direction" 2>/dev/null
+				echo 0 > "/sys/class/gpio/gpio$pad/value" 2>/dev/null
+				continue
+			fi
 			echo in > "/sys/class/gpio/gpio$pad/direction" 2>/dev/null
+			echo "$pad" > /sys/class/gpio/unexport 2>/dev/null
 		done
-		# Unexport unconditionally, not just what this request exported. float
-		# is a caller SAYING "give these back", and by the time it arrives the
-		# pads are exported from the actuation that preceded it — a separate
-		# request, so they look like somebody else's. Judging by who exported
-		# them leaves a sysfs entry behind for every pair a scan rules out.
-		# Nothing assigned can reach here; the guard above refused it.
-		echo "$DRIVE" > /sys/class/gpio/unexport 2>/dev/null
-		echo "$LOWPAD" > /sys/class/gpio/unexport 2>/dev/null
 	else
 		# Everything else leaves the pair BRAKED, and that is not tidiness — on
 		# a brake-held filter the brake is what holds the position the actuation
@@ -329,9 +370,9 @@ if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
 	# next, and a scan works through pairs without pausing to think.
 	usleep "$COOLDOWN_US" 2>/dev/null || sleep 1
 
-	printf '{"drive":%s,"low":%s,"done":%s,"ms":%s,"mode":"%s"}\n' \
+	printf '{"drive":%s,"low":%s,"done":%s,"ms":%s,"mode":"%s","floated":%s}\n' \
 		"$DRIVE" "$LOWPAD" "$([ "$ok" = 1 ] && echo true || echo false)" "$MS" \
-		"${MODE:-pulse}"
+		"${MODE:-pulse}" "${FLOATED:-false}"
 	exit 0
 fi
 


### PR DESCRIPTION
Five things @usa- found on #273 within an hour of the last merge. Two are outright bugs, one of them a regression I shipped in #304 an hour earlier.

## 1. `Save failed: Can't find variable: flashToolbar` — a save that succeeded, reported as a failure

Mine, from #304. `flashToolbar()` is called on the in-place-change path and was never defined:

```js
			else if (appliedInPlace(dirty))
				flashToolbar(
					'Saved and applied. The video streams were not interrupted.');
```

Everything *around* it shipped — `state.flashPending`, `state.flashTimer`, and `renderToolbar()`'s `const show = !!(n || apply || state.flashPending)` — so the surrounding code reads as finished work and only the function is absent. It is called inside `onSubmit`'s `try`, so the `ReferenceError` lands in the catch that says the save failed.

Defined now: it holds the bar open on its own, is cancelled by the next edit (a stale "Saved and applied" beside a live Save button reads as a lie), and takes itself away after six seconds. `setToolbarMsg('')` ends a flash too — a flash *is* a message with a timer, and leaving `flashPending` set would hold an empty bar open.

**The worse half** is that the message was wrong about the camera. Everything after the POST answers ok is the page catching up — re-read, re-baseline, redraw — and a throw in any of it is not a failed save. Reported as one it tells the operator to redo a change the camera is already holding, and it hides a page bug behind a plausible sentence about firmware. That is exactly how this was filed.

`onSubmit` now tracks whether the write landed:

| | message |
|---|---|
| POST never answered ok | `Save failed: …` |
| POST ok, bookkeeping threw | `Saved — the camera has the change — but the page could not finish updating: … Reload to see what the camera is holding now.` |

Verified by poisoning the config re-read's `Response.json` mid-save: the page states the camera has the change, and the camera does.

## 2. Dismiss, reload, banner

> After clicking **Dismiss**, confirming the action in the popup, and reloading the page, the message appears again.

The banner asks `has(nightMode.irCutPin1)` — `toggle_ircut()` returns early without it, whatever the other coil holds. The revocation asked **either** coil. So with only the *opening* coil assigned, majestic moves nothing, the banner shows and offers Dismiss — and the next load reads a coil, calls it a contradiction and deletes the claim.

Reproduced by logging every `ircut.cgi` request across a dismiss-then-reload cycle on an hi3516ev300:

| coils assigned | before | after |
|---|---|---|
| none | `ircut.cgi` → `?dismiss=1` → reload → `ircut.cgi` ✔ | unchanged ✔ |
| opening only | `ircut.cgi` → **`?clear=1`** → `?dismiss=1` → reload → `ircut.cgi` → **`?clear=1`** ✘ | `ircut.cgi` → `?dismiss=1` → reload → `ircut.cgi` ✔ |
| closing set | claim dropped ✔ | claim dropped ✔ |

A claim is only contradicted by a filter the camera can actually drive, which is the same question the banner asks. A half-assignment does not contradict "there is no filter here", and someone pressing Dismiss under a banner is answering about the state they are looking at.

## 3. "Find them for me" finds nothing when a coil is already set

`pairs()` skipped every pad in `info.assigned` — which includes the two IR-cut coils, the pads the sweep exists to find. With one coil set, every pair that could have been the answer was absent from the list; the sweep ran to the end and reported nothing after trying 254 pairs that could not be it.

Roles are filtered now. The coils stay candidates; the illuminator and daylight sensor do not — those are deliberate assignments to another function, and driving the lamp mid-sweep would change the very picture the scan reads its answer off. A pad whose role the camera did not name is still skipped: an unnamed job is still a job.

Measured on the lab camera with both coils assigned: **254 → 267** candidate pairs, and `[11, 10]` is first again instead of absent.

**And a no-hit now names what it cannot find.** A single-pad filter is moved by *holding* a pad at a level, and holding a pad is the one thing this scan may not do — on a two-coil board it leaves a winding carrying current, which is why every actuation here is a brief pulse across a pair. That wiring is set by hand and confirmed by **Test the filter**, and the page says so rather than sweeping 267 pairs and shrugging.

## 4. Single-pad mode: which coil, and should the other be hidden?

> Is it intentional that in **`SINGLE IRcut is inverted`** mode the pin should be assigned to **IR-cut filter, closing coil** rather than **IR-cut filter, opening coil**? Perhaps **IR-cut filter, opening coil** should be hidden in this mode.

Intentional — `night_start()` selects single-pad mode on `irCutPin1` set and `irCutPin2` unset, and `set_ircut_mode()` reads the flag only in that branch.

Hiding the other row would be wrong, though: assigning it is exactly how you *leave* single-pad mode, and the switch does not select the mode — leaving the opening coil unset does. So the switch says when it is inert instead:

> **"Single IRcut is inverted" is doing nothing here** — That switch only applies where one pad drives the filter, and both coils are assigned, so majestic pulses the pair and never reads it. To drive the filter from one pad, leave the opening coil unassigned — the closing coil is the one majestic drives, and this switch then chooses which level means night.

`info`, so the settings page only. It is also the one place this can be said at all right now: the field's own description landed in majestic yesterday and no build carries it yet.

## 5. "the LED ring, infrared or white"

> The illuminator doesn't necessarily have to be a ring, and it doesn't necessarily have to be LED.

Two assumptions too many. It is **"the light, infrared or white"**.

## Verification

On an hi3516ev300 (85H50AI, imx335) against the real page, coils cleared and restored through `POST /api/v1/config`:

- the flash: `1 change pending.` → `Saved and applied. The video streams were not interrupted.` → bar gone at 6 s, no page errors
- the landed/not-landed split: forced throw after a successful POST reports the camera holds the change, and it does
- dismissal: sticks with the opening coil alone; still dropped when the closing coil is assigned
- sweep: 267 pairs with both coils assigned, `[11, 10]` first, `52` and `66` absent
- the inert-switch finding renders with both coils assigned and the switch on, and not otherwise

`npm test` passes, with new coverage for the dismissal rule, the inert switch and the scan's candidate set. `tools/regen-bootstrap-css.sh` reproduces the committed `bootstrap.min.css` byte for byte.
