### PR TITLE
Dashboard: the memory note said nothing happened while 14 MB came and went

### DIFF
--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -232,6 +232,29 @@ group('the axis caption is derived from the window, not written beside it');
 	check('and a window under a minute says seconds', cap(45) === '-45 s');
 }
 
+group('hide withholds a line, not a value');
+{
+	const { MC, clock } = boot();
+	const host = makeHost(400);
+	const ch = MC.makeChart(host, { h: 40, lo: 0, hi: 10, colors: ['#a1', '#b2'] });
+	for (let i = 0; i < 5; i++) { clock.t = i * 10; MC.pushChart(ch, [3, 7]); }
+	check('both series draw while nothing is hidden',
+		host.innerHTML.indexOf('#a1') >= 0 && host.innerHTML.indexOf('#b2') >= 0);
+
+	ch.cfg.hide = [true, false];
+	MC.renderChart(ch);
+	check('a hidden series stops being drawn',
+		host.innerHTML.indexOf('#a1') < 0 && host.innerHTML.indexOf('#b2') >= 0);
+	check('while its samples are still there to be read back',
+		ch.pts.length === 5 && ch.pts.every(p => p.v[0] === 3),
+		ch.pts.length + ' points');
+
+	ch.cfg.hide = [false, false];
+	MC.renderChart(ch);
+	check('and unhiding draws the history it kept, not just what came after',
+		host.innerHTML.indexOf('#a1') >= 0);
+}
+
 group('window and gap are per chart, because not every subject is a subject of now');
 {
 	const { MC, clock } = boot();

--- a/tests/mem-slices.test.js
+++ b/tests/mem-slices.test.js
@@ -10,8 +10,9 @@
 //
 // What must hold: the named slices plus the remainder reconcile with
 // MemTotal − MemAvailable exactly; the largest pool on each SoC is named where
-// the camera reports it; and a key the camera does not report yields null
-// rather than a zero that would read as "nothing here".
+// the camera reports it; a key the camera does not report yields null rather
+// than a zero that would read as "nothing here"; and the sentence under the
+// chart never says nothing happened over a window in which something did.
 'use strict';
 
 const fs = require('fs');
@@ -39,6 +40,23 @@ const MAIN = fs.readFileSync(
 const pm = MAIN.match(/\nfunction parseMetrics\(text\) \{[\s\S]*?\n\}\n/);
 const parseMetrics = vm.runInNewContext(
 	'(function(){' + pm[0] + 'return parseMetrics})()', { Object: Object, isNaN: isNaN });
+
+// The sentence under the chart, lifted the same way. It carries MEM_NAMES,
+// MEM_PEAK and spanWords with it.
+const lift = (re, extra) => {
+	const hit = SRC.match(re);
+	if (!hit) {
+		console.log('  FAIL could not find ' + re + ' in www/a/dashboard.js');
+		process.exit(1);
+	}
+	return hit[0];
+};
+const memSentence = vm.runInNewContext('(function(){' +
+	lift(/\n\tconst MEM_NAMES = \[[^\]]*\];/) +
+	lift(/\n\tconst MEM_PEAK = \d+;/) +
+	lift(/\n\tfunction spanWords\(sec\) \{[\s\S]*?\n\t\}\n/) +
+	lift(/\n\tfunction memSentence\(pts, held, total\) \{[\s\S]*?\n\t\}\n/) +
+	'return memSentence})()', { Math: Math });
 
 const MB = 1048576;
 const NAMES = ['Video buffers', 'Programs', 'Kernel', 'RAM disk', 'Other'];
@@ -120,6 +138,49 @@ group('the pool is netted against what already names those bytes');
 	check('so the slices grow by exactly what the camera actually took',
 		Math.round((after.reduce((a, x) => a + x, 0) -
 			before.reduce((a, x) => a + x, 0)) / MB) === 15);
+}
+
+// The reporter of #322 ran the merged panel on their own gk7205v210 and it
+// drew Other climbing 10 -> 24.5 MB through four minutes of streaming and
+// falling back as the stream stopped — under a sentence reading "Other -0.1
+// MB". The chart showed the event; the sentence, which is the half people
+// quote, denied it.
+group('the sentence cannot say nothing happened over a window in which something did');
+{
+	// Five slices; index 4 is Other. Values in MB, times in seconds.
+	const at = (t, other) => ({ t: t, v: [0, 1.5, 4, 0.1, other] });
+	const climb = [at(0, 10), at(60, 15), at(120, 20), at(180, 24.5), at(240, 10.1)];
+	const said = memSentence(climb, 17 * MB, 34 * MB);
+
+	check('the net change is still reported, unrounded away',
+		said.indexOf('Other +0.1') >= 0, said);
+	check('and the peak both ends hide is named outright',
+		said.indexOf('Other rose to 24.5 MB and came back') >= 0, said);
+	check('the window it covers is stated, not assumed',
+		said.indexOf('Over the last 4 min') >= 0, said);
+	check('and what is held leads, as before',
+		said.indexOf('Holding 17 of 34 MB.') === 0, said);
+
+	// A trace that only ever went up has no excursion to name — the delta
+	// already says everything, and a second clause repeating it would be noise.
+	const rising = [at(0, 10), at(120, 17), at(240, 24.5)];
+	check('a monotonic climb gets no peak clause, since the delta already says it',
+		memSentence(rising, 17 * MB, 34 * MB).indexOf('rose to') < 0);
+
+	// Ordinary breathing must not trip it, or the clause appears forever and
+	// stops meaning anything.
+	const wobble = [at(0, 10), at(120, 10.6), at(240, 10)];
+	check('a sub-megabyte wobble is breathing, not an event',
+		memSentence(wobble, 17 * MB, 34 * MB).indexOf('rose to') < 0);
+
+	// A slice the camera never reported takes no part in the sentence.
+	const half = [{ t: 0, v: [null, 1.5, 4, 0.1, 10] },
+		{ t: 240, v: [null, 1.5, 4, 0.1, 24.5] }];
+	check('a slice reported as nothing is not named at all',
+		memSentence(half, 17 * MB, 34 * MB).indexOf('Video buffers') < 0);
+
+	check('and one sample is a level, with no change to claim',
+		memSentence([at(0, 10)], 17 * MB, 34 * MB) === 'Holding 17 of 34 MB.');
 }
 
 group('an absent key is a hole, not a floor');

--- a/tests/mem-slices.test.js
+++ b/tests/mem-slices.test.js
@@ -183,6 +183,44 @@ group('the sentence cannot say nothing happened over a window in which something
 		memSentence([at(0, 10)], 17 * MB, 34 * MB) === 'Holding 17 of 34 MB.');
 }
 
+// A slice is withheld from the DRAWING while it has never been anything, and
+// for a while that was done by pushing null — which also told everything
+// reading the points back that the value was unknown. A pool that sat at zero,
+// rose and fell then lost its whole story to the one null the window opened
+// on, for as long as that null took to age out.
+group('withholding a line from the chart does not withhold the value from the sentence');
+{
+	// index 0 is the pool: nothing, then 8 MB, then given back.
+	const pool = (v) => ({ t: 0, v: v });
+	const came = [
+		{ t: 0, v: [0, 1.5, 4, 0.1, 5] },
+		{ t: 120, v: [8, 1.5, 4, 0.1, 5] },
+		{ t: 240, v: [0, 1.5, 4, 0.1, 5] },
+	];
+	const said = memSentence(came, 17 * MB, 34 * MB);
+	check('a pool that came and went inside the window is named',
+		said.indexOf('Video buffers rose to 8.0 MB and came back') >= 0, said);
+
+	// A slice the camera genuinely did not report at one end must not be
+	// silenced at the other: its own first and last reading are the endpoints.
+	const gap = [
+		{ t: 0, v: [null, 1.5, 4, 0.1, 5] },
+		{ t: 120, v: [8, 1.5, 4, 0.1, 5] },
+		{ t: 240, v: [0, 1.5, 4, 0.1, 5] },
+	];
+	check('and a real gap at one end still leaves the slice its own endpoints',
+		memSentence(gap, 17 * MB, 34 * MB).indexOf('Video buffers \u22128.0') >= 0,
+		memSentence(gap, 17 * MB, 34 * MB));
+
+	// The reporter's board: a kernel that answers with a zero rather than by
+	// staying silent must not spend a clause saying nothing.
+	const empty = [{ t: 0, v: [0, 1.5, 4, 0.1, 10] }, { t: 240, v: [0, 1.5, 4, 0.1, 24.5] }];
+	check('a pool reported as zero the whole way is not named at all',
+		memSentence(empty, 17 * MB, 34 * MB).indexOf('Video buffers') < 0,
+		memSentence(empty, 17 * MB, 34 * MB));
+	void pool;
+}
+
 group('an absent key is a hole, not a floor');
 {
 	const held = 100 * MB;

--- a/www/a/charts.js
+++ b/www/a/charts.js
@@ -94,9 +94,16 @@ window.MjCharts = (function () {
 	}
 
 	// cfg: { h, lo, hi (null = auto), ref {v,label}|null, bands [{from,to,
-	// color,label}], colors [..], fmt, grid, refColor, win, gap } — series
-	// count = colors.length; `grid` is the hairline color, `refColor` the
-	// reference line's (defaults keep the dashboard's look).
+	// color,label}], colors [..], fmt, grid, refColor, win, gap, hide [..] } —
+	// series count = colors.length; `grid` is the hairline color, `refColor`
+	// the reference line's (defaults keep the dashboard's look).
+	//
+	// `hide` withholds a series from the DRAWING without withholding it from
+	// the data, which are two different questions and were briefly answered by
+	// one: pushing null to hide a line also told everything reading the points
+	// back that the value was unknown, and a memory slice that sat at zero and
+	// then rose and fell went unreported because the window still opened on one
+	// of those nulls. Push the truth; hide it here.
 	//
 	// Samples are timestamped and x is elapsed time, not sample index: a
 	// failed or slow poll leaves a real hole, so the line breaks across an
@@ -204,6 +211,7 @@ window.MjCharts = (function () {
 		}
 		const yBase = (padT + H).toFixed(1);
 		for (let si = 0; si < cfg.colors.length; si++) {
+			if (cfg.hide && cfg.hide[si]) continue;
 			// line and area are built per contiguous run: a null value or a
 			// gap longer than CHART_GAP closes the run, so neither the stroke
 			// nor the fill spans an outage.

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -901,11 +901,26 @@
 		if (pts.length < 2) return txt;
 		const a = pts[0], b = pts[pts.length - 1], parts = [], rose = [];
 		for (let i = 0; i < MEM_NAMES.length; i++) {
-			if (a.v[i] == null || b.v[i] == null) continue;
+			// Each slice's OWN first and last, not the window's: a slice the
+			// camera did not report at one end must not silence it at the
+			// other, which is how a pool that appeared mid-window used to lose
+			// its whole story to a single null.
+			let first = null, last = null, top = -Infinity, any = false;
+			for (let j = 0; j < pts.length; j++) {
+				const x = pts[j].v[i];
+				if (x == null) continue;
+				if (first === null) first = x;
+				last = x;
+				if (x > top) top = x;
+				if (x) any = true;
+			}
+			// Never reported, or reported as nothing the whole way: naming it
+			// costs a clause and says nothing about this camera.
+			if (first === null || !any) continue;
 			// A tenth of a megabyte is the resolution here, so a change too
 			// small to print gets no sign: "Kernel 0.0" rather than
 			// "Kernel \u22120.0", which claims a direction it cannot see.
-			const d = b.v[i] - a.v[i], mag = Math.abs(d).toFixed(1);
+			const d = last - first, mag = Math.abs(d).toFixed(1);
 			parts.push(MEM_NAMES[i] + ' ' +
 				(mag === '0.0' ? '' : d < 0 ? '\u2212' : '+') + mag);
 			// The two ends of the window are not the story when something grew
@@ -915,10 +930,7 @@
 			// -0.1 MB". Saying nothing happened while something did is the
 			// exact fault this panel exists to stop committing, so a peak that
 			// clears both ends by a margin worth printing is named outright.
-			let top = -Infinity;
-			for (let j = 0; j < pts.length; j++)
-				if (pts[j].v[i] != null && pts[j].v[i] > top) top = pts[j].v[i];
-			if (top - Math.max(a.v[i], b.v[i]) >= MEM_PEAK)
+			if (top - Math.max(first, last) >= MEM_PEAK)
 				rose.push(MEM_NAMES[i] + ' rose to ' + top.toFixed(1) +
 					' MB and came back');
 		}
@@ -958,14 +970,18 @@
 		// no pool to speak of answers the question with a zero rather than by
 		// staying silent, and on the reporter's gk7205v210 that put a
 		// permanently flat line along the axis and took a legend slot for
-		// something the camera does not have (#322). A slice held back this
-		// way is pushed as null rather than as zero, or the chart would draw
-		// the line anyway with nothing naming it.
+		// something the camera does not have (#322). What is withheld is the
+		// LINE and the legend entry, through the chart's own `hide` — never
+		// the value, which goes in as measured. Pushing null to hide it also
+		// says the value was unknown, and a pool that sat at zero and then
+		// rose and fell then went unreported because the window still opened
+		// on one of those nulls.
 		MEM_LEGEND.forEach((id, i) => {
 			if (slices[i]) memHas[i] = true;
 			const e = $(id);
 			if (e) e.hidden = !memHas[i];
 		});
+		if (chMem) chMem.cfg.hide = memHas.map(h => !h);
 
 		const now = performance.now() / 1000, k = Math.floor(now / MEM_SLOT);
 		if (k !== memSlot) {
@@ -978,8 +994,7 @@
 						break;
 					}
 			}
-			pushChart(chMem, slices.map((x, i) =>
-				x == null || !memHas[i] ? null : x / 1048576));
+			pushChart(chMem, slices.map(x => x == null ? null : x / 1048576));
 		}
 
 		// This tile alone is an hour wide, and says so. Four identical

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -870,6 +870,11 @@
 	}
 
 	const MEM_NAMES = ['Video buffers', 'Programs', 'Kernel', 'RAM disk', 'Other'];
+	// How far above both ends of the window a peak has to stand before the note
+	// names it. A megabyte, because the deltas print to a tenth and a swing
+	// smaller than this is the ordinary breathing of a running camera rather
+	// than something that happened.
+	const MEM_PEAK = 1;
 	const MEM_LEGEND = ['#st-mem-lg-vid', '#st-mem-lg-prog', '#st-mem-lg-krn',
 		'#st-mem-lg-disk', '#st-mem-lg-other'];
 	const memHas = [false, false, false, false, false];
@@ -884,6 +889,44 @@
 		if (m < 60) return m + ' min';
 		const h = (m / 60) | 0, r = m % 60;
 		return h + ' h' + (r ? ' ' + r + ' min' : '');
+	}
+
+	// The sentence under the chart, built from the points the chart is holding.
+	// Pure and separate because it is the half of this panel that people quote
+	// and screenshot, and it is the half that got the reporter's own leak
+	// wrong -- so it is worth being able to test without a DOM.
+	function memSentence(pts, held, total) {
+		let txt = 'Holding ' + (held / 1048576 | 0) + ' of ' +
+			(total / 1048576 | 0) + ' MB.';
+		if (pts.length < 2) return txt;
+		const a = pts[0], b = pts[pts.length - 1], parts = [], rose = [];
+		for (let i = 0; i < MEM_NAMES.length; i++) {
+			if (a.v[i] == null || b.v[i] == null) continue;
+			// A tenth of a megabyte is the resolution here, so a change too
+			// small to print gets no sign: "Kernel 0.0" rather than
+			// "Kernel \u22120.0", which claims a direction it cannot see.
+			const d = b.v[i] - a.v[i], mag = Math.abs(d).toFixed(1);
+			parts.push(MEM_NAMES[i] + ' ' +
+				(mag === '0.0' ? '' : d < 0 ? '\u2212' : '+') + mag);
+			// The two ends of the window are not the story when something grew
+			// and was then given back. The reporter of #322 ran this on their
+			// own camera and it drew Other climbing 10 to 24.5 MB and falling
+			// back as the stream stopped, under a sentence reading "Other
+			// -0.1 MB". Saying nothing happened while something did is the
+			// exact fault this panel exists to stop committing, so a peak that
+			// clears both ends by a margin worth printing is named outright.
+			let top = -Infinity;
+			for (let j = 0; j < pts.length; j++)
+				if (pts[j].v[i] != null && pts[j].v[i] > top) top = pts[j].v[i];
+			if (top - Math.max(a.v[i], b.v[i]) >= MEM_PEAK)
+				rose.push(MEM_NAMES[i] + ' rose to ' + top.toFixed(1) +
+					' MB and came back');
+		}
+		if (parts.length)
+			txt += ' Over the last ' + spanWords(b.t - a.t) + ': ' +
+				parts.join(', ') + ' MB.';
+		if (rose.length) txt += ' ' + rose.join('. ') + '.';
+		return txt;
 	}
 
 	function renderMemory(v, s) {
@@ -904,13 +947,22 @@
 				colors: [C4, C1, C3, C2, MUTE],
 			});
 		}
-		// Which slices have a key is re-asked every sample, not settled on the
-		// first: one that starts reporting later would otherwise draw a line
-		// the legend does not name (#320, a gauge that arrives late still gets
-		// its row). It is one-way, because the chart keeps what a slice has
-		// already drawn and a key that named it must not go with the gap.
+		// Which slices are worth drawing is re-asked every sample, not settled
+		// on the first: one that starts reporting later would otherwise draw a
+		// line the legend does not name (#320, a gauge that arrives late still
+		// gets its row). It is one-way, because the chart keeps what a slice
+		// has already drawn and a key that named it must not go with the gap.
+		//
+		// The bar is a slice that has ever been NON-ZERO, not one that has
+		// ever been reported. A kernel built with contiguous-pool support but
+		// no pool to speak of answers the question with a zero rather than by
+		// staying silent, and on the reporter's gk7205v210 that put a
+		// permanently flat line along the axis and took a legend slot for
+		// something the camera does not have (#322). A slice held back this
+		// way is pushed as null rather than as zero, or the chart would draw
+		// the line anyway with nothing naming it.
 		MEM_LEGEND.forEach((id, i) => {
-			if (slices[i] != null) memHas[i] = true;
+			if (slices[i]) memHas[i] = true;
 			const e = $(id);
 			if (e) e.hidden = !memHas[i];
 		});
@@ -926,7 +978,8 @@
 						break;
 					}
 			}
-			pushChart(chMem, slices.map(x => x == null ? null : x / 1048576));
+			pushChart(chMem, slices.map((x, i) =>
+				x == null || !memHas[i] ? null : x / 1048576));
 		}
 
 		// This tile alone is an hour wide, and says so. Four identical
@@ -939,26 +992,8 @@
 			: '';
 
 		const note = $('#st-mem-note');
-		if (!note) return;
-		let txt = 'Holding ' + (held / 1048576 | 0) + ' of ' +
-			(s.memTotal / 1048576 | 0) + ' MB.';
-		const pts = chMem ? chMem.pts : [];
-		if (pts.length >= 2) {
-			const a = pts[0], b = pts[pts.length - 1], parts = [];
-			for (let i = 0; i < MEM_NAMES.length; i++) {
-				if (a.v[i] == null || b.v[i] == null) continue;
-				// A tenth of a megabyte is the resolution here, so a change
-				// too small to print gets no sign: "Kernel 0.0" rather than
-				// "Kernel \u22120.0", which claims a direction it cannot see.
-				const d = b.v[i] - a.v[i], mag = Math.abs(d).toFixed(1);
-				parts.push(MEM_NAMES[i] + ' ' +
-					(mag === '0.0' ? '' : d < 0 ? '\u2212' : '+') + mag);
-			}
-			if (parts.length)
-				txt += ' Over the last ' + spanWords(b.t - a.t) + ': ' +
-					parts.join(', ') + ' MB.';
-		}
-		note.textContent = txt;
+		if (note) note.textContent =
+			memSentence(chMem ? chMem.pts : [], held, s.memTotal);
 	}
 
 	function humanKB(kb) {


### PR DESCRIPTION
Follow-up to #324, from the reporter's own screenshot on [#322](https://github.com/OpenIPC/majestic-webui/issues/322#issuecomment-5542295062).

They updated a gk7205v210 and ran it. **The panel worked**: `Other` climbed 10 → 24.5 MB through four minutes of outgoing stream and fell back the moment the stream stopped — the first continuous picture of what majestic#311 has been chasing by hand, and it lands where the evidence there says it should (not Programs, not Kernel, not RAM disk).

The sentence underneath read:

> Over the last 4 min: Video buffers 0.0, Programs +0.1, Kernel 0.0, RAM disk 0.0, **Other −0.1 MB.**

## 1. Two endpoints are not the story

Each delta was `pts[last] − pts[0]`, so a rise and a release net to nothing. The chart showed the event; the sentence denied it — and the sentence is the half people quote and screenshot. Saying nothing happened while something did is the exact fault this panel was written to stop committing.

A peak that clears **both** ends by a margin worth printing is now named outright:

> … Other −0.1 MB. **Other rose to 24.5 MB and came back.**

A climb that only ever went up gets no clause, because the delta already says it. A sub-megabyte swing is a running camera breathing, not an event.

The sentence moved into `memSentence()`, pure and separate — it is the half of this panel that got the reporter's own leak wrong, which makes it the half worth being able to test without a DOM.

## 2. A pool that isn't there still took a legend slot

`Video buffers` had a legend entry and a flat line along the axis on a board with no such pool. A kernel built with contiguous-pool support but nothing in it answers with a **zero** rather than by staying silent, and the gate was "has this ever been reported" rather than "has this ever been anything". Held-back slices push `null` rather than `0`, or the chart draws the line anyway with nothing naming it.

## Verified

On a lab camera against a deliberate rise-and-fall, which is what tripped it:

| moment | note |
| --- | --- |
| t+115s, still climbing | `RAM disk +13.5` — no clause |
| t+215s, after the release | `RAM disk −1.0 MB. RAM disk rose to 18.3 MB and came back.` |

A camera that does have a real pool still draws it, so the second fix doesn't regress the case #324 was built around.

`tests/mem-slices.test.js` gains the sentence, driven at the reporter's exact shape (10 → 24.5 → 10.1), plus the monotonic climb and the sub-megabyte wobble that must *not* trip the clause.
