### PR TITLE
Day / Night: irCutPin1 is the opening coil, and the map said the opposite

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -338,18 +338,25 @@ function runRest() {
 		check('as an observation, not a fault', f && f.level === 'info');
 		check('it names the switch that picks which level is night',
 			f && /Single IRcut is inverted/.test(f.detail));
+		// The pad majestic single-pins is irCutPin1, which is the OPENING coil
+		// — it raises it for night. Both of these read the other way round for
+		// a release, and nothing caught it because the labels are only text
+		// (#273).
+		check('and it is the opening coil that is named as the assigned one',
+			f && /Only the opening coil is assigned/.test(f.detail), f && f.detail);
 		check('and says what it does to a filter that has two coils',
 			f && /carrying current/.test(f.detail));
 		check('both coils assigned says nothing',
 			!ic.diagnose({ irCutPin1: 11, irCutPin2: 10 }, null, null)
 				.some(x => x.id === 'single-coil'));
 
-		// The opening coil on its own drives nothing at all — majestic returns
-		// early without the closing coil's pad — so it is the same fault. But
-		// "nothing is connected to the filter" is a plain untruth on a camera
-		// where something is, and the sentence has to name what is missing.
+		// The closing coil on its own drives nothing at all — majestic returns
+		// early without the opening coil's pad, which is the one it raises for
+		// night — so it is the same fault. But "nothing is connected to the
+		// filter" is a plain untruth on a camera where something is, and the
+		// sentence has to name what is missing.
 		const half = ic.diagnose({ irCutPin2: 10 }, null, null);
-		check('the opening coil alone is still the no-pins fault',
+		check('the closing coil alone is still the no-pins fault',
 			half[0].id === 'no-pins' && half[0].level === 'danger',
 			JSON.stringify(half.map(x => x.id)));
 		check('and not a single-coil observation',
@@ -357,7 +364,7 @@ function runRest() {
 		check('it does not claim nothing is connected',
 			!/Nothing is connected/.test(half[0].detail), half[0].detail);
 		check('it names the coil that is missing instead',
-			/closing coil/.test(half[0].detail), half[0].detail);
+			/opening coil/.test(half[0].detail), half[0].detail);
 	}
 
 	group('wired: only a filter the camera can drive contradicts "there is none"');
@@ -365,12 +372,12 @@ function runRest() {
 		// The dashboard drops the owner's "no filter here" claim the moment
 		// this says yes, so it has to ask the same question the banner does.
 		check('nothing assigned is not wired', ic.wired({}) === false);
-		check('the closing coil alone is', ic.wired({ irCutPin1: 11 }) === true);
+		check('the opening coil alone is', ic.wired({ irCutPin1: 11 }) === true);
 		// It used to be EITHER coil, which made Dismiss unusable on the very
 		// camera that was showing the banner: pressing it recorded the claim,
-		// and the next load read the opening coil, called it a contradiction
+		// and the next load read the closing coil, called it a contradiction
 		// and deleted it again — dismiss, reload, banner (#273).
-		check('the opening coil alone is not, because majestic moves nothing with it',
+		check('the closing coil alone is not, because majestic moves nothing with it',
 			ic.wired({ irCutPin2: 10 }) === false);
 		check('and that is exactly the camera the banner is raised on',
 			ic.diagnose({ irCutPin2: 10 }, null, null)[0].id === 'no-pins');
@@ -386,7 +393,7 @@ function runRest() {
 			!!f, JSON.stringify(both.map(x => x.id)));
 		check('as an observation, not a fault', f && f.level === 'info');
 		check('and it names the coil a single-pad filter goes on',
-			f && /closing coil/.test(f.detail));
+			f && /opening coil/.test(f.detail));
 		check('one coil assigned IS the mode, so nothing is inert',
 			!ic.diagnose({ irCutPin1: 11, irCutSingleInvert: true }, null, null)
 				.some(x => x.id === 'invert-inert'));

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -330,6 +330,39 @@ group('run: it finds the pair, and only the pair');
 		check('one from this boot is not a casualty',
 			scan.casualty({ boot: 2000, scan: { pins: [47, 48], started: 2100 } }) === null);
 		check('no journal, no casualty', scan.casualty({ boot: 2000, scan: {} }) === null);
-		done();
+		return eleventh();
+	}
+
+	// The scan measures which pad opens the filter and which closes it, then
+	// files those two facts into majestic's two config keys. The pin map puts a
+	// NAME on each of those keys. Nothing made the two agree, and for a release
+	// they did not: the map called irCutPin1 the closing coil while the scan
+	// correctly filed the opening pad there, so every sentence naming a coil —
+	// including the one telling someone which coil a single-pad filter goes on —
+	// was inverted (#273).
+	//
+	// It is invisible by construction. A swapped label renders perfectly and
+	// reads plausibly; the only way to know is majestic's own source, where
+	// double_ircut_set(night) raises pin1 for NIGHT, and night is the filter
+	// swung out of the light path. So the check is written here, where the
+	// measurement is, rather than trusted to a reader of either file alone.
+	function eleventh() {
+		group('the measured pad and the name on its field are one fact');
+		const map = require(path.join(__dirname, '..', 'www', 'a', 'ircut-map.js'));
+		const label = {};
+		map.ROLES.forEach((r) => { label[r.key] = r.label; });
+		const c = camera(11, 10);
+		return scan.run(c.io, [[11, 10]], { settleMs: 0 }).then((r) => {
+			const p = r.pins;
+			check('the pad that opens the filter is filed as irCutPin1',
+				p.irCutPin1 === p.opensWhenHigh, JSON.stringify(p));
+			check('and the pad that closes it as irCutPin2',
+				p.irCutPin2 === p.closesWhenHigh, JSON.stringify(p));
+			check('so irCutPin1 is the field the map calls the opening coil',
+				/opening coil/.test(label.irCutPin1 || ''), label.irCutPin1);
+			check('and irCutPin2 the one it calls the closing coil',
+				/closing coil/.test(label.irCutPin2 || ''), label.irCutPin2);
+			done();
+		});
 	}
 }

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -56,7 +56,7 @@
 		// same question. It used to be EITHER coil, on the reasoning that a
 		// half-configured camera is not an unfitted one — true, but it made the
 		// dismissal impossible to use on exactly the camera that was showing
-		// the banner. With only the opening coil assigned majestic still moves
+		// the banner. With only the closing coil assigned majestic still moves
 		// nothing, so the banner stands and offers Dismiss; pressing it
 		// recorded the claim, and the next load read a coil, called it a
 		// contradiction, and deleted it again. Dismiss, reload, banner (#273).
@@ -110,10 +110,11 @@
 		track = track || {};
 		const out = [];
 		const monitor = on(nm.lightMonitor);
-		// majestic drives the filter from irCutPin1 and returns early when it
-		// is unset, whatever else is configured — so a camera holding only the
-		// opening coil is exactly as unable to move the filter as one holding
-		// nothing, and gets the same finding with a different sentence.
+		// majestic drives the filter from irCutPin1 — the OPENING coil, the
+		// pad it raises for night — and returns early when it is unset,
+		// whatever else is configured. So a camera holding only the closing
+		// coil is exactly as unable to move the filter as one holding nothing,
+		// and gets the same finding with a different sentence.
 		const driveable = has(nm.irCutPin1);
 		// One coil assigned is not half a configuration: majestic switches to
 		// single-pin mode and holds that one pad at a LEVEL — high for night,
@@ -148,11 +149,11 @@
 				id: 'no-pins', level: 'danger',
 				title: 'Majestic cannot move the IR-cut filter',
 				detail: (has(nm.irCutPin2)
-					? 'The opening coil is connected, but the closing coil is ' +
-						'not, and majestic drives the filter from the closing ' +
-						'coil\u2019s pad \u2014 without it nothing moves the ' +
-						'filter and it stays wherever it powered up. Left open ' +
-						'in daylight it makes the whole picture magenta.'
+					? 'The closing coil is connected, but the opening coil is ' +
+						'not, and majestic gives up unless the opening coil has ' +
+						'a pad, whatever the other one holds. So nothing moves ' +
+						'the filter and it stays wherever it powered up. Left ' +
+						'open in daylight it makes the whole picture magenta.'
 					: 'Nothing is connected to the filter, so nothing moves it ' +
 						'and it stays wherever it powered up. Left open in ' +
 						'daylight it makes the whole picture magenta.') +
@@ -191,13 +192,13 @@
 			out.push({
 				id: 'single-coil', level: 'info',
 				title: 'The filter is driven from one pad',
-				detail: 'Only the closing coil is assigned, so majestic holds ' +
-					'that one pad at a level \u2014 one for day, the other for ' +
-					'night \u2014 rather than pulsing a pair of coils. That is ' +
+				detail: 'Only the opening coil is assigned, so majestic holds ' +
+					'that one pad at a level \u2014 high for night, low for ' +
+					'day \u2014 rather than pulsing a pair of coils. That is ' +
 					'right for a board whose filter is switched through a ' +
 					'driver chip rather than driven coil by coil, and "Single ' +
 					'IRcut is inverted" is what swaps which level means night. ' +
-					'If the filter in this camera has two coils, assign the opening ' +
+					'If the filter in this camera has two coils, assign the closing ' +
 					'coil as well: on its own, one coil of a pair is left ' +
 					'carrying current for as long as the camera stays in that ' +
 					'position.',
@@ -211,7 +212,7 @@
 		// that predates one, and even with it a settings page cannot say
 		// whether THIS camera is in the mode. Reported here, where it can, and
 		// it is where the reporter's own question gets its answer: the pad that
-		// drives a single-pad filter goes on the closing coil (#273).
+		// drives a single-pad filter goes on the opening coil (#273).
 		if (on(nm.irCutSingleInvert) && driveable && !single) {
 			out.push({
 				id: 'invert-inert', level: 'info',
@@ -219,7 +220,7 @@
 				detail: 'That switch only applies where one pad drives the ' +
 					'filter, and both coils are assigned, so majestic pulses ' +
 					'the pair and never reads it. To drive the filter from one ' +
-					'pad, leave the opening coil unassigned \u2014 the closing ' +
+					'pad, leave the closing coil unassigned \u2014 the opening ' +
 					'coil is the one majestic drives, and this switch then ' +
 					'chooses which level means night.',
 				fix: 'nightMode',

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -60,8 +60,24 @@
 	// The four things a pad can be. Colours are the dashboard's validated
 	// series set, so a pad and its row in the list always agree.
 	const ROLES = [
-		{ key: 'irCutPin1', label: 'IR-cut filter, closing coil', hint: 'pulls the shutter in for daylight', color: '#4c60d8' },
-		{ key: 'irCutPin2', label: 'IR-cut filter, opening coil', hint: 'lets infrared through at night', color: '#0d9488' },
+		// Which coil is which is majestic's to say, not ours, and it is the
+		// opposite of what reads naturally from the key names. night.c drives
+		// pin1 high for NIGHT and pin2 high for DAY (double_ircut_set(night):
+		// set_gpio(pin1, night); set_gpio(pin2, !night)), and night is the
+		// filter swung OUT of the light path. So pin1 is the opening coil and
+		// pin2 the closing one. Measured on the 85H50AI these were written
+		// against: pad 11 driven high opens, pad 10 closes, and its config is
+		// irCutPin1=11 / irCutPin2=10.
+		//
+		// They were the wrong way round here for a release. Nothing broke,
+		// because the labels only name what the fields already do -- but every
+		// sentence that names a coil inherited the error, and single-pin mode
+		// (pin1 set, pin2 unset) was described as putting the pad on the
+		// closing coil when it is the opening one (#273). ircut-scan.js has
+		// always mapped its measured pads the right way; if these two ever
+		// disagree with `irCutPin2: closeHigh` there, that file is right.
+		{ key: 'irCutPin1', label: 'IR-cut filter, opening coil', hint: 'swings the filter out of the way at night', color: '#4c60d8' },
+		{ key: 'irCutPin2', label: 'IR-cut filter, closing coil', hint: 'pulls the filter back in for daylight', color: '#0d9488' },
 		// Not "Infrared lamp": majestic drives this pad for NIGHT and does not
 		// care what is on the end of it, and plenty of boards carry a white
 		// LED ring instead of an IR one. Naming the pad after one of the two

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3800,7 +3800,7 @@
 						'this sweep can find: it works by pulsing pairs, and a ' +
 						'single-pad filter is moved by holding one pad at a level, ' +
 						'which is not safe to do to a pad whose job is unknown. ' +
-						'If yours is wired that way, put the pad on the closing coil ' +
+						'If yours is wired that way, put the pad on the opening coil ' +
 						'yourself and press <b>Test the filter</b>.</div>';
 					return;
 				}


### PR DESCRIPTION
The pin map has labelled majestic's two IR-cut keys the wrong way round since it was written, and every sentence that names a coil inherited the error — including the answer I gave the reporter on #273 yesterday.

### What is actually true

From `night.c`:

```c
static void double_ircut_set(bool night) {
    set_gpio(G.ir_cut_pin1, night);
    set_gpio(G.ir_cut_pin2, !night);
    ev_defer(G.base, double_ircut_reset, NULL);   /* brake both after ~150 ms */
}
```

`irCutPin1` is raised for **night**, and night is the IR-cut filter swung *out* of the light path so infrared reaches the sensor. So **pin1 is the opening coil and pin2 the closing one** — the opposite of what the key names suggest, which is how this came to be written backwards.

Measured on the lab 85H50AI, whose config is `irCutPin1=11 / irCutPin2=10`:

| driven high | gmin | magenta excess p25 | filter |
|---|---|---|---|
| pad 11 against 10 | 0.98 – 1.00 | +0.30 | open |
| pad 10 against 11 | 0.04 – 0.10 | −0.10 | closed |

and majestic's own debug log says it from the other side — a `night_start` asserting DAY logs `set_gpio(11, 0)` then `set_gpio(10, 1)`, then brakes both.

### Why it mattered

Not cosmetically. Single-pin mode is `pin1` set and `pin2` unset, so the one pad goes on the **opening** coil — and the page, the findings, and my reply on the issue all said the closing one. Anyone following that would have put the pad on the key majestic ignores and watched nothing happen, with no diagnostic able to tell them why.

It is invisible by construction: a swapped label renders perfectly and reads plausibly. The only way to know is to go and read `night.c`.

### What changed

- `www/a/ircut-map.js` — the two labels and hints moved onto the right keys, with the derivation written down so the next reader does not have to re-derive it (and does not "fix" it back).
- `www/a/ircut-check.js` — the `no-pins`, `single-coil` and `invert-inert` findings reworded. The no-pins sentence for a camera holding only the closing coil now explains *why* the other one is the one that matters, rather than just asserting it.
- `www/a/mj-settings.js` — the scan's no-hit message, which tells someone with a single-pad filter which coil to put the pad on.
- `tests/ircut-scan.test.js` — a new group tying the two modules together: the pad the scan **measured** as opening must land in the field the map **calls** the opening coil. Verified it fails on a swapped label by swapping them back.

`www/a/ircut-scan.js` needed no change — it always mapped its measured pads correctly (`irCutPin1: otherPad`, `irCutPin2: closeHigh`), and its comment already said so. Where the two disagreed, the scan was right and the label was wrong.

### Verification

`npm test` green. Deployed to the lab hi3516ev300 and confirmed on screen: **opening coil → 11**, **closing coil → 10**, matching the measurement above. Camera left in day mode with the filter closed and `nightMode` unchanged.

The matching correction to majestic's `irCutSingleInvert` schema hint, which carried the same error, goes up separately.

Refs #273
