### PR TITLE
Day / Night: a marker that leaves when the picture moves, and a wait the page invented

### DIFF
--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -305,12 +305,12 @@ group('a band is what the value is compared against, so the scale has to fit it'
 	// in a uniformly tinted box — while the camera was in fact nowhere near
 	// switching, and would have looked identical if it had been one step away
 	// (#325).
-	const bands = [
-		{ from: 0, to: 150000, color: 'rgba(47,182,115,.10)', label: 'day' },
-		{ from: 160000, to: null, color: 'rgba(255,193,7,.10)', label: 'night' },
+	const marks = [
+		{ v: 150000, color: '#2fb673', label: 'day' },
+		{ v: 160000, color: '#e0a020', label: 'night' },
 	];
 	const host = makeHost(400);
-	const ch = MC.makeChart(host, { h: 110, lo: 0, hi: null, colors: ['#000'], bands: bands });
+	const ch = MC.makeChart(host, { h: 110, lo: 0, hi: null, colors: ['#000'], marks: marks });
 	for (let i = 0; i < 3; i++) { clock.t = i * 2; MC.pushChart(ch, [1024]); }
 	const ticks = (host.innerHTML.match(/text-anchor="end">([\d.]+)</g) || [])
 		.map(t => parseFloat(t.replace(/[^\d.]/g, '')));
@@ -318,13 +318,20 @@ group('a band is what the value is compared against, so the scale has to fit it'
 		Math.max.apply(null, ticks) >= 160000,
 		'top tick ' + Math.max.apply(null, ticks));
 
-	// An open end is not a number. Spelt 1e9 as a stand-in for "and above" it
-	// is indistinguishable from a real edge, so the rule above would fit it
-	// and put the data, the day band and everything else in the bottom
+	// A band's open end is not a number either. Spelt 1e9 as a stand-in for
+	// "and above" it is indistinguishable from a real edge, so the rule above
+	// would fit it and put the data and everything else in the bottom
 	// millionth of the box — the same flat, plausible, useless line by another
 	// route.
-	check('and an open band end is not fitted into it',
-		Math.max.apply(null, ticks) < 1e6, 'top tick ' + Math.max.apply(null, ticks));
+	const open = makeHost(400);
+	const ch2 = MC.makeChart(open, { h: 110, lo: 0, hi: null, colors: ['#000'],
+		bands: [{ from: 160000, to: null, color: '#fff', label: 'night' }] });
+	clock.t += 2; MC.pushChart(ch2, [1024]);
+	const t2 = (open.innerHTML.match(/text-anchor="end">([\d.]+)</g) || [])
+		.map(x => parseFloat(x.replace(/[^\d.]/g, '')));
+	check('and an open band end is not fitted into the scale',
+		Math.max.apply(null, t2) >= 160000 && Math.max.apply(null, t2) < 1e6,
+		'top tick ' + Math.max.apply(null, t2));
 }
 
 done();

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -451,13 +451,17 @@ function runRest() {
 		check('auto mode charts gain in multiples',
 			auto && auto.mode === 'auto' && auto.value === 2.567,
 			auto && JSON.stringify(auto.value));
-		check('the day band runs to autoDayGain',
-			auto.bands[0].from === 0 && auto.bands[0].to === 2);
-		check('no night band without an explicit autoNightGain',
-			auto.bands.length === 1);
-		check('an explicit autoNightGain shades a night band',
+		// A threshold is a LEVEL, so it is a rule at its own value rather than
+		// a shaded region whose size follows the scale — which is what made
+		// the only marker on the plot shrink away as the gain rose (#325).
+		check('the day threshold is a rule at autoDayGain',
+			auto.marks.length === 1 && auto.marks[0].v === 2 &&
+			auto.marks[0].label === 'day');
+		check('no night rule without an explicit autoNightGain',
+			!auto.marks.some(m => m.label === 'night'));
+		check('an explicit autoNightGain draws one',
 			ic.monitorView({ lightMonitor: true, autoNightGain: 16 }, vAuto)
-				.bands.some(b => b.from === 16));
+				.marks.some(m => m.v === 16 && m.label === 'night'));
 		const counting = ic.monitorView(nmAuto, Object.assign({}, vAuto, {
 			night_auto_pending: 2, night_auto_streak_seconds: 20,
 			night_auto_dwell_seconds: 60,
@@ -498,9 +502,9 @@ function runRest() {
 		const nmThr = { lightMonitor: true, minThreshold: 1500, maxThreshold: 4000 };
 		const thr = ic.monitorView(nmThr,
 			{ night_mode_source: 2, night_enabled: 1, isp_again: 6000 });
-		check('threshold mode charts raw isp_again with both bands',
+		check('threshold mode charts raw isp_again with both rules',
 			thr && thr.mode === 'thresholds' && thr.value === 6000 &&
-			thr.bands.length === 2);
+			thr.marks.length === 2);
 		check('an old daemon with thresholds still gets the chart',
 			ic.monitorView(nmThr, { isp_again: 2000 }).mode === 'thresholds');
 		// An older daemon publishes no source, so this file has to reproduce
@@ -513,15 +517,10 @@ function runRest() {
 				{ lightMonitor: true, lightSensorPin: 66,
 					minThreshold: 1500, maxThreshold: 4000 },
 				{ isp_again: 2000, night_enabled: 0 }).mode === 'sensor');
-		// The band that means "and everything above" is open-ended, and says so
-		// with null rather than a stand-in ceiling: the chart's auto scale
-		// makes room for a finite edge, so a made-up one would push the whole
-		// plot off the top.
-		check('the night band is open at the top',
-			thr.bands[1].from === 4000 && thr.bands[1].to === null);
-		check('so is the automatic mode\'s',
-			ic.monitorView({ lightMonitor: true, autoNightGain: 16 }, vAuto)
-				.bands.find(b => b.from === 16).to === null);
+		check('the night rule sits at maxThreshold',
+			thr.marks[1].v === 4000 && thr.marks[1].label === 'night');
+		check('and the day rule at minThreshold',
+			thr.marks[0].v === 1500 && thr.marks[0].label === 'day');
 
 		// Every state answers. A view with nothing continuous behind it says
 		// so with chart:false instead of vanishing — the block is the only
@@ -530,7 +529,7 @@ function runRest() {
 		const gpio = ic.monitorView({ lightMonitor: true, lightSensorPin: 66 },
 			{ night_mode_source: 1, night_enabled: 0 });
 		check('a GPIO source has nothing continuous to chart',
-			gpio.chart === false && gpio.value === null && !gpio.bands.length);
+			gpio.chart === false && gpio.value === null && !gpio.marks.length);
 		check('and says which way the sensor is pointing',
 			/^Day\. The daylight sensor decides/.test(gpio.line), gpio.line);
 		const adc = ic.monitorView(
@@ -662,6 +661,41 @@ function runRest() {
 		check('day with a closed filter agrees',
 			!ic.diagnose(cfg, { night: 0, ircut: 0 }, { conflictS: 600, flips: 0 })
 				.some(x => x.id === 'conflict'));
+	}
+
+	group('projector: the local clock the countdown is read forward by');
+	{
+		// A pending switch, sampled by a heartbeat that polls faster than the
+		// camera's own gauge ticks. Both bugs below produce a fluent, moving
+		// sentence — one that counts the wrong way, one that counts for a
+		// camera that has stopped answering — and neither raises anything.
+		const at = (streak) => ({
+			night_auto_pending: 2, night_auto_dwell_seconds: 60,
+			night_auto_streak_seconds: streak,
+		});
+		const p = ic.projector(6);
+		check('a first sample is read as it stands', p.push(at(10), 100) === 0);
+		check('and a tick between polls ages it', p.age(101) === 1);
+		// The camera repeating itself is not the countdown standing still and
+		// is certainly not it going backwards: re-anchoring on a repeat threw
+		// away the second just counted and put the number back up.
+		check('a poll repeating the same reading keeps the projection',
+			p.push(at(10), 102) === 2, String(p.push(at(10), 102)));
+		check('and the camera moving on re-anchors to what it says',
+			p.push(at(15), 105) === 0);
+		// A streak that restarts is a change like any other; only an identical
+		// reading means "no news".
+		check('a restarted streak re-anchors too', p.push(at(0), 106) === 0);
+
+		// Past the stale window there is nothing honest left to count from.
+		const q = ic.projector(6);
+		q.push(at(10), 200);
+		check('a sample inside the window is still projected', q.age(205) === 5);
+		check('and one past it is not projected at all', q.age(207) === null);
+		check('a successful poll starts the window again',
+			q.push(at(10), 208) === 8 && q.age(209) !== null);
+		check('nothing is projected before the camera has answered',
+			ic.projector(6).age(1) === null);
 	}
 
 	group('diagnose: hunting, and the ordering of what it all reports');

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -464,6 +464,36 @@ function runRest() {
 		}));
 		check('a pending switch counts down',
 			/switching in 40 s/.test(counting.line), counting.line);
+		// The camera's streak gauge advances on the camera's schedule, the page
+		// polls on another, and the two beat against each other — so the same
+		// sample is read forward by a local clock between polls. It is the
+		// camera's number carried forward, never a number of the page's own:
+		// every poll resyncs, and neither end of it may run away.
+		const aged = (age) => ic.monitorView(nmAuto, Object.assign({}, vAuto, {
+			night_auto_pending: 2, night_auto_streak_seconds: 20,
+			night_auto_dwell_seconds: 60,
+		}), age);
+		check('and falls a second at a time between polls',
+			/switching in 37 s/.test(aged(3).line), aged(3).line);
+		// Rounded rather than floored: a retell landing just short of a whole
+		// second must still advance, or it reprints the number it just
+		// printed and the countdown stutters instead of counting.
+		check('a retell just short of a second still advances it',
+			/switching in 39 s/.test(aged(0.9).line), aged(0.9).line);
+		check('a sample stamped in the future does not make it climb',
+			/switching in 40 s/.test(aged(-5).line), aged(-5).line);
+		check('and a switch the camera is late making does not go negative',
+			/switching in 0 s/.test(aged(900).line), aged(900).line);
+		// A streak gauge that has gone negative — a stepped clock under a
+		// "seconds held" counter — subtracts into a wait LONGER than the one
+		// configured, which is how a 60 s setting was shown as 250 s. The
+		// countdown cannot outlast its own dwell.
+		const stepped = ic.monitorView(nmAuto, Object.assign({}, vAuto, {
+			night_auto_pending: 2, night_auto_streak_seconds: -190,
+			night_auto_dwell_seconds: 60,
+		}), 0);
+		check('a stepped clock cannot stretch the wait past the dwell',
+			/switching in 60 s/.test(stepped.line), stepped.line);
 
 		const nmThr = { lightMonitor: true, minThreshold: 1500, maxThreshold: 4000 };
 		const thr = ic.monitorView(nmThr,
@@ -643,6 +673,32 @@ function runRest() {
 		check('two switches in the window is not',
 			!ic.diagnose(cfg, { night: 0, ircut: 0 }, { flips: 2, conflictS: 0 })
 				.some(x => x.id === 'hunting'));
+
+		// The finding used to state that automatic mode backs off after each
+		// flip. Nothing had measured that, and the daemon publishes the very
+		// number that would show it — so the sentence is now read off the
+		// gauge. It appears only when the camera is genuinely waiting longer
+		// than it was asked to, and stays silent otherwise, which is the whole
+		// difference between a reading and a claim. Testable only here: it
+		// takes a camera hunting at dusk, which is not a thing that can be
+		// arranged on demand.
+		const auto = { lightMonitor: true, irCutPin1: 11,
+			autoNightDelay: 15, autoDayDelay: 60 };
+		const hunt = (s) => ic.diagnose(auto, s, { flips: 3, conflictS: 0 })
+			.filter(x => x.id === 'hunting')[0].detail;
+		check('a stretched wait is reported as the camera\'s own number',
+			/stretched its wait to 240 s, up from the 60 s/.test(
+				hunt({ night: 1, ircut: 1, src: 4, dwell: 240 })),
+			hunt({ night: 1, ircut: 1, src: 4, dwell: 240 }));
+		check('a dwell equal to what was asked claims no backoff',
+			!/stretched/.test(hunt({ night: 1, ircut: 1, src: 4, dwell: 60 })),
+			hunt({ night: 1, ircut: 1, src: 4, dwell: 60 }));
+		check('and the direction decides which delay it is compared against',
+			!/stretched/.test(hunt({ night: 0, ircut: 0, src: 4, dwell: 15 })) &&
+			/up from the 15 s/.test(hunt({ night: 0, ircut: 0, src: 4, dwell: 40 })),
+			hunt({ night: 0, ircut: 0, src: 4, dwell: 40 }));
+		check('a camera that publishes no dwell gauge is not spoken for',
+			!/stretched/.test(hunt({ night: 1, ircut: 1, src: 4, dwell: null })));
 		const many = ic.diagnose(
 			{ lightMonitor: true, minThreshold: 9, maxThreshold: 9 },
 			{ night: 0, ircut: 1 }, { flips: 9, conflictS: 600 });

--- a/www/a/charts.js
+++ b/www/a/charts.js
@@ -124,7 +124,7 @@ window.MjCharts = (function () {
 	// measured width, which is not knowable this early.
 	const PAD_T = 5;  // headroom above the top gridline
 	const X_BAND = 14; // the "-2 min / now" strip below the plot
-	const LBL_H = 12;  // a band shorter than this has no room for its own label
+	const LBL_H = 12;  // one line of band-label text: the spacing labels keep
 	function chartHeight(cfg) { return PAD_T + cfg.h + X_BAND; }
 	function makeChart(sel, cfg) {
 		const host = typeof sel === 'string' ? $(sel) : sel;
@@ -226,19 +226,38 @@ window.MjCharts = (function () {
 		let s = '';
 		// threshold bands (Wi-Fi grades, luminance floor, day/night) sit under
 		// everything. An open end reaches the edge of the plot.
+		//
+		// Every band that is drawn keeps its name, and the name is PLACED
+		// rather than dropped. Suppressing the label of a band too thin to
+		// hold one looked like the tidy answer to two names landing on the
+		// same pixel, and it was worse than the overlap: on the Day / Night
+		// chart the day band shrinks as the scale grows, so covering the lens
+		// made the only marker on the plot disappear — the reader loses the
+		// legend exactly when the picture starts moving (#325). So a band
+		// narrower than a line of text gets its name centred ON it instead,
+		// and a name that would land on one already taken is nudged clear.
+		const taken = [];
+		const place = (y1, y2) => {
+			const tall = y2 - y1;
+			let y = tall >= LBL_H ? y1 + 10 : y1 + tall / 2 + 3.5;
+			const top = padT + 8, bot = padT + H - 1;
+			const clash = (t) => taken.some(u => Math.abs(u - t) < LBL_H);
+			// Down first — a band's name belongs at its top edge, so the one
+			// that moves is the later, lower band. Up only if down runs out
+			// of plot.
+			while (clash(y) && y + LBL_H <= bot) y += LBL_H;
+			while (clash(y) && y - LBL_H >= top) y -= LBL_H;
+			y = y > bot ? bot : y < top ? top : y;
+			taken.push(y);
+			return y;
+		};
 		bands.forEach(b => {
 			const y1 = b.to == null ? padT : Y(b.to);
 			const y2 = b.from == null ? padT + H : Y(b.from);
 			s += '<rect x="' + padL + '" y="' + y1.toFixed(1) + '" width="' + plotW +
 				'" height="' + (y2 - y1).toFixed(1) + '" fill="' + b.color + '"/>';
-			// A band squeezed off the plot keeps no room for its own name, and
-			// the name does not shrink with it: two bands clamped to the same
-			// edge printed both words on the same pixel, which is how "day" and
-			// "night" came out as one unreadable smudge. Bands do not overlap,
-			// so once each drawn band is at least a label tall their labels are
-			// necessarily that far apart too — the one guard covers both.
-			if (b.label && y2 - y1 >= LBL_H) {
-				s += '<text x="' + (padL + plotW - 4) + '" y="' + (y1 + 10).toFixed(1) +
+			if (b.label) {
+				s += '<text x="' + (padL + plotW - 4) + '" y="' + place(y1, y2).toFixed(1) +
 					'" text-anchor="end" opacity="0.8">' + b.label + '</text>';
 			}
 		});

--- a/www/a/charts.js
+++ b/www/a/charts.js
@@ -176,6 +176,14 @@ window.MjCharts = (function () {
 		// spelt null rather than some large number so the auto scale below can
 		// tell a real edge from a stand-in for infinity.
 		const bands = cfg.bands || [];
+		// A THRESHOLD is a level, not a region — so it is drawn as a rule at
+		// its own value with its name beside it, and it keeps that size at
+		// every scale. Shading the region instead ties the marker's size to
+		// the scale, which is how the Day / Night chart's only marker came to
+		// shrink away as the gain rose (#325): the reporter asked for the line,
+		// and the line is right. Bands stay for the dashboard, where a band
+		// really is a region — the Wi-Fi grades are ranges, not edges.
+		const marks = cfg.marks || [];
 		if (hi == null) {
 			let max = 0;
 			pts.forEach(p => p.v.forEach(v => { if (v != null && v > max) max = v; }));
@@ -198,6 +206,9 @@ window.MjCharts = (function () {
 				[b.from, b.to].forEach(e => {
 					if (e != null && isFinite(e) && e > top) top = e;
 				});
+			});
+			marks.forEach(m => {
+				if (m.v != null && isFinite(m.v) && m.v > top) top = m.v;
 			});
 			hi = niceCeil(Math.max(top, 1));
 		}
@@ -237,20 +248,22 @@ window.MjCharts = (function () {
 		// narrower than a line of text gets its name centred ON it instead,
 		// and a name that would land on one already taken is nudged clear.
 		const taken = [];
-		const place = (y1, y2) => {
-			const tall = y2 - y1;
-			let y = tall >= LBL_H ? y1 + 10 : y1 + tall / 2 + 3.5;
+		// Keeps names off each other and inside the plot. Down first, because
+		// a name belongs at the top of what it names, so the one that gives
+		// way is the lower of the pair; up only when down runs out of plot.
+		const place = (y) => {
 			const top = padT + 8, bot = padT + H - 1;
 			const clash = (t) => taken.some(u => Math.abs(u - t) < LBL_H);
-			// Down first — a band's name belongs at its top edge, so the one
-			// that moves is the later, lower band. Up only if down runs out
-			// of plot.
 			while (clash(y) && y + LBL_H <= bot) y += LBL_H;
 			while (clash(y) && y - LBL_H >= top) y -= LBL_H;
 			y = y > bot ? bot : y < top ? top : y;
 			taken.push(y);
 			return y;
 		};
+		// A band's name sits inside it, or centred on it when it is thinner
+		// than a line of text.
+		const placeBand = (y1, y2) =>
+			place(y2 - y1 >= LBL_H ? y1 + 10 : y1 + (y2 - y1) / 2 + 3.5);
 		bands.forEach(b => {
 			const y1 = b.to == null ? padT : Y(b.to);
 			const y2 = b.from == null ? padT + H : Y(b.from);
@@ -267,6 +280,21 @@ window.MjCharts = (function () {
 			s += '<line x1="' + padL + '" y1="' + y.toFixed(1) + '" x2="' + (padL + plotW) +
 				'" y2="' + y.toFixed(1) + '" stroke="' + grid + '" stroke-width="1"/>';
 			s += '<text x="' + (padL - 5) + '" y="' + (y + 3.5).toFixed(1) + '" text-anchor="end">' + ticks[i] + '</text>';
+		});
+		marks.forEach(m => {
+			if (m.v == null || !isFinite(m.v) || m.v < lo || m.v > hi) return;
+			const y = Y(m.v);
+			s += '<line x1="' + padL + '" y1="' + y.toFixed(1) + '" x2="' +
+				(padL + plotW) + '" y2="' + y.toFixed(1) + '" stroke="' +
+				(m.color || grid) + '" stroke-width="1" stroke-dasharray="3 3"/>';
+			if (m.label) {
+				// Above the rule where there is room for it, below where the
+				// rule is at the very top of the plot.
+				const above = y - 4 >= padT + 8;
+				s += '<text x="' + (padL + plotW - 4) + '" y="' +
+					place(above ? y - 4 : y + 10).toFixed(1) +
+					'" text-anchor="end" opacity="0.9">' + m.label + '</text>';
+			}
 		});
 		if (cfg.ref && cfg.ref.v > lo && cfg.ref.v < hi) {
 			const y = Y(cfg.ref.v);

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -706,6 +706,46 @@
 	// had not shipped for their SoC. A sentence is not a graph, but it is an
 	// answer, and it is beside the switch.
 	//
+	// The local clock behind the countdown, kept here rather than in the page
+	// so that it can be driven by a fake one. Two moments, and conflating them
+	// is what makes this subtle:
+	//
+	//   `seen`   the last time the camera ANSWERED. Past `staleS` of silence
+	//            the projection stops: a failed poll leaves the last sample
+	//            standing, and ageing that one walks the countdown to zero and
+	//            announces a switch on behalf of a camera that has gone away.
+	//   `anchor` the last time its answer CHANGED. The streak gauge is coarse
+	//            — a second on one board, five on another — and the heartbeat
+	//            polls every two, so most polls during a pending switch repeat
+	//            the previous value. Re-anchoring on those throws away the
+	//            second just counted and puts the number back UP: 50, 49, 50,
+	//            49. The anchor therefore moves only on a reading that differs,
+	//            which covers forward progress and a restarted streak alike.
+	function projector(staleS) {
+		const limit = typeof staleS === 'number' ? staleS : 6;
+		let last = null, anchor = 0, seen = 0;
+		const differs = (a, b) =>
+			a.night_auto_streak_seconds !== b.night_auto_streak_seconds ||
+			a.night_auto_pending !== b.night_auto_pending ||
+			a.night_auto_dwell_seconds !== b.night_auto_dwell_seconds;
+		return {
+			// A successful poll. Returns the age to read this sample forward by.
+			push: function (v, nowS) {
+				if (!v) { last = null; return 0; }
+				if (!last || differs(last, v)) anchor = nowS;
+				last = v;
+				seen = nowS;
+				return nowS - anchor;
+			},
+			// A tick between polls; null when there is nothing honest left to
+			// project from.
+			age: function (nowS) {
+				if (!last || nowS - seen > limit) return null;
+				return nowS - anchor;
+			},
+		};
+	}
+
 	// null now means only that the camera has not answered yet.
 	//
 	// `ageS` is how long ago `v` was sampled. The camera advances its streak
@@ -735,7 +775,7 @@
 
 		// A state with no plot: one sentence, no bands, no value.
 		const say = (mode, line) => ({
-			mode: mode, chart: false, value: null, bands: [],
+			mode: mode, chart: false, value: null, marks: [],
 			line: line, unit: '',
 		});
 
@@ -752,19 +792,15 @@
 		if (src === 4) {
 			const dayG = pin(nm.autoDayGain) !== null ? pin(nm.autoDayGain) : 2;
 			const nightG = pin(nm.autoNightGain);
-			const bands = [{
-				from: 0, to: dayG,
-				color: 'rgba(47,182,115,.10)', label: 'day',
-			}];
+			// Each threshold is a rule at its own level rather than a shaded
+			// region: the level is the whole fact, and a region's size follows
+			// the scale, which is what made the day marker shrink to nothing
+			// as the gain rose. Only a threshold that EXISTS gets a line — an
+			// automatic camera with no night gain set has no night level to
+			// draw, and the sentence says so instead.
+			const marks = [{ v: dayG, color: '#2fb673', label: 'day' }];
 			if (nightG !== null) {
-				// Open at the top: "everything above the night threshold"
-				// has no ceiling, and saying so with null rather than a large
-				// number is what keeps the chart's auto scale from trying to
-				// fit one on the plot.
-				bands.push({
-					from: nightG, to: null,
-					color: 'rgba(255,193,7,.10)', label: 'night',
-				});
+				marks.push({ v: nightG, color: '#e0a020', label: 'night' });
 			}
 			const gm = v.night_auto_gain_milli;
 			const pend = v.night_auto_pending;
@@ -808,7 +844,7 @@
 			return {
 				mode: 'auto', chart: true,
 				value: gm != null && gm >= 0 ? gm / 1000 : null,
-				bands: bands, line: line + lampNote,
+				marks: marks, line: line + lampNote,
 				unit: 'x',
 			};
 		}
@@ -827,23 +863,13 @@
 			(src === null && !has(nm.lightSensorPin) &&
 				has(nm.minThreshold) && has(nm.maxThreshold))) {
 			const lo = pin(nm.minThreshold), hi = pin(nm.maxThreshold);
-			const bands = [];
-			if (lo !== null) {
-				bands.push({
-					from: 0, to: lo,
-					color: 'rgba(47,182,115,.10)', label: 'day',
-				});
-			}
-			if (hi !== null) {
-				bands.push({
-					from: hi, to: null,
-					color: 'rgba(255,193,7,.10)', label: 'night',
-				});
-			}
+			const marks = [];
+			if (lo !== null) marks.push({ v: lo, color: '#2fb673', label: 'day' });
+			if (hi !== null) marks.push({ v: hi, color: '#e0a020', label: 'night' });
 			return {
 				mode: 'thresholds', chart: true,
 				value: ('isp_again' in v) ? v.isp_again : null,
-				bands: bands,
+				marks: marks,
 				line: modeWord +
 					'Comparing raw sensor gain against the thresholds ' +
 					'(vendor-specific units).' + lampNote,
@@ -877,6 +903,7 @@
 
 	const api = {
 		diagnose: diagnose, tracker: tracker, monitorView: monitorView,
+		projector: projector,
 		stats: stats, irLook: irLook, colourLook: colourLook,
 		look: look, lookAt: lookAt,
 		verdict: verdict, probe: probe, snapshot: snapshot, wired: wired,

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -99,6 +99,26 @@
 	// view, cannot raise a banner on its own.
 	const PIC_STREAK = 4;
 
+	// What the camera says it is waiting, when that is longer than what was
+	// asked for — and nothing at all when it is not.
+	//
+	// This replaced a sentence stating flatly that automatic mode "slows itself
+	// down after each flip". Nothing here had ever measured that: across every
+	// transition observed on an hi3516ev300 the dwell gauge read back exactly
+	// the configured delay and never more. It may well be true on some build,
+	// and that is the point — the daemon publishes the wait it is applying, so
+	// a page that can READ the number has no business asserting the mechanism
+	// behind it. If a backoff exists, this prints it; if it does not, this says
+	// nothing and the advice below still stands.
+	function stretched(nm, sample) {
+		if (!sample || typeof sample.dwell !== 'number' || sample.dwell < 0) return '';
+		// Whichever way it is about to go decides which delay was asked for.
+		const asked = sample.night ? pin(nm.autoDayDelay) : pin(nm.autoNightDelay);
+		if (asked === null || sample.dwell <= asked) return '';
+		return 'The camera has already stretched its wait to ' + sample.dwell +
+			' s, up from the ' + asked + ' s set below. ';
+	}
+
 	// Findings, worst first. `fix` names the section to send someone to; the
 	// consumer decides whether that becomes a link or a tab switch.
 	//
@@ -367,10 +387,12 @@
 					detail: track.flips + ' switches in the last ' +
 						(HUNT_WINDOW_S / 60) + ' minutes. ' +
 						(sample && sample.src === 4
-							? 'Automatic mode slows itself down after each flip, ' +
-								'but a flashing light aimed at the camera can still ' +
-								'drive it; raising "Seconds of brightness before ' +
-								'day" stretches the cycle further.'
+							? stretched(nm, sample) +
+								'Something in view is moving the light on and off — ' +
+								'a security lamp, headlights, a sign. Raising ' +
+								'"Seconds of brightness before day" and "Seconds ' +
+								'of darkness before night" makes the camera sit ' +
+								'each one out.'
 							: 'Widen the gap between the day and night thresholds ' +
 								'so dusk cannot sit on the boundary.'),
 					fix: 'nightMode',
@@ -685,7 +707,15 @@
 	// answer, and it is beside the switch.
 	//
 	// null now means only that the camera has not answered yet.
-	function monitorView(nm, v) {
+	//
+	// `ageS` is how long ago `v` was sampled. The camera advances its streak
+	// counter on its own schedule — a second here, five seconds on the board
+	// the reporter of #325 was watching — and the page polls on a third, so a
+	// countdown printed straight from the two gauges lurches by whatever the
+	// two cadences happen to beat out. Ageing the streak locally makes it fall
+	// a second at a time and resync on every sample: the number is still the
+	// camera's, read forward by a clock rather than invented.
+	function monitorView(nm, v, ageS) {
 		nm = nm || {};
 		if (!v) return null;
 		const src = ('night_mode_source' in v) ? v.night_mode_source : null;
@@ -742,9 +772,29 @@
 			// there is no number to count from, and "switching in 0 s" would
 			// be a confident sentence made of nothing.
 			const dwell = v.night_auto_dwell_seconds;
-			const streak = v.night_auto_streak_seconds;
-			const left = typeof dwell === 'number' && typeof streak === 'number'
-				? Math.max(0, dwell - streak) : null;
+			const held = v.night_auto_streak_seconds;
+			// Only ever forward, and never past the end: a sample that is
+			// somehow stamped in the future must not make the countdown climb,
+			// and a monitor whose switch is late must not print a negative.
+			// Rounded, not floored. A retell landing 0.9 s after its sample
+			// floors to nothing and reprints the number it just printed, so
+			// the countdown stutters — 13, 13, 11, 11 — which is the jerk it
+			// was meant to remove wearing a smaller amplitude.
+			const streak = typeof held === 'number'
+				? held + (typeof ageS === 'number' && ageS > 0 ? Math.round(ageS) : 0)
+				: null;
+			// Bounded by the dwell at the top as well as by zero at the
+			// bottom. The countdown is arithmetic on two gauges, and a streak
+			// that comes back NEGATIVE — which is what a monotonic-looking
+			// "seconds held" turns into the moment the camera's clock is
+			// stepped by an NTP correction — makes the subtraction produce a
+			// wait LONGER than the one the operator configured. The reporter
+			// of #325 was shown 250 s against a 60 s setting. Nothing can be
+			// held for less than no time, and nothing can be waited for longer
+			// than the dwell, so neither end of that is a reading worth
+			// repeating.
+			const left = typeof dwell === 'number' && streak !== null
+				? Math.max(0, Math.min(dwell, dwell - streak)) : null;
 			const inLeft = left === null ? '.' :
 				' — switching in ' + left + ' s if it stays.';
 			const line = pend === 1

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3425,18 +3425,22 @@
 	// countdown printed only on arrival lurches by whatever the two cadences
 	// beat out — five seconds at a time, unevenly, on the board in #325.
 	let monSample = null;
-	let monAt = 0;
 	let monTick = null;
+	// When to project and by how much is decided in ircut-check.js, where it is
+	// tested against a fake clock; this only turns the handle.
+	const monClock = IRCUT.projector ? IRCUT.projector() : null;
 	function retellMonitor() {
 		const line = document.getElementById('mj-ircut-mon-line');
-		if (!line || !monSample) {
-			// The section is gone; so is the reason to keep a timer for it.
+		const age = monClock && monClock.age(performance.now() / 1000);
+		if (!line || !monSample || age == null) {
+			// The section is gone, or the camera has stopped answering and
+			// there is nothing honest left to count. Freeze on the last thing
+			// it actually said.
 			clearInterval(monTick);
 			monTick = null;
 			return;
 		}
-		const view = IRCUT.monitorView(nightCfg(), monSample,
-			(performance.now() - monAt) / 1000);
+		const view = IRCUT.monitorView(nightCfg(), monSample, age);
 		// The sentence only. Re-dealing the chart every second would push a
 		// duplicate sample into it and re-render the whole plot for nothing.
 		if (view) line.textContent = view.line;
@@ -3446,8 +3450,9 @@
 		if (!box) return;
 		const MC = window.MjCharts;
 		monSample = (s.m && s.m.v) || null;
-		monAt = performance.now();
-		const view = IRCUT.monitorView(nightCfg(), monSample, 0);
+		const age = monClock
+			? monClock.push(monSample, performance.now() / 1000) : 0;
+		const view = IRCUT.monitorView(nightCfg(), monSample, age);
 		if (!view) {
 			box.hidden = true;
 			return;
@@ -3468,7 +3473,7 @@
 			return;
 		}
 		host.hidden = false;
-		const key = view.mode + '|' + JSON.stringify(view.bands);
+		const key = view.mode + '|' + JSON.stringify(view.marks);
 		if (!monChart || monChart.host !== host || monKey !== key) {
 			// The superseded instance is unregistered, not merely abandoned:
 			// every remount of this section makes a new host, and the chart
@@ -3485,7 +3490,7 @@
 				h: 110, lo: 0, hi: null,
 				colors: [tok('--st-c1', '#4c60d8')],
 				grid: tok('--st-grid', '#e9ebf2'),
-				bands: view.bands,
+				marks: view.marks,
 				fmt: view.mode === 'auto'
 					? (x) => (x >= 10 ? String(Math.round(x)) : x.toFixed(1)) + 'x'
 					: undefined,

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3380,6 +3380,12 @@
 				// tells an automatic monitor from a blind one by it, and null
 				// (gauge absent) keeps the older-firmware reading.
 				src: ('night_mode_source' in v) ? v.night_mode_source : null,
+				// The wait the camera says it is currently applying. The
+				// hunting finding used to ASSERT that automatic mode backs off
+				// after a flip; this is the gauge that would show it, so the
+				// finding reads it instead of claiming it.
+				dwell: ('night_auto_dwell_seconds' in v)
+					? v.night_auto_dwell_seconds : null,
 			};
 			ircutStats = ircutTrack.push(ircutSample, performance.now() / 1000);
 			paintFindings();
@@ -3413,11 +3419,35 @@
 			host.hidden = true;
 		}
 	}
+	// The last metric sample and when it arrived, so the sentence can be
+	// re-read a second at a time between polls. The camera advances its streak
+	// counter on its own schedule and the heartbeat polls on another, so a
+	// countdown printed only on arrival lurches by whatever the two cadences
+	// beat out — five seconds at a time, unevenly, on the board in #325.
+	let monSample = null;
+	let monAt = 0;
+	let monTick = null;
+	function retellMonitor() {
+		const line = document.getElementById('mj-ircut-mon-line');
+		if (!line || !monSample) {
+			// The section is gone; so is the reason to keep a timer for it.
+			clearInterval(monTick);
+			monTick = null;
+			return;
+		}
+		const view = IRCUT.monitorView(nightCfg(), monSample,
+			(performance.now() - monAt) / 1000);
+		// The sentence only. Re-dealing the chart every second would push a
+		// duplicate sample into it and re-render the whole plot for nothing.
+		if (view) line.textContent = view.line;
+	}
 	function paintMonitor(s) {
 		const box = document.getElementById('mj-ircut-mon');
 		if (!box) return;
 		const MC = window.MjCharts;
-		const view = IRCUT.monitorView(nightCfg(), (s.m && s.m.v) || null);
+		monSample = (s.m && s.m.v) || null;
+		monAt = performance.now();
+		const view = IRCUT.monitorView(nightCfg(), monSample, 0);
 		if (!view) {
 			box.hidden = true;
 			return;
@@ -3425,6 +3455,12 @@
 		box.hidden = false;
 		const line = document.getElementById('mj-ircut-mon-line');
 		if (line) line.textContent = view.line;
+		// Re-anchored on every sample rather than left free-running, so the
+		// retell falls BETWEEN two polls instead of wherever it happened to
+		// start. Free-running against a 2 s heartbeat it landed a fraction of
+		// a second after each sample and said the same number twice.
+		clearInterval(monTick);
+		monTick = setInterval(retellMonitor, 1000);
 		const host = document.getElementById('mj-ircut-mon-chart');
 		if (!host) return;
 		if (!view.chart || !MC) {


### PR DESCRIPTION
Four things the reporter of #325 found by actually using the feature. Three of them the page was doing to itself, and one of those it had only just started doing.

### The band marker leaves exactly when the picture starts moving

> *"On the graph I can see only the day marker. … As soon as I close the camera lens, the day marker disappears as well."*

Covering the lens raises the gain, the plot rescales, the day band shrinks — and under the *"a band too thin for its label draws none"* guard added in #336, its name goes with it. That guard was the tidy answer to two names landing on the same pixel, and it is worse than the overlap it fixed: the legend leaves at the moment the reader most needs it.

Reproduced with the reporter's own configuration (day band `0..2`, no night threshold set), on an hi3516ev300:

| sensor gain | day band height | marker on `master` | marker here |
|---|---|---|---|
| 1x | 110.0 px | at y=15 | at y=15 |
| 4x | 44.0 px | at y=81 | at y=81 |
| 16x | 11.0 px | **missing** | at y=113 |
| 64x | 2.2 px | **missing** | at y=114 |

**The reporter then answered the design question themselves, and their answer fixes it at the root** rather than working around it:

> *"the day and night markers could simply consist of a short horizontal line indicating the threshold level, with the corresponding day or night label next to it. The markers should move up and down as the graph is scaled, but they should not themselves be scaled."*

That is exactly right, and it is why the band shrank in the first place: a threshold is a **level**, and shading the region below it ties the marker's size to the scale. `charts.js` grows `marks` — a hairline at a value with its name beside it, folded into the auto scale exactly as a finite band edge is — and the Day / Night chart uses those instead of bands. Bands stay for the dashboard, where a band really is a region: the Wi-Fi grades are ranges, not edges. Verified with the night threshold at 8x and again at 64x — both rules keep their weight and their labels while the plot rescales around them.

The other half of that report, *"the night marker is not visible"*, is not a bug and is asked about on the issue: that camera has no **Gain multiple that means night** set, so there is no night threshold to draw. Since #336 a threshold that *is* set can no longer fall off the top of the plot.

### The countdown lurched instead of counting

> *"The countdown also updates in 5-second jumps, and the jumps occur at different speeds. The total measured interval is correct, though."*

The camera advances its streak gauge on its own schedule, the heartbeat polls on another, and the sentence was printed only on arrival — so it moved by whatever the two cadences beat out. `monitorView` now takes the age of the sample and reads the camera's number forward by a local clock, re-anchored and resynced on every poll. It is the camera's figure carried forward, never one of the page's own.

Measured through a pending switch on an hi3516ev300 + imx335 with the automatic monitor on and no thresholds set: thirteen consecutive readings of the sentence previously repeated or skipped values seven times across the sequence, and now fall by exactly one second each.

Rounded rather than floored: a retell landing 0.9 s after its sample floors to nothing and reprints the number it just printed, which is the same stutter at a smaller amplitude.

### And it could state a wait longer than the one configured

> *"Right now it started from as much as 250 seconds, even though SECONDS OF BRIGHTNESS BEFORE DAY is set to 60."*

Not reproducible here — four flap cycles show the dwell tracking the configured 15 / 60 exactly. But a *"seconds held"* counter that comes back **negative**, which is what an NTP step does to one, subtracts into precisely this: `60 − (−190)` is 250. Nothing can be held for less than no time and nothing can be waited for longer than the dwell, so the countdown is bounded at both ends.

### The hunting banner asserted a mechanism nobody had measured

Not from the issue — found while investigating it, and the most serious of the four.

The banner said automatic mode *"slows itself down after each flip"*. Across every transition observed here the dwell gauge read back exactly the configured delay and never more; and every flip that can be arranged in a lit room is driven by rewriting a threshold, which restarts the night service and would reset any such state. So the claim could be neither confirmed nor refuted from this camera — which is the whole problem with it being a claim.

The daemon publishes the wait it is currently applying, and that is the very number a backoff would move. The finding reads it instead of asserting the mechanism behind it: it reports a stretched wait as the camera's own figure when there is one, says nothing when there is not, and on a build without the gauge does not speak for it. The advice that follows was the true half all along and stays, reworded away from the flashing light.

### Tests

New checks in `tests/ircut-check.test.js`, all of the kind this suite is for — a decision table that produces a fluent sentence whichever branch it takes, reachable only with a camera hunting at dusk, an older firmware, or a stepped clock. The band-placement change is verified by rendering rather than frozen into the suite; the measurements above are how.

Suite green (23 files), `npm run build:dist` green.

Refs #325 — **deliberately not a closing trailer.** The reporter's question about what to draw when no night threshold is configured is still open, and that issue has been auto-closed out from under them once already.


---

### Review round

Two real bugs, both in the local countdown clock, both producing a fluent moving sentence with nothing behind it.

- **Every successful poll re-anchored the projection.** The streak gauge is coarse — a second on one board, five on the reporter's — while the heartbeat polls every two, so most polls during a pending switch repeat the previous value. Re-anchoring on a repeat discards the second just counted and puts the number back **up**: 50, 49, 50, 49. The anchor moves only on a reading that differs now, which covers forward progress and a restarted streak alike.
- **A failed poll left the last sample standing** while the tick went on ageing it, so the countdown would walk to zero and sit there announcing a switch on behalf of a camera that had stopped answering. Projection stops after three heartbeats of silence, freezing on the last thing the camera actually said.

Both now live in `ircut-check.js` as `projector()`, beside `tracker()` and for the same reason — driven by a clock the tests supply, rather than buried in the one file here that cannot be unit-tested at all. Nine checks cover them.

The third finding, on lab output in this description, is taken: the measured sequence is summarised in prose and the hardware named by class. For the record it carried no address, credential or device identifier — but the description is the artifact that cannot be corrected after a merge, so the cheap fix is the right one. The finding also cited a source comment naming an hi3516ev300; that one stays, since naming the hardware class is what makes a measurement reproducible and the rule allows it explicitly.