### PR TITLE
Day / Night: the light monitor shows its reasoning, and knows when it has none

### DIFF
--- a/tests/fixtures/metrics-sstar-auto.txt
+++ b/tests/fixtures/metrics-sstar-auto.txt
@@ -1,0 +1,353 @@
+# HELP node_uname_info Labeled system information as provided by the uname system call.
+# TYPE node_uname_info gauge
+node_uname_info{domainname="(null)",machine="armv7l",nodename="camera",release="4.9.84",sysname="Linux",version="#2 SMP PREEMPT Sun Aug 30 17:37:29 UTC 2026"} 1
+# HELP node_boot_time_seconds Node boot time, in unixtime.
+# TYPE node_boot_time_seconds gauge
+node_boot_time_seconds 1788306128
+# HELP node_context_switches_total Total number of context switches.
+# TYPE node_context_switches_total counter
+node_context_switches_total 251768399
+# HELP node_cpu_seconds_total Seconds the cpus spent in each mode.
+# TYPE node_cpu_seconds_total counter
+node_cpu_seconds_total{cpu="0",mode="user"} 6787.32
+node_cpu_seconds_total{cpu="0",mode="nice"} 0
+node_cpu_seconds_total{cpu="0",mode="system"} 23004.9
+node_cpu_seconds_total{cpu="0",mode="idle"} 123439
+node_cpu_seconds_total{cpu="0",mode="iowait"} 0
+node_cpu_seconds_total{cpu="0",mode="irq"} 0
+node_cpu_seconds_total{cpu="0",mode="softirq"} 56.58
+node_cpu_seconds_total{cpu="0",mode="steal"} 0
+node_cpu_seconds_total{cpu="0",mode="guest"} 0
+node_cpu_seconds_total{cpu="0",mode="guest_nice"} 0
+# HELP node_intr_total 
+# TYPE node_intr_total counter
+node_intr_total 104406515
+# HELP node_forks_total 
+# TYPE node_forks_total counter
+node_forks_total 43585
+# HELP node_procs_running_total 
+# TYPE node_procs_running_total gauge
+node_procs_running_total 2
+# HELP node_procs_blocked_total 
+# TYPE node_procs_blocked_total gauge
+node_procs_blocked_total 0
+# HELP node_filefd_allocated File descriptor statistics: allocated.
+# TYPE node_filefd_allocated gauge
+node_filefd_allocated 128
+# HELP node_filefd_maximum File descriptor statistics: maximum.
+# TYPE node_filefd_maximum gauge
+node_filefd_maximum 9039
+# HELP node_load1 1m load average.
+# TYPE node_load1 gauge
+node_load1 13.68
+# HELP node_load5 1m load average.
+# TYPE node_load5 gauge
+node_load5 14.19
+# HELP node_load15 15m load average.
+# TYPE node_load15 gauge
+node_load15 14.32
+# TYPE node_memory_MemTotal_bytes gauge
+node_memory_MemTotal_bytes 94994432
+# TYPE node_memory_MemFree_bytes gauge
+node_memory_MemFree_bytes 37785600
+# TYPE node_memory_MemAvailable_bytes gauge
+node_memory_MemAvailable_bytes 58494976
+# TYPE node_memory_Buffers_bytes gauge
+node_memory_Buffers_bytes 5029888
+# TYPE node_memory_Cached_bytes gauge
+node_memory_Cached_bytes 34222080
+# TYPE node_memory_SwapCached_bytes gauge
+node_memory_SwapCached_bytes 0
+# TYPE node_memory_Active_bytes gauge
+node_memory_Active_bytes 30900224
+# TYPE node_memory_Inactive_bytes gauge
+node_memory_Inactive_bytes 11317248
+# TYPE node_memory_Active_anon_bytes gauge
+node_memory_Active_anon_bytes 14917632
+# TYPE node_memory_Inactive_anon_bytes gauge
+node_memory_Inactive_anon_bytes 4235264
+# TYPE node_memory_Active_file_bytes gauge
+node_memory_Active_file_bytes 15982592
+# TYPE node_memory_Inactive_file_bytes gauge
+node_memory_Inactive_file_bytes 7081984
+# TYPE node_memory_Unevictable_bytes gauge
+node_memory_Unevictable_bytes 0
+# TYPE node_memory_Mlocked_bytes gauge
+node_memory_Mlocked_bytes 0
+# TYPE node_memory_SwapTotal_bytes gauge
+node_memory_SwapTotal_bytes 0
+# TYPE node_memory_SwapFree_bytes gauge
+node_memory_SwapFree_bytes 0
+# TYPE node_memory_Dirty_bytes gauge
+node_memory_Dirty_bytes 0
+# TYPE node_memory_Writeback_bytes gauge
+node_memory_Writeback_bytes 0
+# TYPE node_memory_AnonPages_bytes gauge
+node_memory_AnonPages_bytes 2961408
+# TYPE node_memory_Mapped_bytes gauge
+node_memory_Mapped_bytes 4632576
+# TYPE node_memory_Shmem_bytes gauge
+node_memory_Shmem_bytes 16187392
+# TYPE node_memory_Slab_bytes gauge
+node_memory_Slab_bytes 7286784
+# TYPE node_memory_SReclaimable_bytes gauge
+node_memory_SReclaimable_bytes 2060288
+# TYPE node_memory_SUnreclaim_bytes gauge
+node_memory_SUnreclaim_bytes 5226496
+# TYPE node_memory_KernelStack_bytes gauge
+node_memory_KernelStack_bytes 696320
+# TYPE node_memory_PageTables_bytes gauge
+node_memory_PageTables_bytes 270336
+# TYPE node_memory_NFS_Unstable_bytes gauge
+node_memory_NFS_Unstable_bytes 0
+# TYPE node_memory_Bounce_bytes gauge
+node_memory_Bounce_bytes 0
+# TYPE node_memory_WritebackTmp_bytes gauge
+node_memory_WritebackTmp_bytes 0
+# TYPE node_memory_CommitLimit_bytes gauge
+node_memory_CommitLimit_bytes 47497216
+# TYPE node_memory_Committed_AS_bytes gauge
+node_memory_Committed_AS_bytes 82448384
+# TYPE node_memory_VmallocTotal_bytes gauge
+node_memory_VmallocTotal_bytes 796917760
+# TYPE node_memory_VmallocUsed_bytes gauge
+node_memory_VmallocUsed_bytes 0
+# TYPE node_memory_VmallocChunk_bytes gauge
+node_memory_VmallocChunk_bytes 0
+# TYPE node_memory_CmaTotal_bytes gauge
+node_memory_CmaTotal_bytes 2097152
+# TYPE node_memory_CmaFree_bytes gauge
+node_memory_CmaFree_bytes 1716224
+# TYPE node_network_receive_bytes_total counter
+node_network_receive_bytes_total{device="eth0"} 144589602
+# TYPE node_network_receive_packets_total counter
+node_network_receive_packets_total{device="eth0"} 498425
+# TYPE node_network_receive_errs_total counter
+node_network_receive_errs_total{device="eth0"} 0
+# TYPE node_network_receive_drop_total counter
+node_network_receive_drop_total{device="eth0"} 129
+# TYPE node_network_receive_fifo_total counter
+node_network_receive_fifo_total{device="eth0"} 0
+# TYPE node_network_receive_frame_total counter
+node_network_receive_frame_total{device="eth0"} 0
+# TYPE node_network_receive_compressed_total counter
+node_network_receive_compressed_total{device="eth0"} 0
+# TYPE node_network_receive_multicast_total counter
+node_network_receive_multicast_total{device="eth0"} 45129
+# TYPE node_network_transmit_bytes_total counter
+node_network_transmit_bytes_total{device="eth0"} 278833977
+# TYPE node_network_transmit_packets_total counter
+node_network_transmit_packets_total{device="eth0"} 335058
+# TYPE node_network_transmit_errs_total counter
+node_network_transmit_errs_total{device="eth0"} 0
+# TYPE node_network_transmit_drop_total counter
+node_network_transmit_drop_total{device="eth0"} 0
+# TYPE node_network_transmit_fifo_total counter
+node_network_transmit_fifo_total{device="eth0"} 0
+# TYPE node_network_transmit_colls_total counter
+node_network_transmit_colls_total{device="eth0"} 0
+# TYPE node_network_transmit_carrier_total counter
+node_network_transmit_carrier_total{device="eth0"} 0
+# TYPE node_network_transmit_compressed_total counter
+node_network_transmit_compressed_total{device="eth0"} 0
+node_network_receive_bytes_total{device="tunnel"} 264795
+node_network_receive_packets_total{device="tunnel"} 1341
+node_network_receive_errs_total{device="tunnel"} 0
+node_network_receive_drop_total{device="tunnel"} 726
+node_network_receive_fifo_total{device="tunnel"} 0
+node_network_receive_frame_total{device="tunnel"} 0
+node_network_receive_compressed_total{device="tunnel"} 0
+node_network_receive_multicast_total{device="tunnel"} 0
+node_network_transmit_bytes_total{device="tunnel"} 5236
+node_network_transmit_packets_total{device="tunnel"} 21
+node_network_transmit_errs_total{device="tunnel"} 0
+node_network_transmit_drop_total{device="tunnel"} 0
+node_network_transmit_fifo_total{device="tunnel"} 0
+node_network_transmit_colls_total{device="tunnel"} 0
+node_network_transmit_carrier_total{device="tunnel"} 0
+node_network_transmit_compressed_total{device="tunnel"} 0
+# HELP node_time_seconds Current time.
+# TYPE node_time_seconds gauge
+node_time_seconds 1788475710
+# HELP task_seconds Seconds tasks spent in each mode.
+# TYPE task_seconds counter
+task_seconds{name="majestic.new",tid="2262",mode="user"} 0.29
+task_seconds{name="majestic.new",tid="2262",mode="system"} 0.3
+task_seconds{name="majestic.new",tid="2263",mode="user"} 0
+task_seconds{name="majestic.new",tid="2263",mode="system"} 0
+task_seconds{name="thread-pool-0",tid="2264",mode="user"} 0
+task_seconds{name="thread-pool-0",tid="2264",mode="system"} 0
+task_seconds{name="thread-pool-1",tid="2265",mode="user"} 0
+task_seconds{name="thread-pool-1",tid="2265",mode="system"} 0
+task_seconds{name="3A_Proc",tid="2282",mode="user"} 0.29
+task_seconds{name="3A_Proc",tid="2282",mode="system"} 0.62
+task_seconds{name="majestic.new",tid="2291",mode="user"} 0
+task_seconds{name="majestic.new",tid="2291",mode="system"} 0.28
+# HELP app_boot_time_seconds App boot time, in unixtime.
+# TYPE app_boot_time_seconds gauge
+app_boot_time_seconds 1788475698
+# HELP malloc_mp4_alloc_bytes Number of bytes allocated for MP4 buffer.
+# TYPE malloc_mp4_alloc_bytes gauge
+malloc_mp4_alloc_bytes 0
+# HELP malloc_hls_alloc_bytes Number of bytes the HLS segment ring is holding.
+# TYPE malloc_hls_alloc_bytes gauge
+malloc_hls_alloc_bytes 0
+# HELP jpeg_requests_total Number of JPEG requests made by clients.
+# TYPE jpeg_requests_total counter
+jpeg_requests_total 0
+# HELP jpeg_responses_total Number of JPEG correnponding responses.
+# TYPE jpeg_responses_total counter
+jpeg_responses_total 0
+# HELP http_requests_total Number of requests made to HTTP server.
+# TYPE http_requests_total counter
+http_requests_total 1
+# HELP venc0_rcvd_bytes Number of bytes received from first venc channel
+# TYPE venc0_rcvd_bytes counter
+venc0_rcvd_bytes 3337478
+# HELP venc1_rcvd_bytes Number of bytes received from second venc channel
+# TYPE venc1_rcvd_bytes counter
+venc1_rcvd_bytes 1088458
+# HELP pipeline_rebuilds_total Number of full SDK teardown and rebuild cycles since boot
+# TYPE pipeline_rebuilds_total counter
+pipeline_rebuilds_total 0
+# HELP config_live_applies_total Number of live-apply helper runs that carried a change without a rebuild
+# TYPE config_live_applies_total counter
+config_live_applies_total 0
+# HELP config_service_restarts_total Number of single subsystems restarted without a pipeline rebuild
+# TYPE config_service_restarts_total counter
+config_service_restarts_total 0
+# HELP config_channel_rebuilds_total Number of single encoder channels recreated without a pipeline rebuild
+# TYPE config_channel_rebuilds_total counter
+config_channel_rebuilds_total 0
+# HELP venc_empty_frames Number of venc wakeups that carried no frame
+# TYPE venc_empty_frames counter
+venc_empty_frames 0
+# HELP venc_empty_frames_run Consecutive empty venc wakeups on the worst channel right now
+# TYPE venc_empty_frames_run gauge
+venc_empty_frames_run 0
+# HELP node_hwmon_temp_celsius Chipset temperature
+# TYPE node_hwmon_temp_celsius gauge
+node_hwmon_temp_celsius 65
+# HELP isp_again Analog Gain
+# TYPE isp_again gauge
+isp_again 2077
+# HELP isp_dgain Digital Gain
+# TYPE isp_dgain gauge
+isp_dgain 1024
+# HELP isp_exposure Exposure
+# TYPE isp_exposure gauge
+isp_exposure 33
+# HELP isp_fps Sensor fps
+# TYPE isp_fps gauge
+isp_fps 29
+# HELP isp_avelum Average luminance
+# TYPE isp_avelum gauge
+isp_avelum 37
+# HELP isp_exptime Sensor exposure time
+# TYPE isp_exptime gauge
+isp_exptime 33330
+# HELP isp_exposureismax Exposure reached maximum
+# TYPE isp_exposureismax gauge
+isp_exposureismax 0
+# HELP night_enabled Is night mode enabled
+# TYPE night_enabled gauge
+night_enabled 0
+# HELP ircut_enabled Is ircut mode enabled
+# TYPE ircut_enabled gauge
+ircut_enabled 0
+# HELP light_enabled Is light mode enabled
+# TYPE light_enabled gauge
+light_enabled 0
+# HELP night_mode_source What controls day/night: 0 manual, 1 GPIO sensor, 2 gain thresholds, 3 ADC, 4 automatic
+# TYPE night_mode_source gauge
+night_mode_source 4
+# HELP night_auto_gain_milli Sensor gain as thousandths of 1x, as the automatic day/night monitor sees it
+# TYPE night_auto_gain_milli gauge
+night_auto_gain_milli 2028
+# HELP night_auto_pending 0 stable, 1 counting toward night, 2 counting toward day
+# TYPE night_auto_pending gauge
+night_auto_pending 0
+# HELP night_auto_streak_seconds Seconds the pending condition has held
+# TYPE night_auto_streak_seconds gauge
+night_auto_streak_seconds 0
+# HELP night_auto_dwell_seconds Seconds the pending condition must hold to switch
+# TYPE night_auto_dwell_seconds gauge
+night_auto_dwell_seconds 15
+# HELP md_rects_recv_total Number of rectangles returned by HW MD algorithm.
+# TYPE md_rects_recv_total counter
+md_rects_recv_total 0
+# HELP md_rects_acc_total Number of rectangles fit into ROI.
+# TYPE md_rects_acc_total counter
+md_rects_acc_total 0
+# HELP hls_clients_total Number of connected clients by HLS protocol.
+# TYPE hls_clients_total gauge
+hls_clients_total 0
+# HELP rtsp_clients_total Number of connected RTSP clients.
+# TYPE rtsp_clients_total gauge
+rtsp_clients_total 0
+# HELP rtsp_tx_bytes RTP bytes sent to RTSP clients.
+# TYPE rtsp_tx_bytes counter
+rtsp_tx_bytes 0
+# HELP ws_video_clients_total Number of connected /ws/video (MSE) clients.
+# TYPE ws_video_clients_total gauge
+ws_video_clients_total 0
+# HELP webrtc_sessions_total Number of live WebRTC sessions.
+# TYPE webrtc_sessions_total gauge
+webrtc_sessions_total 0
+# HELP webrtc_tx_bytes SRTP bytes sent to WebRTC peers.
+# TYPE webrtc_tx_bytes counter
+webrtc_tx_bytes 0
+# HELP outgoing_streams_total Live outgoing push streams (RTMP + RTP).
+# TYPE outgoing_streams_total gauge
+outgoing_streams_total 0
+# HELP outgoing_tx_bytes Bytes pushed to outgoing RTMP/RTP destinations.
+# TYPE outgoing_tx_bytes counter
+outgoing_tx_bytes 0
+# HELP records_fragments_dropped_total Number of finished fragments discarded because storage fell behind
+# TYPE records_fragments_dropped_total counter
+records_fragments_dropped_total 0
+# HELP records_dropped_ticks_total Presentation time lost to dropped fragments, in media timescale units
+# TYPE records_dropped_ticks_total counter
+records_dropped_ticks_total 0
+# HELP records_fragments_skipped_total Number of fragments skipped waiting for a keyframe to open a clip on
+# TYPE records_fragments_skipped_total counter
+records_fragments_skipped_total 0
+# HELP records_queue_fragments Fragments waiting to be written to storage
+# TYPE records_queue_fragments gauge
+records_queue_fragments 0
+# HELP records_queue_bytes Bytes waiting to be written to storage
+# TYPE records_queue_bytes gauge
+records_queue_bytes 0
+# HELP records_storage_used_percent Percentage of the recording volume in use, or -1 if not measured yet
+# TYPE records_storage_used_percent gauge
+records_storage_used_percent -1
+# HELP records_cleanup_unlinks_total Number of recordings deleted to keep storage under records.maxUsage
+# TYPE records_cleanup_unlinks_total counter
+records_cleanup_unlinks_total 0
+# HELP records_state Recorder verdict on storage: 0 ok, 1 degraded, 2 failed, 3 offline
+# TYPE records_state gauge
+records_state 0
+# HELP records_bytes_written_total Number of bytes the recorder has written to storage
+# TYPE records_bytes_written_total counter
+records_bytes_written_total 0
+# HELP records_fragments_written_total Number of MP4 fragments the recorder has written
+# TYPE records_fragments_written_total counter
+records_fragments_written_total 0
+# HELP records_write_errors_total Number of writes to storage that failed outright
+# TYPE records_write_errors_total counter
+records_write_errors_total 0
+# HELP records_short_writes_total Number of writes to storage that completed in more than one call
+# TYPE records_short_writes_total counter
+records_short_writes_total 0
+# HELP records_sync_errors_total Number of failed fsync calls on a recording
+# TYPE records_sync_errors_total counter
+records_sync_errors_total 0
+# HELP records_fsync_us_last Duration of the last fsync of a recording
+# TYPE records_fsync_us_last gauge
+records_fsync_us_last 0
+# HELP records_fsync_us_max Longest fsync of a recording since startup
+# TYPE records_fsync_us_max gauge
+records_fsync_us_max 0
+# HELP records_reopens_total Number of times the recorder recovered a card it had given up on
+# TYPE records_reopens_total counter
+records_reopens_total 0

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -420,6 +420,64 @@ function runRest() {
 		check('pins wired but no monitor is only an observation',
 			ic.diagnose({ irCutPin1: 11 }, null, null)
 				.some(x => x.id === 'manual-only' && x.level === 'info'));
+		// The daemon says who decides via night_mode_source (sample.src).
+		// Source 4 turns "blind" into the automatic-mode observation; source
+		// 0 means the SoC could not answer and the monitor stood down; no
+		// source at all keeps the old warning for older firmware.
+		const auto = ic.diagnose({ irCutPin1: 11, lightMonitor: true },
+			{ night: 0, ircut: 0, light: 0, src: 4 }, null);
+		check('an automatic monitor is an observation, not a fault',
+			auto.some(x => x.id === 'auto-active' && x.level === 'info') &&
+			!auto.some(x => x.id === 'monitor-blind'));
+		check('a monitor the SoC could not feed is flagged as retired',
+			ic.diagnose({ irCutPin1: 11, lightMonitor: true },
+				{ night: 0, ircut: 0, light: 0, src: 0 }, null)
+				.some(x => x.id === 'auto-retired' && x.level === 'warning'));
+		check('no source gauge keeps the older-firmware warning',
+			ic.diagnose({ irCutPin1: 11, lightMonitor: true },
+				{ night: 0, ircut: 0, light: 0, src: null }, null)
+				.some(x => x.id === 'monitor-blind'));
+	}
+
+	group('monitorView: what the panel charts');
+	{
+		const nmAuto = { lightMonitor: true, autoDayGain: 2 };
+		const vAuto = {
+			night_mode_source: 4, night_enabled: 0,
+			night_auto_gain_milli: 2567, night_auto_pending: 0,
+			night_auto_streak_seconds: 0, night_auto_dwell_seconds: 15,
+		};
+		const auto = ic.monitorView(nmAuto, vAuto);
+		check('auto mode charts gain in multiples',
+			auto && auto.mode === 'auto' && auto.value === 2.567,
+			auto && JSON.stringify(auto.value));
+		check('the day band runs to autoDayGain',
+			auto.bands[0].from === 0 && auto.bands[0].to === 2);
+		check('no night band without an explicit autoNightGain',
+			auto.bands.length === 1);
+		check('an explicit autoNightGain shades a night band',
+			ic.monitorView({ lightMonitor: true, autoNightGain: 16 }, vAuto)
+				.bands.some(b => b.from === 16));
+		const counting = ic.monitorView(nmAuto, Object.assign({}, vAuto, {
+			night_auto_pending: 2, night_auto_streak_seconds: 20,
+			night_auto_dwell_seconds: 60,
+		}));
+		check('a pending switch counts down',
+			/switching in 40 s/.test(counting.line), counting.line);
+
+		const nmThr = { lightMonitor: true, minThreshold: 1500, maxThreshold: 4000 };
+		const thr = ic.monitorView(nmThr,
+			{ night_mode_source: 2, night_enabled: 1, isp_again: 6000 });
+		check('threshold mode charts raw isp_again with both bands',
+			thr && thr.mode === 'thresholds' && thr.value === 6000 &&
+			thr.bands.length === 2);
+		check('an old daemon with thresholds still gets the chart',
+			ic.monitorView(nmThr, { isp_again: 2000 }).mode === 'thresholds');
+		check('a GPIO source has nothing continuous to chart',
+			ic.monitorView({ lightMonitor: true, lightSensorPin: 66 },
+				{ night_mode_source: 1 }) === null);
+		check('monitor off charts nothing',
+			ic.monitorView({}, vAuto) === null);
 	}
 
 	group('diagnose: thresholds need a band, not a point');

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -476,8 +476,24 @@ function runRest() {
 		check('a GPIO source has nothing continuous to chart',
 			ic.monitorView({ lightMonitor: true, lightSensorPin: 66 },
 				{ night_mode_source: 1 }) === null);
+		check('an ADC source has nothing continuous to chart either',
+			ic.monitorView({ lightMonitor: true, minThreshold: 100, maxThreshold: 400 },
+				{ night_mode_source: 3, isp_again: 200 }) === null);
 		check('monitor off charts nothing',
 			ic.monitorView({}, vAuto) === null);
+		// Missing gauges stay unknown: no countdown made of coerced zeros,
+		// and no "Day" invented for a camera that never said.
+		const noTimers = ic.monitorView(nmAuto, {
+			night_mode_source: 4, night_enabled: 1,
+			night_auto_gain_milli: 8000, night_auto_pending: 2,
+		});
+		check('a countdown with no gauges behind it is not spoken',
+			!/switching in \d+ s/.test(noTimers.line), noTimers.line);
+		const noNight = ic.monitorView(nmAuto,
+			{ night_mode_source: 4, night_auto_gain_milli: 2000 });
+		check('an absent night_enabled is not called Day',
+			!/^Day/.test(noNight.line) && !/^Night/.test(noNight.line),
+			noNight.line);
 	}
 
 	group('diagnose: thresholds need a band, not a point');

--- a/tests/metrics-parse.test.js
+++ b/tests/metrics-parse.test.js
@@ -74,6 +74,24 @@ check('sstar: sensor fps and encoder stall gauges', 'isp_fps' in sstar.v && 'ven
 check('absent stays absent — no zero-filling across vendors',
 	!('isp_fps' in hisi.v) && !('isp_exptime' in sstar.v) && !('node_hwmon_temp_celsius' in ingenic.v), '');
 
+group('a current daemon in automatic day/night mode');
+// metrics-sstar-auto.txt is a real dump from the same SSC30KQ running a
+// daemon with the automatic light monitor active — the cross-vendor isp set
+// plus the night_auto_* gauges the Day/Night panel charts.
+{
+	const auto = parse(fixture('sstar-auto'));
+	check('portable isp set present',
+		'isp_avelum' in auto.v && 'isp_exptime' in auto.v &&
+		'isp_exposureismax' in auto.v, '');
+	check('mode source names the automatic monitor',
+		auto.v.night_mode_source === 4, 'got ' + auto.v.night_mode_source);
+	check('auto gauges parse as numbers',
+		auto.v.night_auto_gain_milli > 0 &&
+		'night_auto_pending' in auto.v &&
+		'night_auto_streak_seconds' in auto.v &&
+		auto.v.night_auto_dwell_seconds > 0, '');
+}
+
 group('MemAvailable: pre-3.14 fallback and clamp');
 // The T31 runs 3.10 — no MemAvailable line. The parser must rebuild the
 // kernel's own estimate from the parts, exactly as pulse.cgi's awk used to.

--- a/www/a/charts.js
+++ b/www/a/charts.js
@@ -197,6 +197,16 @@ window.MjCharts = (function () {
 	}
 	function renderAll() { charts.forEach(renderChart); }
 
+	// Forget a chart that is being replaced. The dashboard's charts live as
+	// long as the page and never need this; a settings panel that is unmounted
+	// and remade on every visit does, or the registry accumulates detached
+	// hosts and their sample history for the life of the tab.
+	function dropChart(ch) {
+		if (!ch) return;
+		const i = charts.indexOf(ch);
+		if (i >= 0) charts.splice(i, 1);
+	}
+
 	// One debounced resize listener for every chart on the page, whichever
 	// script created it.
 	let rt = null;
@@ -207,7 +217,7 @@ window.MjCharts = (function () {
 
 	return {
 		makeSpark: makeSpark, pushSpark: pushSpark,
-		makeChart: makeChart, pushChart: pushChart,
+		makeChart: makeChart, pushChart: pushChart, dropChart: dropChart,
 		renderChart: renderChart, renderAll: renderAll,
 		fmtNum: fmtNum, niceCeil: niceCeil,
 	};

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -571,11 +571,16 @@
 
 		const dn = $('#st-daynight');
 		// A gauge this majestic does not publish reads as "not reported", never
-		// as day with the filter closed.
+		// as day with the filter closed. The source word says who decided —
+		// absent on daemons that predate night_mode_source, and unsaid for 0
+		// (manual is the absence of a decider, not a decider).
+		const srcWord = ['', ' · sensor pin', ' · thresholds', ' · ADC',
+			' · auto'][v.night_mode_source] || '';
 		if (dn) dn.textContent = s.night == null ? 'Day / night not reported'
 			: (s.night ? '🌙 Night' : '☀️ Day') +
 				' · IR-cut ' + (s.ircut == null ? '?' : (s.ircut ? 'on' : 'off')) +
-				' · lamp ' + (s.light == null ? '?' : (s.light ? 'on' : 'off'));
+				' · lamp ' + (s.light == null ? '?' : (s.light ? 'on' : 'off')) +
+				srcWord;
 		renderIrcut(s);
 		// Only SigmaStar reports the empty-wakeup run; a sustained one means
 		// the encoder has stopped producing frames while all else looks alive.

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -645,6 +645,12 @@
 		if (!on(nm.lightMonitor) || !v) return null;
 		const src = ('night_mode_source' in v) ? v.night_mode_source : null;
 
+		// An absent night_enabled is a camera whose state is unknown, and an
+		// unknown is not a day — the sentence then simply skips the word.
+		const modeWord = v.night_enabled === 1 || v.night_enabled === true
+			? 'Night. '
+			: v.night_enabled === 0 || v.night_enabled === false ? 'Day. ' : '';
+
 		if (src === 4) {
 			const dayG = pin(nm.autoDayGain) !== null ? pin(nm.autoDayGain) : 2;
 			const nightG = pin(nm.autoNightGain);
@@ -662,15 +668,20 @@
 			}
 			const gm = v.night_auto_gain_milli;
 			const pend = v.night_auto_pending;
-			const left = Math.max(0,
-				(v.night_auto_dwell_seconds | 0) -
-				(v.night_auto_streak_seconds | 0));
+			// A countdown is arithmetic on two gauges; with either missing
+			// there is no number to count from, and "switching in 0 s" would
+			// be a confident sentence made of nothing.
+			const dwell = v.night_auto_dwell_seconds;
+			const streak = v.night_auto_streak_seconds;
+			const left = typeof dwell === 'number' && typeof streak === 'number'
+				? Math.max(0, dwell - streak) : null;
+			const inLeft = left === null ? '.' :
+				' — switching in ' + left + ' s if it stays.';
 			const line = pend === 1
-				? 'Dark enough for night — switching in ' + left + ' s if it stays.'
+				? 'Dark enough for night' + inLeft
 				: pend === 2
-					? 'Bright enough for day — switching in ' + left + ' s if it stays.'
-					: (v.night_enabled ? 'Night. ' : 'Day. ') +
-						'Watching the sensor gain' +
+					? 'Bright enough for day' + inLeft
+					: modeWord + 'Watching the sensor gain' +
 						(nightG === null
 							? '; night comes when the exposure runs out.'
 							: '.');
@@ -682,7 +693,10 @@
 			};
 		}
 
-		if (src === 2 || src === 3 ||
+		// Source 3 (ADC) is deliberately not here: its reading never appears
+		// on /metrics, so there is nothing continuous to chart and isp_again
+		// would be a different quantity wearing the monitor's clothes.
+		if (src === 2 ||
 			(src === null && has(nm.minThreshold) && has(nm.maxThreshold))) {
 			const lo = pin(nm.minThreshold), hi = pin(nm.maxThreshold);
 			const bands = [];
@@ -702,7 +716,7 @@
 				mode: 'thresholds',
 				value: ('isp_again' in v) ? v.isp_again : null,
 				bands: bands,
-				line: (v.night_enabled ? 'Night. ' : 'Day. ') +
+				line: modeWord +
 					'Comparing raw sensor gain against the thresholds ' +
 					'(vendor-specific units).',
 				unit: '',

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -229,20 +229,55 @@
 			});
 		}
 
-		// A monitor with nothing to watch is worse than no monitor: it owns the
-		// three runtime switches (wireRuntime hides them while it is on) and
-		// then never decides anything, so day/night is frozen AND unreachable.
+		// With nothing wired and nothing calibrated, what happens next depends
+		// on the daemon. A current one takes the automatic exposure-based mode
+		// — an observation, not a fault — and says so in night_mode_source
+		// (carried here as sample.src, null when the gauge is absent). One
+		// whose SoC reports no exposure state retires the monitor and says
+		// source 0. An older daemon says nothing and is genuinely blind: it
+		// owns the three runtime switches (wireRuntime hides them while the
+		// monitor is on) and then never decides anything, so day/night is
+		// frozen AND unreachable.
 		const senses = has(nm.lightSensorPin) ||
 			(has(nm.minThreshold) && has(nm.maxThreshold));
 		if (monitor && !senses) {
-			out.push({
-				id: 'monitor-blind', level: 'warning',
-				title: 'The light monitor has nothing to watch',
-				detail: 'The light monitor is on, but nothing tells it how dark ' +
-					'it is: no daylight sensor is connected, and no day or night ' +
-					'threshold is set.',
-				fix: 'nightMode',
-			});
+			const src = sample && sample.src != null ? sample.src : null;
+			if (src === 4) {
+				out.push({
+					id: 'auto-active', level: 'info',
+					title: 'Automatic day/night is watching the exposure',
+					detail: 'No sensor is wired and no thresholds are set, so ' +
+						'the camera decides from its own exposure state: night ' +
+						'when the sensor runs out of shutter and gain, day when ' +
+						'the gain settles back down. Nothing needs calibrating; ' +
+						'the thresholds and delays below tune it if the defaults ' +
+						'switch too early or too late.',
+					fix: 'nightMode',
+				});
+			} else if (src === 0) {
+				out.push({
+					id: 'auto-retired', level: 'warning',
+					title: 'This camera cannot watch the light by itself',
+					detail: 'The light monitor is on, but this SoC reports no ' +
+						'exposure state to decide from, so automatic day/night ' +
+						'stood down. Wire a daylight sensor to a GPIO pad and ' +
+						'assign it on the map for the monitor to have something ' +
+						'to watch.',
+					fix: 'nightMode',
+				});
+			} else {
+				out.push({
+					id: 'monitor-blind', level: 'warning',
+					title: 'The light monitor has nothing to watch',
+					detail: 'The light monitor is on, but nothing tells it how ' +
+						'dark it is: no daylight sensor is connected, and no day ' +
+						'or night threshold is set. Current firmware decides ' +
+						'from the sensor’s own exposure in this situation — ' +
+						'this camera has not reported that mode, so a firmware ' +
+						'update would give it automatic day/night.',
+					fix: 'nightMode',
+				});
+			}
 		}
 
 		// Thresholds are compared against isp_again, so min must sit BELOW max
@@ -296,9 +331,14 @@
 					id: 'hunting', level: 'warning',
 					title: 'The camera keeps switching between day and night',
 					detail: track.flips + ' switches in the last ' +
-						(HUNT_WINDOW_S / 60) + ' minutes. Widen the gap between the ' +
-						'day and night thresholds so dusk cannot sit on the ' +
-						'boundary.',
+						(HUNT_WINDOW_S / 60) + ' minutes. ' +
+						(sample && sample.src === 4
+							? 'Automatic mode slows itself down after each flip, ' +
+								'but a flashing light aimed at the camera can still ' +
+								'drive it; raising "Seconds of brightness before ' +
+								'day" stretches the cycle further.'
+							: 'Widen the gap between the day and night thresholds ' +
+								'so dusk cannot sit on the boundary.'),
 					fix: 'nightMode',
 				});
 			}
@@ -591,8 +631,89 @@
 			}));
 	}
 
+	// What the light-monitor panel should show for the current sample: the
+	// value to chart, the threshold bands to shade behind it, and the one
+	// sentence that says what the monitor is doing right now. Pure — the
+	// gauges arrive in `v` (the heartbeat's metric map) and the config in
+	// `nm` — so the countdown arithmetic and the band construction are
+	// testable without a camera at dusk.
+	//
+	// null when there is nothing to chart: monitor off, a GPIO/ADC source
+	// (nothing continuous to draw), an old daemon, or a retired monitor.
+	function monitorView(nm, v) {
+		nm = nm || {};
+		if (!on(nm.lightMonitor) || !v) return null;
+		const src = ('night_mode_source' in v) ? v.night_mode_source : null;
+
+		if (src === 4) {
+			const dayG = pin(nm.autoDayGain) !== null ? pin(nm.autoDayGain) : 2;
+			const nightG = pin(nm.autoNightGain);
+			const bands = [{
+				from: 0, to: dayG,
+				color: 'rgba(47,182,115,.10)', label: 'day',
+			}];
+			if (nightG !== null) {
+				// The top edge is clamped to the plot, so "everything above
+				// the user's night threshold" needs no real ceiling.
+				bands.push({
+					from: nightG, to: 1e9,
+					color: 'rgba(255,193,7,.10)', label: 'night',
+				});
+			}
+			const gm = v.night_auto_gain_milli;
+			const pend = v.night_auto_pending;
+			const left = Math.max(0,
+				(v.night_auto_dwell_seconds | 0) -
+				(v.night_auto_streak_seconds | 0));
+			const line = pend === 1
+				? 'Dark enough for night — switching in ' + left + ' s if it stays.'
+				: pend === 2
+					? 'Bright enough for day — switching in ' + left + ' s if it stays.'
+					: (v.night_enabled ? 'Night. ' : 'Day. ') +
+						'Watching the sensor gain' +
+						(nightG === null
+							? '; night comes when the exposure runs out.'
+							: '.');
+			return {
+				mode: 'auto',
+				value: gm != null && gm >= 0 ? gm / 1000 : null,
+				bands: bands, line: line,
+				unit: 'x',
+			};
+		}
+
+		if (src === 2 || src === 3 ||
+			(src === null && has(nm.minThreshold) && has(nm.maxThreshold))) {
+			const lo = pin(nm.minThreshold), hi = pin(nm.maxThreshold);
+			const bands = [];
+			if (lo !== null) {
+				bands.push({
+					from: 0, to: lo,
+					color: 'rgba(47,182,115,.10)', label: 'day',
+				});
+			}
+			if (hi !== null) {
+				bands.push({
+					from: hi, to: 1e9,
+					color: 'rgba(255,193,7,.10)', label: 'night',
+				});
+			}
+			return {
+				mode: 'thresholds',
+				value: ('isp_again' in v) ? v.isp_again : null,
+				bands: bands,
+				line: (v.night_enabled ? 'Night. ' : 'Day. ') +
+					'Comparing raw sensor gain against the thresholds ' +
+					'(vendor-specific units).',
+				unit: '',
+			};
+		}
+
+		return null;
+	}
+
 	const api = {
-		diagnose: diagnose, tracker: tracker,
+		diagnose: diagnose, tracker: tracker, monitorView: monitorView,
 		stats: stats, irLook: irLook, colourLook: colourLook,
 		look: look, lookAt: lookAt,
 		verdict: verdict, probe: probe, snapshot: snapshot, wired: wired,

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3296,10 +3296,54 @@
 		if (!IRCUT || typeof mjMetricsSubscribe !== 'function') return;
 		mjMetricsSubscribe((s) => {
 			if (!s.ok) return;
-			ircutSample = { night: s.night, ircut: s.ircut, light: s.light };
+			const v = (s.m && s.m.v) || {};
+			ircutSample = {
+				night: s.night, ircut: s.ircut, light: s.light,
+				// Which door the daemon says is being watched — diagnose()
+				// tells an automatic monitor from a blind one by it, and null
+				// (gauge absent) keeps the older-firmware reading.
+				src: ('night_mode_source' in v) ? v.night_mode_source : null,
+			};
 			ircutStats = ircutTrack.push(ircutSample, performance.now() / 1000);
 			paintFindings();
+			paintMonitor(s);
 		});
+	}
+
+	// The light monitor's live view: one sentence about what it is doing and a
+	// chart of the value it is watching, with the switching bands shaded. What
+	// to show is decided in ircut-check.js (monitorView, tested); this only
+	// mounts it. The chart is remade when the mode or the bands change — a
+	// superseded instance holds a detached host and renders as a no-op.
+	let monChart = null;
+	let monKey = '';
+	function paintMonitor(s) {
+		const box = document.getElementById('mj-ircut-mon');
+		if (!box) return;
+		const MC = window.MjCharts;
+		const view = IRCUT.monitorView(nightCfg(), (s.m && s.m.v) || null);
+		if (!view || !MC) {
+			box.hidden = true;
+			return;
+		}
+		box.hidden = false;
+		const line = document.getElementById('mj-ircut-mon-line');
+		if (line) line.textContent = view.line;
+		const host = document.getElementById('mj-ircut-mon-chart');
+		if (!host) return;
+		const key = view.mode + '|' + JSON.stringify(view.bands);
+		if (!monChart || monChart.host !== host || monKey !== key) {
+			host.innerHTML = '';
+			monChart = MC.makeChart(host, {
+				h: 110, lo: 0, hi: null, colors: ['#4c60d8'],
+				bands: view.bands,
+				fmt: view.mode === 'auto'
+					? (x) => (x >= 10 ? String(Math.round(x)) : x.toFixed(1)) + 'x'
+					: undefined,
+			});
+			monKey = key;
+		}
+		if (view.value != null) MC.pushChart(monChart, [view.value]);
 	}
 
 	function nightCfg() { return (state.config && state.config.nightMode) || {}; }
@@ -3555,7 +3599,13 @@
 			'<div class="small text-secondary mt-2" id="mj-ircut-why" hidden></div>' +
 			'<div class="small text-secondary mt-2" id="mj-ircut-status"></div>' +
 			'<div id="mj-ircut-result" class="small" hidden></div>' +
-			'</div></div>';
+			'</div></div>' +
+			'<div id="mj-ircut-mon" hidden>' +
+			'<div class="mj-live-grp-head mt-3"><span class="mj-cap">Light monitor</span>' +
+			'<span class="mj-live-rule"></span></div>' +
+			'<div class="small text-secondary mb-1" id="mj-ircut-mon-line"></div>' +
+			'<div id="mj-ircut-mon-chart"></div>' +
+			'</div>';
 
 		// Wired once, gated every time.
 		const btn = box.querySelector('#mj-ircut-run');

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3313,8 +3313,8 @@
 	// The light monitor's live view: one sentence about what it is doing and a
 	// chart of the value it is watching, with the switching bands shaded. What
 	// to show is decided in ircut-check.js (monitorView, tested); this only
-	// mounts it. The chart is remade when the mode or the bands change — a
-	// superseded instance holds a detached host and renders as a no-op.
+	// mounts it. The chart is remade when the mode or the bands change, and
+	// the superseded instance is dropped from the registry.
 	let monChart = null;
 	let monKey = '';
 	function paintMonitor(s) {
@@ -3333,6 +3333,10 @@
 		if (!host) return;
 		const key = view.mode + '|' + JSON.stringify(view.bands);
 		if (!monChart || monChart.host !== host || monKey !== key) {
+			// The superseded instance is unregistered, not merely abandoned:
+			// every remount of this section makes a new host, and the chart
+			// registry would otherwise keep each one for the life of the tab.
+			MC.dropChart(monChart);
 			host.innerHTML = '';
 			monChart = MC.makeChart(host, {
 				h: 110, lo: 0, hi: null, colors: ['#4c60d8'],

--- a/www/cgi-bin/camera.cgi
+++ b/www/cgi-bin/camera.cgi
@@ -116,6 +116,11 @@ fi
 <script src="/a/ircut-check.js" defer></script>
 <script src="/a/ircut-map.js" defer></script>
 <script src="/a/ircut-scan.js" defer></script>
+<%
+# The Day/Night section's light-monitor chart shares the dashboard's chart
+# primitives rather than growing its own.
+%>
+<script src="/a/charts.js" defer></script>
 <script src="/a/mj-requires.js" defer></script>
 <script src="/a/mj-settings.js" defer></script>
 


### PR DESCRIPTION
Companion to the camera side of automatic day/night (the out-of-the-box replacement for the community backlight-control scripts). Current firmware can drive day/night from the sensor's own exposure with nothing wired and nothing calibrated, and names who decides in a new `night_mode_source` gauge. The Day/Night section now meets it:

- **A Light monitor block** under the pin map: one live sentence about what the monitor is doing ("Bright enough for day — switching in 40 s if it stays.") and a chart of the value it watches — sensor gain in multiples of 1× with the day band and any explicit night threshold shaded, or, in legacy threshold mode, raw `isp_again` between the min/max bands. What to chart is a pure, tested `monitorView()`; the chart reuses the dashboard's primitives (camera.cgi now loads them).
- **Findings understand the three-way chain**: an automatic monitor is an observation, not a fault; a monitor the SoC could not feed says so and points at the sensor-pin alternative; only a daemon that reports no source keeps the old "nothing to watch" warning, reworded to say a firmware update fills this gap. The hunting finding stops prescribing thresholds to a camera that has none.
- **The dashboard's day/night line carries the decision source** ("🌙 Night · IR-cut on · lamp on · auto").
- A real dump from a camera running the automatic monitor joins the parser fixtures; the three existing fixtures stay untouched — they pin how older daemons read.

Full test suite passes; `node --check` clean on the touched files.