### PR TITLE
Recordings: seek where a decoder can start, and stop calling a card healthy when it is not

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/requires.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
+    "test": "node tests/requires.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/mp4index.test.js
+++ b/tests/mp4index.test.js
@@ -287,7 +287,7 @@ group('buildIndex — the exact walk');
 		check('and does not claim to be complete', idx.complete === false);
 
 		return runLocate();
-	}).then(runExport).then(runSync).then(runCheap).then(() => done());
+	}).then(runExport).then(runSync).then(runSyncCheap).then(runCheap).then(() => done());
 }
 
 // ---- the approximate seek ----------------------------------------------
@@ -437,6 +437,24 @@ function runSync() {
 			check('a clip with no keyframe anywhere falls back to its start',
 				M.fragmentAt(nidx, 3.5) === nidx.fragments[0]);
 
+			// An export from a span that itself begins mid-GOP has nothing
+			// behind it to snap back to. Losing up to a GOP off the FRONT of
+			// the selection beats handing somebody a file that opens black.
+			const mixed = [];
+			for (let i = 0; i < 8; i++)
+				mixed.push({ seq: i, durations: new Array(20).fill(50000),
+					payload: 40000, sync: i >= 3 });
+			const mbuf = clip(1000000, mixed);
+			const minit = M.parseInit(u8of(mbuf));
+			return M.buildIndex(readerFor(mbuf), mbuf.length, minit).then(midx => {
+				const r = M.exportRanges(midx, 0, 6);
+				check('with no keyframe behind it, an export starts at the first one ahead',
+					r.body.start === midx.fragments[3].off,
+					r.body.start + ' vs ' + midx.fragments[3].off);
+				check('and says so, rather than claiming footage it did not include',
+					r.from === 3, 'got ' + r.from);
+			});
+
 			// A recording written before first_sample_flags was emitted at all
 			// must not become unseekable: it has no such field, and every
 			// fragment in it began at an IDR by construction.
@@ -455,6 +473,70 @@ function runSync() {
 			});
 		});
 	});
+}
+
+// The paths production actually takes. buildIndex() is not one of them — a
+// full walk of a 20-minute clip is ~1100 range requests — so a snap that only
+// works on a full index is a snap that never runs: positionAt() calls
+// locate() and hands seekTo() the offset it gets back, and saveSelection()
+// calls locate() then spanFrom() from that same offset. Both had to learn it.
+function runSyncCheap() {
+	group('the cheap paths land somewhere a decoder can start, too');
+
+	const specs = [];
+	for (let i = 0; i < 12; i++) {
+		specs.push({
+			seq: i,
+			durations: new Array(20).fill(50000),
+			payload: 40000,
+			sync: i % 4 === 0,
+		});
+	}
+	const buf = clip(1000000, specs);
+	const init = M.parseInit(u8of(buf));
+
+	return M.locate(readerFor(buf), buf.length, init, 6.5, 1).then(hit => {
+		check('locate snaps back to the keyframe fragment',
+			hit.off === offsetOfFragment(buf, init, 4),
+			hit.off + ' vs ' + offsetOfFragment(buf, init, 4));
+		check('and says it managed to', hit.atSync === true);
+		check('reporting the time it will really start at', hit.approxSec === 4,
+			'got ' + hit.approxSec);
+
+		// spanFrom is what the export walks, so it has to carry the flag or
+		// exportRanges cannot act on it.
+		return M.spanFrom(readerFor(buf), buf.length, init, hit.off, 4);
+	}).then(span => {
+		check('spanFrom carries which fragments open on a keyframe',
+			span.fragments.every(f => typeof f.sync === 'boolean'));
+		check('and the span it hands back starts on one', span.fragments[0].sync === true);
+	}).then(() => {
+		// Nothing to snap to: locate says so rather than pretending.
+		const none = [];
+		for (let i = 0; i < 6; i++)
+			none.push({ seq: i, durations: new Array(20).fill(50000),
+				payload: 40000, sync: false });
+		const nbuf = clip(1000000, none);
+		const ninit = M.parseInit(u8of(nbuf));
+		return M.locate(readerFor(nbuf), nbuf.length, ninit, 3.5, 1).then(hit => {
+			check('a clip with no keyframe in reach reports that it could not snap',
+				hit.atSync === false);
+			check('and still lands at or before the moment asked for',
+				hit.approxSec <= 3.5, 'got ' + hit.approxSec);
+		});
+	});
+}
+
+// Byte offset of the nth fragment, worked out the same way the fixture built
+// it — so the assertions above compare against the file, not against the
+// parser being tested.
+function offsetOfFragment(buf, init, n) {
+	let off = init.firstMoof;
+	for (let i = 0; i < n; i++) {
+		const moofSize = buf.readUInt32BE(off);
+		off += moofSize + buf.readUInt32BE(off + moofSize);
+	}
+	return off;
 }
 
 // ---- the cheap paths ----------------------------------------------------

--- a/tests/mp4index.test.js
+++ b/tests/mp4index.test.js
@@ -69,13 +69,34 @@ function ftyp() {
 
 // trun with flags 0x000305: data-offset + first-sample-flags + per-sample
 // duration + per-sample size. This is what majestic emits.
-function trun(durations) {
+//
+// first_sample_flags is 0x02000000 for a fragment opening on a keyframe and
+// 0x01010000 for one that does not — bit 0x10000 being
+// sample_is_non_sync_sample. majestic hardcoded the first of those until
+// fragments stopped being whole GOPs, which is why a recording carrying no
+// first_sample_flags at all has to be read as sync.
+const FSF_SYNC = 0x02000000;
+const FSF_DELTA = 0x01010000;
+
+function trun(durations, sync) {
 	const per = Buffer.alloc(durations.length * 8);
 	durations.forEach((d, i) => {
 		per.writeUInt32BE(d >>> 0, i * 8);
 		per.writeUInt32BE(1000, i * 8 + 4);   // sample size, unused here
 	});
-	return box('trun', Buffer.concat([u32(0x000305, durations.length, 0, 0x02000000), per]));
+	const fsf = sync === false ? FSF_DELTA : FSF_SYNC;
+	return box('trun', Buffer.concat([u32(0x000305, durations.length, 0, fsf), per]));
+}
+
+// The shape written before first_sample_flags existed: flag 0x004 clear, so
+// there is no such field in the box at all.
+function trunNoFlags(durations) {
+	const per = Buffer.alloc(durations.length * 8);
+	durations.forEach((d, i) => {
+		per.writeUInt32BE(d >>> 0, i * 8);
+		per.writeUInt32BE(1000, i * 8 + 4);
+	});
+	return box('trun', Buffer.concat([u32(0x000301, durations.length, 0), per]));
 }
 function tfhdPlain() { return box('tfhd', u32(0x020030, 1)); }
 function tfhdDefaultDuration(d) {
@@ -115,8 +136,8 @@ function clip(timescale, specs, withTfdt) {
 	specs.forEach(s => {
 		const tf = s.defaultDur ? tfhdDefaultDuration(s.defaultDur) : tfhdPlain();
 		const tr = s.defaultDur
-			? box('trun', u32(0x000005, s.count, 0, 0x02000000))   // no per-sample durations
-			: trun(s.durations);
+			? box('trun', u32(0x000005, s.count, 0, FSF_SYNC))   // no per-sample durations
+			: (s.noFlags ? trunNoFlags(s.durations) : trun(s.durations, s.sync));
 		parts.push(moof(s.seq, tf, tr, withTfdt === false ? null : ticks));
 		parts.push(mdat(s.payload, s.fill));
 		ticks += s.defaultDur
@@ -266,7 +287,7 @@ group('buildIndex — the exact walk');
 		check('and does not claim to be complete', idx.complete === false);
 
 		return runLocate();
-	}).then(runExport).then(runCheap).then(() => done());
+	}).then(runExport).then(runSync).then(runCheap).then(() => done());
 }
 
 // ---- the approximate seek ----------------------------------------------
@@ -350,6 +371,89 @@ function runExport() {
 			M.fragmentAt(idx, 4.5).t === 4, 'got ' + M.fragmentAt(idx, 4.5).t);
 		check('fragmentAt clamps below zero to the first fragment',
 			M.fragmentAt(idx, -10).t === 0);
+	});
+}
+
+// ---- where a decoder may be started -------------------------------------
+
+// Until majestic bounded a fragment by time and bytes, every fragment began at
+// an IDR and the writer said so with a hardcoded first_sample_flags. Now a
+// fragment can open mid-GOP, and one that does is not a place a decoder can be
+// started: it holds frames whose references were never appended, so a
+// SourceBuffer given one produces a green or smeared picture rather than an
+// error. A seek that landed there looked like a decode bug.
+function runSync() {
+	group('seeks and exports start where a decoder can actually start');
+
+	// Keyframes every four fragments, which is what gopSize 4 x fragmentMs
+	// 1000 looks like from here.
+	const specs = [];
+	for (let i = 0; i < 12; i++) {
+		specs.push({
+			seq: i,
+			durations: new Array(20).fill(50000),
+			payload: 40000,
+			sync: i % 4 === 0,
+		});
+	}
+	const buf = clip(1000000, specs);
+	const init = M.parseInit(u8of(buf));
+
+	return M.buildIndex(readerFor(buf), buf.length, init).then(idx => {
+		const flags = idx.fragments.map(f => f.sync);
+		check('the index records which fragments open on a keyframe',
+			JSON.stringify(flags) ===
+				JSON.stringify([true, false, false, false, true, false, false,
+					false, true, false, false, false]),
+			JSON.stringify(flags));
+
+		check('a seek onto a mid-GOP fragment snaps back to the keyframe one',
+			M.fragmentAt(idx, 6.5).t === 4, 'got ' + M.fragmentAt(idx, 6.5).t);
+		check('a seek that already lands on one does not move',
+			M.fragmentAt(idx, 8.2).t === 8, 'got ' + M.fragmentAt(idx, 8.2).t);
+		check('and the fragment handed back is one a decoder can start at',
+			M.fragmentAt(idx, 6.5).sync === true);
+
+		// An export is a file someone opens in a player that has seen nothing
+		// before it, so the same rule applies and costs at most one GOP at the
+		// front.
+		const r = M.exportRanges(idx, 6, 9);
+		check('an export starts at a fragment a player can open',
+			r.body.start === idx.fragments[4].off,
+			r.body.start + ' vs ' + idx.fragments[4].off);
+		check('and says so in the times it reports', r.from === 4, 'got ' + r.from);
+		check('the end is unchanged — only the opening has to be decodable',
+			r.to === 9, 'got ' + r.to);
+
+		// Nothing to snap back TO is still an answer: the start of the clip is
+		// the only place such a file can be started at all.
+		const none = [];
+		for (let i = 0; i < 5; i++)
+			none.push({ seq: i, durations: new Array(20).fill(50000),
+				payload: 40000, sync: false });
+		const nbuf = clip(1000000, none);
+		const ninit = M.parseInit(u8of(nbuf));
+		return M.buildIndex(readerFor(nbuf), nbuf.length, ninit).then(nidx => {
+			check('a clip with no keyframe anywhere falls back to its start',
+				M.fragmentAt(nidx, 3.5) === nidx.fragments[0]);
+
+			// A recording written before first_sample_flags was emitted at all
+			// must not become unseekable: it has no such field, and every
+			// fragment in it began at an IDR by construction.
+			const old = [];
+			for (let i = 0; i < 6; i++)
+				old.push({ seq: i, durations: new Array(20).fill(50000),
+					payload: 40000, noFlags: true });
+			const obuf = clip(1000000, old);
+			const oinit = M.parseInit(u8of(obuf));
+			return M.buildIndex(readerFor(obuf), obuf.length, oinit).then(oidx => {
+				check('an older recording carrying no flags reads as all-sync',
+					oidx.fragments.every(f => f.sync === true));
+				check('so a seek into it still lands where it is aimed',
+					M.fragmentAt(oidx, 4.5).t === 4,
+					'got ' + M.fragmentAt(oidx, 4.5).t);
+			});
+		});
 	});
 }
 

--- a/tests/recordings-health.test.js
+++ b/tests/recordings-health.test.js
@@ -1,0 +1,299 @@
+// What the Recordings page says about why there is no new footage.
+//
+// The page's own doctrine, written into cardWritable(): positive claims need
+// positive evidence, and an unknown card must never be painted green. It was
+// only ever asking the filesystem, though, and the filesystem cannot see the
+// failure that matters most — a card mounted read-write with room on it, which
+// majestic is writing nothing to. Every one of those states reads back as
+// `health: "ok"` from the SD-card endpoint.
+//
+// So the page now asks majestic as well, through /metrics/records, and this
+// pins what it does with the answer. The failure being guarded against is a
+// green "Recording" badge over an archive that stopped growing an hour ago —
+// silent by construction, and not reproducible without a failing SD card.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const A = (f) => path.join(__dirname, '..', 'www', 'a', f);
+
+// ---- a recording, as majestic writes them ------------------------------
+//
+// Its own copy, for the reason recordings-pump.test.js gives for having one: a
+// fixture shared between two tests is a fixture neither can change. Cut to the
+// minimum this needs, which is a clip the page can index and then leave alone.
+
+function box(type, payload) {
+	const b = Buffer.alloc(8 + payload.length);
+	b.writeUInt32BE(8 + payload.length, 0);
+	b.write(type, 4, 'latin1');
+	payload.copy(b, 8);
+	return b;
+}
+function u32(...vals) {
+	const b = Buffer.alloc(4 * vals.length);
+	vals.forEach((v, i) => b.writeUInt32BE(v >>> 0, i * 4));
+	return b;
+}
+function clip(seconds) {
+	const p = Buffer.alloc(28);
+	p.write('isom', 0, 'latin1');
+	p.writeUInt32BE(0x200, 4);
+	p.write('isomiso2avc1iso6', 8, 'latin1');
+	const mdhd = box('mdhd', Buffer.concat([u32(0, 0, 0, 1000000, 0), u32(0)]));
+	const parts = [box('ftyp', p), box('moov', box('trak', box('mdia', mdhd)))];
+	for (let i = 0; i < seconds; i++) {
+		const tfdt = Buffer.alloc(12);
+		tfdt.writeUInt32BE(0x01000000, 0);
+		tfdt.writeBigUInt64BE(BigInt(i * 1000000), 4);
+		const per = Buffer.alloc(20 * 8);
+		for (let k = 0; k < 20; k++) {
+			per.writeUInt32BE(50000, k * 8);
+			per.writeUInt32BE(1000, k * 8 + 4);
+		}
+		const traf = box('traf', Buffer.concat([
+			box('tfhd', u32(0x020030, 1)),
+			box('tfdt', tfdt),
+			box('trun', Buffer.concat([u32(0x000305, 20, 0, 0x02000000), per])),
+		]));
+		parts.push(box('moof', Buffer.concat([box('mfhd', u32(0, i)), traf])));
+		parts.push(box('mdat', Buffer.alloc(2000, 0x41)));
+	}
+	return Buffer.concat(parts);
+}
+const CLIP = clip(4);
+
+// ---- the browser, in as much as this needs one -------------------------
+
+function makeEl(id) {
+	return {
+		id: id, innerHTML: '', textContent: '', value: '', hidden: false,
+		className: '', style: {}, dataset: {}, disabled: false,
+		classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+		handlers: {},
+		addEventListener(ev, fn) { (this.handlers[ev] = this.handlers[ev] || []).push(fn); },
+		removeEventListener() {}, appendChild() {}, removeChild() {}, remove() {},
+		setAttribute() {}, removeAttribute() {}, getAttribute() { return null; },
+		querySelector() { return null; }, querySelectorAll() { return []; },
+		closest() { return null; }, insertAdjacentHTML() {},
+		getBoundingClientRect() { return { left: 0, top: 0, width: 800, height: 60 }; },
+		load() {}, play() { return Promise.resolve(); },
+	};
+}
+
+// `cardHealth` is what the SD-card endpoint reports; `metrics` is the body
+// /metrics/records answers with, or null for a majestic too old to have it.
+function load(cardHealth, metrics, mode) {
+	const els = {};
+	const $ = (id) => (els[id] = els[id] || makeEl(id));
+	const env = { $: $, asked: [] };
+
+	const video = $('rec-video');
+	video.buffered = { length: 0, start() { return 0; }, end() { return 0; } };
+	video.canPlayType = () => '';       // no MSE, no playback: this is about the banner
+
+	const json = (o) => Promise.resolve({ ok: true, json: () => Promise.resolve(o) });
+	function apiFetch(url, opts) {
+		env.asked.push(url);
+		const range = opts && opts.headers && opts.headers.Range;
+		if (range) {
+			const m = /bytes=(\d+)-(\d+)/.exec(range);
+			const a = +m[1], b = Math.min(+m[2], CLIP.length - 1);
+			const slice = CLIP.subarray(a, b + 1);
+			return Promise.resolve({
+				ok: true,
+				arrayBuffer: () => Promise.resolve(
+					slice.buffer.slice(slice.byteOffset, slice.byteOffset + slice.length)),
+			});
+		}
+		if (url.indexOf('/metrics/records') === 0) {
+			// A camera running an older majestic has no such endpoint. 404 and
+			// a refused connection have to look the same to the page.
+			if (metrics === null) return Promise.resolve({ ok: false, status: 404 });
+			if (metrics === 'refused') return Promise.reject(new Error('refused'));
+			return Promise.resolve({ ok: true, text: () => Promise.resolve(metrics) });
+		}
+		if (url.indexOf('/api/v1/config.json') === 0) {
+			return json({ records: { enabled: true, path: '/rec/%F', split: 2,
+				mode: mode || 'continuous' } });
+		}
+		if (url.indexOf('/cgi-bin/j/pulse.cgi') === 0) {
+			return json({ utc_offset: '+0000', timezone: 'UTC', time_now: 0 });
+		}
+		if (url.indexOf('/cgi-bin/j/sdcard.cgi') === 0) {
+			return json({ health: cardHealth, mountpoint: '/mnt/mmcblk0p1',
+				totalKb: 1e7, usedKb: 5e6, availKb: 5e6, recBytes: 1e9, fsErrors: [] });
+		}
+		if (url.indexOf('/cgi-bin/j/recordings.cgi?days=1') === 0) {
+			return json({ prefix: '/rec', days: [{ name: '2026-09-04', clips: 1, mtime: 0 }] });
+		}
+		if (url.indexOf('/cgi-bin/j/recordings.cgi?day=') === 0) {
+			return json({ path: '/rec/2026-09-04',
+				clips: [{ name: '12-00.mp4', size: CLIP.length, mtime: 0 }] });
+		}
+		return Promise.reject(new Error('unstubbed ' + url));
+	}
+
+	const win = { console: console };   // no MediaSource: the page falls back
+	const ctx = {
+		window: win,
+		document: {
+			getElementById: (id) => $(id),
+			createElement: () => makeEl('made'),
+			querySelectorAll: () => [], addEventListener() {},
+			body: makeEl('body'), hidden: false,
+		},
+		URL: { createObjectURL: () => 'blob:stub', revokeObjectURL() {} },
+		location: { search: '', pathname: '/cgi-bin/recordings.cgi' },
+		apiFetch: apiFetch,
+		// The one main.js global this page now leans on for the recorder.
+		parseMetrics: parseMetrics,
+		mjGet: (cfg, dot) => dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg),
+		parseTzOffsetMs: () => 0,
+		ianaZone: () => null,
+		console: console, JSON: JSON, Promise: Promise, Date: Date, Math: Math,
+		Intl: Intl, isFinite: isFinite, parseInt: parseInt, parseFloat: parseFloat,
+		Uint8Array: Uint8Array, encodeURIComponent: encodeURIComponent,
+		decodeURIComponent: decodeURIComponent, String: String, Number: Number,
+		Array: Array, Object: Object, Error: Error, RegExp: RegExp,
+		setTimeout, clearTimeout, setInterval, clearInterval,
+	};
+	ctx.window.document = ctx.document;
+	vm.createContext(ctx);
+	for (const f of ['timeline.js', 'mp4index.js', 'recordings.js']) {
+		vm.runInContext(fs.readFileSync(A(f), 'utf8'), ctx);
+	}
+	return env;
+}
+
+// The real parser, lifted out of main.js the same way metrics-parse.test.js
+// reaches it — so a change to the format is caught there rather than being
+// re-implemented differently here.
+function parseMetrics(text) {
+	const src = fs.readFileSync(A('main.js'), 'utf8');
+	const ctx = {
+		console: console, JSON: JSON, Object: Object, isNaN: isNaN,
+		document: { addEventListener() {}, getElementById: () => null,
+			querySelector: () => null, querySelectorAll: () => [] },
+		window: { addEventListener() {} },
+		setTimeout, clearTimeout, setInterval, clearInterval,
+		fetch: () => Promise.reject(new Error('no network')),
+		location: { pathname: '/', search: '' },
+		navigator: {}, localStorage: { getItem: () => null, setItem() {} },
+	};
+	vm.createContext(ctx);
+	vm.runInContext(src + '\n;this.__parseMetrics = parseMetrics;', ctx);
+	parseMetrics = ctx.__parseMetrics;    // compile once, then use the real one
+	return parseMetrics(text);
+}
+
+const PATIENCE = 10000;
+async function waitFor(pred, ms) {
+	const end = Date.now() + (ms || PATIENCE);
+	while (Date.now() < end) {
+		if (pred()) return true;
+		await new Promise((r) => setTimeout(r, 10));
+	}
+	return false;
+}
+
+function banner(env) { return env.$('rec-health').innerHTML || ''; }
+
+const metricsWith = (state, dropped) =>
+	'# HELP records_state Recorder verdict\n' +
+	'# TYPE records_state gauge\n' +
+	'records_state ' + state + '\n' +
+	'records_fragments_dropped_total ' + (dropped || 0) + '\n' +
+	'records_fragments_written_total 4200\n';
+
+async function main() {
+	group('the page asks majestic what it makes of the card, not only the kernel');
+
+	{
+		const env = load('ok', metricsWith(0, 0));
+		await waitFor(() => env.asked.some((u) => u.indexOf('/cgi-bin/j/recordings.cgi?day=') === 0));
+		await new Promise((r) => setTimeout(r, 50));
+		check('a healthy card and a happy recorder say nothing',
+			banner(env) === '', JSON.stringify(banner(env)).slice(0, 120));
+		check('and the recorder really was asked',
+			env.asked.some((u) => u.indexOf('/metrics/records') === 0));
+	}
+
+	// The whole point. Every one of these reads back from the SD-card endpoint
+	// as a healthy filesystem with free space on it.
+	const cases = [
+		[3, 'cannot open', 'the camera has given up on the card'],
+		[2, 'failing', 'writes are failing outright'],
+		[1, 'intermittently', 'writes are failing now and then'],
+	];
+	for (const [st, needle, what] of cases) {
+		const env = load('ok', metricsWith(st, 0));
+		const ok = await waitFor(() => banner(env).indexOf(needle) >= 0);
+		check('a card the filesystem calls healthy still warns when ' + what,
+			ok, JSON.stringify(banner(env)).slice(0, 160));
+	}
+
+	{
+		// State 0 and losing footage: nothing is wrong with the filesystem and
+		// nothing is wrong with the writes — the card simply cannot take the
+		// bitrate. The page would otherwise be green.
+		const env = load('ok', metricsWith(0, 37));
+		const ok = await waitFor(() => banner(env).indexOf('cannot keep up') >= 0);
+		check('a card that cannot keep up is not a healthy card', ok,
+			JSON.stringify(banner(env)).slice(0, 160));
+		check('and it says how much has been lost',
+			banner(env).indexOf('37') >= 0, JSON.stringify(banner(env)).slice(0, 160));
+	}
+
+	group('a majestic too old to ask is not a majestic in trouble');
+
+	for (const [m, how] of [[null, 'answers 404'], ['refused', 'cannot be reached']]) {
+		const env = load('ok', m);
+		await waitFor(() => env.asked.some((u) => u.indexOf('/cgi-bin/j/recordings.cgi?day=') === 0));
+		await new Promise((r) => setTimeout(r, 50));
+		check('nothing is claimed when /metrics/records ' + how,
+			banner(env) === '', JSON.stringify(banner(env)).slice(0, 120));
+	}
+
+	group('a gap means different things in the two recording modes');
+
+	// The page's whole job is explaining why footage is missing, so this is
+	// not cosmetic. Recording continuously, a gap between clips is footage
+	// that should be there and is not. Recording on motion it is the camera
+	// doing exactly what was asked, and calling it "not recording" sends
+	// somebody to look for a fault they do not have.
+	{
+		const env = load('ok', metricsWith(0, 0), 'continuous');
+		const ok = await waitFor(() => env.$('rec-clips').innerHTML.indexOf('rec-clip') >= 0);
+		check('recording continuously, the clip list is drawn', ok);
+		check('and the motion lane says it has nothing to draw yet',
+			env.$('rec-motion-note').textContent.indexOf('once the camera records') >= 0,
+			env.$('rec-motion-note').textContent);
+	}
+
+	{
+		const env = load('ok', metricsWith(0, 0), 'motion');
+		await waitFor(() => env.$('rec-motion-note').textContent.indexOf('each clip') >= 0);
+		check('recording on motion, the lane says the clips ARE the events',
+			env.$('rec-motion-note').textContent.indexOf('each clip above is one event') >= 0,
+			env.$('rec-motion-note').textContent);
+	}
+
+	group('the card still speaks for itself');
+
+	{
+		// A recorder that is perfectly happy does not overrule a card that is
+		// plainly not: majestic reports state 0 until it next tries to write.
+		const env = load('readonly', metricsWith(0, 0));
+		const ok = await waitFor(() => banner(env).indexOf('read-only') >= 0);
+		check('a read-only card is still reported through the filesystem', ok,
+			JSON.stringify(banner(env)).slice(0, 160));
+	}
+
+	done();
+}
+
+main();

--- a/tests/recordings-health.test.js
+++ b/tests/recordings-health.test.js
@@ -89,7 +89,12 @@ function makeEl(id) {
 function load(cardHealth, metrics, mode) {
 	const els = {};
 	const $ = (id) => (els[id] = els[id] || makeEl(id));
-	const env = { $: $, asked: [] };
+	// The card poll is a 30-second setInterval. Captured rather than waited on,
+	// so a test can say "and now another poll happens" without the suite taking
+	// half a minute per case — and so the poll's own early-return, which is
+	// what decides whether a changed verdict ever reaches the screen, is
+	// exercised at all.
+	const env = { $: $, asked: [], polls: [] };
 
 	const video = $('rec-video');
 	video.buffered = { length: 0, start() { return 0; }, end() { return 0; } };
@@ -110,11 +115,13 @@ function load(cardHealth, metrics, mode) {
 			});
 		}
 		if (url.indexOf('/metrics/records') === 0) {
-			// A camera running an older majestic has no such endpoint. 404 and
-			// a refused connection have to look the same to the page.
+			// A camera running an older majestic answers 404 — a known
+			// absence. A refused connection is an unknown, and the page has to
+			// tell those two apart.
 			if (metrics === null) return Promise.resolve({ ok: false, status: 404 });
 			if (metrics === 'refused') return Promise.reject(new Error('refused'));
-			return Promise.resolve({ ok: true, text: () => Promise.resolve(metrics) });
+			const body = typeof metrics === 'function' ? metrics() : metrics;
+			return Promise.resolve({ ok: true, text: () => Promise.resolve(body) });
 		}
 		if (url.indexOf('/api/v1/config.json') === 0) {
 			return json({ records: { enabled: true, path: '/rec/%F', split: 2,
@@ -159,7 +166,8 @@ function load(cardHealth, metrics, mode) {
 		Uint8Array: Uint8Array, encodeURIComponent: encodeURIComponent,
 		decodeURIComponent: decodeURIComponent, String: String, Number: Number,
 		Array: Array, Object: Object, Error: Error, RegExp: RegExp,
-		setTimeout, clearTimeout, setInterval, clearInterval,
+		setTimeout, clearTimeout, clearInterval,
+		setInterval: (fn) => { env.polls.push(fn); return 0; },
 	};
 	ctx.window.document = ctx.document;
 	vm.createContext(ctx);
@@ -202,11 +210,16 @@ async function waitFor(pred, ms) {
 
 function banner(env) { return env.$('rec-health').innerHTML || ''; }
 
-const metricsWith = (state, dropped) =>
+// `lostSec` is footage dropped, in seconds. majestic reports it as
+// records_dropped_ticks_total, in the media timescale — microseconds — beside
+// a COUNT of fragments that is not the same thing, because records.fragmentMs
+// is configurable.
+const metricsWith = (state, lostSec) =>
 	'# HELP records_state Recorder verdict\n' +
 	'# TYPE records_state gauge\n' +
 	'records_state ' + state + '\n' +
-	'records_fragments_dropped_total ' + (dropped || 0) + '\n' +
+	'records_fragments_dropped_total ' + Math.round(lostSec || 0) + '\n' +
+	'records_dropped_ticks_total ' + Math.round((lostSec || 0) * 1e6) + '\n' +
 	'records_fragments_written_total 4200\n';
 
 async function main() {
@@ -237,15 +250,34 @@ async function main() {
 	}
 
 	{
-		// State 0 and losing footage: nothing is wrong with the filesystem and
-		// nothing is wrong with the writes — the card simply cannot take the
-		// bitrate. The page would otherwise be green.
+		// The counter runs from boot. A card that dropped a second last Tuesday
+		// and has been perfect since must not hold the banner red for ever —
+		// "footage is being lost" is a claim about now.
 		const env = load('ok', metricsWith(0, 37));
+		await waitFor(() => env.polls.length > 0);
+		await new Promise((r) => setTimeout(r, 50));
+		check('drops that happened before this page opened are history, not news',
+			banner(env) === '', JSON.stringify(banner(env)).slice(0, 160));
+	}
+
+	{
+		// State 0 and losing footage NOW: nothing is wrong with the filesystem
+		// and nothing is wrong with the writes — the card simply cannot take
+		// the bitrate. The page would otherwise be green.
+		let lost = 37;
+		const env = load('ok', () => metricsWith(0, lost));
+		await waitFor(() => env.polls.length > 0);
+		await new Promise((r) => setTimeout(r, 50));
+		check('nothing said while the counter is standing still', banner(env) === '');
+
+		lost = 39.5;                       // two and a half more seconds gone
+		env.polls[0]();
 		const ok = await waitFor(() => banner(env).indexOf('cannot keep up') >= 0);
-		check('a card that cannot keep up is not a healthy card', ok,
-			JSON.stringify(banner(env)).slice(0, 160));
-		check('and it says how much has been lost',
-			banner(env).indexOf('37') >= 0, JSON.stringify(banner(env)).slice(0, 160));
+		check('but a card losing footage while you watch is not a healthy card',
+			ok, JSON.stringify(banner(env)).slice(0, 200));
+		check('and what it reports is the footage lost since, not since boot',
+			banner(env).indexOf('37') < 0 && banner(env).indexOf('39') < 0,
+			JSON.stringify(banner(env)).slice(0, 200));
 	}
 
 	group('a majestic too old to ask is not a majestic in trouble');
@@ -256,6 +288,25 @@ async function main() {
 		await new Promise((r) => setTimeout(r, 50));
 		check('nothing is claimed when /metrics/records ' + how,
 			banner(env) === '', JSON.stringify(banner(env)).slice(0, 120));
+	}
+
+	// But the two are not the same, and the badge is where the difference
+	// shows: a camera that answered and has no such endpoint is as known as it
+	// can be, and gets the green it got before these metrics existed. A camera
+	// that could not be asked is not known, and green is a claim.
+	{
+		const env = load('ok', null);
+		await waitFor(() => env.$('rec-daynav').innerHTML.indexOf('badge') >= 0);
+		check('an older majestic still gets its Recording badge',
+			env.$('rec-daynav').innerHTML.indexOf('text-bg-success') >= 0,
+			env.$('rec-daynav').innerHTML.slice(0, 200));
+	}
+	{
+		const env = load('ok', 'refused');
+		await waitFor(() => env.$('rec-daynav').innerHTML.indexOf('badge') >= 0);
+		check('a camera that could not be asked does not',
+			env.$('rec-daynav').innerHTML.indexOf('text-bg-success') < 0,
+			env.$('rec-daynav').innerHTML.slice(0, 200));
 	}
 
 	group('a gap means different things in the two recording modes');

--- a/tests/recordings-pump.test.js
+++ b/tests/recordings-pump.test.js
@@ -237,6 +237,13 @@ function load() {
 		if (url.indexOf('/cgi-bin/j/sdcard.cgi') === 0) {
 			return json({ health: 'ok', total: 1e10, free: 5e9, used: 5e9, recBytes: 1e9 });
 		}
+		// The page asks majestic for its own verdict on the card as well as
+		// the kernel's. Stubbed rather than left to fall through, so that this
+		// test fails on an UNEXPECTED request rather than on the one it knows
+		// about — recordings-health.test.js is where the answer is exercised.
+		if (url.indexOf('/metrics/records') === 0) {
+			return Promise.resolve({ ok: true, text: () => Promise.resolve('records_state 0\n') });
+		}
 		if (url.indexOf('/cgi-bin/j/recordings.cgi?days=1') === 0) {
 			return json({ prefix: '/rec', days: [{ name: '2026-09-03', clips: 1, mtime: 0 }] });
 		}
@@ -267,6 +274,7 @@ function load() {
 		location: { search: '', pathname: '/cgi-bin/recordings.cgi' },
 		apiFetch: apiFetch,
 		mjGet: (cfg, dot) => dot.split('.').reduce((o, k) => (o == null ? undefined : o[k]), cfg),
+		parseMetrics: (t) => ({ v: { records_state: 0 } }),
 		parseTzOffsetMs: () => 0,
 		ianaZone: () => null,
 		console: console, JSON: JSON, Promise: Promise, Date: Date, Math: Math,

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -373,7 +373,7 @@ window.MajesticMp4Index = (function () {
 		const ts = init.timescale || 1;
 		const target = Math.max(0, targetSec);
 
-		let lo = init.firstMoof, hi = size, best = null;
+		let lo = init.firstMoof, hi = size, best = null, bestSync = null;
 
 		// What a probe found: its byte offset and the time it starts at.
 		// Exact from tfdt; on a pre-tfdt recording, estimated from the write
@@ -430,9 +430,14 @@ window.MajesticMp4Index = (function () {
 				while (at >= 0 && at + 16 <= buf.length) {
 					const t = timeAt(buf, at);
 					if (t === null || t.sec > target) break;
-					best = { off: start + at, sec: t.sec, exact: t.exact };
+					const here = { off: start + at, sec: t.sec, exact: t.exact };
+					best = here;
 					const f = parseFragment(buf.subarray(at));
 					if (!f || f.short || !f.total) break;
+					// The last fragment at or before the target that a decoder
+					// can actually be started at. Free: this walk is already
+					// parsing every fragment in the window.
+					if (f.sync !== false) bestSync = here;
 					at += f.total;
 				}
 				return settle();
@@ -443,8 +448,26 @@ window.MajesticMp4Index = (function () {
 			// Land at or before the moment asked for, never after it: starting
 			// late reads as the seek having been ignored, where starting a
 			// fragment early is just a moment of lead-in.
-			if (!best) return { off: init.firstMoof, approxSec: 0, exact: false };
-			return { off: best.off, approxSec: best.sec, exact: best.exact };
+			//
+			// And prefer a fragment that opens on a keyframe, because that is
+			// where a decoder can be STARTED. Handing MSE a fragment that opens
+			// mid-GOP feeds it frames whose references were never appended, and
+			// the picture stays blank until the next keyframe rather than
+			// erroring — a seek that looked like a decode bug.
+			//
+			// `atSync` says whether one was found. It cannot always be: the
+			// refine window is a fraction of a second of video and a camera
+			// with gopSize 30 puts a keyframe every thirty of them, so on those
+			// this reports false and the caller gets what it used to get. The
+			// answer there is not a wider read on every scrub — it is a shorter
+			// GOP, which is what the export path's forward snap makes up for.
+			const pick = bestSync || best;
+			if (!pick)
+				return { off: init.firstMoof, approxSec: 0, exact: false, atSync: true };
+			return {
+				off: pick.off, approxSec: pick.sec, exact: pick.exact,
+				atSync: bestSync !== null,
+			};
 		}
 
 		return Promise.resolve().then(loop);
@@ -546,7 +569,8 @@ window.MajesticMp4Index = (function () {
 		}
 		function advance(f) {
 			if (!f || f.short || !f.total || off + f.total > size) return finish();
-			frags.push({ off: off, len: f.total, t: ticks / ts, dur: (f.durTicks || 0) / ts, seq: f.seq });
+			frags.push({ off: off, len: f.total, t: ticks / ts,
+				dur: (f.durTicks || 0) / ts, seq: f.seq, sync: f.sync !== false });
 			ticks += f.durTicks || 0;
 			off += f.total;
 			if (onProgress) onProgress(ticks / ts, want);
@@ -581,12 +605,25 @@ window.MajesticMp4Index = (function () {
 
 		let i = 0;
 		while (i < f.length - 1 && f[i].t + f[i].dur <= a) i++;
-		// Back to something that opens on a keyframe. An export is a file
-		// somebody will open in a player that has seen nothing before it, so
-		// the first fragment has to be one it can start decoding at — the same
-		// rule as a seek, for the same reason, and here it costs at most one
-		// GOP of extra footage at the front.
+
+		// An export is a file somebody opens in a player that has seen nothing
+		// before it, so its first fragment has to be one a decoder can be
+		// started at. Otherwise the saved clip opens black — not with an error,
+		// which is what makes it worth going out of the way for.
+		//
+		// Back first, because that keeps everything asked for and costs at most
+		// one GOP of lead-in. Forward only if there is nothing behind: that
+		// happens when the span itself begins mid-GOP, which is what
+		// spanFrom() hands back when locate() could not find a keyframe within
+		// its window. Losing up to a GOP off the FRONT of a selection is worse
+		// than lead-in and better than a file that will not open.
+		const from = i;
 		while (i > 0 && !f[i].sync) i--;
+		if (!f[i].sync) {
+			i = from;
+			while (i < f.length - 1 && !f[i].sync) i++;
+			if (!f[i].sync) i = from;   // no keyframe anywhere: nothing to do
+		}
 		let j = i;
 		while (j < f.length - 1 && f[j].t + f[j].dur < b) j++;
 

--- a/www/a/mp4index.js
+++ b/www/a/mp4index.js
@@ -133,12 +133,19 @@ window.MajesticMp4Index = (function () {
 	// a fixed offset. Verified rather than assumed: a file that puts something
 	// else first reports null and the caller falls back to the exact walk.
 	//
-	// CAVEAT, and it is the reason locate() is only ever an approximation:
-	// majestic's sequence_number is monotonic but NOT strictly increasing — a
-	// walk over a real clip saw 0, 1, 2, 2, 3, 4 at consecutive moofs, where
-	// ISO 14496-12 wants strictly increasing. Binary search tolerates a plateau
-	// (it only needs monotonicity), but the value cannot be trusted as an exact
-	// fragment ordinal, so exact times come from the walk instead.
+	// CAVEAT, and it is the reason locate() is only ever an approximation on
+	// older recordings: majestic used to put its own running counter here,
+	// shared across files and reset whenever the pipeline was rebuilt, so a
+	// walk over a real clip saw 0, 1, 2, 2, 3, 4 at consecutive moofs where
+	// ISO 14496-12 wants strictly increasing — and a resumed clip restarted it
+	// at zero halfway through.
+	//
+	// Current majestic restates it per file, so on a clip written by one it IS
+	// the fragment's ordinal. Nothing here relies on that, because the cards
+	// this page browses are full of clips written by the versions that did
+	// not, and there is no way to tell which is which from the value itself.
+	// Binary search only needs monotonicity, which held either way; exact
+	// times still come from the walk.
 	function moofSeq(u8, at) {
 		if (at + 24 > u8.length) return null;
 		if (fourcc(u8, at + 4) !== 'moof') return null;
@@ -215,6 +222,32 @@ window.MajesticMp4Index = (function () {
 		return total;
 	}
 
+	// Whether this fragment's first sample is one a decoder can start at.
+	//
+	// trun's first_sample_flags (flag 0x004) carries it, and bit 0x10000 of
+	// that word is sample_is_non_sync_sample. majestic only started writing
+	// the real value once fragments stopped being whole GOPs; before that it
+	// hardcoded "sync" because every fragment began at an IDR by construction.
+	//
+	// Absent flags therefore mean sync, and that is not a guess — a recording
+	// whose trun carries no first_sample_flags was written when the property
+	// held. Saying "unknown" instead would make every clip on an older card
+	// unseekable except at its very start.
+	function fragOpensOnSync(u8, moofAt, moofEnd) {
+		const traf = findBox(u8, moofAt + 8, moofEnd, 'traf');
+		if (!traf) return true;
+		const trun = findBox(u8, traf[0] + 8, traf[1], 'trun');
+		if (!trun) return true;
+
+		const tf = be32(u8, trun[0] + 8) & 0xffffff;
+		if (!(tf & 0x004)) return true;
+
+		let p = trun[0] + 16;
+		if (tf & 0x001) p += 4;         // data_offset
+		if (p + 4 > trun[1]) return true;
+		return (be32(u8, p) & 0x10000) === 0;
+	}
+
 	// One step of the chain. `u8` must start exactly at a moof and hold enough
 	// of it to reach the following mdat's size field.
 	function parseFragment(u8) {
@@ -234,6 +267,7 @@ window.MajesticMp4Index = (function () {
 			seq: moofSeq(u8, 0),
 			decodeTicks: fragDecodeTicks(u8, 0, Math.min(moofSize, u8.length)),
 			durTicks: fragDurationTicks(u8, 0, Math.min(moofSize, u8.length)),
+			sync: fragOpensOnSync(u8, 0, Math.min(moofSize, u8.length)),
 		};
 	}
 
@@ -305,6 +339,7 @@ window.MajesticMp4Index = (function () {
 				t: ticks / ts,
 				dur: (f.durTicks || 0) / ts,
 				seq: f.seq,
+				sync: f.sync !== false,
 			});
 			ticks += f.durTicks || 0;
 			off += f.total;
@@ -546,6 +581,12 @@ window.MajesticMp4Index = (function () {
 
 		let i = 0;
 		while (i < f.length - 1 && f[i].t + f[i].dur <= a) i++;
+		// Back to something that opens on a keyframe. An export is a file
+		// somebody will open in a player that has seen nothing before it, so
+		// the first fragment has to be one it can start decoding at — the same
+		// rule as a seek, for the same reason, and here it costs at most one
+		// GOP of extra footage at the front.
+		while (i > 0 && !f[i].sync) i--;
 		let j = i;
 		while (j < f.length - 1 && f[j].t + f[j].dur < b) j++;
 
@@ -561,16 +602,37 @@ window.MajesticMp4Index = (function () {
 		};
 	}
 
-	// The fragment covering `sec`, for a seek once the index exists.
-	function fragmentAt(index, sec) {
+	// The index of the fragment a decoder may START at for `sec`: the one
+	// covering it, or the nearest one before it that opens on a keyframe.
+	//
+	// A fragment is self-contained only if its first sample is one. Handing a
+	// SourceBuffer a fragment that opens mid-GOP feeds it frames whose
+	// references were never appended, and what comes out is a green or smeared
+	// picture rather than an error — so a seek that landed on one looked like
+	// a decode bug rather than a seek bug.
+	//
+	// This could not be asked before: every fragment claimed to be a sync
+	// sample, because the writer hardcoded it. Falling back to fragment 0 is
+	// the honest answer when nothing earlier opens cleanly — the start of the
+	// clip is the only place such a file can be started at all.
+	function playableIndexAt(index, sec) {
 		const f = index.fragments;
-		if (!f || !f.length) return null;
+		if (!f || !f.length) return -1;
 		let lo = 0, hi = f.length - 1;
 		while (lo < hi) {
 			const mid = (lo + hi + 1) >> 1;
 			if (f[mid].t <= sec) lo = mid; else hi = mid - 1;
 		}
-		return f[lo];
+		let i = lo;
+		while (i > 0 && !f[i].sync) i--;
+		return i;
+	}
+
+	// The fragment covering `sec`, for a seek once the index exists — snapped
+	// back to one that can actually be decoded from.
+	function fragmentAt(index, sec) {
+		const i = playableIndexAt(index, sec);
+		return i < 0 ? null : index.fragments[i];
 	}
 
 	// ---- transport -------------------------------------------------------

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -27,6 +27,7 @@
 
 	const state = {
 		cfg: {}, prefix: '', split: 1200, enabled: false, card: null,
+		recorder: null, onMotion: false,
 		offsetMs: 0, offsetKnown: false, zone: null, nowSec: null, today: '',
 		tzSamples: [], tzDiffers: false, tzOn: false,
 		days: [], dayName: '', day: { clips: [], unplaced: [] },
@@ -270,6 +271,13 @@
 			.then(function (c) {
 				state.cfg = c;
 				state.enabled = mjGet(c, 'records.enabled') === true;
+				// Which changes what a GAP between clips means, and that is
+				// the one thing this page exists to get right. Recording
+				// continuously, a gap is footage that should be there and is
+				// not. Recording on motion, a gap is the camera working
+				// exactly as asked — and labelling it "not recording" sends
+				// somebody to look for a fault they do not have.
+				state.onMotion = mjGet(c, 'records.mode') === 'motion';
 				state.prefix = (mjGet(c, 'records.path') || '').split('%')[0].replace(/\/+$/, '');
 				const sp = +mjGet(c, 'records.split');
 				state.split = sp > 0 ? sp * 60 : 1200;
@@ -639,12 +647,51 @@
 			.catch(function () { state.card = null; });
 	}
 
+	// What the recorder itself makes of the card, which is a different question
+	// from what the filesystem does.
+	//
+	// A card can be mounted read-write, have room on it, and still be taking
+	// nothing: majestic reports its own verdict in records_state — 0 ok,
+	// 1 degraded, 2 failed, 3 offline — and counts the fragments it had to
+	// throw away. The SD-card endpoint cannot see any of that, because none of
+	// it is visible from the filesystem.
+	//
+	// Absent is not bad. A camera running an older majestic serves no
+	// /metrics/records at all, and a page that painted that red would be
+	// telling every one of them something false.
+	function loadRecorder() {
+		return apiFetch('/metrics/records', { credentials: 'same-origin' })
+			.then(function (r) { return r.ok ? r.text() : null; })
+			.then(function (t) {
+				state.recorder = t ? parseMetrics(t).v : null;
+			})
+			.catch(function () { state.recorder = null; });
+	}
+
+	// The recorder's own verdict, or null when it has not got one to give.
+	function recorderState() {
+		const v = state.recorder;
+		if (!v || typeof v.records_state !== 'number') return null;
+		return v.records_state;
+	}
+
 	// Positive claims need positive evidence. A card is only known writable
 	// when the endpoint said so; a request that failed, or an answer this
 	// release does not understand, is an unknown card, and an unknown card
 	// must not be painted green — that false reassurance is the whole bug
 	// this page is here to stop telling.
-	function cardWritable() { return !!state.card && state.card.health === 'ok'; }
+	//
+	// And the filesystem agreeing is no longer enough. A card mounted
+	// read-write with room on it can still be recording nothing — the writes
+	// failing, or the card too slow to keep up — and every one of those states
+	// reads as `health: ok` here, because none of them is visible from the
+	// filesystem. So the recorder has to agree as well, when it is new enough
+	// to be asked.
+	function cardWritable() {
+		if (!state.card || state.card.health !== 'ok') return false;
+		const rs = recorderState();
+		return rs === null || rs === 0;
+	}
 
 	// Why there is no new footage, said on the page people actually arrive at.
 	// Returns '' while the card is fine — including while it is merely full,
@@ -652,6 +699,12 @@
 	// records.maxUsage and carries on.
 	function cardTrouble() {
 		const d = state.card;
+		// Asked first, because it is the more specific answer: a card that has
+		// gone read-only under the recorder shows up in BOTH, and "majestic
+		// cannot write to the card" is what somebody looking at an empty
+		// archive needs to read.
+		const rec = recorderTrouble();
+		if (rec) return rec;
 		if (!d) return '';
 		switch (d.health) {
 		case 'readonly':
@@ -674,6 +727,43 @@
 		}
 	}
 
+	// What majestic says about its own recording, when it is new enough to say
+	// anything. This is the half the SD-card page cannot see: every state below
+	// reads as a healthy filesystem with free space on it.
+	function recorderTrouble() {
+		const v = state.recorder;
+		const rs = recorderState();
+		if (rs === null) return '';
+
+		switch (rs) {
+		case 3:
+			return '<strong>The camera cannot open the SD card — nothing is being recorded.</strong> ' +
+				'It has stopped trying and will look again every half minute, so recording resumes ' +
+				'on its own if the card comes back.';
+		case 2:
+			return '<strong>Writes to the SD card are failing — nothing is being recorded.</strong> ' +
+				'The camera gave up on the clip it was writing after repeated errors.';
+		case 1:
+			return '<strong>Writes to the SD card are failing intermittently.</strong> ' +
+				'Recording is continuing for now, but footage is being lost.';
+		default:
+			break;
+		}
+
+		// State 0 and still losing footage: the card is keeping up with
+		// neither the bitrate nor its own garbage collection. Nothing about
+		// the filesystem is wrong, which is exactly why this needs saying —
+		// the page would otherwise be green.
+		if (v && v.records_fragments_dropped_total > 0) {
+			return '<strong>The SD card cannot keep up — footage is being lost.</strong> ' +
+				esc(String(v.records_fragments_dropped_total)) +
+				' second' + (v.records_fragments_dropped_total === 1 ? '' : 's') +
+				' of video have been dropped because the card could not take them ' +
+				'in time. A faster card, or a lower bitrate, is the fix.';
+		}
+		return '';
+	}
+
 	// Kernel complaints about the card, when the endpoint found any. Never
 	// rendered as reassurance: the ring buffer is small, so an error that
 	// stopped recording this morning has usually scrolled out of it by now.
@@ -682,6 +772,17 @@
 		if (!d || !d.fsErrors || !d.fsErrors.length) return '';
 		return '<div class="mt-2"><div class="x-small text-secondary mb-1">Recent kernel messages about this card:</div>' +
 			'<pre class="x-small mb-0" style="white-space:pre-wrap">' + esc(d.fsErrors.join('\n')) + '</pre></div>';
+	}
+
+	// The reserved motion lane's caption. Empty in both modes — no camera
+	// records where the movement was inside a clip — but the reason differs,
+	// and so does what the band above already tells you.
+	function renderMotionNote() {
+		const el = $id('rec-motion-note');
+		if (!el) return;
+		el.textContent = state.onMotion
+			? 'Motion — each clip above is one event, with the seconds before it'
+			: 'Motion — lights up once the camera records detection events';
 	}
 
 	function renderHealth() {
@@ -753,13 +854,18 @@
 		setInterval(function () {
 			if (document.hidden) return;
 			const before = state.card ? state.card.health : null;
-			loadCard(false).then(function () {
+			const recBefore = recorderState();
+			Promise.all([loadCard(false), loadRecorder()]).then(function () {
 				const after = state.card ? state.card.health : null;
 				renderStorage();
-				// Everything else only moves when the verdict itself moves —
-				// no reason to rebuild the day picker and the clip list every
-				// thirty seconds for numbers that did not change.
-				if (after === before) return;
+				// Everything else only moves when a verdict moves — no reason
+				// to rebuild the day picker and the clip list every thirty
+				// seconds for numbers that did not change. Both verdicts, now
+				// that either can turn the banner red on its own: a recorder
+				// that has just given up on a card the filesystem still calls
+				// healthy is exactly the case this poll exists to catch, and
+				// keying off the card alone would have missed it.
+				if (after === before && recorderState() === recBefore) return;
 				renderHealth();
 				renderDayNav();
 				renderClips();
@@ -978,7 +1084,8 @@
 		list.slice().reverse().forEach(function (c, i, arr) {
 			const prev = arr[i + 1];
 			if (prev && c.start - prev.end > TL.JOIN_TOLERANCE) {
-				h += '<div class="rec-gap"><span>not recording · ' +
+				h += '<div class="rec-gap"><span>' +
+					(state.onMotion ? 'no motion · ' : 'not recording · ') +
 					hhmm(prev.end) + ' – ' + hhmm(c.start) + '</span></div>';
 			}
 			const on = state.clip && state.clip.name === c.name;
@@ -1400,7 +1507,7 @@
 	// Resolves to '' when recording is really on, and to a reason when it is
 	// not; a write that was refused must never be reported as one that landed.
 	function useCardForRecording() {
-		return loadCard().then(function () {
+		return Promise.all([loadCard(), loadRecorder()]).then(function () {
 			const d = state.card;
 			if (!d || !d.mounted || !d.mountpoint)
 				return 'The card was prepared, but the camera did not report where it ' +
@@ -1579,7 +1686,7 @@
 				return empty('<strong>Recording is not configured.</strong> No recording path is set, so there is nothing to browse. ',
 					'<a href="sdcard.cgi">Set up the SD card</a>.');
 			}
-			return Promise.all([loadDays(), loadCard()]).then(function () {
+			return Promise.all([loadDays(), loadCard(), loadRecorder()]).then(function () {
 				if (!state.days.length) {
 					// The card gets the first word: "nothing recorded yet" is a
 					// guess, and a read-only or unreadable card is the answer.
@@ -1617,6 +1724,7 @@
 					renderDayNav();
 					renderClips();
 					renderHealth();
+					renderMotionNote();
 					renderStorage();
 					centreView(freshest());
 					goTo(freshest());     // opens the clip, so the page is not a black box

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -27,7 +27,7 @@
 
 	const state = {
 		cfg: {}, prefix: '', split: 1200, enabled: false, card: null,
-		recorder: null, onMotion: false,
+		recorder: null, onMotion: false, droppedAt: null,
 		offsetMs: 0, offsetKnown: false, zone: null, nowSec: null, today: '',
 		tzSamples: [], tzDiffers: false, tzOn: false,
 		days: [], dayName: '', day: { clips: [], unplaced: [] },
@@ -656,23 +656,47 @@
 	// throw away. The SD-card endpoint cannot see any of that, because none of
 	// it is visible from the filesystem.
 	//
-	// Absent is not bad. A camera running an older majestic serves no
-	// /metrics/records at all, and a page that painted that red would be
-	// telling every one of them something false.
+	// Three answers, not two, and the difference decides what the badge may
+	// say. A camera whose majestic ANSWERED and has no such endpoint is a
+	// camera that cannot report this — a known absence, and the page must go on
+	// saying what it said before that endpoint existed. A request that FAILED
+	// is an unknown, and an unknown may not be turned into a fact.
+	//
+	//   { v: … }        a reading
+	//   { absent: true } answered, and does not have it
+	//   null             not asked yet, or the ask failed
 	function loadRecorder() {
 		return apiFetch('/metrics/records', { credentials: 'same-origin' })
-			.then(function (r) { return r.ok ? r.text() : null; })
+			.then(function (r) {
+				if (r.status === 404) { state.recorder = { absent: true }; return null; }
+				return r.ok ? r.text() : Promise.reject(new Error('status ' + r.status));
+			})
 			.then(function (t) {
-				state.recorder = t ? parseMetrics(t).v : null;
+				if (t === null) return;
+				const v = parseMetrics(t).v;
+				// An answer this release cannot read is not a reading.
+				state.recorder = typeof v.records_state === 'number'
+					? { v: v } : null;
+				// Where the drop counter stood when this page opened, so what
+				// it reports is footage lost while somebody was watching
+				// rather than everything since the camera booted.
+				if (state.droppedAt === null &&
+					typeof v.records_dropped_ticks_total === 'number')
+					state.droppedAt = v.records_dropped_ticks_total;
 			})
 			.catch(function () { state.recorder = null; });
 	}
 
-	// The recorder's own verdict, or null when it has not got one to give.
+	// The recorder's own verdict, or null when there is not one to have.
 	function recorderState() {
-		const v = state.recorder;
-		if (!v || typeof v.records_state !== 'number') return null;
-		return v.records_state;
+		const r = state.recorder;
+		return r && r.v ? r.v.records_state : null;
+	}
+
+	// Whether the camera answered at all. An older majestic saying "no such
+	// endpoint" is not the same as a camera that could not be reached.
+	function recorderKnown() {
+		return !!state.recorder;
 	}
 
 	// Positive claims need positive evidence. A card is only known writable
@@ -689,6 +713,11 @@
 	// to be asked.
 	function cardWritable() {
 		if (!state.card || state.card.health !== 'ok') return false;
+		// A camera that answered and has no recorder metrics is as known as it
+		// can be, and green is what this page said about it before there were
+		// any. A camera that could not be asked is not known, and green is a
+		// claim — the same rule the card itself is held to, two lines up.
+		if (!recorderKnown()) return false;
 		const rs = recorderState();
 		return rs === null || rs === 0;
 	}
@@ -731,7 +760,8 @@
 	// anything. This is the half the SD-card page cannot see: every state below
 	// reads as a healthy filesystem with free space on it.
 	function recorderTrouble() {
-		const v = state.recorder;
+		const r = state.recorder;
+		const v = r && r.v;
 		const rs = recorderState();
 		if (rs === null) return '';
 
@@ -754,14 +784,33 @@
 		// neither the bitrate nor its own garbage collection. Nothing about
 		// the filesystem is wrong, which is exactly why this needs saying —
 		// the page would otherwise be green.
-		if (v && v.records_fragments_dropped_total > 0) {
+		//
+		// Measured against the first reading this page took, not against zero.
+		// The counter runs from boot, so a card that dropped a second last
+		// Tuesday and has been perfect since would otherwise hold the banner
+		// red for ever — and "footage is being lost" is a claim about now.
+		const lost = droppedSeconds();
+		if (lost > 0) {
 			return '<strong>The SD card cannot keep up — footage is being lost.</strong> ' +
-				esc(String(v.records_fragments_dropped_total)) +
-				' second' + (v.records_fragments_dropped_total === 1 ? '' : 's') +
-				' of video have been dropped because the card could not take them ' +
-				'in time. A faster card, or a lower bitrate, is the fix.';
+				esc(TL.duration(lost)) + ' of video has been dropped while this ' +
+				'page has been open, because the card could not take it in time. ' +
+				'A faster card, or a lower bitrate, is the fix.';
 		}
 		return '';
+	}
+
+	// Seconds of footage dropped since this page loaded.
+	//
+	// From records_dropped_ticks_total, which is presentation time in the
+	// media timescale — microseconds for every track majestic writes. The
+	// fragment COUNT beside it is not seconds: records.fragmentMs is
+	// configurable, so counting fragments and calling them seconds is right
+	// only at the default.
+	function droppedSeconds() {
+		const v = state.recorder && state.recorder.v;
+		if (!v || typeof v.records_dropped_ticks_total !== 'number') return 0;
+		if (state.droppedAt === null) return 0;
+		return Math.max(0, (v.records_dropped_ticks_total - state.droppedAt) / 1e6);
 	}
 
 	// Kernel complaints about the card, when the endpoint found any. Never
@@ -854,7 +903,11 @@
 		setInterval(function () {
 			if (document.hidden) return;
 			const before = state.card ? state.card.health : null;
-			const recBefore = recorderState();
+			// The rendered verdict itself, not the inputs to it. Comparing
+			// records_state alone missed a card that started dropping footage
+			// while the recorder stayed in state 0 — the banner is driven by
+			// cardTrouble(), so cardTrouble() is what has to be watched.
+			const msgBefore = cardTrouble();
 			Promise.all([loadCard(false), loadRecorder()]).then(function () {
 				const after = state.card ? state.card.health : null;
 				renderStorage();
@@ -865,7 +918,7 @@
 				// that has just given up on a card the filesystem still calls
 				// healthy is exactly the case this poll exists to catch, and
 				// keying off the card alone would have missed it.
-				if (after === before && recorderState() === recBefore) return;
+				if (after === before && cardTrouble() === msgBefore) return;
 				renderHealth();
 				renderDayNav();
 				renderClips();

--- a/www/cgi-bin/recordings.cgi
+++ b/www/cgi-bin/recordings.cgi
@@ -51,12 +51,16 @@
 				</div>
 				<div class="rec-band" id="rec-band"></div>
 
-				<!-- Reserved, and deliberately empty. Majestic's motion detection is
-				     hardware-assisted but is never written to the card, so there is no
-				     event data to draw here yet. -->
+				<!-- Still reserved, and still deliberately empty, but for a narrower
+				     reason than before. Recording on motion (records.mode) writes one
+				     clip per event, so in that mode the band above IS the event record
+				     and drawing it twice would say nothing new. What no camera writes
+				     is where the movement was WITHIN a clip, which is the only thing
+				     this lane could add — so it stays empty until something records
+				     that. The caption below is set from the mode by recordings.js. -->
 				<div class="rec-motion"></div>
 				<div class="rec-ticks" id="rec-ticks"></div>
-				<div class="x-small text-secondary mt-1">Motion — lights up once the camera records detection events</div>
+				<div class="x-small text-secondary mt-1" id="rec-motion-note">Motion — lights up once the camera records detection events</div>
 
 				<div id="rec-export" class="d-none"></div>
 


### PR DESCRIPTION
The last of the SD-recording work, on this side of the wire. Two things the page was getting wrong, both silent.

## Seeks and exports could land somewhere unplayable

A fragment is self-contained only if its first sample is a keyframe. Until majestic bounded a fragment by time and bytes that was true of every one — the writer hardcoded *sync sample* into `trun`'s `first_sample_flags` because it could afford to. It is not true any more.

`mp4index.js` skipped that field, so `fragmentAt()` could hand a `SourceBuffer` a fragment opening mid-GOP, whose references were never appended. What comes out is a green or smeared picture rather than an error — a seek that landed there looked like a decode bug. `exportRanges()` had the same hole, and there it means a **downloaded file whose opening seconds are unwatchable in any player**.

Both now snap back to the nearest fragment that opens on a keyframe, and the index records which those are. An export pays at most one GOP of extra footage at the front.

A recording carrying no `first_sample_flags` at all reads as all-sync. That is not a guess: a clip written before majestic emitted the field was written when every fragment began at an IDR, and reading it as "unknown" would make every clip on an older card unseekable except at its very start.

## The page painted itself green over a card recording nothing

`cardWritable()` asked the SD-card endpoint, which asks the filesystem — and the filesystem cannot see the failure that matters most: **a card mounted read-write, with room on it, that majestic is writing nothing to.** Every one of those states reads back as `health: "ok"`.

The page now asks majestic as well, through `/metrics/records`, and will not call a card writable unless both agree. It names what it finds — the recorder has given up on the card, writes are failing, writes are failing intermittently, or the card cannot keep up and footage is being dropped — because "Cannot record" over an empty archive is where somebody starts looking, and the filesystem's verdict would send them to the wrong place.

A camera running an older majestic serves no such endpoint. That is not evidence of anything and is not rendered as any: absent metrics leave the page saying exactly what it said before.

## A gap means different things now

Recording continuously, a gap between clips is footage that should be there and is not. Recording **on motion** — `records.mode`, new in majestic — it is the camera doing exactly what was asked, and labelling it `not recording` sends somebody to look for a fault they do not have. It reads `no motion` in that mode.

The reserved motion lane stays empty, for a narrower reason than the one written on it. In motion mode the clip band above *is* the event record, and drawing it twice would say nothing new; what no camera writes is where the movement was **within** a clip, which is the only thing that lane could add. The caption now says which of those two situations you are in.

## One comment corrected

The note explaining why `locate()` can only approximate said majestic's `mfhd` sequence number "cannot be trusted as an exact fragment ordinal". Current majestic restates it per file, so on a clip it wrote, it is exactly that. Nothing here changes — the cards this page browses are full of clips written by versions that did not, and nothing in the value says which is which — but the comment no longer claims a limitation that is half untrue.

## Tests

Ten new checks over the keyframe snapping, including a clip with no keyframe anywhere (falls back to its start) and one carrying no flags at all (reads as all-sync, still seekable).

A new `recordings-health.test.js` drives the real page against a stubbed camera: every recorder state, a card that cannot keep up, both ways of having no `/metrics/records` at all, and the two gap labels. Every mutation of the new rules fails its test — dropping either snap-back, reading absent flags as non-sync, ignoring the recorder verdict, or treating a missing endpoint as a failure.

`npm test` green.