### PR TITLE
Live: the control bar wraps on a phone, and the pad steps out of its way

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/requires.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js"
+    "test": "node tests/requires.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js && node tests/preview-hero.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/preview-hero.test.js
+++ b/tests/preview-hero.test.js
@@ -1,0 +1,200 @@
+// preview-hero.js — how the control bar and the PTZ pad share the bottom of
+// the Live stage.
+//
+// What must hold, in one sentence each: the bar's measured strip is published
+// for the two pieces of chrome that have to keep off it; the pad rides above
+// that strip where the stage is tall enough to stack them; where it is not and
+// the stage is wider than tall the bar gives way sideways instead; and the
+// answer is a function of the stage's size alone, never of the order it was
+// resized in — which is the one that is easy to get wrong, because reserving
+// the pad's column makes the bar taller and a naive second pass reads that
+// back as even less room.
+//
+// It is here rather than left to the camera because reaching the fault needs a
+// phone, a camera with a PTZ pad and a particular orientation, and it is
+// silent when it happens: the pad simply draws over two of the bar's rows, the
+// page reports nothing, and every control it covers is still in the DOM.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-hero.js');
+
+// A stand-in for the parts of an element this file measures. The bar's height
+// is not a constant given to the test: it is derived from the lane it has,
+// the way a wrapping flex row derives it, so reserving the pad's column really
+// does cost rows here as it does in a browser.
+function makeStage(opts) {
+	const groups = opts.groups; // widths, in the bar's own order
+	const gap = 8, padX = 24, padTop = 20, padBottom = 8, rowH = 52;
+	const el = (id) => ({
+		id,
+		style: {
+			_v: {},
+			setProperty(k, v) { this._v[k] = v; },
+			getPropertyValue(k) { return this._v[k] || ''; },
+		},
+		_cls: new Set(),
+		classList: {
+			add(c) { el._self._cls.add(c); },
+			remove(c) { el._self._cls.delete(c); },
+			contains(c) { return el._self._cls.has(c); },
+			toggle(c, on) { on ? this.add(c) : this.remove(c); },
+		},
+		addEventListener() {},
+	});
+	const mk = (id) => { const o = el(id); o._self = o; o.classList = {
+		add: (c) => o._cls.add(c), remove: (c) => o._cls.delete(c),
+		contains: (c) => o._cls.has(c),
+		toggle: (c, on) => (on ? o._cls.add(c) : o._cls.delete(c)),
+	}; return o; };
+
+	const stage = mk('mj-stage'), bar = mk('mj-bar'), ptz = mk('mj-ptz');
+	stage.clientWidth = opts.w;
+	stage.clientHeight = opts.h;
+	ptz.offsetHeight = opts.padH;
+	ptz.offsetWidth = opts.padW;
+	// The bar wraps into whatever lane it is left, and .mj-ptz-beside is the
+	// stylesheet reserving the pad's column out of that lane. Read off the
+	// stage's CURRENT width, so a resize moves the rows as it would in a
+	// browser — the first draft of this stub kept the width it was built with
+	// and made every post-resize assertion meaningless.
+	Object.defineProperty(bar, 'clientHeight', {
+		get() {
+			const lane = stage.clientWidth - padX -
+				(stage._cls.has('mj-ptz-beside') ? ptz.offsetWidth + 16 : 0);
+			let rows = 1, cur = 0;
+			for (const g of groups) {
+				const need = cur === 0 ? g : cur + gap + g;
+				if (need > lane && cur > 0) { rows++; cur = g; } else { cur = need; }
+			}
+			return padTop + rows * rowH + (rows - 1) * gap + padBottom;
+		},
+	});
+	return { stage, bar, ptz, padTop };
+}
+
+// Runs the module against one stage and hands back what it published, plus the
+// ResizeObserver callback so a test can re-run a layout after a resize.
+function boot(opts) {
+	const { stage, bar, ptz, padTop } = makeStage(opts);
+	const els = { '#mj-stage': stage, '#mj-bar': bar, '#mj-ptz': ptz };
+	let onResize = null;
+	const sandbox = {
+		window: {},
+		document: { addEventListener() {}, fullscreenEnabled: false },
+		$: (sel) => (sel in els ? els[sel] : null),
+		getComputedStyle: () => ({ paddingTop: padTop + 'px' }),
+		ResizeObserver: function (fn) { onResize = fn; this.observe = () => {}; },
+		setTimeout, clearTimeout, console,
+		mjConfig: () => ({ then: () => {} }),
+		mjGet: () => undefined,
+		apiFetch: () => ({ then: () => ({ then: () => ({ catch: () => ({ finally: () => {} }) }) }) }),
+	};
+	vm.createContext(sandbox);
+	vm.runInContext(fs.readFileSync(SRC, 'utf8'), sandbox, { filename: 'preview-hero.js' });
+	const read = () => ({
+		barH: stage.style._v['--mj-bar-h'],
+		padHVar: stage.style._v['--mj-ptz-h'],
+		padWVar: stage.style._v['--mj-ptz-w'],
+		beside: stage._cls.has('mj-ptz-beside'),
+		strip: bar.clientHeight - padTop,
+	});
+	return { stage, bar, ptz, read, resize: (w, h) => {
+		stage.clientWidth = w; stage.clientHeight = h;
+		if (onResize) onResize();
+	} };
+}
+
+// The six groups a camera without audio or talkback shows, measured on an
+// hi3516ev300: View, Area, Stream, Transport, Stats, icons.
+const SIX = [161, 108, 189, 146, 113, 98];
+// The eight a camera with both shows, with the volume group and Talk.
+const EIGHT = [161, 108, 189, 150, 110, 146, 113, 98];
+const PELCO = { padH: 211, padW: 134 };
+
+group('the strip the bar occupies is published, measured, not assumed');
+{
+	const b = boot({ w: 390, h: 785, groups: SIX, ...PELCO });
+	const r = b.read();
+	check('--mj-bar-h is the rows, without the gradient padding',
+		r.barH === '180.00px', 'got ' + r.barH);
+	check('the pad publishes its own size for the stylesheet clamp',
+		r.padHVar === '211px' && r.padWVar === '134px',
+		r.padHVar + ' / ' + r.padWVar);
+}
+
+group('a camera with no pad still publishes the strip');
+{
+	const b = boot({ w: 390, h: 785, groups: SIX, padH: 0, padW: 0 });
+	const r = b.read();
+	check('the stats panel gets its ceiling anyway', r.barH === '180.00px', 'got ' + r.barH);
+	check('nothing claims an arrangement', r.beside === false);
+	check('no pad size is invented', r.padHVar === undefined && r.padWVar === undefined);
+}
+
+group('which way the two give depends on which dimension has room');
+{
+	const portrait = boot({ w: 390, h: 785, groups: SIX, ...PELCO });
+	check('a portrait phone stacks: the pad rides above the bar',
+		portrait.read().beside === false);
+
+	const landscape = boot({ w: 740, h: 301, groups: SIX, ...PELCO });
+	check('a landscape phone cannot stack, and gives way sideways instead',
+		landscape.read().beside === true);
+
+	const desk = boot({ w: 1440, h: 841, groups: SIX, ...PELCO });
+	check('a desktop window stacks', desk.read().beside === false);
+}
+
+group('a portrait stage too small for either arrangement keeps the stacking');
+{
+	// 320x568 with audio and talkback: reserving the column would leave a lane
+	// narrower than one group, and the bar would answer with a row per group.
+	const b = boot({ w: 320, h: 509, groups: EIGHT, ...PELCO });
+	const r = b.read();
+	check('the column is not reserved', r.beside === false);
+	// Five rows and the bar's own bottom padding, against the eight rows the
+	// reserved column would have forced.
+	check('the bar is not driven to a row per group',
+		r.strip <= 5 * 52 + 4 * 8 + 8, 'strip ' + r.strip);
+}
+
+group('the arrangement is a function of the size, not of the resize history');
+{
+	// Landscape short first (beside, so the bar is taller), then the same
+	// stage as the portrait case above. Reading the bar back as the previous
+	// answer left it is what used to keep .mj-ptz-beside alive.
+	const b = boot({ w: 740, h: 301, groups: SIX, ...PELCO });
+	check('starts beside', b.read().beside === true);
+	b.resize(390, 785);
+	const after = b.read();
+	const fresh = boot({ w: 390, h: 785, groups: SIX, ...PELCO }).read();
+	check('resized into a portrait stage, it stacks like a fresh one',
+		after.beside === fresh.beside && after.barH === fresh.barH,
+		after.beside + '/' + after.barH + ' vs ' + fresh.beside + '/' + fresh.barH);
+
+	// The same in the one dimension that keeps the stage wider than tall: a
+	// short landscape stage growing tall enough to stack.
+	const c = boot({ w: 740, h: 301, groups: SIX, ...PELCO });
+	check('starts beside', c.read().beside === true);
+	c.resize(740, 600);
+	const grown = c.read();
+	const freshWide = boot({ w: 740, h: 600, groups: SIX, ...PELCO }).read();
+	check('grown taller, it stops reserving the column',
+		grown.beside === false && grown.barH === freshWide.barH,
+		grown.beside + '/' + grown.barH + ' vs ' + freshWide.barH);
+}
+
+group('the published strip describes the arrangement in force');
+{
+	const b = boot({ w: 740, h: 301, groups: SIX, ...PELCO });
+	const r = b.read();
+	check('beside publishes the taller, column-reserving bar',
+		r.barH === r.strip.toFixed(2) + 'px', r.barH + ' vs ' + r.strip);
+}
+
+done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2472,8 +2472,11 @@ mark {
 	z-index: 5;
 	width: min(92%, 21rem);
 	/* Leave the bar's strip free below, and scroll rather than grow: on a
-	   short viewport the numbers yield, not the picture. */
-	max-height: calc(100% - 5rem);
+	   short viewport the numbers yield, not the picture. The strip is as tall as
+	   the bar actually is (--mj-bar-h, preview-hero.js) — the 5rem this used to
+	   be is one row of it, and the panel ran under the other rows wherever the
+	   bar wrapped. */
+	max-height: calc(100% - var(--mj-bar-h, 4.5rem) - 0.5rem);
 	overflow: auto;
 	background: rgba(13, 15, 20, 0.72);
 	border: 1px solid rgba(255, 255, 255, 0.09);
@@ -2947,49 +2950,22 @@ mark {
 }
 
 /* On a phone the control groups do not fit one bar row — measured at 390px the
-   stage is 330 wide and the groups want ~413 — and letting them wrap stacks the
-   bar two or three rows deep over a stage that is only 186px tall. One row,
-   scrolled sideways. (After the base .mj-bar rule — same specificity, so order
-   is what makes it win.) */
+   six groups this camera shows want 855px against a 366px lane — so the bar
+   wraps onto as many rows as it needs, which is what it already does at every
+   other width.
+
+   It was one row scrolled sideways until #318, and that was right for the page
+   this used to be: the Live stage was a card 330×186, and three rows of bar
+   would have been most of the picture. #289 made the page the picture, and the
+   same phone's stage is 390×785 — where three rows are 200px, a quarter of it,
+   and only while the bar is up, since a tap is what reveals it. What the scroll
+   cost is measured on the same phone: 489px of the bar's 879 were off-screen,
+   more than half of it, behind a sideways gesture over a picture where every
+   other drag pans or draws. (After the base .mj-bar rule — same specificity,
+   so order is what makes it win.) */
 @media (max-width: 767.98px) {
 	.mj-bar {
-		flex-wrap: nowrap;
-		/* Back to the start edge: a centred flex row that overflows puts its
-		   first group off the left of the scrollport, where no scroll gesture
-		   reaches it. */
-		justify-content: flex-start;
-		overflow-x: auto;
 		padding-top: 1.25rem;
-		/* A default scrollbar draws a bright strip the width of the picture.
-		   Kept rather than hidden — with a group cut off at the right edge it
-		   is the second half of the affordance — but drawn as the glass would
-		   draw it. */
-		scrollbar-width: thin;
-		scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
-	}
-
-	.mj-bar::-webkit-scrollbar {
-		height: 3px;
-	}
-
-	.mj-bar::-webkit-scrollbar-track {
-		background: transparent;
-	}
-
-	.mj-bar::-webkit-scrollbar-thumb {
-		border-radius: 2px;
-		background: rgba(255, 255, 255, 0.25);
-	}
-
-	/* Fullscreen is what a phone actually needs from this bar — it is how a
-	   330px stage becomes a usable one — so the icon group is pinned to the
-	   right edge of the scrollport instead of being the thing that falls off
-	   it. What gets cut mid-group is then a stateful control that is already
-	   visible, and a group cut in half is the only scroll affordance a bar
-	   this size can carry. */
-	.mj-ico-wrap {
-		position: sticky;
-		right: 0;
 	}
 
 	/* Thumb-sized while still on the picture. The bar stays overlaid here
@@ -3012,11 +2988,33 @@ mark {
 /* PTZ pad, above the bar's strip so a hold cannot land on a bar control. The
    buttons are real buttons this time — focusable, labelled, and big enough
    that a thumb finds them on the first try. touch-action:none or a
-   press-and-hold scrolls the page instead of panning the camera. */
+   press-and-hold scrolls the page instead of panning the camera.
+
+   --mj-bar-h is where the bar's top row of controls is (preview-hero.js
+   measures it), because the strip the pad has to clear is not one row high on
+   every camera and at every width: the bar wraps, and how many rows it takes
+   depends on the window, on which groups this camera has, and on whether the
+   transport picker is there at all. The 3.25rem it used to be was one row's
+   worth, so a bar that wrapped — a phone, or any window under about 900px —
+   put its upper rows underneath the pad, which draws over them. The fallback
+   is that same 3.25rem, so a page whose chrome script did not load lands
+   exactly where it used to.
+
+   Measured on layout, not on reveal: the bar fades (opacity), so its height is
+   the same whether it is on screen or not, and the pad never moves under a
+   thumb that is holding it.
+
+   The min() is the floor of the whole arrangement: a pad pushed off the top of
+   the stage is not awkward, it is gone — there is no page to scroll to reach
+   it — so where the strip and the pad cannot both fit, the pad stops at the
+   top and takes the overlap. --mj-ptz-h is 0 until the script has measured the
+   pad, which leaves the first term to win, exactly as it did before there was
+   a second one. */
 .mj-ptz {
 	position: absolute;
 	right: 0.5rem;
-	bottom: 3.25rem;
+	bottom: max(0.5rem, min(calc(var(--mj-bar-h, 3.25rem) + 0.5rem),
+		calc(100% - var(--mj-ptz-h, 0px) - 0.5rem)));
 	/* Above the bar: the bar is later in the DOM and its (transparent)
 	   gradient padding reaches up over the pad's lower row — at equal
 	   z-index it swallows the pointerdown that starts a hold. */
@@ -3026,6 +3024,22 @@ mark {
 	flex-direction: column;
 	align-items: flex-end;
 	gap: 6px;
+}
+
+/* The other half of that arrangement, for a stage too short to stack the two —
+   a phone in landscape, where 301px of picture has to hold a 211px zoom/focus
+   cluster and a two-row bar. The pad goes back to its corner and the bar keeps
+   out of its column instead, which is affordable there for the same reason the
+   stacking is not: the stage is 740 wide, so the groups take the same two rows
+   in the lane that is left. preview-hero.js decides which case this is and
+   measures the column; the fallback width is only used if that measurement has
+   not happened, which is also the only state in which the class is never set. */
+.mj-stage.mj-ptz-beside .mj-ptz {
+	bottom: 0.5rem;
+}
+
+.mj-stage.mj-ptz-beside .mj-bar {
+	padding-right: calc(var(--mj-ptz-w, 9rem) + 1rem);
 }
 
 /* Both pads are one glass panel with the buttons inside it, rather than a

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2475,8 +2475,11 @@ mark {
 	   short viewport the numbers yield, not the picture. The strip is as tall as
 	   the bar actually is (--mj-bar-h, preview-hero.js) — the 5rem this used to
 	   be is one row of it, and the panel ran under the other rows wherever the
-	   bar wrapped. */
-	max-height: calc(100% - var(--mj-bar-h, 4.5rem) - 0.5rem);
+	   bar wrapped. --mj-pic-top is in here for the same reason it is in the top
+	   above: the height available is measured from where the panel STARTS, and a
+	   letterboxed picture starts it that far down, so leaving it out let a full
+	   panel reach into the bar by exactly the depth of the band. */
+	max-height: calc(100% - var(--mj-pic-top, 0px) - var(--mj-bar-h, 4.5rem) - 1rem);
 	overflow: auto;
 	background: rgba(13, 15, 20, 0.72);
 	border: 1px solid rgba(255, 255, 255, 0.09);

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -103,9 +103,14 @@
 	// stage too small for either arrangement keeps the stacking and lets the
 	// stylesheet's clamp hold the pad on screen (--mj-ptz-h).
 	//
-	// The flip only ever runs one way on its own: reserving the column can make
-	// the bar taller, which leaves the pad less room, which is the same answer
-	// again. So there is no width at which the two settings chase each other.
+	// The question is asked of the bar's NATURAL height, which is why the class
+	// comes off before the measurement rather than being toggled at the end:
+	// reserving the column makes the bar taller, so a second pass that measured
+	// the bar as the first pass left it would find even less room and keep the
+	// answer alive after the stage had grown enough to make it wrong. The
+	// arrangement would then depend on the order a window was resized in rather
+	// than on the size it ended up. Removing and re-adding inside one callback
+	// costs a second layout and paints nothing in between.
 	//
 	// The height published is to the top of the top ROW, not to the top of the
 	// element: the bar's padding-top is the transparent end of its gradient, and
@@ -117,23 +122,32 @@
 	// nothing keyed to it moves while somebody is holding the pad.
 	const ptz = $('#mj-ptz');
 	const GAP = 8;
-	const layoutChrome = () => {
-		const padTop = parseFloat(getComputedStyle(bar).paddingTop) || 0;
-		const strip = bar.clientHeight - padTop;
+	const stripHeight = () =>
+		bar.clientHeight - (parseFloat(getComputedStyle(bar).paddingTop) || 0);
+	const publishStrip = (strip) => {
 		if (strip > 0) stage.style.setProperty('--mj-bar-h', strip.toFixed(2) + 'px');
+	};
+	const layoutChrome = () => {
 		// offsetHeight rather than a class check: a camera with no PTZ at all
 		// mounts nothing into #mj-ptz, and one whose ptz_caps drop the direction
-		// pad mounts a shorter cluster than one that keeps it.
+		// pad mounts a shorter cluster than one that keeps it. With no pad there
+		// is nothing to arrange — the stats panel still wants the strip's height.
 		const padH = ptz ? ptz.offsetHeight : 0;
-		if (!padH) return;
-		const sw = stage.clientWidth, sh = stage.clientHeight;
+		if (!padH) {
+			publishStrip(stripHeight());
+			return;
+		}
+		stage.classList.remove('mj-ptz-beside');
+		const natural = stripHeight();
+		const beside = natural + GAP + padH > stage.clientHeight &&
+			stage.clientWidth > stage.clientHeight;
+		if (beside) stage.classList.add('mj-ptz-beside');
+		publishStrip(beside ? stripHeight() : natural);
 		// Published for the clamp that keeps the pad inside the stage whichever
 		// arrangement is in force: pushed off the top it is not merely awkward,
 		// it is unreachable — there is nothing to scroll.
 		stage.style.setProperty('--mj-ptz-h', padH + 'px');
 		stage.style.setProperty('--mj-ptz-w', ptz.offsetWidth + 'px');
-		const stacks = strip + GAP + padH <= sh;
-		stage.classList.toggle('mj-ptz-beside', !stacks && sw > sh);
 	};
 	layoutChrome();
 	// The bar and the pad themselves, not the window: the groups the bar holds

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -73,6 +73,87 @@
 	const stage = $('#mj-stage'), bar = $('#mj-bar');
 	if (!stage || !bar) return;
 
+	// --- The bar and the PTZ pad share the bottom of the stage, and this is what
+	// keeps them off each other. Both used to be placed against constants — the
+	// pad at 3.25rem, the stats panel's ceiling at 5rem — and a constant is one
+	// row of a bar that WRAPS. Measured at 390px the six groups this camera shows
+	// want 855px against a 366px lane, so the bar is three rows there; the pad
+	// draws over the bar, so it covered two of them (#318).
+	//
+	// Which of the two gives way depends on which dimension has room, and that is
+	// the whole of the rule:
+	//
+	//   * Where the stage is tall enough to stack them, the pad rides ABOVE the
+	//     bar's top row: --mj-bar-h, below. A portrait phone is this case —
+	//     390x785 of stage, 200px of bar, and the pad clears it with 370 to
+	//     spare.
+	//   * Where it is not AND the stage is wider than it is tall, the pad stays
+	//     in its corner and the BAR gives way sideways instead, reserving the
+	//     pad's column (.mj-ptz-beside + --mj-ptz-w). A phone in landscape is
+	//     this case and cannot be the other one: 301px of stage against a 211px
+	//     zoom/focus cluster and a two-row bar do not stack in any arrangement —
+	//     but the stage is 740 wide there, so the same groups take the same two
+	//     rows in the lane that is left.
+	//
+	// Wider-than-tall is what says the second arrangement is affordable, and it
+	// has to be asked: reserving 150px of a 320px stage leaves a lane narrower
+	// than one group, and the bar answers by giving every group a row of its own
+	// — measured at 320x568 with audio, 8 rows and 500px of bar over a 509px
+	// stage. That is worse than the overlap it was trying to avoid, so a portrait
+	// stage too small for either arrangement keeps the stacking and lets the
+	// stylesheet's clamp hold the pad on screen (--mj-ptz-h).
+	//
+	// The flip only ever runs one way on its own: reserving the column can make
+	// the bar taller, which leaves the pad less room, which is the same answer
+	// again. So there is no width at which the two settings chase each other.
+	//
+	// The height published is to the top of the top ROW, not to the top of the
+	// element: the bar's padding-top is the transparent end of its gradient, and
+	// clearing that as well would push the pad a further 2rem up the picture for
+	// nothing.
+	//
+	// Layout is when this runs, never the reveal: the bar fades in and out on
+	// opacity, so its height is the same whether it is on screen or not, and
+	// nothing keyed to it moves while somebody is holding the pad.
+	const ptz = $('#mj-ptz');
+	const GAP = 8;
+	const layoutChrome = () => {
+		const padTop = parseFloat(getComputedStyle(bar).paddingTop) || 0;
+		const strip = bar.clientHeight - padTop;
+		if (strip > 0) stage.style.setProperty('--mj-bar-h', strip.toFixed(2) + 'px');
+		// offsetHeight rather than a class check: a camera with no PTZ at all
+		// mounts nothing into #mj-ptz, and one whose ptz_caps drop the direction
+		// pad mounts a shorter cluster than one that keeps it.
+		const padH = ptz ? ptz.offsetHeight : 0;
+		if (!padH) return;
+		const sw = stage.clientWidth, sh = stage.clientHeight;
+		// Published for the clamp that keeps the pad inside the stage whichever
+		// arrangement is in force: pushed off the top it is not merely awkward,
+		// it is unreachable — there is nothing to scroll.
+		stage.style.setProperty('--mj-ptz-h', padH + 'px');
+		stage.style.setProperty('--mj-ptz-w', ptz.offsetWidth + 'px');
+		const stacks = strip + GAP + padH <= sh;
+		stage.classList.toggle('mj-ptz-beside', !stacks && sw > sh);
+	};
+	layoutChrome();
+	// The bar and the pad themselves, not the window: the groups the bar holds
+	// are unhidden as the player learns what this camera has — a substream,
+	// audio, a transport to offer — and preview-ptz.js mounts the pad when
+	// j/ptz.cgi answers. Every one of those changes the arithmetic above with
+	// the window standing still.
+	if (typeof ResizeObserver === 'function') {
+		try {
+			const ro = new ResizeObserver(layoutChrome);
+			ro.observe(bar);
+			ro.observe(stage);
+			if (ptz) ro.observe(ptz);
+		} catch (e) {
+			window.addEventListener('resize', layoutChrome);
+		}
+	} else {
+		window.addEventListener('resize', layoutChrome);
+	}
+
 	// --- Bar visibility. CSS shows the bar on :hover (mouse) and
 	// :focus-within (keyboard); this handles the rest: mouse movement keeps it
 	// up briefly even when :hover is unreliable (e.g. straight after


### PR DESCRIPTION
Closes #318.

On a phone the Live bar was one row scrolled sideways. Measured on an hi3516ev300 at 390 CSS px, its six groups want **879px in a 390px scrollport — 489px of it, more than half, off screen**, behind a sideways gesture on a picture where every other drag pans or draws a zoom box. At 320px, 559px are hidden. The reporter's video shows the sticky icon group sitting on the transport picker while they scroll to reach it.

**The rule was stale rather than wrong.** The `flex-wrap: nowrap` block's own comment said "the stage is 330 wide … only 186px tall" — true while Live was a card. #289 made the page full-bleed, and the same phone's stage measures **390×785**; that commit rewrote the PTZ pad's comment for the new geometry and left the bar's rationale describing a page that no longer existed. So most of this is a deletion: the nowrap, the `overflow-x`, the scrollbar styling and the sticky `.mj-ico-wrap` go, and the bar wraps below `md` as it already does at every other width. Three centred rows at 390px are 200px, a quarter of the stage, and only while a tap has the bar up.

**Wrapping alone would have hidden two controls.** The pad is `bottom: 3.25rem; z-index: 7` — it draws *over* the bar, and 3.25rem is one row's worth; wrapped, it covered Area and the transport picker. That overlap was already there unfixed on any window under about 900px (at 768×1024 the pad covers the transport picker on master today), and the stats panel carried the same constant (`max-height: calc(100% - 5rem)`). So `preview-hero.js` publishes `--mj-bar-h`, the measured height of the bar's rows — the way `--mj-chip-h` already carries the chip's for the toast stack — and both old constants stay as the var's fallback, so a page whose chrome script did not load lands exactly where it used to.

**Two arrangements, chosen by which dimension has room.** Where the stage is too short to stack them *and* wider than tall, `.mj-ptz-beside` returns the pad to its corner and reserves its column in the bar instead. A phone in landscape is that case and cannot be the other one — 301px of stage against a 211px zoom/focus cluster and a two-row bar — but it is 740 wide, so the same groups take the same two rows in the lane left over. Wider-than-tall has to be asked: reserving 150px of a 320px stage leaves a lane narrower than one group, and the bar answers with a row per group (8 rows, 500px over a 509px stage — worse than the overlap being avoided).

Measured after the change, on a camera with a Pelco zoom/focus cluster:

| viewport | rows | bar | off-screen | pad over a control |
|---|---|---|---|---|
| 390×844 | 3 | 200px (25% of stage) | 0 | none |
| 360×740 | 4 | 260px | 0 | none |
| 430×932 | 3 | 200px | 0 | none |
| 740×360 landscape | 2 | 140px, beside | 0 | none |
| 844×390 landscape | 2 | 129px | 0 | none |
| 768×1024 | 3 | 129px | 0 | none (master: transport picker) |
| 1440×900 | 2 | 82px | 0 | none |
| 320×568 + audio + talkback | 5 | 320px | 0 | clips one control |

The last row is the single geometry where neither arrangement fits — smallest phone, a camera with audio *and* talkback *and* a Pelco cluster. A CSS clamp keeps the pad inside the stage there: off the top it would be unreachable, since a full-bleed page has nothing to scroll, so it stops at the top and clips the corner of Area.

Full suite passes. No markup changed, so `bootstrap.min.css` is untouched.