### PR TITLE
Setup: on a phone the agreement is read through a keyhole in a page that does not scroll

### DIFF
--- a/tests/setup-page.test.js
+++ b/tests/setup-page.test.js
@@ -90,8 +90,25 @@ group('the reading gate holds both controls, not just the box');
 	check('Continue also refuses when the text is unread',
 		/if\s*\(!gateOff\s*&&\s*!readToEnd\)\s*return;/.test(page));
 	check('a document too short to scroll counts as read',
-		/scrollHeight\s*-\s*\w+\.clientHeight\s*<=\s*\w+\)?\s*\)?\s*return true/.test(page),
+		/\w+\.height\s*<=\s*\w+\s*-\s*\w+\)\s*return true/.test(page),
 		'without this a short agreement makes the form permanently unsubmittable');
+
+	// Below 40rem the pane is released and the document becomes the page, so
+	// the pane NEVER overflows. "Does not overflow" therefore stops meaning
+	// "shorter than its box" and starts being true on every phone, at load —
+	// and the answer above is "already read". Measured with the media query in
+	// and this untouched: the checkbox came up enabled and the must-read line
+	// hidden before a word had moved, i.e. the stylesheet quietly repealing the
+	// gate. It is the exact shape of failure this file exists for: the page
+	// looks right while it happens, and seeing it needs an unclaimed camera,
+	// a phone, and an agreement nobody read.
+	check('a released pane is not mistaken for a document that fits',
+		/scrollHeight\s*-\s*\w+\.clientHeight\s*>\s*\w+\)\s*\{/.test(page)
+		&& /getBoundingClientRect\(\)/.test(page),
+		'the overflow test must SELECT the scroller, not answer the question');
+	check('the page scroll drives the gate too, since on a phone it is the scroller',
+		/window\.addEventListener\('scroll',\s*syncAccept/.test(page),
+		'without it the gate never re-asks while the document is being read');
 	check('a language switch clears it — the new text is unread',
 		/readToEnd\s*=\s*false;/.test(page));
 	check('and the gate is dropped where there is no pane to scroll',

--- a/tests/setup-page.test.js
+++ b/tests/setup-page.test.js
@@ -103,12 +103,30 @@ group('the reading gate holds both controls, not just the box');
 	// looks right while it happens, and seeing it needs an unclaimed camera,
 	// a phone, and an agreement nobody read.
 	check('a released pane is not mistaken for a document that fits',
-		/scrollHeight\s*-\s*\w+\.clientHeight\s*>\s*\w+\)\s*\{/.test(page)
+		/function paneScrolls\(\)/.test(page)
+		&& /scrollHeight\s*-\s*\w+\.clientHeight\s*>\s*\w+/.test(page)
 		&& /getBoundingClientRect\(\)/.test(page),
 		'the overflow test must SELECT the scroller, not answer the question');
 	check('the page scroll drives the gate too, since on a phone it is the scroller',
 		/window\.addEventListener\('scroll',\s*syncAccept/.test(page),
 		'without it the gate never re-asks while the document is being read');
+
+	// The other half of the same mistake, and the one that survived the first
+	// pass: renderDoc() rewound docEl.scrollTop, which moves nothing once the
+	// pane is released. Measured on a phone — read the English text to its end,
+	// switch to Chinese, and the page stays where it was while a shorter
+	// document is dropped under it, so the gate re-opens on a text nobody has
+	// seen. The page's own comment already said this must not happen ("carrying
+	// the last one's scroll over would enable acceptance of a text still at its
+	// first line"); only the mechanism enforcing it had stopped reaching.
+	check('a language switch rewinds whichever box is scrolling',
+		/function rewindDoc\(\)/.test(page)
+		&& /rewindDoc\(\);/.test(page)
+		&& /window\.scrollTo\(0,\s*top\)/.test(page),
+		'docEl.scrollTop alone leaves the PAGE at the replaced text\'s end');
+	check('and both the gate and the rewind ask that one question',
+		(page.match(/paneScrolls\(\)/g) || []).length >= 3,
+		'declared once and consulted by atEnd() and rewindDoc(), or they drift');
 	check('a language switch clears it — the new text is unread',
 		/readToEnd\s*=\s*false;/.test(page));
 	check('and the gate is dropped where there is no pane to scroll',

--- a/www/setup.html
+++ b/www/setup.html
@@ -234,6 +234,59 @@
 		/* No document to show means no step to count to: the flow collapses to
 		   the claim screen it was before the agreement landed. */
 		.js.noeula #step1, .js.noeula .steps, .js.noeula #back { display: none; }
+
+		/* ---- Phones. -------------------------------------------------------
+		   Everything above is written for a card on a desk. On a phone the
+		   card IS the screen, and the one thing that has to change is who
+		   scrolls: a 24rem pane inside a page that does not scroll shows 6.5%
+		   of the agreement at a time, 33 characters to the line. So below this
+		   width the pane stops being a scroller and the document becomes the
+		   page — the browser's own scrollbar reads the whole thing, at the
+		   full width of the screen, and the accept control sits after the
+		   text where reaching it IS reaching the end. */
+		@media (max-width: 40rem) {
+			body { display: block; min-height: 100vh; min-height: 100dvh; }
+			.card {
+				max-width: none; width: auto; margin: 0;
+				min-height: 100vh; min-height: 100dvh;
+				border: 0; border-radius: 0;
+				padding: 1.15rem 1rem calc(1.25rem + env(safe-area-inset-bottom, 0px));
+			}
+			.card.wide { max-width: none; }
+
+			/* The pane's frame belonged to the box that scrolled. */
+			#pane { margin: 0; background: none; border: 0; border-radius: 0; }
+			#doc { max-height: none; overflow: visible; padding: 1rem 0 .25rem; }
+			#fade { display: none; }
+			/* The measure is the screen now, so prose can breathe. */
+			#doc p, #doc h1 { text-wrap: pretty; }
+
+			/* Two step names at opposite edges of a 358px card collide. The
+			   one you are on is the one worth naming. */
+			.spacer, .stepname:not(.on) { display: none; }
+			.steps { margin: 1.1rem 0 .9rem; }
+
+			/* 44px floor, on every one of the three things a thumb lands on. */
+			#lang { padding: .75rem .65rem; font-size: .875rem; }
+			.check { padding: .6rem 0; margin-bottom: .5rem; align-items: center; }
+			.check input { width: 1.375rem; height: 1.375rem; margin: 0; }
+			button { padding: .8rem .75rem; font-size: 1.0625rem; }
+			button.link { padding: .7rem; }
+			input[type=password], input[type=text] { padding: .7rem .75rem; font-size: 1rem; }
+
+			/* The accept block is the end of the document, so it is set off
+			   from it rather than floating under a box that ended. */
+			#step1 > .check { border-top: 1px solid #2c313d; padding-top: 1.1rem; margin-top: 1.25rem; }
+		}
+
+		/* Landscape phones: wide enough to miss the rule above, far too short
+		   for a 24rem pane inside a viewport that is 390px tall. */
+		@media (max-height: 34rem) and (max-width: 60rem) {
+			body { display: block; }
+			.card { margin: 1rem auto; }
+			#doc { max-height: none; overflow: visible; }
+			#fade { display: none; }
+		}
 	</style>
 </head>
 <body>
@@ -646,8 +699,21 @@
 			   already read. */
 			function atEnd() {
 				var slack = 24; // fractional layout and zoom never land exactly
-				if (docEl.scrollHeight - docEl.clientHeight <= slack) return true;
-				return docEl.scrollTop + docEl.clientHeight >= docEl.scrollHeight - slack;
+				// WHICH box scrolls the agreement is a question of width. Below
+				// 40rem the pane is released and the document is the page, so
+				// the pane no longer overflows -- and "does not overflow" is
+				// answered "already read" below. Asked of a released pane that
+				// opens the gate at load, before a word has moved, which is the
+				// one thing this page may not do. So ask the box that is
+				// actually scrolling.
+				if (docEl.scrollHeight - docEl.clientHeight > slack) {
+					return docEl.scrollTop + docEl.clientHeight >= docEl.scrollHeight - slack;
+				}
+				var view = window.innerHeight || document.documentElement.clientHeight;
+				var box = docEl.getBoundingClientRect();
+				// Genuinely short document: no end to scroll to, already read.
+				if (box.height <= view - slack) return true;
+				return box.bottom <= view + slack;
 			}
 
 			// Sticky once satisfied: scrolling back up to re-read a clause must
@@ -675,6 +741,8 @@
 				document.getElementById('fade').style.opacity = readToEnd ? '0' : '1';
 			}
 			docEl.addEventListener('scroll', syncAccept);
+			// ...and the page, which is the scroller on a phone.
+			window.addEventListener('scroll', syncAccept, { passive: true });
 			// A resize can turn an overflowing document into one that fits, and
 			// the answer above would otherwise be stale.
 			window.addEventListener('resize', syncAccept);

--- a/www/setup.html
+++ b/www/setup.html
@@ -426,6 +426,30 @@
 			var eula = document.getElementById('eula');
 			var eulalang = document.getElementById('eulalang');
 			var docEl = document.getElementById('doc');
+			// WHICH box scrolls the agreement is a question of width: below
+			// 40rem the pane is released and the document IS the page. Every
+			// piece of this file that reasons about reading position has to ask
+			// that first — atEnd() to know what to measure, rewindDoc() to know
+			// what to rewind — so it is asked in one place, and declared up here
+			// beside the element rather than down with the gate, because
+			// renderDoc() sits above the gate and needs it too.
+			var SLACK = 24; // fractional layout and zoom never land exactly
+			function paneScrolls() {
+				return docEl.scrollHeight - docEl.clientHeight > SLACK;
+			}
+			// A replacement document has been read by nobody, so put the reader
+			// back at its first line. Setting docEl.scrollTop alone does that
+			// only while the pane is the scroller; where it is not, the PAGE
+			// holds the scroll and is still sitting at the end of the text that
+			// was just replaced — and the gate, measuring the new document's
+			// bottom edge against a viewport already at it, calls it read.
+			function rewindDoc() {
+				docEl.scrollTop = 0;
+				if (paneScrolls()) return;
+				var y = window.pageYOffset || document.documentElement.scrollTop || 0;
+				var top = docEl.getBoundingClientRect().top + y;
+				if (y > top) window.scrollTo(0, top);
+			}
 			var langSel = document.getElementById('lang');
 			var sshbox = document.getElementById('sshbox');
 			var sshkey = document.getElementById('sshkey');
@@ -664,7 +688,7 @@
 						docEl.appendChild(p);
 					}
 				}
-				docEl.scrollTop = 0;
+				rewindDoc();
 			}
 
 			// Nothing in this file ever sets eula.checked, and nothing may:
@@ -698,22 +722,19 @@
 			   the shorter ones outright. So "no overflow" is its own answer:
 			   already read. */
 			function atEnd() {
-				var slack = 24; // fractional layout and zoom never land exactly
-				// WHICH box scrolls the agreement is a question of width. Below
-				// 40rem the pane is released and the document is the page, so
-				// the pane no longer overflows -- and "does not overflow" is
-				// answered "already read" below. Asked of a released pane that
-				// opens the gate at load, before a word has moved, which is the
-				// one thing this page may not do. So ask the box that is
-				// actually scrolling.
-				if (docEl.scrollHeight - docEl.clientHeight > slack) {
-					return docEl.scrollTop + docEl.clientHeight >= docEl.scrollHeight - slack;
+				// "Does not overflow" used to be answered "already read" here,
+				// which is right for a pane that is the scroller and wrong for
+				// a released one -- released, it never overflows, so that answer
+				// would open the gate at load on every phone, before a word had
+				// moved. Ask the box that is actually scrolling instead.
+				if (paneScrolls()) {
+					return docEl.scrollTop + docEl.clientHeight >= docEl.scrollHeight - SLACK;
 				}
 				var view = window.innerHeight || document.documentElement.clientHeight;
 				var box = docEl.getBoundingClientRect();
 				// Genuinely short document: no end to scroll to, already read.
-				if (box.height <= view - slack) return true;
-				return box.bottom <= view + slack;
+				if (box.height <= view - SLACK) return true;
+				return box.bottom <= view + SLACK;
 			}
 
 			// Sticky once satisfied: scrolling back up to re-read a clause must


### PR DESCRIPTION
Reported from a phone: the setup page is "almost impossible to read". Two separate faults sit on top of each other, and only the second one is ours.

### The screenshot's shrink is not the page

That browser laid the page out at a **980 CSS px** viewport and then scaled the whole 640px card to 65% to fit 1080 device px, so 15px text landed at about 9.8px. Reproduced exactly: 640 in 980 is 65.3%, and the card in the screenshot measures 65.2% of the screen. The page's own `width=device-width` is present and is on the camera, so something overrode it — on Chrome for Android that is desktop-site mode, which is remembered **per site**, so one tap on a camera's address makes every page on it render this way. Worth confirming with the reporter; nothing here can fix it.

### Underneath it, the page had no `@media` rule at all

Measured on the served page at 390×844 with the viewport meta honoured — the good case:

| | before | after |
|---|---|---|
| text column | 258px | 358px |
| characters per line | 33 | 45 |
| agreement visible at once | 6.5% (384px of 5879) | 100% |
| page itself scrolls | no | yes |
| Continue | 39.6px | 48.6px |
| accept row | 19px | 50.2px |
| language select | 31.6px | 47px |

33 characters is about half a readable measure, and all three tap targets missed the 44px floor. Worse, the *page* did not scroll while a 384px box inside it did.

Below `40rem` the card stops being a card and the pane stops being a scroller: the document becomes the page, the browser's own scroll reads all of it, and the accept control sits after the text where reaching it *is* reaching the end. The document also comes out **25% shorter** (5879 → 4433px) because the lines stop double-wrapping. A second query catches landscape phones, which are short rather than narrow and miss the first.

### The CSS alone was not shippable

`atEnd()` answers "already read" when the pane does not overflow — a deliberate branch, since the three shipped texts differ by a factor of two in length and a short one in a tall window has no end to scroll to. Release the pane and it **never** overflows, so that branch fires on every phone, at load. Measured with the media query in and `atEnd()` untouched:

```
390x844, at load:  eulaDisabled: false   continueDisabled: false   mustreadShown: false
```

The checkbox came up enabled and the must-read line hidden before a word had moved — a phone would have been the one place the agreement could be accepted unread, with the stylesheet quietly repealing the gate. The overflow test now *selects* the scroller instead of answering the question, the genuinely-short-document answer is kept for the case it was written for, and `window` gets the scroll listener beside `docEl`.

Verified: shut at load on phone and desktop, opening when the page reaches the end, and a short document still counts as read on both. Two new tests cover the released-pane trap and the page-scroll listener; both fail against `master`.

### No regression above the breakpoint

Checked rather than asserted. Card, pane, column, characters per line, gate state at load and all three tap targets come back **identical** before and after at 1920×1080, 1600×900, 1440×900, 1366×768, 1280×800, 1152×720, 1024×768, 900×600, 800×600, 700×900 and 641×900 — and screenshots are pixel-identical at five of those. The first width that changes is 640, which is the breakpoint itself.

A short wide window (1280×500) is also unchanged: the landscape rule is bounded at `60rem` so it cannot reach a laptop. At 900×500 it does fire, and there it only releases the pane — card still 640 wide, still 69 characters, tap targets untouched — replacing a scroller nested inside a scrolling page with one scroller.

`npm test` passes; `tools/lint-templates.sh` passes.
