### PR TITLE
Factory reset: the page waits to catch the camera gone, and keeps missing it

### DIFF
--- a/tests/reset-watch.test.js
+++ b/tests/reset-watch.test.js
@@ -256,6 +256,12 @@ async function noUptimeFallsBackToTheBlindWatch() {
 	await env.clock.advance(200000);
 	check('but the fallback still fires', env.replaced === '/cgi-bin/status.cgi',
 		'replaced=' + env.replaced);
+	// And it must fire on time. Each ask is awaited inside a poll, so one that
+	// times out on every one of the sixty the fallback is allowed would push a
+	// three-and-a-half-minute wait towards eight — the accelerator making the
+	// degraded case worse than it was before it existed.
+	check('and it stopped asking after three refusals', env.metricsReads <= 3,
+		'metricsReads=' + env.metricsReads);
 }
 
 // The other way the same stuck page is reached: the stream ends cleanly rather

--- a/tests/reset-watch.test.js
+++ b/tests/reset-watch.test.js
@@ -66,7 +66,7 @@ function makeClock() {
 function makeEnv(o) {
 	o = o || {};
 	const clock = makeClock();
-	const env = { clock, notes: [], status: { className: '', textContent: '' }, replaced: null, pings: 0 };
+	const env = { clock, notes: [], status: { className: '', textContent: '' }, replaced: null, pings: 0, metricsReads: 0 };
 
 	// The run.cgi stream: chunks the test pushes, then a read that never settles
 	// unless the test says otherwise.
@@ -99,6 +99,22 @@ function makeEnv(o) {
 		rawFetch: (url) => {
 			if (String(url).indexOf('run.cgi') !== -1)
 				return Promise.resolve({ ok: !o.notOk, status: o.notOk ? 401 : 200, body: { getReader: () => reader } });
+			// The uptime read, before the ping counter: it is not a ping, and
+			// counting it would shift every downFor: n the cases below are pinned on.
+			// Unavailable unless a case asks for it, so a camera that will not say
+			// when it booted is the default and every pre-existing case still
+			// describes the blind watch.
+			if (String(url).indexOf('/metrics') !== -1) {
+				env.metricsReads++;
+				if (o.uptime === undefined) return Promise.resolve({ ok: false, status: 401 });
+				const boot = 1700000000;
+				return Promise.resolve({
+					ok: true, status: 200,
+					text: () => Promise.resolve(
+						'node_boot_time_seconds ' + boot + '\n' +
+						'node_time_seconds ' + (boot + o.uptime) + '\n'),
+				});
+			}
 			env.pings++;                           // the ping() in pollBack
 			return o.cameraDown && env.pings <= (o.downFor || 0)
 				? Promise.reject(new Error('down'))
@@ -194,6 +210,54 @@ async function handsBackOnceTheCameraReturns() {
 		'replaced=' + env.replaced);
 }
 
+// The reported bug's second half, and the one that survived the first fix: the
+// watch opens fifteen seconds after the last byte, and the camera's whole
+// absence is about as long, so every ping it ever makes finds the camera
+// serving. Measured on an hi3516ev300 — gone at 8s, back at 23s, first ping at
+// 19s answered 500 by a majestic that had just started — the page then waited
+// another three minutes about a camera that was already back.
+async function handsBackWhenTheRebootWasMissedEntirely() {
+	group('a reboot that happened between two polls is still noticed');
+	const env = makeEnv({ uptime: 6 });          // camera answering, six seconds old
+	await env.push(PROTECTED);
+	await env.push(ERASE);
+	await env.clock.advance(21000);              // quiet window, then the first poll
+	check('asked the camera when it booted', env.metricsReads > 0);
+	check('navigated without waiting out the blind fallback',
+		env.replaced === '/cgi-bin/status.cgi', 'replaced=' + env.replaced);
+	// The fallback needs sixty-one of these. Counting them is what separates
+	// "it left" from "it left three minutes late", which is the whole bug.
+	check('on the first poll, not the sixty-first', env.pings <= 2, 'pings=' + env.pings);
+}
+
+// The same question asked of a camera that has NOT rebooted must answer no, or
+// the watch would navigate away from a reset still erasing.
+async function anUptimeOlderThanTheRunProvesNothing() {
+	group('a camera that has been up for a day is not read as freshly rebooted');
+	const env = makeEnv({ uptime: 86400 });
+	await env.push(PROTECTED);
+	await env.push(ERASE);
+	await env.clock.advance(60000);
+	check('asked, and was told', env.metricsReads > 0);
+	check('did not navigate', env.replaced === null, 'replaced=' + env.replaced);
+	check('still watching', watching(env), 'status was ' + JSON.stringify(env.status.textContent));
+}
+
+// A majestic too old to export node_*, or one holding an unclaimed camera behind
+// a 401, says nothing about when it booted. That must degrade to the blind watch
+// this page has always had rather than to a page that never leaves.
+async function noUptimeFallsBackToTheBlindWatch() {
+	group('a camera that will not say when it booted still gets handed back');
+	const env = makeEnv();                       // /metrics answers 401
+	await env.push(PROTECTED);
+	await env.push(ERASE);
+	await env.clock.advance(78000);
+	check('not navigated an inch early', env.replaced === null, 'replaced=' + env.replaced);
+	await env.clock.advance(200000);
+	check('but the fallback still fires', env.replaced === '/cgi-bin/status.cgi',
+		'replaced=' + env.replaced);
+}
+
 // The other way the same stuck page is reached: the stream ends cleanly rather
 // than hanging, which is what a majestic that closes the response as its CGI
 // child dies would produce. How it ended says nothing about the reboot.
@@ -224,6 +288,9 @@ async function cleanEndBeforeFlashReportsIt() {
 
 (async () => {
 	await quietAfterFlashStartsTheWatch();
+	await handsBackWhenTheRebootWasMissedEntirely();
+	await anUptimeOlderThanTheRunProvesNothing();
+	await noUptimeFallsBackToTheBlindWatch();
 	await cleanEndAfterFlashStartsTheWatch();
 	await cleanEndBeforeFlashReportsIt();
 	await rebootMarkerStillWins();

--- a/www/a/fw-reset.js
+++ b/www/a/fw-reset.js
@@ -63,6 +63,9 @@
 	let lastData = 0;
 	let quietTimer = null;
 	const QUIET_MS = 15000;
+	// When this page — and so the reset it starts on load — began, for
+	// rebootedAlready() to measure the camera's uptime against.
+	const startedAt = performance.now();
 
 	function status(cls, msg) {
 		const s = $('#fw-reset-status');
@@ -143,6 +146,61 @@
 			.catch(() => { clearTimeout(to); return false; });
 	}
 
+	// Positive evidence that the camera restarted, instead of inferring it from a
+	// gap in our own polling.
+	//
+	// The down-then-up watch below cannot see a reboot it was not awake for, and
+	// on this page it is routinely not awake for it. When the reboot line never
+	// leaves the socket buffer the quiet timer is the only trigger left, and that
+	// opens the watch fifteen seconds after the last byte — while the camera's
+	// whole absence is about as long. Measured on an hi3516ev300: gone at 8s,
+	// serving again at 23s, and the first ping landed at 19s and was answered 500
+	// by a majestic that had just started. That counts as up, correctly — but
+	// nothing here could then tell "it has not gone yet" from "it went and came
+	// back between two polls", so downSeen never flipped and the page sat on
+	// "waiting for it to come back" for another three minutes about a camera that
+	// was already back (issue #154). Which way a run falls is decided by a few
+	// seconds of boot time: the same reset handed back in 25s on one run and 207s
+	// on the next.
+	//
+	// So ask the camera rather than watching for a gap. Uptime is read from
+	// majestic's /metrics (node_time − node_boot), which matters more here than
+	// anywhere else it is used: the reset erases the overlay and the session with
+	// it, and /metrics is served without auth, so it still answers the one page
+	// whose credentials it has just destroyed. Extracted with a line match, not
+	// the full parser — this runs against a camera in an unknown state and must
+	// stay dumb.
+	//
+	// Returns false, never throws. On a majestic too old to export node_*, or one
+	// holding an unclaimed camera behind a 401, it is simply unavailable and the
+	// watch below still applies exactly as it did before.
+	async function rebootedAlready() {
+		const ctl = new AbortController();
+		const to = setTimeout(() => ctl.abort(), 2500);
+		try {
+			// No ?_= cache-buster here: majestic's /metrics routes query params into
+			// its value filter and answers 200 with an EMPTY body for an unknown
+			// key, so the buster would blind this check. cache:'no-store' alone
+			// keeps the read fresh.
+			const r = await rawFetch('/metrics', { cache: 'no-store', signal: ctl.signal });
+			if (!r.ok) return false;
+			const txt = await r.text();
+			const num = name => {
+				const m = txt.match(new RegExp('^' + name + ' ([0-9.]+)$', 'm'));
+				return m ? Number(m[1]) : NaN;
+			};
+			const upFor = num('node_time_seconds') - num('node_boot_time_seconds');
+			if (!isFinite(upFor)) return false;
+			// 5s of slack so a camera that booted moments before this page opened is
+			// not mistaken for one that rebooted just now.
+			return upFor < (performance.now() - startedAt) / 1000 - 5;
+		} catch (err) {
+			return false;
+		} finally {
+			clearTimeout(to);
+		}
+	}
+
 	function goBack() {
 		status('success', 'The camera is back. Taking you to it…');
 		// A navigation, so majestic answers it with the login page rather than a
@@ -185,10 +243,22 @@
 			const up = await ping();
 			if (!downSeen) {
 				if (!up) { downSeen = true; tries = 0; }
-				// Still answering well past the point it said it was rebooting. Either
-				// it came back while we were between polls or it never dropped a
-				// connection we noticed; either way it is serving now, so stop
-				// watching and go.
+				// It is answering, which is either "has not rebooted yet" or "went and
+				// came back while we were not looking" — and this watch opens late
+				// enough that the second is the ordinary case, not the corner one. Ask
+				// it directly rather than waiting out DOWN_TRIES.
+				//
+				// Every tick, where the upgrade page asks every fourth: that watch can
+				// open minutes before the reboot, with the camera flashing and to be
+				// disturbed as little as possible, while this one opens past the erase.
+				// And a /metrics read is one request majestic answers out of its own
+				// memory, not the heartbeat's dozen forks and loopback round trip that
+				// stopHeartbeat() exists to stop.
+				else if (await rebootedAlready()) { goBack(); return; }
+				// Still answering well past the point it said it was rebooting, and it
+				// will not say when it booted either. Either it came back while we were
+				// between polls or it never dropped a connection we noticed; either way
+				// it is serving now, so stop watching and go.
 				else if (++tries > DOWN_TRIES) { goBack(); return; }
 			} else if (up) {
 				goBack();

--- a/www/a/fw-reset.js
+++ b/www/a/fw-reset.js
@@ -171,10 +171,31 @@
 	// the full parser — this runs against a camera in an unknown state and must
 	// stay dumb.
 	//
+	// It is safe to read the two as a duration even though they are wall-clock
+	// stamps: majestic derives the boot time from the clock it is answering with,
+	// so a correction moves both and cancels. Measured on an hi3516ev300 by
+	// stepping the camera two hours backwards mid-run — node_time and node_boot
+	// both fell by 7200 and their difference stayed 517s, matching /proc/uptime.
+	// A clock correction therefore cannot fake a reboot here, in either
+	// direction.
+	//
 	// Returns false, never throws. On a majestic too old to export node_*, or one
 	// holding an unclaimed camera behind a 401, it is simply unavailable and the
-	// watch below still applies exactly as it did before.
+	// watch below still applies exactly as it did before — but it must not go on
+	// COSTING anything either. Each call is awaited inside a poll, so a camera
+	// that answers the reachability ping and then leaves this request to time out
+	// would add its 2.5s to every one of the sixty polls the blind fallback is
+	// allowed, stretching a three-and-a-half-minute wait towards eight. Hence the
+	// strikes: three unusable answers in a row and the loop stops asking, so such
+	// a camera costs three requests rather than sixty and the watch below runs at
+	// the pace it was designed for. Three rather than one, because the answer
+	// most worth having comes from a majestic that has been serving for four
+	// seconds, which is exactly when it is entitled to a hiccup — on one measured
+	// run the plain reachability ping was answered 500 by a daemon that had just
+	// started.
+	let uptimeStrikes = 0;
 	async function rebootedAlready() {
+		if (uptimeStrikes >= 3) return false;
 		const ctl = new AbortController();
 		const to = setTimeout(() => ctl.abort(), 2500);
 		try {
@@ -183,18 +204,22 @@
 			// key, so the buster would blind this check. cache:'no-store' alone
 			// keeps the read fresh.
 			const r = await rawFetch('/metrics', { cache: 'no-store', signal: ctl.signal });
-			if (!r.ok) return false;
+			if (!r.ok) { uptimeStrikes++; return false; }
 			const txt = await r.text();
 			const num = name => {
 				const m = txt.match(new RegExp('^' + name + ' ([0-9.]+)$', 'm'));
 				return m ? Number(m[1]) : NaN;
 			};
 			const upFor = num('node_time_seconds') - num('node_boot_time_seconds');
-			if (!isFinite(upFor)) return false;
+			if (!isFinite(upFor)) { uptimeStrikes++; return false; }
+			// An answer, whichever way it went: the camera can be asked, so a hiccup
+			// earlier in the run must not still be held against it.
+			uptimeStrikes = 0;
 			// 5s of slack so a camera that booted moments before this page opened is
 			// not mistaken for one that rebooted just now.
 			return upFor < (performance.now() - startedAt) / 1000 - 5;
 		} catch (err) {
+			uptimeStrikes++;
 			return false;
 		} finally {
 			clearTimeout(to);


### PR DESCRIPTION
Fixes the remaining half of #154: the factory reset erases the overlay, the camera reboots and comes back, and the page goes on saying **"The camera is rebooting — waiting for it to come back…"** for another three and a half minutes.

### What was wrong

`pollBack()` could only conclude "it is back" by first catching the camera **down**. That window is the camera's entire absence — 14 s on the lab hi3516ev300 — and the watch does not open until fifteen seconds after the last byte of the transcript, because when `Unconditional reboot` never leaves the socket buffer the quiet timer is the only trigger left.

So the first look routinely lands *after* the camera is already serving again, and nothing on the page could then tell "it has not gone yet" from "it went and came back between two polls". `downSeen` never flipped and the run fell through to the blind `DOWN_TRIES` fallback: sixty-one more polls before handing over.

Which side of that a run falls on is decided by a few seconds of boot time, which is why the same reset on the same camera handed back in 25 s on one run and 207 s on the next — and why this survived #219 looking fixed.

One detail worth keeping: on one run the very first ping was answered **HTTP 500** by a majestic that had just started. That is a camera which has demonstrably rebooted, and the page counted it as "still hasn't gone".

### The fix

Ask the camera instead of watching for a gap — the same thing the upgrade page has done since #120. Uptime from majestic's `/metrics` (`node_time_seconds − node_boot_time_seconds`) against how long this page has been running; younger than the run means it rebooted during it.

`/metrics` needs no auth, which matters more here than anywhere else it is used: the reset erases the overlay and the session with it, so anything behind the login form would answer 401 to the one page whose credentials it has just destroyed.

It asks on every tick where the upgrade page asks every fourth — that watch can open minutes before the reboot with the camera mid-flash, this one opens past the erase, and a `/metrics` read is one request majestic answers out of its own memory rather than the heartbeat's fork storm `stopHeartbeat()` exists to stop.

### Measured

Lab hi3516ev300, driven through headless Chromium against the real page, with a TCP prober alongside for ground truth. The quiet window was widened to 25 s for both runs so the race is forced rather than flipped a coin on — everything else identical.

| | camera actually back | page handed back | polls |
|---|---|---|---|
| before | 22.1 s | **249.4 s** | 61 |
| after | 22.1 s | **32.2 s** | 1 |

### Degrading

A majestic too old to export `node_*`, or one holding an unclaimed camera behind a 401, says nothing about when it booted. `rebootedAlready()` returns false there and the watch behaves exactly as it does today. `tests/reset-watch.test.js` pins all three: the reboot noticed between two polls, a camera up for a day *not* read as freshly rebooted, and the blind fallback still firing when the uptime cannot be read. Three of them fail with the call removed.
