### PR TITLE
Day / Night: a dimmable lamp says how bright it is

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -538,11 +538,15 @@ function runRest() {
 				null, null)
 				.some(x => x.id === 'light-parked' && x.level === 'info'));
 		check('a parked lamp on a PWM channel says so too',
-			ic.diagnose({ backlightEnabled: false, backlightPwmChannel: 1 },
+			ic.diagnose({ backlightEnabled: false, backlightPwmChannel: 'pwm1' },
 				null, null)
 				.some(x => x.id === 'light-parked'));
 		check('a lamp with no wiring at all stays silent',
 			!ic.diagnose({ backlightEnabled: false }, null, null)
+				.some(x => x.id === 'light-parked'));
+		check('channel "none" is not wiring',
+			!ic.diagnose({ backlightEnabled: false, backlightPwmChannel: 'none' },
+				null, null)
 				.some(x => x.id === 'light-parked'));
 	}
 

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -514,6 +514,38 @@ function runRest() {
 			/Lamp at 80%\.$/.test(thrLamp.line), thrLamp.line);
 	}
 
+	group('diagnose: parked actuators are decisions, not defects');
+	{
+		const wired = { irCutPin1: 11, irCutPin2: 10 };
+		const parked = Object.assign({ irCutEnabled: false }, wired);
+		const f = ic.diagnose(parked, { night: 1, ircut: 0, light: 0 },
+			{ conflictS: 999, flips: 0 });
+		check('a parked filter is an observation',
+			f.some(x => x.id === 'ircut-parked' && x.level === 'info'));
+		check('a parked filter is never "cannot move"',
+			!f.some(x => x.id === 'no-pins'));
+		check('a parked filter cannot be convicted of a conflict',
+			!f.some(x => x.id === 'conflict'));
+		check('an open-looking picture does not accuse a parked filter',
+			!ic.diagnose(parked, { night: 0, ircut: 0, light: 0 }, {},
+				{ look: 'open', streak: 9 })
+				.some(x => x.id === 'picture-open'));
+		check('an absent key on an older daemon is not "parked"',
+			!ic.diagnose(wired, null, null)
+				.some(x => x.id === 'ircut-parked'));
+		check('a parked lamp with wiring says so',
+			ic.diagnose({ backlightEnabled: false, backlightPin: 52 },
+				null, null)
+				.some(x => x.id === 'light-parked' && x.level === 'info'));
+		check('a parked lamp on a PWM channel says so too',
+			ic.diagnose({ backlightEnabled: false, backlightPwmChannel: 1 },
+				null, null)
+				.some(x => x.id === 'light-parked'));
+		check('a lamp with no wiring at all stays silent',
+			!ic.diagnose({ backlightEnabled: false }, null, null)
+				.some(x => x.id === 'light-parked'));
+	}
+
 	group('diagnose: thresholds need a band, not a point');
 	{
 		const bad = (lo, hi) => ic.diagnose(

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -494,6 +494,24 @@ function runRest() {
 		check('an absent night_enabled is not called Day',
 			!/^Day/.test(noNight.line) && !/^Night/.test(noNight.line),
 			noNight.line);
+		// A dimmable lamp speaks its duty; a switched one is never given a
+		// percentage, and a parked dimmer (0) is a reading, not an absence.
+		const dimmer = ic.monitorView(nmAuto, Object.assign({}, vAuto,
+			{ night_light_duty: 45 }));
+		check('a dimmable lamp reports its duty in the sentence',
+			/Lamp at 45%\.$/.test(dimmer.line), dimmer.line);
+		const parked = ic.monitorView(nmAuto, Object.assign({}, vAuto,
+			{ night_light_duty: 0 }));
+		check('a parked dimmer still says 0%',
+			/Lamp at 0%\.$/.test(parked.line), parked.line);
+		check('a switched lamp gets no invented percentage',
+			!/Lamp at/.test(ic.monitorView(nmAuto, vAuto).line));
+		const thrLamp = ic.monitorView(
+			{ lightMonitor: true, minThreshold: 1500, maxThreshold: 4000 },
+			{ night_mode_source: 2, night_enabled: 1, isp_again: 6000,
+				night_light_duty: 80 });
+		check('threshold mode carries the lamp note too',
+			/Lamp at 80%\.$/.test(thrLamp.line), thrLamp.line);
 	}
 
 	group('diagnose: thresholds need a band, not a point');

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -576,10 +576,15 @@
 		// (manual is the absence of a decider, not a decider).
 		const srcWord = ['', ' · sensor pin', ' · thresholds', ' · ADC',
 			' · auto'][v.night_mode_source] || '';
+		// A dimmable lamp reports its duty; only then is a percentage said.
+		// A switched lamp keeps on/off, and an absent gauge stays unknown.
+		const duty = v.night_light_duty;
+		const lampWord = typeof duty === 'number' && duty >= 0 ? duty + '%'
+			: s.light == null ? '?' : (s.light ? 'on' : 'off');
 		if (dn) dn.textContent = s.night == null ? 'Day / night not reported'
 			: (s.night ? '🌙 Night' : '☀️ Day') +
 				' · IR-cut ' + (s.ircut == null ? '?' : (s.ircut ? 'on' : 'off')) +
-				' · lamp ' + (s.light == null ? '?' : (s.light ? 'on' : 'off')) +
+				' · lamp ' + lampWord +
 				srcWord;
 		renderIrcut(s);
 		// Only SigmaStar reports the empty-wakeup run; a sustained one means

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -318,7 +318,8 @@
 		// The lamp's own park switch, same shape as the filter's: wiring
 		// kept, nothing driven, said once as an observation.
 		if (nm.backlightEnabled === false &&
-			(has(nm.backlightPin) || has(nm.backlightPwmChannel))) {
+			(has(nm.backlightPin) || (nm.backlightPwmChannel &&
+				nm.backlightPwmChannel !== 'none'))) {
 			out.push({
 				id: 'light-parked', level: 'info',
 				title: 'The camera light is switched off',

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -651,6 +651,13 @@
 			? 'Night. '
 			: v.night_enabled === 0 || v.night_enabled === false ? 'Day. ' : '';
 
+		// Only a camera with a dimmable lamp publishes a duty; a switched
+		// lamp gets no invented percentage, and 0 on a dimmer is a real
+		// reading (the lamp parked dark), not an absence.
+		const duty = v.night_light_duty;
+		const lampNote = typeof duty === 'number' && duty >= 0
+			? ' Lamp at ' + duty + '%.' : '';
+
 		if (src === 4) {
 			const dayG = pin(nm.autoDayGain) !== null ? pin(nm.autoDayGain) : 2;
 			const nightG = pin(nm.autoNightGain);
@@ -688,7 +695,7 @@
 			return {
 				mode: 'auto',
 				value: gm != null && gm >= 0 ? gm / 1000 : null,
-				bands: bands, line: line,
+				bands: bands, line: line + lampNote,
 				unit: 'x',
 			};
 		}
@@ -718,7 +725,7 @@
 				bands: bands,
 				line: modeWord +
 					'Comparing raw sensor gain against the thresholds ' +
-					'(vendor-specific units).',
+					'(vendor-specific units).' + lampNote,
 				unit: '',
 			};
 		}

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -146,7 +146,26 @@
 		const pictureOpen = !!(pic && pic.look === 'open' && pic.streak >= PIC_STREAK &&
 			sample && sample.night === 0);
 
-		if (!driveable) {
+		// Parked (#219): the operator switched the filter off while keeping
+		// its wiring. That is a decision, not a defect — every accusation
+		// about a filter that does not move stands down, and one observation
+		// says what is going on and where the switch is. Explicit === false:
+		// an older daemon has no such key, and absent must not read as off.
+		const ircutParked = nm.irCutEnabled === false;
+		if (ircutParked) {
+			if (driveable) {
+				out.push({
+					id: 'ircut-parked', level: 'info',
+					title: 'The IR-cut filter is switched off',
+					detail: 'Its pins stay configured, but nothing moves the ' +
+						'filter until "Drive the IR-cut filter" is turned back ' +
+						'on. Wherever it sits now is where it stays — open in ' +
+						'daylight reads magenta, and that is the switch, not ' +
+						'the wiring.',
+					fix: 'nightMode',
+				});
+			}
+		} else if (!driveable) {
 			out.push({
 				id: 'no-pins', level: 'danger',
 				title: 'Majestic cannot move the IR-cut filter',
@@ -296,6 +315,19 @@
 			});
 		}
 
+		// The lamp's own park switch, same shape as the filter's: wiring
+		// kept, nothing driven, said once as an observation.
+		if (nm.backlightEnabled === false &&
+			(has(nm.backlightPin) || has(nm.backlightPwmChannel))) {
+			out.push({
+				id: 'light-parked', level: 'info',
+				title: 'The camera light is switched off',
+				detail: 'Its wiring stays configured, but night mode leaves ' +
+					'it dark until "Drive the camera light" is turned back on.',
+				fix: 'nightMode',
+			});
+		}
+
 		if (driveable && !monitor) {
 			out.push({
 				id: 'manual-only', level: 'info',
@@ -312,7 +344,9 @@
 		// driving. With it off, every switch on the Live tab is manual and a
 		// deliberate disagreement — filter open in daylight to check an IR
 		// lamp, say — is exactly what someone might be doing right now.
-		if (monitor && driveable && known(sample)) {
+		// A parked filter cannot follow the monitor, so the disagreement the
+		// conflict finding convicts on is the expected state, not a fault.
+		if (monitor && driveable && !ircutParked && known(sample)) {
 			if (!agrees(sample) && track.conflictS >= CONFLICT_S) {
 				out.push({
 					id: 'conflict', level: 'danger',

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1072,14 +1072,28 @@
 			return;
 		}
 
-		ircut.disabled = !active(getDotted(state.config, 'nightMode.irCutPin1'));
-		light.disabled = !active(getDotted(state.config, 'nightMode.backlightPin'));
-		// A control that cannot work should say which pin is missing rather than
-		// just refusing to move.
+		// Parked (nightMode.*Enabled: false) outranks wired: the daemon
+		// refuses the toggle, so a live-looking switch would move and snap
+		// back. Explicit === false — an absent key on an older daemon means
+		// the switch does not exist there, not that it is off.
+		const ircutParked =
+			getDotted(state.config, 'nightMode.irCutEnabled') === false;
+		const lightParked =
+			getDotted(state.config, 'nightMode.backlightEnabled') === false;
+		ircut.disabled = ircutParked ||
+			!active(getDotted(state.config, 'nightMode.irCutPin1'));
+		light.disabled = lightParked ||
+			!active(getDotted(state.config, 'nightMode.backlightPin'));
+		// A control that cannot work should say which pin is missing — or that
+		// the actuator is deliberately parked — rather than just refusing.
 		if (ircut.disabled && lbl('toggle-ircut'))
-			lbl('toggle-ircut').title = 'Nothing is connected to the IR-cut filter.';
+			lbl('toggle-ircut').title = ircutParked
+				? 'The IR-cut filter is switched off in Day / Night settings; its wiring is kept.'
+				: 'Nothing is connected to the IR-cut filter.';
 		if (light.disabled && lbl('toggle-light'))
-			lbl('toggle-light').title = 'Nothing is connected to the night illuminator.';
+			lbl('toggle-light').title = lightParked
+				? 'The lamp is switched off in Day / Night settings; its wiring is kept.'
+				: 'Nothing is connected to the night illuminator.';
 
 		[['night', night], ['ircut', ircut], ['light', light]].forEach(([n, el2]) =>
 			apiFetch('/metrics/night?value=' + n + '_enabled', { credentials: 'same-origin' })
@@ -3359,6 +3373,12 @@
 		const nm = nightCfg();
 		if (!isNumish(nm.irCutPin1))
 			return 'Nothing is connected to the filter yet, so there is nothing to test.';
+		// Parked outranks wired: the daemon refuses to move a parked filter,
+		// so the test's toggle would silently do nothing and every verdict
+		// would read "stuck" on a filter that is fine.
+		if (nm.irCutEnabled === false)
+			return 'The filter is switched off (its wiring is kept). Turn "Drive the ' +
+				'IR-cut filter" on to test it.';
 		if (!toBool(getDotted(state.config, 'jpeg.enabled')))
 			return 'The test reads a still picture, and this camera has JPEG snapshots turned off.';
 		// The monitor re-drives the filter on its own schedule, and a snapshot


### PR DESCRIPTION
Companion to the camera side of the PWM backlight. Cameras with a dimmable lamp now publish its duty in a `night_light_duty` gauge; where it exists, the dashboard's day/night line says "lamp 45%" instead of on/off, and the Day/Night monitor sentence carries "Lamp at 45%." in both automatic and threshold modes.

The rules that got the last round through review hold here: a switched lamp is never given an invented percentage (the gauge is simply absent and today's on/off wording stays), and 0 on a dimmer is a real reading — the lamp parked dark — not an absence. Four new monitorView tests pin all of it; full suite passes.