### PR TITLE
Dashboard: the warning's way out is a ×, not a second link

### DIFF
--- a/www/a/status.js
+++ b/www/a/status.js
@@ -248,10 +248,11 @@
 		const no = $('#st-alert-ircut-no');
 		if (!no) return;
 		no.addEventListener('click', () => {
-			// The button says only "Dismiss", so the whole claim is made here.
-			// It has to be anyway: this writes a fact to the camera and every
-			// browser that opens the page reads it, which is more than a
-			// word on a button can be asked to carry.
+			// The button is a bare ×, so the whole claim is made here. It had
+			// to be anyway: this writes a fact to the camera and every browser
+			// that opens the page reads it, which is more than any word on a
+			// button could be asked to carry — which is also why losing the
+			// word costs nothing.
 			if (!confirm('Hide this warning for good?\n\nThis records on the ' +
 				'camera that it has no IR-cut filter fitted, so the warning ' +
 				'stays away in every browser that opens this page.\n\nSay yes ' +

--- a/www/cgi-bin/status.cgi
+++ b/www/cgi-bin/status.cgi
@@ -58,11 +58,18 @@ done) %>
 		<span class="st-alert-ico" aria-hidden="true">&#9888;</span>
 		<span class="small"><b id="st-alert-ircut-t"></b> &mdash; <span id="st-alert-ircut-d"></span></span>
 		<a class="small ms-auto" href="mj-settings.cgi?tab=nightMode">Open Day / Night &rarr;</a>
-		<!-- "Dismiss", not "No filter here": the reporter of #273 read the latter
-		     as something the page was asserting rather than a button, and the
-		     sentence it would have carried belongs in the confirm dialog anyway —
-		     this records a fact on the camera, for every browser, permanently. -->
-		<button type="button" class="btn btn-link btn-sm small p-0 ms-3" id="st-alert-ircut-no" aria-label="Dismiss: this camera has no IR-cut filter" hidden>Dismiss</button>
+		<!-- A bare ×, and it has been three things. "No filter here" read as
+		     something the page was ASSERTING rather than a button; "Dismiss"
+		     fixed that but put a second link-styled phrase beside "Open Day /
+		     Night", and two of those in a row read as a pair of choices rather
+		     than an action and a way out (#273). The × is the convention every
+		     dismissible notice already uses — including this UI's own modal
+		     headers — so it needs no word to be understood, and it stops
+		     competing with the link for the eye.
+		     The name it loses lives in aria-label and title, and the claim it
+		     never carried is still made in full by the confirm dialog: this
+		     records a fact on the camera, for every browser, permanently. -->
+		<button type="button" class="btn-close" id="st-alert-ircut-no" aria-label="Dismiss: this camera has no IR-cut filter" title="Dismiss: this camera has no IR-cut filter" hidden></button>
 	</div>
 	<!-- Nothing to see, and the wording is written by status.js from the finding
 	     (video-check.js), because one banner covers three of them: a camera


### PR DESCRIPTION
The dashboard's IR-cut warning ended its row with two link-styled phrases — "Open Day / Night →" and "Dismiss" — so they read as a pair of equal choices rather than an action and a way out. The reporter of #273 asked for the familiar **×** instead, [with an example](https://github.com/OpenIPC/majestic-webui/issues/273#issuecomment-5528815456), and they are right.

```
before   [⚠]  Majestic cannot move the IR-cut filter — Nothing is
              connected to the filter…            Open Day / Night →   Dismiss
                                                  └── link ──────┘   └─ link ─┘

after    [⚠]  Majestic cannot move the IR-cut filter — Nothing is
              connected to the filter…            Open Day / Night →      ✕
                                                  └── link ──────┘   └ glyph ┘
```

### Why a glyph is the right answer here and not a loss

This is the control's third wording, and the history is the argument. **"No filter here"** read as something the page was *asserting* rather than a button. **"Dismiss"** fixed that and introduced the crowding above. The **×** fixes the crowding without reintroducing the first problem, precisely because it makes no claim at all — it is the one mark on a notice that is universally understood as "put this away".

The word is not lost. `aria-label` carries it exactly as before, and a new `title` gives a sighted pointer user the same name on hover.

What the button never carried is the *claim*. Dismissing writes a fact to the camera — that it has no IR-cut filter fitted — which every browser that later opens the page then believes. No word on a button could be asked to carry that, which is why the confirm dialog has always stated it in full, and why dropping the word costs nothing.

### No new CSS

`.btn-close` is already in the purged stylesheet, because `tool-files.cgi` and `tool-sdcard.cgi` use it in their modal headers. `tools/regen-bootstrap-css.sh` therefore regenerates `bootstrap.min.css` **byte for byte** — verified — so nothing ships but the markup.

One rule worth naming: `.alert-dismissible .btn-close` is what would have made it `position: absolute`, and `.st-alert` is not that, so it stays an ordinary flex item under the existing `.st-alert > button { flex: 0 0 auto }`. Below 576 px the row wraps and both actions take their own line, with the × still last.

### Verification

Rendered the real markup against the real stylesheets in isolated frames at 1200 px and 390 px, in both camera themes — the close glyph is a black SVG that `[data-bs-theme=dark]` inverts, so the two themes reach the same mark by different routes and both were checked.

`npm test` passes. purgecss regeneration produces no drift. `tools/lint-templates.sh` fails only on `p/fpv_common.cgi`, identically with and without this change (confirmed by stashing) — pre-existing in that haserl build.

Refs #273
