### PR TITLE
Motion detection: a region the camera will ignore says so before it is saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/requires.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js && node tests/preview-hero.test.js"
+    "test": "node tests/requires.test.js && node tests/region-verdict.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js && node tests/preview-hero.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/tests/region-verdict.test.js
+++ b/tests/region-verdict.test.js
@@ -1,0 +1,169 @@
+// The region editor's verdict on a rectangle somebody typed.
+//
+// This exists because the subject fails silently, and in the direction that
+// costs the most. Every branch renders a confident-looking chip beside the
+// coordinates -- the version this replaced printed `0%` for a region of zero
+// width, `1%` for one nine thousand pixels off the picture and `1085048%` for
+// one bigger than the sensor, all in the same quiet grey as a region that
+// works -- so a wrong branch does not degrade the fix for
+// OpenIPC/majestic-webui#330, it reverts it.
+//
+// It also cannot be reproduced on demand: reaching most of these branches on a
+// real camera needs one at a known main resolution, a frame size that has
+// already arrived from the player's codec event, and someone willing to type
+// coordinates the editor is supposed to talk them out of. The numbers below
+// are the ones majestic actually stores and the ones the lab camera actually
+// reported.
+'use strict';
+
+const path = require('path');
+const { check, group, done } = require('./assert');
+
+const R = require(path.join(__dirname, '..', 'www', 'a', 'mj-region.js'));
+
+// The lab camera's main stream, and a rotated one: portrait is where a typed
+// coordinate is most likely to be out of bounds, because the two numbers swap
+// and nothing on the page says so.
+const MAIN = { w: 2592, h: 1520 };
+const PORTRAIT = { w: 1080, h: 1920 };
+
+group('parse accepts exactly what the camera can store');
+{
+	const r = R.parse('10x20x300x400');
+	check('four whole numbers', r && r.x === 10 && r.y === 20 && r.w === 300 && r.h === 400);
+	check('zero is a number', !!R.parse('0x0x0x0'));
+	// The camera accepts a blank there, so this IS a region it stores.
+	// Rejecting it here would be the page inventing a rule the camera has not
+	// got, and the page would be wrong about a config already on a card.
+	const sp = R.parse('0x0x10x 10');
+	check('a leading blank is skipped, as the camera skips it', sp && sp.h === 10);
+
+	// The one that mattered: the camera stores "-5" as 4294967291 while the
+	// editor drew it at minus five. Neither is what was typed and only one was
+	// on screen.
+	check('a minus sign is not a coordinate', R.parse('-5x-5x100x100') === null);
+	check('a fraction is not a coordinate', R.parse('1.5x2x3x4') === null);
+	check('three numbers are not a region', R.parse('10x20x30') === null);
+	check('five numbers are not a region', R.parse('1x2x3x4x5') === null);
+	check('words are not a region', R.parse('abcxdefxghixjkl') === null);
+	check('an empty string is not a region', R.parse('') === null);
+	check('nothing at all is not a region', R.parse(null) === null);
+	check('a stray comma is not a separator', R.parse('0x0x10x10,9x9x19x19') === null);
+}
+
+group('a region with no area is named, not scored');
+{
+	// Point 3 of the issue, in the reporter's own example: "100x100x 0x10 is a
+	// size error ... it is not visible".
+	const v = R.verdict(R.parse('100x100x0x10'), MAIN, 'region');
+	check('zero width is bad', v.cls === 'bad');
+	check('and is called what it is', v.text === 'no area');
+	check('with a sentence behind it', /no width or height/.test(v.title));
+
+	check('zero height too', R.verdict(R.parse('100x100x10x0'), MAIN).cls === 'bad');
+	check('zero everything too', R.verdict(R.parse('0x0x0x0'), MAIN).cls === 'bad');
+
+	// Said without bounds as well: this verdict needs no frame to be certain,
+	// and a camera whose frame size has not arrived yet is exactly when
+	// somebody is typing.
+	const nb = R.verdict(R.parse('100x100x0x10'), null);
+	check('and said before the frame size arrives', nb.cls === 'bad' && nb.text === 'no area');
+}
+
+group('a region outside the picture is named, not scored');
+{
+	// Point 4: the camera clamps every edge into the frame, so this arrives as
+	// a rectangle with no area. It used to read `1%`.
+	const off = R.verdict(R.parse('9000x9000x100x100'), MAIN, 'region');
+	check('entirely outside is bad', off.cls === 'bad');
+	check('and is called what it is', off.text === 'off picture');
+	check('the sentence names the frame it is outside of', /2592 × 1520/.test(off.title));
+
+	// Exactly at the far edge is outside it: a region starting on the last
+	// column has no column left to watch.
+	check('starting at the right edge is outside', R.verdict(R.parse('2592x0x10x10'), MAIN).cls === 'bad');
+	check('starting at the bottom edge is outside', R.verdict(R.parse('0x1520x10x10'), MAIN).cls === 'bad');
+	// One pixel inside the edge is still a region, and the last pixel of the
+	// frame is a region that fits exactly: "outside" has to mean outside, or
+	// the editor talks people out of the edges of their own picture.
+	check('the last pixel of the frame fits', R.verdict(R.parse('2591x1519x1x1'), MAIN).cls === 'ok');
+	check('and one that overhangs it is clipped, not off',
+		R.verdict(R.parse('2591x1519x10x10'), MAIN).text === '0% · clipped');
+}
+
+group('a region hanging over the edge is scored on the part that counts');
+{
+	// Half in, half out. The share is of the CLIPPED rectangle, because the
+	// clipped one is what the camera watches; scoring the typed one overstates
+	// the watch by exactly the part that was thrown away.
+	const v = R.verdict(R.parse('2542x0x100x1520'), MAIN, 'region');
+	check('clipping is flagged', v.cls === 'bad');
+	check('and the share is of what is left', v.text === '2% · clipped');
+	check('the sentence says which part counts', /Only the part inside/.test(v.title));
+
+	// The one bigger than the sensor: it used to read 1085048%, which is not a
+	// share of anything.
+	const huge = R.verdict(R.parse('0x0x99999x99999'), MAIN);
+	check('a region bigger than the frame is clipped, not 1085048%', huge.text === '100% · clipped');
+}
+
+group('a region that fits is scored, quietly');
+{
+	const half = R.verdict(R.parse('0x0x1296x1520'), MAIN, 'region');
+	check('half the frame is 50%', half.text === '50%');
+	check('and is not flagged', half.cls === 'ok');
+	check('the whole frame is 100%', R.verdict(R.parse('0x0x2592x1520'), MAIN).text === '100%');
+
+	// Rotated: the same coordinates that fit a landscape frame hang off a
+	// portrait one, and this is the case the reporter's camera was in.
+	check('landscape coordinates on a portrait frame are clipped',
+		R.verdict(R.parse('0x0x1920x1080'), PORTRAIT).cls === 'bad');
+	check('portrait coordinates on a portrait frame are not',
+		R.verdict(R.parse('0x0x1080x1920'), PORTRAIT).text === '100%');
+}
+
+group('without a frame size, only the verdicts that need none are given');
+{
+	// A judgement that cannot be made is not made: with no main resolution set
+	// and the picture on the sub stream, the editor does not know what the
+	// coordinates are in, so it must not call an in-bounds region out of them.
+	const v = R.verdict(R.parse('9000x9000x100x100'), null, 'region');
+	check('nothing is claimed about bounds', v.cls === 'ok');
+	check('and nothing is printed', v.text === '');
+	check('a zero-size frame is no frame at all',
+		R.verdict(R.parse('9000x9000x100x100'), { w: 0, h: 0 }).text === '');
+}
+
+group('the noun comes from the caller, because the promises differ');
+{
+	// The motion list and the privacy-mask list share this control and must not
+	// share a sentence: one says where to watch, the other burns black into
+	// everybody's picture.
+	check('a region does nothing with it',
+		/This region has no width/.test(R.verdict(R.parse('0x0x0x10'), MAIN, 'region').title));
+	check('a mask says mask', /This mask has no width/.test(
+		R.verdict(R.parse('0x0x0x10'), MAIN, 'mask').title));
+	check('the default is region', /This region/.test(R.verdict(R.parse('0x0x0x10'), MAIN).title));
+}
+
+group('the tally counts what the rows say, so the head cannot disagree');
+{
+	const rows = ['0x0x100x100', '100x100x0x10', '9000x9000x100x100', '', 'nonsense'];
+	const t = R.tally(rows, MAIN, 'region');
+	check('an empty row is not a region yet', t.n === 4);
+	check('three of the four are unusable', t.bad === 3);
+
+	const good = R.tally(['0x0x100x100', '200x200x300x300'], MAIN);
+	check('all usable counts none bad', good.n === 2 && good.bad === 0);
+	check('no rows at all is not an error', R.tally([], MAIN).n === 0);
+	check('no list at all is not an error', R.tally(null, MAIN).n === 0);
+
+	// The case the reporter was in: every region unusable. The count is what
+	// the page words its loudest sentence from -- detection is limited to the
+	// regions listed and does not fall back to the whole picture, so this is
+	// not a narrowed watch, it is no watch at all.
+	const dead = R.tally(['100x100x0x10', '9000x9000x100x100'], MAIN);
+	check('all bad is all bad', dead.n === 2 && dead.bad === 2);
+}
+
+done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2260,6 +2260,15 @@ mark {
 	color: var(--bs-warning);
 }
 
+/* The coordinate space the boxes above are written in. Tertiary and last,
+   because it is a fact you look up once and then stop reading — unlike the
+   warning above it, which is about what the camera is failing to do. */
+.mj-md-space {
+	margin-top: 0.5rem;
+	color: var(--bs-tertiary-color);
+	font-variant-numeric: tabular-nums;
+}
+
 /* Save and Apply live here together, and the bar is only in the document while
    one of them has something to do. It is the form's last child, so appearing
    and disappearing costs nothing above it — measured: the section card's top

--- a/www/a/mj-region.js
+++ b/www/a/mj-region.js
@@ -1,0 +1,119 @@
+// What the camera will do with a rectangle somebody typed.
+//
+// The region editor on the Motion detection and Overlay leaves stores
+// "XxYxWxH" strings, and until now it accepted whatever four numbers it could
+// read out of one. OpenIPC/majestic-webui#330 is what that costs, in the
+// reporter's own words: "it is possible to enter the size of the zone with a
+// zero value, which is incorrect -- it is not visible", and "entering
+// coordinates and size is not limited by the image resolution field".
+//
+// Both land in the same place on the camera. Each region edge is clamped into
+// the frame before anything is compared against it, so a region of zero width
+// and a region nine thousand pixels off the picture BOTH end up as a rectangle
+// with no area, and a rectangle with no area can never contain movement.
+// Detection is limited to the regions listed and does not fall back to the
+// whole picture when they are unusable, so one mistyped region does not narrow
+// the watch: it ends it. Nothing on the camera says so. The stream keeps
+// running, the counters keep counting, and majestic.yaml holds exactly what
+// was typed.
+//
+// This module is the decision, kept away from the DOM so it can be tested:
+// getting it wrong is silent in the worst way, because every branch of it
+// renders a confident-looking chip beside the coordinates -- the shipped
+// version printed `0%` for a zero-width region, `1%` for one entirely off the
+// picture, and `1085048%` for one bigger than the sensor, all in the same
+// quiet grey as a region that works.
+(function () {
+	'use strict';
+
+	// Four UNSIGNED WHOLE numbers, because that is the whole of what the camera
+	// can store -- measured by writing each of these through /api/v1/config and
+	// reading back what it did with them, not assumed.
+	//
+	// The editor used to use `Number`, which accepts more, and the difference
+	// was not cosmetic: `-5` parses there as minus five, and the camera stores
+	// it as 4294967291. The editor drew a rectangle off the top-left corner
+	// while the camera held one four billion pixels to the right. Neither was
+	// what was typed, and only one of them was on screen.
+	//
+	// Each part is trimmed first, because the camera accepts a blank there:
+	// `0x0x10x 10` is a region it stores, and calling it invalid here would be
+	// the page inventing a rule the camera does not have.
+	function parse(s) {
+		const p = String(s == null ? '' : s).split('x').map(function (t) {
+			return t.trim();
+		});
+		if (p.length !== 4) return null;
+		for (let i = 0; i < 4; i++)
+			if (!/^[0-9]+$/.test(p[i])) return null;
+		return { x: +p[0], y: +p[1], w: +p[2], h: +p[3] };
+	}
+
+	// The part of `r` that is inside a `b`-sized frame, which is the part the
+	// camera keeps. Null when nothing of it is.
+	function clip(r, b) {
+		if (!r || !b || !b.w || !b.h) return null;
+		const w = Math.min(r.x + r.w, b.w) - Math.max(r.x, 0);
+		const h = Math.min(r.y + r.h, b.h) - Math.max(r.y, 0);
+		return w > 0 && h > 0 ? { w: w, h: h } : null;
+	}
+
+	// The verdict for one row: a class, the chip's text, and the sentence
+	// behind it. `thing` is the caller's noun ("region", "mask") -- the two
+	// callers of the editor promise different things and must not share a
+	// sentence, but they fail in exactly the same way and can share this.
+	//
+	// `b` may be null: the frame size has not arrived yet, or the camera has no
+	// main resolution set. Then only the two verdicts that need no bounds are
+	// available, and the rest is left unsaid rather than guessed. A judgement
+	// that cannot be made is not made.
+	function verdict(r, b, thing) {
+		thing = thing || 'region';
+		if (!r) return { cls: 'bad', text: 'not XxYxWxH', title: '' };
+		if (!r.w || !r.h)
+			return {
+				cls: 'bad', text: 'no area',
+				title: 'This ' + thing + ' has no width or height, so the camera ' +
+					'does nothing with it.',
+			};
+		if (!b || !b.w || !b.h) return { cls: 'ok', text: '', title: '' };
+		const c = clip(r, b);
+		const size = b.w + ' × ' + b.h;
+		if (!c)
+			return {
+				cls: 'bad', text: 'off picture',
+				title: 'This ' + thing + ' is entirely outside the ' + size +
+					' picture, so the camera does nothing with it.',
+			};
+		// The share of the CLIPPED rectangle, not of the typed one: the clipped
+		// one is what is really being watched, and the difference is the whole
+		// of what an out-of-bounds region gets wrong.
+		const pct = Math.round(c.w * c.h / (b.w * b.h) * 100) + '%';
+		if (c.w < r.w || c.h < r.h)
+			return {
+				cls: 'bad', text: pct + ' · clipped',
+				title: 'Part of this ' + thing + ' is outside the ' + size +
+					' picture. Only the part inside it counts, and that is the ' +
+					'share shown.',
+			};
+		return { cls: 'ok', text: pct, title: 'share of the frame' };
+	}
+
+	// How many rows are regions, and how many of those the camera will do
+	// nothing with. Counted from the same verdict the rows print, so the head's
+	// count and the list beside it can never disagree. An empty row is not a
+	// region yet -- it is the one somebody has just opened to type into.
+	function tally(rows, b, thing) {
+		let n = 0, bad = 0;
+		(rows || []).forEach(function (raw) {
+			if (!raw) return;
+			n++;
+			if (verdict(parse(raw), b, thing).cls === 'bad') bad++;
+		});
+		return { n: n, bad: bad };
+	}
+
+	const api = { parse: parse, clip: clip, verdict: verdict, tally: tally };
+	if (typeof module === 'object' && module.exports) module.exports = api;
+	if (typeof window === 'object') window.MajesticRegion = api;
+})();

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1707,7 +1707,7 @@
 			if (!strip.querySelector('.mj-live-row')) strip.remove();
 		}
 
-		if (roiField && preview) {
+		if (roiField && preview && window.MajesticRegion) {
 			repaint = mountRegions(preview, roiField, regionBody, regionNote).repaint;
 			// The field's own reset, MOVED into the group head rather than made
 			// again — the same relocation dockRuntime does with the runtime
@@ -1723,12 +1723,15 @@
 			const gh = colRegions.querySelector('.mj-live-grp-head');
 			if (rst && gh) gh.appendChild(rst);
 		} else if (roiField) {
-			// No picture to draw on: say why once, rather than leaving the
-			// coordinate boxes to be explained by nothing.
+			// Nothing to draw on, or nothing to judge the drawing with: say
+			// which, rather than leaving the coordinate boxes to be explained by
+			// nothing — or explained by the wrong half, which is what naming the
+			// preview would do on a camera whose preview came up fine.
 			roiField.p.hidden = false;
 			const p = el('p', 'mj-live-hint');
-			p.textContent = 'The preview could not be loaded, so regions can only be ' +
-				'given as coordinates here.';
+			p.textContent = (preview ? 'The region editor could not be loaded'
+				: 'The preview could not be loaded') +
+				', so regions can only be given as coordinates here.';
 			regionBody.appendChild(p);
 		}
 
@@ -1780,6 +1783,19 @@
 			base: words.base ||
 				'Regions are stored in the main stream’s pixels, and this camera has ' +
 				'no main resolution set. Switch the picture to Main to draw them.',
+			// The singular noun the row verdicts build their sentences from,
+			// and the two things a rectangle the camera cannot use is failing
+			// to do. Kept as words rather than as a boolean, because "watches"
+			// and "hides" are not the same promise and the whole reason these
+			// two callers share a control is that only the sentences differ.
+			thing: words.thing || 'region',
+			deadSome: words.deadSome ||
+				'A region with no area, or one outside the picture, is saved but never watched.',
+			deadAll: words.deadAll ||
+				'None of these regions watches anything, so nothing will be detected: ' +
+				'detection is limited to the regions listed and does not fall back to ' +
+				'the whole picture.',
+			space: words.space || 'Coordinates are main-stream pixels',
 		};
 		// Ungated callers are always live; a gated one starts off and is turned
 		// on by the caller's own mode control.
@@ -1818,11 +1834,15 @@
 			return { x: (w - f.w * s) / 2, y: (h - f.h * s) / 2, w: f.w * s, h: f.h * s };
 		}
 
-		const parse = (s) => {
-			const p = String(s).split('x').map(Number);
-			return p.length === 4 && p.every(n => isFinite(n))
-				? { x: p[0], y: p[1], w: p[2], h: p[3] } : null;
-		};
+		// The geometry verdicts live in mj-region.js, away from the DOM, because
+		// every branch of them renders a confident-looking chip and only a
+		// camera at a particular resolution reaches most of them. What is left
+		// here is where the answers are put on screen.
+		const RGN = window.MajesticRegion;
+		const parse = RGN.parse;
+		// The verdict's class in the module's own vocabulary, dressed here:
+		// the module has no idea what this page's stylesheet calls things.
+		const CLS = { bad: 'mj-md-bad', ok: 'mj-md-pct' };
 		// The underlying inputs, empties INCLUDED — _rows() drops those, and an
 		// empty row is exactly the one somebody is about to type coordinates
 		// into. Read from the DOM rather than kept alongside it: the field's
@@ -1830,6 +1850,11 @@
 		const inputs = () => Array.prototype.slice.call(
 			ctl.querySelectorAll('.mj-array-row input'));
 		const list = () => inputs().map(i => i.value.trim());
+
+		// Declared below list() rather than beside the other geometry helpers:
+		// it reads one, and a const read from above its own declaration is the
+		// temporal dead zone this file has already been bitten by once.
+		const tally = () => RGN.tally(list(), base(), W.thing);
 
 		// ── the layers ────────────────────────────────────────────────────
 		//
@@ -1906,8 +1931,41 @@
 		const view = el('div', 'mj-md-list');
 		const warn = el('p', 'mj-live-hint mj-md-warn');
 		warn.hidden = true;
+		// What an unusable rectangle costs, under the list rather than in the
+		// row: the row says WHICH one, this says what happens because of it,
+		// and the sentence changes when every one of them is unusable — that is
+		// the case the reporter of #330 was in, and it is the only one where a
+		// mistyped region turns the whole feature off.
+		const dead = el('p', 'mj-live-hint mj-md-warn');
+		dead.hidden = true;
+		// The coordinate space, stated once. The editor knew it all along and
+		// never said it, so the numbers in these boxes were the only ones on
+		// the page with no scale printed anywhere near them.
+		const space = el('p', 'mj-live-hint mj-md-space');
+		space.hidden = true;
 		listBox.appendChild(view);
 		listBox.appendChild(warn);
+		listBox.appendChild(dead);
+		listBox.appendChild(space);
+
+		// The head's count and the two lines under the list. Called from paint()
+		// and from every keystroke in a coordinate box: the count used to be
+		// written only by the full paint, so it lagged one row behind the list
+		// beside it — three rows on screen under a head that said "2 regions".
+		function paintTally() {
+			const t = tally(), b = base();
+			if (noteEl) {
+				noteEl.textContent = !t.n ? 'none'
+					: (t.n === 1 ? W.one : t.n + W.many) +
+						(t.bad ? ' · ' + t.bad + ' unusable' : '');
+				noteEl.classList.toggle('mj-md-warn', t.bad > 0);
+			}
+			dead.textContent = !t.bad ? ''
+				: (t.bad === t.n ? W.deadAll : W.deadSome);
+			dead.hidden = !t.bad;
+			space.textContent = b ? W.space + ' — ' + b.w + ' × ' + b.h + '.' : '';
+			space.hidden = !b || !t.n;
+		}
 
 		// The rectangles alone. Split out because typing in a coordinate box has
 		// to move its rectangle without rebuilding the box being typed into.
@@ -1953,16 +2011,10 @@
 			paintBoxes();
 			const rows = list();
 
-			// Counts what is actually a region: a row you have just opened to
-			// type into is not one yet, and saying "1 region" over an empty box
-			// would be the page agreeing with something nobody has said.
 			// A selection that outlived its row would put handles on somebody
 			// else's rectangle: deleting region 2 of 3 renumbers the third.
 			if (sel >= rows.length) sel = -1;
-			const n = rows.filter(Boolean).length;
-			if (noteEl) {
-				noteEl.textContent = n ? (n === 1 ? W.one : n + W.many) : 'none';
-			}
+			paintTally();
 
 			// The list beside the picture is a VIEW of the field, rebuilt from
 			// it, never a second copy kept in step by hand: the hidden field is
@@ -2006,8 +2058,12 @@
 					// value still read "not XxYxWxH" and a resized one still
 					// showed the share of the frame it used to have. Both are
 					// the row saying something about text that is no longer in
-					// it.
+					// it. The head's count and the lines under the list are
+					// derived from the same verdicts, so they move with the
+					// keystroke too — everything except the list itself, which
+					// is what holds the caret.
 					says(parse(co.value));
+					paintTally();
 					paintBoxes();
 				});
 				const del = el('button', 'mj-md-del');
@@ -2025,23 +2081,15 @@
 				// silently missing rectangle — so it is said here, beside the
 				// box you would fix it in. Built once and rewritten in place,
 				// because it has to keep up with typing.
-				const verdict = el('span', 'mj-md-pct');
-				verdict.title = 'share of the frame';
-				row.appendChild(verdict);
+				const vd = el('span', 'mj-md-pct');
+				vd.title = 'share of the frame';
+				row.appendChild(vd);
 				const says = (rr) => {
-					if (!rr) {
-						verdict.className = 'mj-md-bad';
-						verdict.textContent = 'not XxYxWxH';
-						verdict.removeAttribute('title');
-					} else if (b) {
-						verdict.className = 'mj-md-pct';
-						verdict.textContent =
-							Math.round(rr.w * rr.h / (b.w * b.h) * 100) + '%';
-						verdict.title = 'share of the frame';
-					} else {
-						verdict.className = 'mj-md-pct';
-						verdict.textContent = '';
-					}
+					const v = RGN.verdict(rr, b, W.thing);
+					vd.className = CLS[v.cls];
+					vd.textContent = v.text;
+					if (v.title) vd.title = v.title;
+					else vd.removeAttribute('title');
 				};
 				says(r);
 				row.appendChild(del);
@@ -2575,12 +2623,18 @@
 			held[k] = field;
 		}
 
+		// One question, asked once: hiding the raw coordinate rows is only
+		// right where something is going to draw them instead. Asked twice —
+		// once for the row and once for the mount — a missing geometry module
+		// would hide the field and then mount nothing over it, which is the one
+		// outcome the hidden-field pattern exists to rule out.
+		const canRegion = !!preview && !!window.MajesticRegion;
 		const maskSchema = fields.find(f => f.key === 'privacyMasks');
 		let maskField = null;
 		if (maskSchema) {
 			maskField = renderField(maskBody, maskSchema.dot, 'privacyMasks',
 				maskSchema.sub, getDotted(state.config, maskSchema.dot),
-				preview ? { hidden: true } : undefined);
+				canRegion ? { hidden: true } : undefined);
 			if (maskField) {
 				state.fields.push(maskField);
 				state.initial[maskSchema.dot] = maskField.getValue();
@@ -2600,7 +2654,7 @@
 		}
 
 		let masks = null;
-		if (maskField && preview) {
+		if (maskField && canRegion) {
 			masks = mountRegions(preview, maskField, maskBody, maskNote, {
 				gated: true,
 				one: '1 mask', many: ' masks',
@@ -2610,6 +2664,15 @@
 				clearAsk: 'Remove every mask? Everything they cover becomes visible again.',
 				base: 'Masks are stored in the main stream’s pixels, and this camera ' +
 					'has no main resolution set. Switch the picture to Main to draw them.',
+				thing: 'mask',
+				deadSome: 'A mask with no area, or one outside the picture, is saved ' +
+					'but hides nothing.',
+				// No "and so the whole picture is hidden" counterpart: an
+				// unusable mask hides nothing, and every unusable mask still
+				// hides nothing. The all-unusable case is only worth its own
+				// sentence where it inverts the feature, which is the motion
+				// list's case and not this one.
+				deadAll: 'None of these masks hides anything.',
 			});
 			// The masks the camera has already applied are painted into the
 			// stream as solid blocks. The outlines here are for grabbing them;

--- a/www/cgi-bin/camera.cgi
+++ b/www/cgi-bin/camera.cgi
@@ -122,6 +122,7 @@ fi
 %>
 <script src="/a/charts.js" defer></script>
 <script src="/a/mj-requires.js" defer></script>
+<script src="/a/mj-region.js" defer></script>
 <script src="/a/mj-settings.js" defer></script>
 
 <% fi %>


### PR DESCRIPTION
Picks up #330 ("Motion Detector Errors", ssc338q + imx415), re-checking all five reported points against current `master` and the motion editor as it was rebuilt in #297 / #299. Two of them are this repo's and are fixed here; one was already fixed; two are firmware-side and are tracked there.

## Points 3 and 4 — still exactly as reported, and fixed here

> it is possible to enter the size of the zone with a zero value, which is incorrect. It is not visible. That is, `100x100x 0x10` is a size error
>
> Entering coordinates and size is not limited by the image resolution field. This leads to the possibility of going beyond the size

Measured in headless Chrome against an hi3516ev300, typing into the coordinate boxes:

| typed | chip said | Save |
|---|---|---|
| `100x100x0x10` | `0%` | enabled |
| `9000x9000x100x100` | `1%` | enabled |
| `-5x-5x100x100` | `1%`, rectangle drawn at negative offsets | enabled |
| `0x0x99999x99999` | `1085048%` | enabled |

All four were then accepted by `POST /api/v1/config` and written to `majestic.yaml` verbatim, with no log line. The drag path clamps properly and always did; only typing was unbounded.

**The cost is not a wrong number.** Each region edge is clamped into the frame before anything is compared against it, so a zero-size region and one entirely off the picture *both* end up as a rectangle with no area, which no movement can ever fall inside. And the region list is a whitelist with no fallback — what gates the filter is the regions that **parsed**, not the regions that can ever match. So one mistyped region does not narrow the watch, it ends it, while the camera goes on streaming, recording, answering ONVIF and reporting healthy counters. This page is the only place anyone can be told.

### What the rows say now

```
REGIONS                              5 regions · 4 unusable  ↺
 1  0x0x400x400                                        17%  ×
 2  100x100x0x10                                   no area  ×
 3  9000x9000x100x100                          off picture  ×
 4  1100x600x400x400                          2% · clipped  ×
 5  nonsense                                   not XxYxWxH  ×
A region with no area, or one outside the picture, is saved but never watched.
Coordinates are main-stream pixels — 1280 × 720.
 + Add by coordinates    🗑 Clear all
```

- `N% · clipped` is scored on the **clipped** rectangle, because that is the part being watched; scoring the typed one overstates the watch by exactly the part the camera throws away.
- `not XxYxWxH` now also covers the minus sign and the decimal point, because the camera cannot store either. `-5` came back from the camera as 4294967291 while the editor drew minus five: neither was what was typed, and only one was on screen. Inner blanks stay valid — the camera accepts those, so `0x0x10x 10` *is* a region it stores and calling it invalid would be the page inventing a rule.
- The head's count updates per keystroke. It used to be written only by the full paint, so it lagged one row behind the list beside it — three rows on screen under a head reading "2 regions".
- The consequence line is worded harder when **every** region is unusable, since that is the only case that inverts the feature rather than narrowing it.
- The coordinate space is stated. The editor always knew it and never printed it, which is the whole of why "not limited by the image resolution field" was possible to walk into.

Privacy masks go through the same control and get the same verdicts with their own nouns — a mask that hides nothing is not a region that watches nothing, and those two callers share everything except the sentences.

Nothing is silently repaired: a number somebody typed from a spec is not rewritten behind them, it is named where they would fix it.

## Point 2 — already fixed, verified

> the values of the sequence without a space are entered into the region of interest, that is `0x0x10x10,9x9x19x19` instead of `0x0x10x10,  9x9x19x19`, which leads to ignoring the entered data. In the visual editor, the entered zones disappear after saving.

There is no comma-joined encoding left anywhere to get wrong: regions are a real YAML/JSON array now, one string per element, and the page posts them as an array. Verified end to end — three regions typed, saved, survived a reload, and landed in `/etc/majestic.yaml` as a block sequence.

## Points 1 and 5 — not this repo's

The only comment on #330 sent points 1–4 here. Point 1 is not the editor's: the regions reach `majestic.yaml` correctly and are parsed correctly, and it is the firmware's region filter that discards the events. Both of these reproduce only on SigmaStar, which is why the reporter (ssc338q) hit them and HiSilicon users do not — verified as working on an hi3516ev300 with the same configuration.

Both are diagnosed and tracked firmware-side, outside this repository. They should stay open on #330 until the firmware fixes land; nothing in this PR addresses them.

## Testing

`tests/region-verdict.test.js`, over the extracted `www/a/mj-region.js`. It earns its place the way `ircut-check` does: every branch renders a confident-looking chip in the same quiet grey, so a wrong one does not degrade this fix, it reverts it — and reaching most of them on a real camera needs one at a known main resolution, a frame size that has already arrived from the codec event, and somebody willing to type what the editor exists to talk them out of. The numbers in it are the ones the camera stores and the ones the lab camera reported.

The geometry moved out of `mj-settings.js` for that reason alone, following `mj-requires.js`. Both callers now ask one question (`canRegion`) rather than two, so a missing module cannot hide the coordinate rows and then mount nothing over them — the field falls back to plain coordinate boxes with a sentence naming which half is missing, instead of blaming the preview on a camera whose preview came up fine.

`npm test` passes; `tools/regen-bootstrap-css.sh` reproduces the committed `bootstrap.min.css` byte for byte (the new class is in the override, which is not purged).

## Verified on

hi3516ev300 + imx335, main stream 1280x720. Before and after: the four typed values above, a drag that creates a region, a drag that shoves one past the right edge (clamped at `880x181x400x400` on a 1280-wide frame), a save round trip, and the Overlay leaf's masks still mounting with the raw row hidden and no page errors.
