### PR TITLE
Live: a socket that gave up on a software codec tries the decoder, not MJPEG

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -111,6 +111,12 @@ function load(cfg) {
 				return bits[0] === 'undecodable' &&
 					!!(w && w.available && w.handles && w.handles(bits[1]));
 			},
+			softwareRungForCodec: (d, codec) => {
+				const bits = String(d || '').split(' ');
+				const w = win.MajesticWasm;
+				return (bits[0] === 'unreachable' || bits[0] === 'mse-error') &&
+					!!(w && w.available && w.handles && w.handles(codec));
+			},
 			chosenStream: () => (cfg.picked === undefined ? null : cfg.picked),
 			chooseStream(where, n) { env.stored = n; },
 		},

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -132,6 +132,12 @@ function load(pickedTransport, cfg, cfgDelay, wasmOk) {
 				return bits[0] === 'undecodable' &&
 					!!(w && w.available && w.handles && w.handles(bits[1]));
 			},
+			softwareRungForCodec: (d, codec) => {
+				const bits = String(d || '').split(' ');
+				const w = win.MajesticWasm;
+				return (bits[0] === 'unreachable' || bits[0] === 'mse-error') &&
+					!!(w && w.available && w.handles && w.handles(codec));
+			},
 			chosenStream: () => null, chooseStream() {},
 		},
 	};
@@ -574,16 +580,67 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			env.el('mj-transport-w').checked === false);
 	}
 
-	group('the rung is not taken for a failure that is not about the codec');
+	group('a non-codec failure on a natively-playable channel goes to MJPEG');
 	{
+		// The channel is H.264, which the browser plays natively, so none of
+		// these — a socket that would not stay open, no MSE, a source-buffer
+		// refusal — is worth handing to the H.265 software decoder.
 		for (const reason of ['unreachable', 'no-mse', 'mse-error']) {
-			const env = load('mse', { 'jpeg.enabled': true }, 0, true);
+			const env = load('mse',
+				{ 'jpeg.enabled': true, 'video0.codec': 'h264' }, 0, true);
 			await tick();
 			env.made[0].say('mjpeg', reason);
-			check('`' + reason + '` goes straight to MJPEG',
+			check('`' + reason + '` on H.264 goes straight to MJPEG',
 				env.made.length === 1 && env.el('live-mjpeg').src === '/mjpeg',
 				'made=' + env.made.length);
 		}
+	}
+
+	// The #288 hardening: MSE could not hold the socket long enough to read a
+	// codec ('unreachable'), but the config says the channel is H.265 — a codec
+	// the software decoder handles — so its own socket is worth a try before
+	// MJPEG, rather than stranding a remote viewer on the worst option.
+	group('an unreachable socket on a configured software codec tries the decoder');
+	{
+		const env = load('mse',
+			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');
+		check('the software decoder is tried, not MJPEG',
+			env.made.length === 2 && env.made[1] && env.made[1].kind === 'wasm',
+			'made=' + env.made.length + ' kind=' + (env.made[1] && env.made[1].kind));
+		check('and no fallback picture went up', env.el('live-mjpeg').src === '');
+		env.made[1].say('playing');
+		check('when it plays, MSE stays lit as the transport underneath',
+			env.el('mj-transport-m').checked === true);
+	}
+
+	group('a rescue that also fails does not loop back');
+	{
+		const env = load('mse',
+			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');
+		const wasm = env.made[1];
+		check('the decoder was tried', wasm && wasm.kind === 'wasm');
+		// Its worker could not hold the socket either — same flaky link.
+		wasm.say('mjpeg', 'unreachable');
+		check('it falls to MJPEG rather than round again',
+			env.made.length === 2 && env.el('live-mjpeg').src === '/mjpeg',
+			'made=' + env.made.length);
+	}
+
+	group('the rescue needs the decoder to actually be present');
+	{
+		// Same unreachable H.265 channel, but no software decoder in the page
+		// (an offline camera, the common case) — straight to MJPEG.
+		const env = load('mse',
+			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 0, false);
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');
+		check('with no decoder it goes to MJPEG',
+			env.made.length === 1 && env.el('live-mjpeg').src === '/mjpeg',
+			'made=' + env.made.length);
 	}
 
 	group('the rung is not taken for a codec it cannot decode');

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -643,6 +643,23 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			'made=' + env.made.length);
 	}
 
+	// The socket can give up before the config fetch lands — the same flaky
+	// link slows both — so the rescue has to be reconsidered when the codec
+	// finally becomes known, not only at the moment of failure.
+	group('a late config that reveals a software codec takes the rescue');
+	{
+		const env = load('mse',
+			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 2600, true);
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');
+		check('with no codec known yet, it falls to the picture',
+			env.made.length === 1, 'made=' + env.made.length);
+		await new Promise((r) => setTimeout(r, 1600));
+		check('once the config reveals H.265, the decoder is tried',
+			env.made.length === 2 && env.made[1] && env.made[1].kind === 'wasm',
+			'made=' + env.made.length + ' kind=' + (env.made[1] && env.made[1].kind));
+	}
+
 	group('the rung is not taken for a codec it cannot decode');
 	{
 		const env = load('mse', { 'jpeg.enabled': true }, 0, true);

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -99,6 +99,34 @@ group('softwareRungFor() gates the software rung');
 		t.softwareRungFor('undecodable h265') === false);
 }
 
+group('softwareRungForCodec() rescues a socket that gave up on a software codec');
+{
+	const t = load(true);
+	const setWasm = (w) => { t.__ctx.window.MajesticWasm = w; };
+	const h265 = { available: true, handles: (c) => /^h265$|^hevc$/i.test(c || '') };
+	setWasm(h265);
+
+	// MSE never read a codec — the socket would not stay open — but the config
+	// says the channel is H.265, which this decoder handles.
+	check('an unreachable H.265 channel is worth handing to the decoder',
+		t.softwareRungForCodec('unreachable', 'h265') === true);
+	check('so is a MediaSource that refused its own mime',
+		t.softwareRungForCodec('mse-error', 'h265') === true);
+	// An H.264 channel plays natively; the software decoder is not for it.
+	check('an unreachable H.264 channel is not',
+		t.softwareRungForCodec('unreachable', 'h264') === false);
+	// `undecodable` is the strict test's job; this softer one must not also
+	// fire on it, or the same failure would take the rung twice.
+	check('an undecodable verdict is not this test’s to answer',
+		t.softwareRungForCodec('undecodable h265', 'h265') === false);
+	check('and neither is a missing codec',
+		t.softwareRungForCodec('unreachable', '') === false);
+
+	setWasm(undefined);
+	check('with no decoder present it is never worth trying',
+		t.softwareRungForCodec('unreachable', 'h265') === false);
+}
+
 group('impl() maps a kind to a player');
 {
 	const t = load(true);

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -311,6 +311,15 @@ window.MajesticPreview = (function () {
 				swap.start('wasm');
 				return;
 			}
+			// MSE could not hold the socket to read a codec ('unreachable'); if
+			// the config says this channel is one the software decoder handles,
+			// let its worker try before the panel gives up. Same reasoning as
+			// preview-page.js:nextRung (#288).
+			if (kind === 'mse' && window.MajesticTransport.softwareRungForCodec(
+				detail, get(stream ? 'video1.codec' : 'video0.codec'))) {
+				swap.start('wasm');
+				return;
+			}
 			exhausted = true;
 			// A canvas that has stopped being painted keeps its last frame and
 			// nothing hides it, so anything sampling the picture — the Live

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -78,6 +78,11 @@
 		// The configured frame rates, which are what the chip shows on MSE —
 		// that player measures nothing.
 		cfgFps = [+mjGet(cfg, 'video0.fps') || 0, +mjGet(cfg, 'video1.fps') || 0];
+		// The configured codec per channel — the only thing that says what a
+		// stream is when the socket never delivered an init to say it. Read by
+		// nextRung to decide whether a socket that gave up ('unreachable') is
+		// still worth handing to the software decoder.
+		cfgCodec = [mjGet(cfg, 'video0.codec') || '', mjGet(cfg, 'video1.codec') || ''];
 		// The configured bitrates, which are what the adaptation toast names
 		// as the rate the encoder returns to when nothing is holding it down.
 		cfgKbps = [+mjGet(cfg, 'video0.bitrate') || 0, +mjGet(cfg, 'video1.bitrate') || 0];
@@ -349,6 +354,10 @@
 	// reported about its own picture.
 	let chipMedia = null, chipFps = 0;
 	let cfgFps = [0, 0];
+	// Filled from the config when it lands; '' until then, which the codec
+	// helper treats as "not software-decodable", so nothing new happens before
+	// the config is known.
+	let cfgCodec = ['', ''];
 	// The camera's own statement of which channel this WebRTC session serves,
 	// from the `served` signalling reply — or null on an older majestic, over
 	// MSE, and between sessions, in which case the size inference below stands
@@ -866,6 +875,17 @@
 		}
 		if (kind === 'webrtc') { attachPlayer('mse'); return; }
 		if (kind === 'mse' && MajesticTransport.softwareRungFor(detail)) {
+			attachPlayer('wasm');
+			return;
+		}
+		// MSE gave up without a codec verdict — the socket would not stay open
+		// ('unreachable'), so the browser never saw what the stream is. If the
+		// config says this channel is a codec the software decoder handles, let
+		// its worker try its own socket before falling to MJPEG; on a flaky or
+		// remote link that has kept the software decoder working moments before,
+		// dropping to MJPEG here strands the viewer on the worst option (#288).
+		if (kind === 'mse' &&
+			MajesticTransport.softwareRungForCodec(detail, cfgCodec[stream ? 1 : 0])) {
 			attachPlayer('wasm');
 			return;
 		}

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -34,6 +34,10 @@
 	let jpegOn = false;
 	mjConfig().then(cfg => {
 		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
+		// Read before the fallback is re-decided below: the codec is what says
+		// whether a socket that gave up is worth handing to the software rung,
+		// and that decision has to be made with the real answer.
+		cfgCodec = [mjGet(cfg, 'video0.codec') || '', mjGet(cfg, 'video1.codec') || ''];
 		// The first attach does not wait for this fetch past CONFIG_WAIT_MS,
 		// and a player can refuse before it even starts — MSE reports 'no-mse'
 		// from inside attach(). Until this line runs, jpegOn is false because
@@ -41,7 +45,19 @@
 		// decided on it would offer "Enable JPEG" for a camera that has JPEG
 		// enabled and would leave the picture it could have shown unshown.
 		// Re-decided here against the real answer; harmless when it agrees.
-		if (fellBack) showFallback(fellBack);
+		//
+		// And if that fallback was a socket giving up ('unreachable') on what
+		// the config now says is a software-decodable channel, the rescue in
+		// nextRung could not have fired — cfgCodec was empty when the failure
+		// arrived. Take it now rather than only re-rendering the MJPEG picture,
+		// or a camera whose config lands slowly (the same flaky link that
+		// caused the giving-up) would never reach the decoder (#288).
+		if (fellBack && MajesticTransport.softwareRungForCodec(
+			fellBack, cfgCodec[stream ? 1 : 0])) {
+			retryFromFallback('wasm');
+		} else if (fellBack) {
+			showFallback(fellBack);
+		}
 		const subOk = mjGet(cfg, 'video1.enabled') === true;
 		subAvailable = subOk;
 		if (subOk) $('#mj-sub').hidden = false;
@@ -78,11 +94,7 @@
 		// The configured frame rates, which are what the chip shows on MSE —
 		// that player measures nothing.
 		cfgFps = [+mjGet(cfg, 'video0.fps') || 0, +mjGet(cfg, 'video1.fps') || 0];
-		// The configured codec per channel — the only thing that says what a
-		// stream is when the socket never delivered an init to say it. Read by
-		// nextRung to decide whether a socket that gave up ('unreachable') is
-		// still worth handing to the software decoder.
-		cfgCodec = [mjGet(cfg, 'video0.codec') || '', mjGet(cfg, 'video1.codec') || ''];
+		// (cfgCodec is read earlier, before the fallback is re-decided.)
 		// The configured bitrates, which are what the adaptation toast names
 		// as the rate the encoder returns to when nothing is holding it down.
 		cfgKbps = [+mjGet(cfg, 'video0.bitrate') || 0, +mjGet(cfg, 'video1.bitrate') || 0];

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -141,6 +141,25 @@ window.MajesticTransport = (function () {
 			!!(w && w.available && w.handles && w.handles(bits[1]));
 	}
 
+	// A softer test than the one above, for when MSE never got far enough to
+	// return a codec verdict. `undecodable` carries the codec the browser
+	// refused; `unreachable` and `mse-error` do not — the socket could not be
+	// held open to read the init (six reconnects, a flaky or high-latency link)
+	// or the MediaSource refused a mime it had claimed. Neither means "this
+	// browser cannot decode"; both would otherwise fall straight to MJPEG. So
+	// fall back to what the CONFIG says the channel is encoded as: if the
+	// software decoder handles that codec, its worker holds its own /ws/video
+	// socket with its own reconnect and is worth a try — it may survive where
+	// the MSE player's ladder gave up (measured: a Raspberry Pi over a remote
+	// link, majestic #288). It cannot loop, because the software rung's own
+	// failure reports kind `wasm`, which the caller's walk does not route here.
+	function softwareRungForCodec(detail, codec) {
+		const bits = String(detail || '').split(' ');
+		const w = window.MajesticWasm;
+		return (bits[0] === 'unreachable' || bits[0] === 'mse-error') &&
+			!!(w && w.available && w.handles && w.handles(codec));
+	}
+
 	function impl(kind) {
 		return kind === 'webrtc' ? window.MajesticWebRTC
 			: kind === 'wasm' ? window.MajesticWasm
@@ -267,6 +286,7 @@ window.MajesticTransport = (function () {
 		demote: demote,
 		impl: impl,
 		softwareRungFor: softwareRungFor,
+		softwareRungForCodec: softwareRungForCodec,
 		iceServers: iceServers,
 		chosenStream: chosenStream,
 		chooseStream: chooseStream,


### PR DESCRIPTION
## The problem

When the MSE player can't hold the `/ws/video` socket open long enough to read an init — six reconnects, reported `unreachable` — the chain fell straight to **MJPEG**. But `unreachable` isn't a *this-browser-can't-decode* verdict; it's a flaky or high-latency link.

On a **remote camera** (measured on a Raspberry Pi 4 over a distant link, #288), a `Main → Sub → Main` round trip could strand the viewer on MJPEG even though the software H.265 decoder had been working on that same channel seconds earlier — recoverable only by a full browser restart.

## The fix

The socket never delivered a codec, so the **config** supplies it. A new `softwareRungForCodec(detail, codec)` opens the software rung on `unreachable`/`mse-error` **when the configured codec for the channel is one the decoder handles**. The decoder's worker holds its own socket with its own reconnect and may survive where the MSE ladder gave up.

- **No loop:** the software rung's own failure reports kind `wasm`, which the chain doesn't route back here → it falls to MJPEG cleanly.
- **Narrow:** only fires for a *configured software codec* (H.265) with the decoder present; an H.264 channel, or an offline camera with no decoder, still goes straight to MJPEG.
- `preview-page.js` (Live) and `mj-preview.js` (Live adjustments) each read their channel's configured codec; the `<video>` path and every existing reason code are unchanged.

## Verification

- Unit tests for the gate (`transport.test.js`) and the chain (`staging.test.js`): rescue on `unreachable`+H.265, **not** on H.264, not on a missing codec, not without a decoder, and no loop when the rescue also fails.
- No regression on the ordinary `undecodable → wasm` flow.
- **End-to-end in real Chromium on a Raspberry Pi 4** against a live H.265 camera: forcing the MSE player to `unreachable` now yields software H.265 (`H265 1280×720`) instead of MJPEG.

This ships the hardening for the #288 reporter to confirm on their own camera, since their specific majestic build's `/ws/video` close behaviour isn't reproducible on lab hardware.

Refs #288.