### PR TITLE
Dashboard: the alert's warning mark was the smallest thing in its row

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3817,9 +3817,17 @@ dialog.mj-modal::backdrop {
 	}
 }
 
+/* Sized against the close button opposite it, not by eye. A glyph paints a
+   good deal smaller than its em box, so at the inherited 1rem the warning mark
+   was 13x12px of ink while .btn-close paints 16x16 — the severity indicator was
+   the smallest thing in the row and the way out was the biggest, which is
+   exactly backwards. 1.35rem paints 17x16 and the two ends match (#273).
+   line-height is pinned so the taller glyph cannot stretch a one-line banner. */
 .st-alert-ico {
 	color: var(--bs-warning);
 	flex: 0 0 auto;
+	font-size: 1.35rem;
+	line-height: 1;
 }
 
 /* auto-fit, so a tile that never mounts (no temp sensor / no Wi-Fi) closes


### PR DESCRIPTION
[The reporter of #273](https://github.com/OpenIPC/majestic-webui/issues/273#issuecomment-5530188813) asked for a slightly bigger ⚠ on the dashboard banners. Measuring first, they were reading a real imbalance rather than stating a preference.

A glyph paints well inside its em box, so at the inherited `1rem` the warning mark was **13 × 12 px** of ink, while `.btn-close` next to it paints **16 × 16**:

| `.st-alert-ico` font-size | painted ink |
|---|---|
| 16px — inherited, before | 13 × 12 |
| 18.4px = 1.15rem | 15 × 14 |
| 20px = 1.25rem | 16 × 15 |
| **21.6px = 1.35rem** | **17 × 16** |
| 24px = 1.5rem | 19 × 18 |
| *the close glyph, for scale* | *16 × 16* |

So the banner's **severity indicator was the smallest thing in its row and the way out was the biggest** — exactly backwards for a warning. It only became visible once #312 turned the dismiss control from a word into a mark of its own to compare against; beside the old "Dismiss" text there was nothing to be out of scale with.

`1.35rem` is picked from that constraint rather than by eye: it paints 17 × 16, so the two ends of the row match. The extra pixel of width is the triangle being wider than it is tall.

### Nothing moves

`line-height` is pinned to `1` so the taller glyph cannot stretch a one-line banner. Measured before and after, at 1400 px:

| | before | after |
|---|---|---|
| one-line alert | 45 px | 45 px |
| two-line alert | 63 px | 63 px |

### Scope

The rule is shared by all four banner icons in `status.cgi` — three ⚠ and the ℹ on the "you were brought here" banner — so that one grows with it: **7 × 17**, the same optical height, narrow because the glyph is narrow. That is the consistency you would want anyway.

No new class is introduced, so `tools/regen-bootstrap-css.sh` produces a byte-identical `bootstrap.min.css` — verified. `npm test` passes.

Refs #273
