### PR TITLE
Dashboard: a gauge that arrives late still gets its row

### DIFF
--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -269,10 +269,11 @@
 	}
 
 	// The ISP panel shows what this SoC's ISP actually reports and nothing
-	// else — the isp_* set is vendor-shaped (only again/dgain are universal)
-	// and values are raw SDK units, deliberately not converted. Scene
-	// luminance is charted separately (it feeds the exposure warning), so it
-	// is not in the row set.
+	// else — the isp_* set is vendor-shaped (again/dgain/exptime/avelum and
+	// exposureismax are on every current daemon, the rest is per-vendor) and
+	// values are raw SDK units, deliberately not converted. Scene luminance
+	// is charted separately (it feeds the exposure warning), so it is not in
+	// the row set.
 	const ISP_ROWS = [
 		['isp_exptime', 'Exposure time'],
 		['isp_exposure', 'Exposure'],
@@ -477,10 +478,11 @@
 		setInterval(tick, 5000);
 	}
 
-	// Absent reads as "not at maximum" rather than as a row of its own: this
-	// gauge is HiSilicon's alone — Ingenic publishes isp_avelum but not this,
-	// SigmaStar neither — and a camera that cannot answer must say nothing
-	// here, not zero.
+	// Absent reads as "not at maximum" rather than as a row of its own: every
+	// current daemon publishes this gauge — HiSilicon reads it from the SDK,
+	// Ingenic and SigmaStar derive it from their AE's own limits — but an
+	// older daemon or an Ingenic T40 does not, and a camera that cannot
+	// answer must say nothing here, not zero.
 	function setLumaNote(v) {
 		const note = $('#st-luma-note');
 		if (!note) return;
@@ -527,7 +529,17 @@
 		setAlert('#st-alert-stale', false);
 		const v = s.m.v;
 		lastV = v;
-		if (!ispEls) buildImaging(v);
+		// Rebuilt, not only built once: the first heartbeat can beat the ISP
+		// up — majestic answers /metrics before the vendor SDK does, and a
+		// SigmaStar daemon whose CUS3A call fails emits no isp_* at all — and
+		// the panel then said "This SoC reports no ISP metrics" until the page
+		// was reloaded. A row set is for the gauges that exist; a gauge
+		// arriving late is the same fact arriving later. Sparkline history
+		// restarts on rebuild, which is the price of not freezing the panel to
+		// whatever the first sample happened to carry.
+		if (!ispEls || ISP_ROWS.some(r => (r[0] in v) && !(r[0] in ispEls)) ||
+			(mdEnabled && 'md_rects_recv_total' in v && !motionEl))
+			buildImaging(v);
 
 		if (s.cpu != null) {
 			$('#st-cpu').textContent = s.cpu.toFixed(0);

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -131,13 +131,15 @@
 		//
 		// There is no brightness gate, because there is no brightness to read.
 		// isp_again would be the obvious one and it is not comparable across
-		// vendors — the same "no gain at all" reads 1024 on HiSilicon, 126 on
-		// Ingenic and 20855 on SigmaStar, and SigmaStar reports no isp_avelum
-		// to fall back on. Nor can the frame supply it: auto-exposure drives
-		// average luminance toward its target whatever the light, so a
-		// correctly exposed midnight frame and a correctly exposed noon frame
-		// have the same mean by construction. Hence the wording of the finding
-		// below names what it cannot rule out instead of pretending to.
+		// vendors — the units differ (Q10 on HiSilicon and SigmaStar, log2×32
+		// on Ingenic) and so do the sensor-specific ceilings, so no one
+		// threshold means anything. isp_avelum is published everywhere now and
+		// does not help either, for the same reason the frame cannot supply
+		// it: auto-exposure drives metered luminance toward its target
+		// whatever the light, so a correctly exposed midnight frame and a
+		// correctly exposed noon frame have the same mean by construction.
+		// Hence the wording of the finding below names what it cannot rule
+		// out instead of pretending to.
 		// The day gate needs a camera that SAID it is day. Coercing an absent
 		// gauge to 0 would let the picture warn about an open filter on a
 		// camera that never reported day or night at all.

--- a/www/a/video-check.js
+++ b/www/a/video-check.js
@@ -21,12 +21,15 @@
 //   /image.jpg       392 KB               62 KB, solid black
 //
 // Only two of those are tested. isp_again moved further than anything else and
-// is deliberately not in the predicate: the scale is vendor-specific -- the
-// same idle state reads 1024 on HiSilicon, 126 on Ingenic and 20855 on
-// SigmaStar -- so there is no portable way to ask whether a gain is at its
-// ceiling, and a threshold picked from one board would fire on another camera
-// doing nothing wrong. It is recorded here because it is what the fault looked
-// like, not because anything reads it.
+// is deliberately not in the predicate: the scale is vendor-specific (Q10 on
+// HiSilicon and SigmaStar, log2×32 on Ingenic) and the ceiling is
+// sensor-specific -- an Ingenic camera reads 126 at its own maximum where a
+// HiSilicon board reads tens of thousands -- so a browser-side threshold
+// picked from one board would fire on another camera doing nothing wrong. The
+// portable form of "is the gain at its ceiling" is isp_exposureismax, which
+// each daemon answers against its own AE limits, and which IS in the
+// predicate. The raw number is recorded here because it is what the fault
+// looked like, not because anything reads it.
 //
 // Two independent signals, and they answer different halves. The camera's own
 // gauges say it is holding the shutter open as long as it can and still
@@ -72,8 +75,9 @@
 
 	// The camera's own opinion: exposure at its ceiling and the metered scene
 	// luminance at zero. true / false / null, and null is load-bearing --
-	// isp_avelum is not published by every vendor (SigmaStar reports none), so
-	// a camera that cannot answer must not be read as answering no.
+	// current daemons publish both gauges on HiSilicon, Ingenic and SigmaStar
+	// alike, but an older daemon or an Ingenic T40 does not, and a camera
+	// that cannot answer must not be read as answering no.
 	function ispBlind(v) {
 		if (!v || !('isp_avelum' in v) || !('isp_exposureismax' in v)) return null;
 		return v.isp_avelum === 0 && v.isp_exposureismax > 0;
@@ -211,11 +215,12 @@
 		// Only what the predicate actually tested. The measured signature had
 		// gain pinned at maximum too (32381 against a healthy 1024), and the
 		// first draft of these sentences said so -- but ispBlind() never looks
-		// at isp_again, and it cannot: the gain scale is vendor-specific, the
-		// same idle state reads 1024 on HiSilicon, 126 on Ingenic and 20855 on
-		// SigmaStar, and there is no portable "is this its ceiling" test. A
-		// sentence that states an observation the code did not make is the
-		// same failure as a finding reached from a test that could not look.
+		// at isp_again, and it cannot: the gain scale and ceiling are
+		// vendor- and sensor-specific, so no browser-side "is this its
+		// ceiling" threshold is portable; that question lives daemon-side in
+		// isp_exposureismax, which the predicate does read. A sentence that
+		// states an observation the code did not make is the same failure as
+		// a finding reached from a test that could not look.
 		const both = ispSays === true && ispHeld && picHeld;
 		const detail = both
 			? 'The picture is completely black, and the sensor is at its ' +


### PR DESCRIPTION
Two things, found while auditing the Dashboard's ISP panel against what the daemons publish on all three lab camera families (HiSilicon/Goke, Ingenic, SigmaStar):

**Fix — late-appearing gauges.** The ISP panel built its row set once, from the first good heartbeat. The first heartbeat can beat the ISP up — majestic answers /metrics before the vendor SDK does, and a SigmaStar daemon whose CUS3A call fails emits no `isp_*` at all — and the panel then said "This SoC reports no ISP metrics" until the page was reloaded. The row set now rebuilds whenever a gauge appears that has no row yet (same for the Motion row). Sparkline history restarts on rebuild.

**Docs — the cross-vendor commentary was drifting from reality.** Current daemons publish `isp_avelum` and `isp_exposureismax` on HiSilicon, Ingenic and SigmaStar alike (older daemons and Ingenic T40 excepted), so the comments claiming "HiSilicon's alone" / "SigmaStar reports none" are updated — the feature-detecting code needed no change, which is the design working as intended. The oft-quoted 1024/126/20855 idle gain readings are explained rather than repeated: 126 is an Ingenic camera at its own maximum (log2×32 units), not a small gain, and the portable form of "is the gain at its ceiling" is `isp_exposureismax`, answered daemon-side against each AE's own limits.

Full test suite passes; `node --check` clean on the three touched files.