### PR TITLE
Day / Night: a panel visible only when it is already on, and a chart drawn in the wrong stylesheet

### DIFF
--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -286,4 +286,70 @@ group('window and gap are per chart, because not every subject is a subject of n
 		(narrow.innerHTML.match(/M/g) || []).length > 4);
 }
 
+group('a band is what the value is compared against, so the scale has to fit it');
+{
+	const { MC, clock } = boot();
+	// The Day / Night light monitor's shape, measured on an hi3516ev300: gain
+	// idling near 1024 while the day and night thresholds sit at 150000 and
+	// 160000. Scaled from the data alone the plot topped out at 2000, both
+	// bands clamped to the top edge, and the chart drew a flat line in a
+	// uniformly tinted box — no answer at all to "how far is this from
+	// switching" (#325).
+	const bands = [
+		{ from: 0, to: 150000, color: 'rgba(47,182,115,.10)', label: 'day' },
+		{ from: 160000, to: null, color: 'rgba(255,193,7,.10)', label: 'night' },
+	];
+	const host = makeHost(400);
+	const ch = MC.makeChart(host, { h: 110, lo: 0, hi: null, colors: ['#000'], bands: bands });
+	for (let i = 0; i < 3; i++) { clock.t = i * 2; MC.pushChart(ch, [1024]); }
+	const ticks = (host.innerHTML.match(/text-anchor="end">([\d.]+)</g) || [])
+		.map(t => parseFloat(t.replace(/[^\d.]/g, '')));
+	check('the top of the plot clears the night threshold',
+		Math.max.apply(null, ticks) >= 160000,
+		'top tick ' + Math.max.apply(null, ticks));
+
+	// Both band labels used to be drawn at y1 + 10 whatever the band's drawn
+	// height, so two bands clamped to the same edge printed "day" and "night"
+	// on the same pixel — one unreadable smudge in the corner.
+	const labelY = w => {
+		const m = host.innerHTML.match(new RegExp('y="([\\d.]+)"[^>]*>' + w + '<'));
+		return m ? parseFloat(m[1]) : null;
+	};
+	check('and both band names are on the plot, a line apart',
+		labelY('day') != null && labelY('night') != null &&
+		Math.abs(labelY('day') - labelY('night')) >= 12,
+		'day at ' + labelY('day') + ', night at ' + labelY('night'));
+
+	// An open end is not a number: 1e9 as a stand-in for "and above" would be
+	// folded into the scale above and push the whole plot off the top.
+	check('an open band end is not fitted into the scale',
+		Math.max.apply(null, ticks) < 1e6, 'top tick ' + Math.max.apply(null, ticks));
+
+	// The gutter has to hold the numbers it is about to print. At a flat 30px
+	// — four monospace characters — a six-digit threshold lost its first two
+	// digits off the left edge and read as "0000".
+	const gutter = html => {
+		const m = html.match(/text-anchor="end">[\d.]+<\/text>/) &&
+			html.match(/<text x="([\d.]+)" y="[\d.]+" text-anchor="end">[\d.]+</);
+		return m ? parseFloat(m[1]) : null;
+	};
+	check('the gutter widens for a six-digit axis',
+		gutter(host.innerHTML) >= 6 * 6, 'label right edge at ' + gutter(host.innerHTML));
+	const small = makeHost(400);
+	const ch3 = MC.makeChart(small, { h: 110, lo: 0, hi: 100, colors: ['#000'] });
+	MC.pushChart(ch3, [50]);
+	check('and a short one still gets the gutter it always had',
+		gutter(small.innerHTML) === 25, 'label right edge at ' + gutter(small.innerHTML));
+
+	// A band with no room for its own name does not print it anywhere.
+	const tight = makeHost(400);
+	const ch2 = MC.makeChart(tight, {
+		h: 110, lo: 0, hi: 100, colors: ['#000'],
+		bands: [{ from: 99, to: 100, color: '#fff', label: 'sliver' }],
+	});
+	MC.pushChart(ch2, [50]);
+	check('a band squeezed thinner than its label draws no label',
+		tight.innerHTML.indexOf('sliver') < 0);
+}
+
 done();

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -286,15 +286,25 @@ group('window and gap are per chart, because not every subject is a subject of n
 		(narrow.innerHTML.match(/M/g) || []).length > 4);
 }
 
+// This is the same failure the file opens with, reached from the other side.
+// The groups above are here because a scale can flatten a trend into three
+// pixels while drawing a perfectly confident line; a scale that fits the data
+// and ignores the bands does it to the DISTANCE instead — the one quantity a
+// banded chart exists to show — and is just as quiet about it. Nothing renders
+// an error, the trace is smooth, the box is tinted, and the picture answers a
+// question nobody asked. The layout defects this shipped alongside (a clipped
+// axis number, two band names on one pixel) are not here: those are visible in
+// one page load, which is the line this suite holds.
 group('a band is what the value is compared against, so the scale has to fit it');
 {
 	const { MC, clock } = boot();
-	// The Day / Night light monitor's shape, measured on an hi3516ev300: gain
+	// The Day / Night monitor's real shape, measured on an hi3516ev300: gain
 	// idling near 1024 while the day and night thresholds sit at 150000 and
 	// 160000. Scaled from the data alone the plot topped out at 2000, both
-	// bands clamped to the top edge, and the chart drew a flat line in a
-	// uniformly tinted box — no answer at all to "how far is this from
-	// switching" (#325).
+	// bands clamped flat against the top edge, and the chart drew a level line
+	// in a uniformly tinted box — while the camera was in fact nowhere near
+	// switching, and would have looked identical if it had been one step away
+	// (#325).
 	const bands = [
 		{ from: 0, to: 150000, color: 'rgba(47,182,115,.10)', label: 'day' },
 		{ from: 160000, to: null, color: 'rgba(255,193,7,.10)', label: 'night' },
@@ -308,48 +318,13 @@ group('a band is what the value is compared against, so the scale has to fit it'
 		Math.max.apply(null, ticks) >= 160000,
 		'top tick ' + Math.max.apply(null, ticks));
 
-	// Both band labels used to be drawn at y1 + 10 whatever the band's drawn
-	// height, so two bands clamped to the same edge printed "day" and "night"
-	// on the same pixel — one unreadable smudge in the corner.
-	const labelY = w => {
-		const m = host.innerHTML.match(new RegExp('y="([\\d.]+)"[^>]*>' + w + '<'));
-		return m ? parseFloat(m[1]) : null;
-	};
-	check('and both band names are on the plot, a line apart',
-		labelY('day') != null && labelY('night') != null &&
-		Math.abs(labelY('day') - labelY('night')) >= 12,
-		'day at ' + labelY('day') + ', night at ' + labelY('night'));
-
-	// An open end is not a number: 1e9 as a stand-in for "and above" would be
-	// folded into the scale above and push the whole plot off the top.
-	check('an open band end is not fitted into the scale',
+	// An open end is not a number. Spelt 1e9 as a stand-in for "and above" it
+	// is indistinguishable from a real edge, so the rule above would fit it
+	// and put the data, the day band and everything else in the bottom
+	// millionth of the box — the same flat, plausible, useless line by another
+	// route.
+	check('and an open band end is not fitted into it',
 		Math.max.apply(null, ticks) < 1e6, 'top tick ' + Math.max.apply(null, ticks));
-
-	// The gutter has to hold the numbers it is about to print. At a flat 30px
-	// — four monospace characters — a six-digit threshold lost its first two
-	// digits off the left edge and read as "0000".
-	const gutter = html => {
-		const m = html.match(/text-anchor="end">[\d.]+<\/text>/) &&
-			html.match(/<text x="([\d.]+)" y="[\d.]+" text-anchor="end">[\d.]+</);
-		return m ? parseFloat(m[1]) : null;
-	};
-	check('the gutter widens for a six-digit axis',
-		gutter(host.innerHTML) >= 6 * 6, 'label right edge at ' + gutter(host.innerHTML));
-	const small = makeHost(400);
-	const ch3 = MC.makeChart(small, { h: 110, lo: 0, hi: 100, colors: ['#000'] });
-	MC.pushChart(ch3, [50]);
-	check('and a short one still gets the gutter it always had',
-		gutter(small.innerHTML) === 25, 'label right edge at ' + gutter(small.innerHTML));
-
-	// A band with no room for its own name does not print it anywhere.
-	const tight = makeHost(400);
-	const ch2 = MC.makeChart(tight, {
-		h: 110, lo: 0, hi: 100, colors: ['#000'],
-		bands: [{ from: 99, to: 100, color: '#fff', label: 'sliver' }],
-	});
-	MC.pushChart(ch2, [50]);
-	check('a band squeezed thinner than its label draws no label',
-		tight.innerHTML.indexOf('sliver') < 0);
 }
 
 done();

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -473,6 +473,16 @@ function runRest() {
 			thr.bands.length === 2);
 		check('an old daemon with thresholds still gets the chart',
 			ic.monitorView(nmThr, { isp_again: 2000 }).mode === 'thresholds');
+		// An older daemon publishes no source, so this file has to reproduce
+		// the precedence rather than read it: a daylight sensor pin decides
+		// before the thresholds do. Charting the gain there would draw a
+		// confident line under a gauge that is not driving anything, on a
+		// firmware/wiring pair nothing here can go and look at.
+		check('and a sensor pin outranks them on that daemon, as on the camera',
+			ic.monitorView(
+				{ lightMonitor: true, lightSensorPin: 66,
+					minThreshold: 1500, maxThreshold: 4000 },
+				{ isp_again: 2000, night_enabled: 0 }).mode === 'sensor');
 		// The band that means "and everything above" is open-ended, and says so
 		// with null rather than a stand-in ceiling: the chart's auto scale
 		// makes room for a finite edge, so a made-up one would push the whole

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -473,14 +473,47 @@ function runRest() {
 			thr.bands.length === 2);
 		check('an old daemon with thresholds still gets the chart',
 			ic.monitorView(nmThr, { isp_again: 2000 }).mode === 'thresholds');
+		// The band that means "and everything above" is open-ended, and says so
+		// with null rather than a stand-in ceiling: the chart's auto scale
+		// makes room for a finite edge, so a made-up one would push the whole
+		// plot off the top.
+		check('the night band is open at the top',
+			thr.bands[1].from === 4000 && thr.bands[1].to === null);
+		check('so is the automatic mode\'s',
+			ic.monitorView({ lightMonitor: true, autoNightGain: 16 }, vAuto)
+				.bands.find(b => b.from === 16).to === null);
+
+		// Every state answers. A view with nothing continuous behind it says
+		// so with chart:false instead of vanishing — the block is the only
+		// place on the page that names the switch, so a camera in any of these
+		// states used to have no section to find (#325).
+		const gpio = ic.monitorView({ lightMonitor: true, lightSensorPin: 66 },
+			{ night_mode_source: 1, night_enabled: 0 });
 		check('a GPIO source has nothing continuous to chart',
-			ic.monitorView({ lightMonitor: true, lightSensorPin: 66 },
-				{ night_mode_source: 1 }) === null);
+			gpio.chart === false && gpio.value === null && !gpio.bands.length);
+		check('and says which way the sensor is pointing',
+			/^Day\. The daylight sensor decides/.test(gpio.line), gpio.line);
+		const adc = ic.monitorView(
+			{ lightMonitor: true, minThreshold: 100, maxThreshold: 400 },
+			{ night_mode_source: 3, isp_again: 200 });
 		check('an ADC source has nothing continuous to chart either',
-			ic.monitorView({ lightMonitor: true, minThreshold: 100, maxThreshold: 400 },
-				{ night_mode_source: 3, isp_again: 200 }) === null);
-		check('monitor off charts nothing',
-			ic.monitorView({}, vAuto) === null);
+			adc.chart === false && adc.mode === 'adc', adc.line);
+		const off = ic.monitorView({}, vAuto);
+		check('monitor off charts nothing', off.chart === false);
+		check('and points at the switch by the name the page prints on it',
+			/Turn on Automatic day\/night below/.test(off.line), off.line);
+		const retired = ic.monitorView({ lightMonitor: true },
+			{ night_mode_source: 0, night_enabled: 0 });
+		check('a monitor that stood down still has a sentence',
+			retired.chart === false && /Nothing is deciding/.test(retired.line),
+			retired.line);
+		check('and an older daemon that names no source has one too',
+			ic.monitorView({ lightMonitor: true }, { night_enabled: 0 })
+				.mode === 'unknown');
+		check('only a camera that has not answered hides the block',
+			ic.monitorView({ lightMonitor: true }, null) === null);
+		check('a charted view says so',
+			auto.chart === true && thr.chart === true);
 		// Missing gauges stay unknown: no countdown made of coerced zeros,
 		// and no "Day" invented for a camera that never said.
 		const noTimers = ic.monitorView(nmAuto, {

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2613,12 +2613,12 @@ mark {
 .mj-ns-chart {
 	margin-top: 0.45rem;
 }
-.mj-ns-chart svg {
-	display: block;
-	width: 100%;
-}
-.mj-ns-chart text {
-	font-family: var(--bs-font-monospace);
+/* Structure comes from .mj-chart; only the ink differs, because this panel's
+   black glass is the same in both themes and must not read the page's.
+   Both classes are named so this outranks the shared rule outright: equal
+   specificity would leave the winner to source order, and .mj-chart is
+   declared further down this file. */
+.mj-chart.mj-ns-chart text {
 	font-size: 9px;
 	fill: rgba(255, 255, 255, 0.5);
 }
@@ -4036,12 +4036,22 @@ dialog.mj-modal::backdrop {
 	text-overflow: ellipsis;
 }
 
-.st-chart svg {
+/* Every MjCharts axis chart's host. The primitives were lifted out of the
+   dashboard into charts.js so that other pages could draw with the same
+   pencil, but their stylesheet stayed behind under the dashboard's own
+   `.st-` prefix — so the third caller, the Day / Night light monitor, drew
+   its axis in the page's 16px body font and its default BLACK fill: numbers
+   too wide for the 25px gutter charts.js reserves ("2000" arriving as ")00"),
+   band names printed on top of each other, all of it near-invisible on a dark
+   card (#325). A chart styled only where it was born is a chart that silently
+   comes out wrong everywhere else, so the rules are named after the thing
+   rather than the page and every host carries this class. */
+.mj-chart svg {
 	display: block;
 	width: 100%;
 }
 
-.st-chart text {
+.mj-chart text {
 	font-family: var(--bs-font-monospace);
 	font-size: 10px;
 	fill: var(--bs-tertiary-color);
@@ -4415,6 +4425,14 @@ dialog.mj-modal::backdrop {
 	display: flex;
 	gap: 0.5rem;
 	margin-top: 0.75rem;
+}
+
+/* Automatic day/night's readout closes the panel, and its last row is the
+   chart's own "-2 min / now" strip — which runs to the block's bottom edge,
+   so without this the first field caption below sits directly under it and
+   reads as another axis label. */
+#mj-ircut-mon {
+	margin-bottom: 1rem;
 }
 
 .mj-ircut-scan {

--- a/www/a/charts.js
+++ b/www/a/charts.js
@@ -124,6 +124,7 @@ window.MjCharts = (function () {
 	// measured width, which is not knowable this early.
 	const PAD_T = 5;  // headroom above the top gridline
 	const X_BAND = 14; // the "-2 min / now" strip below the plot
+	const LBL_H = 12;  // a band shorter than this has no room for its own label
 	function chartHeight(cfg) { return PAD_T + cfg.h + X_BAND; }
 	function makeChart(sel, cfg) {
 		const host = typeof sel === 'string' ? $(sel) : sel;
@@ -166,18 +167,54 @@ window.MjCharts = (function () {
 		if (!W) return;
 		const cfg = ch.cfg;
 		const win = cfg.win || CHART_WINDOW, gap = cfg.gap || CHART_GAP;
-		const padL = 30, padR = 6, padT = PAD_T, H = cfg.h, XB = X_BAND;
-		const plotW = W - padL - padR;
+		const padR = 6, padT = PAD_T, H = cfg.h, XB = X_BAND;
 		const lo = cfg.lo;
 		let hi = cfg.hi;
 		const pts = ch.pts, n = pts.length;
+		// A band is a range with an OPEN end where `from`/`to` is null — "and
+		// everything above", which is what a night threshold means. That is
+		// spelt null rather than some large number so the auto scale below can
+		// tell a real edge from a stand-in for infinity.
+		const bands = cfg.bands || [];
 		if (hi == null) {
 			let max = 0;
 			pts.forEach(p => p.v.forEach(v => { if (v != null && v > max) max = v; }));
-			hi = niceCeil(Math.max(max * 1.15, 1));
+			// The bands are what the value is being COMPARED against, so a
+			// scale that fits only the data can leave every threshold off the
+			// top: the plot then draws a flat line in a uniformly tinted box
+			// and cannot answer the one question it is on the page for — how
+			// far is this from switching. Day/night on a HiSilicon camera is
+			// exactly that shape, gain idling near 1024 against thresholds in
+			// the 150000s.
+			//
+			// The 15% headroom is for the DATA, which has to have somewhere to
+			// go: a trace pinned to the top edge cannot show that it rose. A
+			// band edge is a fixed number and needs none, and giving it some
+			// pushes the plot a whole nice-number step further out — a day
+			// band ending at 2 asked for a ceiling of 5 and then filled only
+			// the bottom two fifths of its own chart.
+			let top = max * 1.15;
+			bands.forEach(b => {
+				[b.from, b.to].forEach(e => {
+					if (e != null && isFinite(e) && e > top) top = e;
+				});
+			});
+			hi = niceCeil(Math.max(top, 1));
 		}
 		const fmt = cfg.fmt || fmtNum;
 		const grid = cfg.grid || '#e9ebf2';
+		// The gutter is sized to the numbers about to go in it. It was a flat
+		// 30px, which is about four monospace characters — fine for a
+		// percentage or a signal level, and not for the day/night thresholds,
+		// where "150000" lost its first two digits off the left edge of the
+		// plot and read as "0000" (#325). There is no text measurement to be
+		// had from an SVG built as a string, so this is the advance width of
+		// the monospace faces the stylesheets set (~0.6em at 10px) with the
+		// same 5px breathing room the labels always had on each side.
+		const ticks = [lo, (lo + hi) / 2, hi].map(fmt);
+		const wide = ticks.reduce((m, t) => Math.max(m, String(t).length), 0);
+		const padL = Math.min(Math.max(30, Math.ceil(wide * 6.1) + 6), W * 0.4);
+		const plotW = W - padL - padR;
 		const Y = v => {
 			let y = padT + (1 - (v - lo) / (hi - lo)) * H;
 			return y < padT ? padT : y > padT + H ? padT + H : y;
@@ -187,20 +224,30 @@ window.MjCharts = (function () {
 		const tNow = performance.now() / 1000;
 		const X = t => padL + plotW * (1 - (tNow - t) / win);
 		let s = '';
-		// threshold bands (Wi-Fi grades, luminance floor) sit under everything
-		(cfg.bands || []).forEach(b => {
-			const y1 = Y(b.to), y2 = Y(b.from);
+		// threshold bands (Wi-Fi grades, luminance floor, day/night) sit under
+		// everything. An open end reaches the edge of the plot.
+		bands.forEach(b => {
+			const y1 = b.to == null ? padT : Y(b.to);
+			const y2 = b.from == null ? padT + H : Y(b.from);
 			s += '<rect x="' + padL + '" y="' + y1.toFixed(1) + '" width="' + plotW +
 				'" height="' + (y2 - y1).toFixed(1) + '" fill="' + b.color + '"/>';
-			if (b.label) s += '<text x="' + (padL + plotW - 4) + '" y="' + (y1 + 10).toFixed(1) +
-				'" text-anchor="end" opacity="0.8">' + b.label + '</text>';
+			// A band squeezed off the plot keeps no room for its own name, and
+			// the name does not shrink with it: two bands clamped to the same
+			// edge printed both words on the same pixel, which is how "day" and
+			// "night" came out as one unreadable smudge. Bands do not overlap,
+			// so once each drawn band is at least a label tall their labels are
+			// necessarily that far apart too — the one guard covers both.
+			if (b.label && y2 - y1 >= LBL_H) {
+				s += '<text x="' + (padL + plotW - 4) + '" y="' + (y1 + 10).toFixed(1) +
+					'" text-anchor="end" opacity="0.8">' + b.label + '</text>';
+			}
 		});
 		// hairline grid at lo / mid / hi, labels on the left
-		[lo, (lo + hi) / 2, hi].forEach(t => {
+		[lo, (lo + hi) / 2, hi].forEach((t, i) => {
 			const y = Y(t);
 			s += '<line x1="' + padL + '" y1="' + y.toFixed(1) + '" x2="' + (padL + plotW) +
 				'" y2="' + y.toFixed(1) + '" stroke="' + grid + '" stroke-width="1"/>';
-			s += '<text x="' + (padL - 5) + '" y="' + (y + 3.5).toFixed(1) + '" text-anchor="end">' + fmt(t) + '</text>';
+			s += '<text x="' + (padL - 5) + '" y="' + (y + 3.5).toFixed(1) + '" text-anchor="end">' + ticks[i] + '</text>';
 		});
 		if (cfg.ref && cfg.ref.v > lo && cfg.ref.v < hi) {
 			const y = Y(cfg.ref.v);

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -277,23 +277,22 @@
 				out.push({
 					id: 'auto-retired', level: 'warning',
 					title: 'This camera cannot watch the light by itself',
-					detail: 'The light monitor is on, but this SoC reports no ' +
-						'exposure state to decide from, so automatic day/night ' +
-						'stood down. Wire a daylight sensor to a GPIO pad and ' +
-						'assign it on the map for the monitor to have something ' +
-						'to watch.',
+					detail: 'Automatic day/night is on, but this SoC reports ' +
+						'no exposure state to decide from, so it has stood ' +
+						'down. Wire a daylight sensor to a GPIO pad and assign ' +
+						'it on the map for it to have something to watch.',
 					fix: 'nightMode',
 				});
 			} else {
 				out.push({
 					id: 'monitor-blind', level: 'warning',
-					title: 'The light monitor has nothing to watch',
-					detail: 'The light monitor is on, but nothing tells it how ' +
+					title: 'Automatic day/night has nothing to watch',
+					detail: 'Automatic day/night is on, but nothing tells it how ' +
 						'dark it is: no daylight sensor is connected, and no day ' +
 						'or night threshold is set. Current firmware decides ' +
 						'from the sensor’s own exposure in this situation — ' +
 						'this camera has not reported that mode, so a firmware ' +
-						'update would give it automatic day/night.',
+						'update would give it that.',
 					fix: 'nightMode',
 				});
 			}
@@ -333,7 +332,7 @@
 			out.push({
 				id: 'manual-only', level: 'info',
 				title: 'Day/night switching is manual',
-				detail: 'The filter is wired but the light monitor is off, so ' +
+				detail: 'The filter is wired but Automatic day/night is off, so ' +
 					'nothing moves it at dusk. That is a valid setup for a ' +
 					'camera driven over the API; it is a fault if you expected ' +
 					'the camera to switch itself.',
@@ -352,7 +351,7 @@
 				out.push({
 					id: 'conflict', level: 'danger',
 					title: 'Night mode and the IR-cut filter disagree',
-					detail: 'The light monitor says it is ' +
+					detail: 'Automatic day/night says it is ' +
 						(sample.night ? 'night' : 'day') + ', but the filter has ' +
 						'been in the ' + (sample.ircut ? 'night (open)' : 'day (closed)') +
 						' position for ' + Math.round(track.conflictS) + 's. The ' +
@@ -673,11 +672,22 @@
 	// `nm` — so the countdown arithmetic and the band construction are
 	// testable without a camera at dusk.
 	//
-	// null when there is nothing to chart: monitor off, a GPIO/ADC source
-	// (nothing continuous to draw), an old daemon, or a retired monitor.
+	// `chart` says whether there is a continuous value to plot. It is false
+	// for every state that has nothing to draw — the switch off, a wired
+	// daylight sensor (light or dark and nothing in between), an ADC pad whose
+	// reading is never published, a monitor that stood down, an older daemon
+	// that says nothing about what it watches. Those used to return null,
+	// which took the whole block off the page, so the panel existed only in
+	// the two configurations that draw a graph. The reporter of #325 searched
+	// a camera in none of them for a section naming the very switch they were
+	// being asked to turn on, found it in two hints, and concluded the feature
+	// had not shipped for their SoC. A sentence is not a graph, but it is an
+	// answer, and it is beside the switch.
+	//
+	// null now means only that the camera has not answered yet.
 	function monitorView(nm, v) {
 		nm = nm || {};
-		if (!on(nm.lightMonitor) || !v) return null;
+		if (!v) return null;
 		const src = ('night_mode_source' in v) ? v.night_mode_source : null;
 
 		// An absent night_enabled is a camera whose state is unknown, and an
@@ -693,6 +703,22 @@
 		const lampNote = typeof duty === 'number' && duty >= 0
 			? ' Lamp at ' + duty + '%.' : '';
 
+		// A state with no plot: one sentence, no bands, no value.
+		const say = (mode, line) => ({
+			mode: mode, chart: false, value: null, bands: [],
+			line: line, unit: '',
+		});
+
+		// The name is the one the switch itself wears on this page. Everything
+		// here used to call it "the light monitor", which is what majestic's
+		// own hints call it and what nothing on screen is labelled — so the
+		// page explained a control using a word the page never printed.
+		if (!on(nm.lightMonitor)) {
+			return say('off', 'Off — nothing switches this camera between day ' +
+				'and night on its own. Turn on Automatic day/night below and ' +
+				'this panel says what it is watching.');
+		}
+
 		if (src === 4) {
 			const dayG = pin(nm.autoDayGain) !== null ? pin(nm.autoDayGain) : 2;
 			const nightG = pin(nm.autoNightGain);
@@ -701,10 +727,12 @@
 				color: 'rgba(47,182,115,.10)', label: 'day',
 			}];
 			if (nightG !== null) {
-				// The top edge is clamped to the plot, so "everything above
-				// the user's night threshold" needs no real ceiling.
+				// Open at the top: "everything above the night threshold"
+				// has no ceiling, and saying so with null rather than a large
+				// number is what keeps the chart's auto scale from trying to
+				// fit one on the plot.
 				bands.push({
-					from: nightG, to: 1e9,
+					from: nightG, to: null,
 					color: 'rgba(255,193,7,.10)', label: 'night',
 				});
 			}
@@ -728,7 +756,7 @@
 							? '; night comes when the exposure runs out.'
 							: '.');
 			return {
-				mode: 'auto',
+				mode: 'auto', chart: true,
 				value: gm != null && gm >= 0 ? gm / 1000 : null,
 				bands: bands, line: line + lampNote,
 				unit: 'x',
@@ -737,7 +765,8 @@
 
 		// Source 3 (ADC) is deliberately not here: its reading never appears
 		// on /metrics, so there is nothing continuous to chart and isp_again
-		// would be a different quantity wearing the monitor's clothes.
+		// would be a different quantity wearing the monitor's clothes. It gets
+		// a sentence of its own below instead.
 		if (src === 2 ||
 			(src === null && has(nm.minThreshold) && has(nm.maxThreshold))) {
 			const lo = pin(nm.minThreshold), hi = pin(nm.maxThreshold);
@@ -750,12 +779,12 @@
 			}
 			if (hi !== null) {
 				bands.push({
-					from: hi, to: 1e9,
+					from: hi, to: null,
 					color: 'rgba(255,193,7,.10)', label: 'night',
 				});
 			}
 			return {
-				mode: 'thresholds',
+				mode: 'thresholds', chart: true,
 				value: ('isp_again' in v) ? v.isp_again : null,
 				bands: bands,
 				line: modeWord +
@@ -765,7 +794,28 @@
 			};
 		}
 
-		return null;
+		// A wired photocell is the one door with no reading behind it: the pad
+		// is high or low and nothing in between, so the honest answer is which
+		// way it is pointing and why there is no line under it.
+		if (src === 1 || (src === null && has(nm.lightSensorPin))) {
+			return say('sensor', modeWord + 'The daylight sensor decides. It ' +
+				'reports light or dark and nothing in between, so there is no ' +
+				'reading to plot here.' + lampNote);
+		}
+		if (src === 3) {
+			return say('adc', modeWord + 'A voltage on the daylight sensor pad ' +
+				'decides. The camera does not publish that voltage, so there ' +
+				'is nothing to plot here.' + lampNote);
+		}
+		// The monitor is on and the daemon says nothing is driving it. The
+		// finding above names the two ways out; this only says the state.
+		if (src === 0) {
+			return say('idle', modeWord + 'Nothing is deciding: this camera ' +
+				'reports no exposure to watch, and no daylight sensor or ' +
+				'threshold is set.' + lampNote);
+		}
+		return say('unknown', modeWord + 'This firmware does not report what ' +
+			'the monitor is watching.' + lampNote);
 	}
 
 	const api = {

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -767,8 +767,15 @@
 		// on /metrics, so there is nothing continuous to chart and isp_again
 		// would be a different quantity wearing the monitor's clothes. It gets
 		// a sentence of its own below instead.
+		//
+		// The `src === null` half is the older daemon that publishes no
+		// source, and there the precedence has to be reproduced rather than
+		// guessed at: a daylight sensor pin decides BEFORE the thresholds do,
+		// so a camera holding both is charting a gauge that is not driving it.
+		// Hence the pin test here as well as in its own branch below.
 		if (src === 2 ||
-			(src === null && has(nm.minThreshold) && has(nm.maxThreshold))) {
+			(src === null && !has(nm.lightSensorPin) &&
+				has(nm.minThreshold) && has(nm.maxThreshold))) {
 			const lo = pin(nm.minThreshold), hi = pin(nm.maxThreshold);
 			const bands = [];
 			if (lo !== null) {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -919,8 +919,8 @@
 			// with the title carrying the rest, and below md dockRuntime moves
 			// it off the picture entirely, where it has a line to itself.
 			'<span class="mj-hud-chip mj-glass" id="mj-lightmon" hidden' +
-			' title="Light monitor is driving night, IR-cut and the lamp">' +
-			'<a href="camera.cgi?tab=nightMode">Light monitor is driving night, IR&#8209;cut and the lamp</a>' +
+			' title="Automatic day/night is driving night, IR-cut and the lamp">' +
+			'<a href="camera.cgi?tab=nightMode">Automatic day/night is driving night, IR&#8209;cut and the lamp</a>' +
 			'</span>';
 	}
 
@@ -3387,19 +3387,38 @@
 		});
 	}
 
-	// The light monitor's live view: one sentence about what it is doing and a
-	// chart of the value it is watching, with the switching bands shaded. What
-	// to show is decided in ircut-check.js (monitorView, tested); this only
-	// mounts it. The chart is remade when the mode or the bands change, and
-	// the superseded instance is dropped from the registry.
+	// Automatic day/night's live view: one sentence about what the camera is
+	// doing and, where there is something continuous to watch, a chart of the
+	// value with the switching bands shaded. What to show is decided in
+	// ircut-check.js (monitorView, tested); this only mounts it. The chart is
+	// remade when the mode or the bands change, and the superseded instance is
+	// dropped from the registry.
+	//
+	// The block is hidden only while the camera has not answered at all. Every
+	// other state — the switch off, a wired photocell, a monitor that stood
+	// down — gets the sentence without the chart, because a section that
+	// appears only in the configuration it is describing cannot be found from
+	// any of the others (#325).
 	let monChart = null;
 	let monKey = '';
+	function dropMonChart(MC, host) {
+		if (MC) MC.dropChart(monChart);
+		monChart = null;
+		monKey = '';
+		if (host) {
+			host.innerHTML = '';
+			// makeChart reserved this before it had a sample to draw; left
+			// behind it is 129px of empty card under a one-line sentence.
+			host.style.minHeight = '';
+			host.hidden = true;
+		}
+	}
 	function paintMonitor(s) {
 		const box = document.getElementById('mj-ircut-mon');
 		if (!box) return;
 		const MC = window.MjCharts;
 		const view = IRCUT.monitorView(nightCfg(), (s.m && s.m.v) || null);
-		if (!view || !MC) {
+		if (!view) {
 			box.hidden = true;
 			return;
 		}
@@ -3408,6 +3427,11 @@
 		if (line) line.textContent = view.line;
 		const host = document.getElementById('mj-ircut-mon-chart');
 		if (!host) return;
+		if (!view.chart || !MC) {
+			dropMonChart(MC, host);
+			return;
+		}
+		host.hidden = false;
 		const key = view.mode + '|' + JSON.stringify(view.bands);
 		if (!monChart || monChart.host !== host || monKey !== key) {
 			// The superseded instance is unregistered, not merely abandoned:
@@ -3415,8 +3439,16 @@
 			// registry would otherwise keep each one for the life of the tab.
 			MC.dropChart(monChart);
 			host.innerHTML = '';
+			// The dashboard's ink, read the way the dashboard reads it. A
+			// hardcoded series colour is the light theme's, and a hairline
+			// left at the module default is the light theme's too — both were
+			// drawn as-is on this card's dark surface.
+			const css = getComputedStyle(document.documentElement);
+			const tok = (n, d) => (css.getPropertyValue(n) || d).trim();
 			monChart = MC.makeChart(host, {
-				h: 110, lo: 0, hi: null, colors: ['#4c60d8'],
+				h: 110, lo: 0, hi: null,
+				colors: [tok('--st-c1', '#4c60d8')],
+				grid: tok('--st-grid', '#e9ebf2'),
 				bands: view.bands,
 				fmt: view.mode === 'auto'
 					? (x) => (x >= 10 ? String(Math.round(x)) : x.toFixed(1)) + 'x'
@@ -3449,7 +3481,7 @@
 		// moved" — convicting a correctly wired camera. Refusing to run beats
 		// running and possibly lying.
 		if (toBool(nm.lightMonitor))
-			return 'The light monitor would drive the filter back mid-test. Turn it off, ' +
+			return 'Automatic day/night would drive the filter back mid-test. Turn it off, ' +
 				'run the test, then turn it back on.';
 		return null;
 	}
@@ -3688,10 +3720,10 @@
 			'<div id="mj-ircut-result" class="small" hidden></div>' +
 			'</div></div>' +
 			'<div id="mj-ircut-mon" hidden>' +
-			'<div class="mj-live-grp-head mt-3"><span class="mj-cap">Light monitor</span>' +
+			'<div class="mj-live-grp-head mt-3"><span class="mj-cap">Automatic day/night</span>' +
 			'<span class="mj-live-rule"></span></div>' +
 			'<div class="small text-secondary mb-1" id="mj-ircut-mon-line"></div>' +
-			'<div id="mj-ircut-mon-chart"></div>' +
+			'<div class="mj-chart" id="mj-ircut-mon-chart" hidden></div>' +
 			'</div>';
 
 		// Wired once, gated every time.

--- a/www/a/preview-stats.js
+++ b/www/a/preview-stats.js
@@ -108,7 +108,7 @@ window.MajesticStats = (function () {
 				'<div class="mj-ns-row"><span>camera sending</span><b id="mj-ns-send">–</b></div>' +
 				'<div class="mj-ns-row"><span>you receive</span><b id="mj-ns-recv">–</b></div>' +
 			'</div>' +
-			'<div class="mj-ns-chart" id="mj-ns-bw"></div>' +
+			'<div class="mj-chart mj-ns-chart" id="mj-ns-bw"></div>' +
 			'<div class="mj-ns-legend">' +
 				'<span>' + seg(C1) + 'received</span>' +
 				'<span id="mj-ns-leg-est">' + seg(C2) + 'link estimate</span></div>' +

--- a/www/cgi-bin/dashboard.cgi
+++ b/www/cgi-bin/dashboard.cgi
@@ -177,7 +177,7 @@ done) %>
 					<span class="mj-cap">Encoder output &mdash; main stream</span>
 					<span class="st-now" id="st-enc-now"></span>
 				</div>
-				<div class="st-chart" id="ch-enc"></div>
+				<div class="mj-chart" id="ch-enc"></div>
 			</div>
 		</div>
 
@@ -190,14 +190,14 @@ done) %>
 						<span><i class="st-dot st-dot-c2"></i>down</span>
 					</span>
 				</div>
-				<div class="st-chart" id="ch-net"></div>
+				<div class="mj-chart" id="ch-net"></div>
 			</div>
 			<div class="st-panel st-chartbox" id="st-wifi-panel" hidden>
 				<div class="st-chart-head">
 					<span class="mj-cap">Wi-Fi signal</span>
 					<span class="st-now" id="st-rssi-now"></span>
 				</div>
-				<div class="st-chart" id="ch-rssi"></div>
+				<div class="mj-chart" id="ch-rssi"></div>
 				<div class="x-small text-secondary" id="st-wifi-sub"></div>
 			</div>
 		</div>
@@ -220,7 +220,7 @@ done) %>
 						<span id="st-mem-lg-other"><i class="st-dot st-dot-mute"></i>Other</span>
 					</span>
 				</div>
-				<div class="st-chart" id="ch-mem"></div>
+				<div class="mj-chart" id="ch-mem"></div>
 				<div class="x-small text-secondary" id="st-mem-note"></div>
 			</div>
 		</div>
@@ -231,7 +231,7 @@ done) %>
 					<span class="mj-cap">Scene luminance</span>
 					<span class="st-now" id="st-luma-now"></span>
 				</div>
-				<div class="st-chart" id="ch-luma"></div>
+				<div class="mj-chart" id="ch-luma"></div>
 				<div class="x-small text-secondary" id="st-luma-note"></div>
 			</div>
 			<div class="st-panel st-chartbox">


### PR DESCRIPTION
The reporter of #325 could not find the Light monitor block on one camera and found it on another, and read that as the feature not having shipped for their processor. Their two attached configs answer the question by themselves: the camera without the block has automatic day/night **switched off**, the one with it has it **on**. Same code, different switch.

That is the bug rather than the explanation for it — twice over.

### A panel that appears only in the state it describes

`monitorView()` returned `null`, and took the whole block off the page, in every state except the two that draw a graph: the switch off, a wired photocell, an ADC pad, a monitor that stood down, an older daemon. Each of those is a defensible "there is no graph here". Together they meant the only section on the page that **names the control** was visible only to people who had already found the control.

It answers in every state now, with `chart: false` where there is nothing continuous to plot, and hides itself only while the camera has not answered at all:

| state | what it says |
|---|---|
| switch off | *Off — nothing switches this camera between day and night on its own. Turn on Automatic day/night below and this panel says what it is watching.* |
| daylight sensor pin | *Night. The daylight sensor decides. It reports light or dark and nothing in between, so there is no reading to plot here.* |
| ADC pad | *Day. A voltage on the daylight sensor pad decides. The camera does not publish that voltage, so there is nothing to plot here.* |
| stood down | *Day. Nothing is deciding: this camera reports no exposure to watch, and no daylight sensor or threshold is set.* |
| older daemon | *This firmware does not report what the monitor is watching.* |

### And the words follow the switch

The block heading, four findings, the filter test's refusal and the Live tab's chip all said "the light monitor" — which is what the firmware's own hints call it, and what nothing on screen is labelled. The switch is titled **Automatic day/night**. Searching the page for the thing you have just been told to turn on has to find it, so that is what they all say now.

### The chart was drawn in no stylesheet at all

`charts.js` was lifted out of the dashboard so other pages could draw with the same pencil, but its rules stayed behind under the dashboard's own `.st-chart` prefix. The third caller matched nothing, so its SVG text took the page's body font and SVG's default fill. Measured in the page:

| | unclassed host (what shipped) | styled host |
|---|---|---|
| font | `16px Montserrat` | `10px` PT Mono |
| fill | `rgb(0, 0, 0)` | `var(--bs-tertiary-color)` |
| display | `inline` | `block` |
| width | 300px intrinsic | 100% |

The axis numbers were about 1.7x wider than the 25px gutter the renderer reserves, so `2000` came out as `)00` and `150000` as `0000`, in black on a dark card — which is exactly what the reporter's screenshot shows. The rules are named after the thing now (`.mj-chart`) and every host carries it, the dashboard's five and the stats panel's included; the panel keeps its own ink and says so with both class names, because equal specificity would have left the winner to source order. The series colour and the grid hairline are read from the same theme tokens the dashboard reads, rather than being the light theme's, hardcoded.

### Three in `charts.js`

All visible in the reporter's own screenshot, all reproduced on an hi3516ev300 + imx335 running a 2026-09-04 nightly.

- **The auto ceiling fitted the data alone.** Gain idles near 1024 in raw units while the legacy thresholds people actually set are around 150000, so both bands clamped flat to the top edge and the plot became a flat line in a uniformly tinted box — no answer at all to the one question it is on the page for. Finite band edges count toward the ceiling now. The 15% headroom stays with the data, which needs somewhere to rise into; a threshold is a fixed number, and giving it headroom pushed a day band ending at 2 out to a ceiling of 5 and left it filling the bottom two fifths of its own chart.
- **"Everything above the night threshold" was spelt `1e9`**, which is indistinguishable from a real edge and would drag the whole plot off the top once the scale started fitting edges. An open band end is `null`.
- **Both band names were drawn at the same offset whatever the band's drawn height**, so two bands clamped to one edge printed "day" and "night" on the same pixel. A band shorter than a label draws none — and since bands do not overlap, that single guard also keeps the survivors a line apart.

Plus: the left gutter sizes itself to the numbers about to go in it, instead of staying at the four monospace characters that were enough for a percentage and not for a six-digit gain.

### Verified

On an hi3516ev300 + imx335 (lite, 2026-09-04 nightly), in four configurations:

- automatic — axis `2.0x / 1.0x / 0.0x`, day band shaded, gain trace drawn;
- thresholds 150000/160000 — axis `200000 / 100000 / 0`, both bands separately labelled, the gain visibly far below its night threshold (this is the reporter's remote camera's shape);
- switch off, and daylight-sensor pin — sentence, no chart, no empty reserved box.

Dashboard charts and the Live stats panel render as before. 8 new tests across `tests/charts.test.js` and `tests/ircut-check.test.js`; suite green, `npm run build:dist` green, the purged bootstrap subset regenerates identical.

Fixes #325
