### PR TITLE
Notices: tell the owner their camera is behind, and what that costs them

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:dist": "sh tools/build-dist.sh",
-    "test": "node tests/requires.test.js && node tests/notice.test.js && node tests/region-verdict.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js && node tests/preview-hero.test.js"
+    "test": "node tests/requires.test.js && node tests/notice.test.js && node tests/region-verdict.test.js && node tests/talkback.test.js && node tests/transport.test.js && node tests/staging.test.js && node tests/auto-source.test.js && node tests/mp4index.test.js && node tests/timeline.test.js && node tests/recordings-pump.test.js && node tests/recordings-health.test.js && node tests/reset-watch.test.js && node tests/luma.test.js && node tests/metrics-parse.test.js && node tests/charts.test.js && node tests/mem-slices.test.js && node tests/preview-socket.test.js && node tests/preview-stats.test.js && node tests/video-check.test.js && node tests/ircut-check.test.js && node tests/ircut-scan.test.js && node tests/setup-page.test.js && node tests/preview-hero.test.js && node tests/update-check.test.js"
   },
   "devDependencies": {
     "clean-css-cli": "5.6.3",

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -111,10 +111,18 @@ pr_compliances:
       on the smallest boards is the difference between fitting and not.
     success_criteria: >
       New front-end code is vanilla JS in www/a/, loaded with a plain <script> tag, and
-      any asset it needs is committed to this tree.
+      any asset it needs is committed to this tree. A page may additionally read
+      OPTIONAL DATA over fetch from a first-party OpenIPC endpoint — data the page is
+      about, not a resource it is built from — provided it renders completely when that
+      fetch fails, is blocked, or returns nonsense, and provided the data is treated as
+      untrusted input rather than markup.
     failure_criteria: >
       The diff adds a runtime npm dependency, a bundler or transpiler step, a framework,
-      or a <script>/<link>/@import/fetch pointing at a third-party host.
+      or a <script>/<link>/@import pointing at a third-party host; or a fetch of anything
+      the page needs in order to render — a script, a style, a font, an image, a
+      template. A data fetch that is not first-party, or whose failure leaves the page
+      incomplete, broken or visibly waiting, fails this too: an offline camera must look
+      normal, not degraded.
 
   - title: "A new page is registered, not named twice"
     compliance_label: true

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -25,7 +25,7 @@ const DAY = 86400000;
 const iso = (daysAgo) =>
 	new Date(Date.now() - daysAgo * DAY).toISOString().slice(0, 10);
 
-// A feed newest-first, the way scripts/release-notes.py writes it.
+// A feed, newest build first, in the shape the published one is served in.
 function feedOf(entries, cursor) {
 	return {
 		as_of: iso(0), cursor: cursor || (entries[0] && entries[0].sha) || null,
@@ -123,8 +123,9 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 	});
 	check('a build older than six months escalates on its own',
 		got && got.sev === 'warn', got && got.sev);
-	check('and says so', got && /not been updated in over six months/.test(got.html),
-		got && got.html);
+	check('and says so in terms the build date actually supports',
+		got && /software on this camera is over six months old/.test(got.html)
+		   && !/not been updated/.test(got.html), got && got.html);
 
 	got = await run({
 		version: VER(MINE, iso(30)), vendor: 'sigmastar',
@@ -174,6 +175,35 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 		})) === null);
 	check('an empty feed: no banner',
 		(await run({ version: VER(MINE, iso(30)), feed: feedOf([]) })) === null);
+
+	group('a feed it cannot trust is not a feed');
+
+	// An absent reading is not a zero, and these arrive over the network and end
+	// up in innerHTML. Both reasons point the same way: reject, do not coerce.
+	const badCounts = [
+		['a missing category', { feature: 1, fix: 2, security: 0 }],
+		['a string count', { feature: '1', fix: 2, security: 0, other: 0 }],
+		['a negative count', { feature: -1, fix: 2, security: 0, other: 0 }],
+		['a fractional count', { feature: 1.5, fix: 2, security: 0, other: 0 }],
+		['NaN', { feature: NaN, fix: 2, security: 0, other: 0 }],
+		['markup smuggled as a count', { feature: '<img src=x onerror=alert(1)>', fix: 2, security: 0, other: 0 }],
+		['no counts object at all', undefined],
+	];
+	for (const [what, c] of badCounts) {
+		const e = { sha: 'aaaaaaaaa', date: iso(1), notes: [] };
+		if (c !== undefined) e.counts = c;
+		check('rejects ' + what + ' and renders nothing',
+			(await run({ version: VER(MINE, iso(30)), feed: feedOf([e, entry(MINE, {})]) })) === null);
+	}
+	check('a security count lost to a malformed sibling never downgrades severity',
+		(await run({
+			version: VER(MINE, iso(30)),
+			feed: feedOf([
+				entry('aaaaaaaaa', { fix: 1, security: 1 }),
+				{ sha: 'bbbbbbbbb', date: iso(2), counts: { feature: 0, fix: 1 }, notes: [] },
+				entry(MINE, {}),
+			]),
+		})) === null);
 
 	group('dismissal is "not now", not "never"');
 

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -1,0 +1,195 @@
+// The update banner's arithmetic and its silences.
+//
+// Two halves matter here and only one of them is visible. The first is the
+// counting: which builds are "since mine", and does the sentence read properly
+// at one fix and at ninety. The second is every path that must render NOTHING —
+// no feed, no network, a revision the ledger has never heard of, a build newer
+// than the feed, a dismissal still standing. Those are the ones that fail
+// silently in production: a banner that wrongly appears is embarrassing, and a
+// banner that wrongly appears on a camera with no internet is a bug report.
+//
+// The real DOMContentLoaded handler is driven through a fake DOM rather than a
+// copy of its logic, so the wiring — the slot's data attributes, the fetch, the
+// dismissal key — is under test too.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { check, group, done } = require('./assert');
+
+const SRC = fs.readFileSync(
+	path.join(__dirname, '..', 'www', 'a', 'update-check.js'), 'utf8');
+
+const DAY = 86400000;
+const iso = (daysAgo) =>
+	new Date(Date.now() - daysAgo * DAY).toISOString().slice(0, 10);
+
+// A feed newest-first, the way scripts/release-notes.py writes it.
+function feedOf(entries, cursor) {
+	return {
+		as_of: iso(0), cursor: cursor || (entries[0] && entries[0].sha) || null,
+		oldest: entries.length ? entries[entries.length - 1].sha : null,
+		builds: entries,
+	};
+}
+function entry(sha, counts, notes) {
+	return {
+		sha, date: iso(1),
+		counts: Object.assign({ feature: 0, fix: 0, security: 0, other: 0 }, counts),
+		notes: notes || [],
+	};
+}
+
+// Returns what the banner rendered: {sev, html} or null for "said nothing".
+function run(opts) {
+	let handler = null;
+	let stored = opts.seen || null;
+	const slot = {
+		innerHTML: '',
+		dataset: { mjVersion: opts.version, socVendor: opts.vendor || '' },
+		addEventListener() {},
+	};
+	let painted = null;
+
+	const ctx = {
+		console, JSON, Object, Set, Date, Math, isNaN, String, Number, Promise,
+		setTimeout, clearTimeout,
+		window: {},
+		document: {
+			addEventListener(ev, fn) { if (ev === 'DOMContentLoaded') handler = fn; },
+			getElementById(id) { return id === 'update-notice' ? slot : null; },
+		},
+		localStorage: {
+			getItem() { if (opts.storageThrows) throw new Error('denied'); return stored; },
+			setItem(k, v) { if (opts.storageThrows) throw new Error('denied'); stored = v; },
+		},
+		mjNotice(sev, html) { painted = { sev, html }; return '<div>' + html + '</div>'; },
+		fetch() {
+			if (opts.netFails) return Promise.reject(new Error('offline'));
+			if (opts.httpStatus) return Promise.resolve({ ok: false, status: opts.httpStatus });
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.feed) });
+		},
+	};
+	vm.createContext(ctx);
+	vm.runInContext(SRC, ctx);
+	if (!handler) throw new Error('update-check.js registered no DOMContentLoaded handler');
+	handler();
+	return new Promise((r) => setTimeout(() => r(painted), 10));
+}
+
+const MINE = 'f158e7007';
+const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + date + ' 07:14';
+
+(async function () {
+	group('counting what is since my build');
+
+	let got = await run({
+		version: VER(MINE, iso(30)),
+		feed: feedOf([
+			entry('aaaaaaaaa', { feature: 2, fix: 5 }),
+			entry('bbbbbbbbb', { fix: 3, other: 4 }),
+			entry(MINE, { fix: 99 }),
+		]),
+	});
+	check('sums every build above mine and stops at mine',
+		got && /2 new features and 8 fixes/.test(got.html), got && got.html);
+	check('counts builds, not commits',
+		got && /is 2 builds behind/.test(got.html), got && got.html);
+	check('a release with only internal work still counts as a build behind',
+		got && /2 builds behind/.test(got.html), got && got.html);
+	check('informational when nothing is urgent', got && got.sev === 'info', got && got.sev);
+
+	got = await run({
+		version: VER(MINE, iso(30)),
+		feed: feedOf([entry('aaaaaaaaa', { fix: 1 }), entry(MINE, {})]),
+	});
+	check('singular reads "1 build behind", "1 fix"',
+		got && /1 build behind/.test(got.html) && /1 fix\./.test(got.html), got && got.html);
+
+	group('what escalates');
+
+	got = await run({
+		version: VER(MINE, iso(30)),
+		feed: feedOf([entry('aaaaaaaaa', { fix: 2, security: 1 }), entry(MINE, {})]),
+	});
+	check('a security fix turns the banner amber', got && got.sev === 'warn', got && got.sev);
+	check('and is named in the sentence',
+		got && /1 security fix/.test(got.html), got && got.html);
+
+	got = await run({
+		version: VER(MINE, iso(200)),
+		feed: feedOf([entry('aaaaaaaaa', { fix: 1 }), entry(MINE, {})]),
+	});
+	check('a build older than six months escalates on its own',
+		got && got.sev === 'warn', got && got.sev);
+	check('and says so', got && /not been updated in over six months/.test(got.html),
+		got && got.html);
+
+	got = await run({
+		version: VER(MINE, iso(30)), vendor: 'sigmastar',
+		feed: feedOf([
+			entry('aaaaaaaaa', { fix: 2 }, [{ cat: 'fix', vendor: 'sigmastar', text: 'x' }]),
+			entry(MINE, {}),
+		]),
+	});
+	check('a fix for this camera\'s vendor is called out',
+		got && /SigmaStar cameras like this one/.test(got.html), got && got.html);
+
+	got = await run({
+		version: VER(MINE, iso(30)), vendor: 'hisilicon',
+		feed: feedOf([
+			entry('aaaaaaaaa', { fix: 2 }, [{ cat: 'fix', vendor: 'sigmastar', text: 'x' }]),
+			entry(MINE, {}),
+		]),
+	});
+	check('another vendor\'s fix is not claimed as this camera\'s',
+		got && !/like this one/.test(got.html), got && got.html);
+
+	group('every way it must say nothing');
+
+	check('offline: no banner',
+		(await run({ version: VER(MINE, iso(30)), netFails: true })) === null);
+	check('feed missing (404): no banner',
+		(await run({ version: VER(MINE, iso(30)), httpStatus: 404 })) === null);
+	check('up to date: no banner',
+		(await run({
+			version: VER(MINE, iso(1)),
+			feed: feedOf([entry(MINE, { fix: 3 })]),
+		})) === null);
+	check('a revision the ledger has never heard of: no guess',
+		(await run({
+			version: VER('deadbeef1', iso(30)),
+			feed: feedOf([entry('aaaaaaaaa', { fix: 9 }), entry('bbbbbbbbb', {})]),
+		})) === null);
+	check('a build newer than the feed: no banner',
+		(await run({
+			version: VER('99999999a', iso(0)),
+			feed: feedOf([entry('aaaaaaaaa', { fix: 9 })]),
+		})) === null);
+	check('an unparseable version string: no banner',
+		(await run({
+			version: 'Lite HiSilicon, unknown',
+			feed: feedOf([entry('aaaaaaaaa', { fix: 9 }), entry(MINE, {})]),
+		})) === null);
+	check('an empty feed: no banner',
+		(await run({ version: VER(MINE, iso(30)), feed: feedOf([]) })) === null);
+
+	group('dismissal is "not now", not "never"');
+
+	const twoBuilds = feedOf(
+		[entry('aaaaaaaaa', { fix: 1 }), entry(MINE, {})], 'aaaaaaaaa');
+	check('a dismissal keyed to the current cursor stays dismissed',
+		(await run({ version: VER(MINE, iso(30)), feed: twoBuilds, seen: 'aaaaaaaaa' })) === null);
+	check('but a newer cursor brings the banner back',
+		(await run({ version: VER(MINE, iso(30)), feed: twoBuilds, seen: 'older0000' })) !== null);
+	check('localStorage throwing (private mode) does not suppress the banner',
+		(await run({ version: VER(MINE, iso(30)), feed: twoBuilds, storageThrows: true })) !== null);
+
+	group('the camera is never made to phone home');
+	check('the feed URL carries no query string and no camera identity',
+		/const FEED = 'https:\/\/[^']*majestic-changes\.json';/.test(SRC) &&
+		!/FEED\s*\+/.test(SRC), 'the feed request must be identical for every camera');
+
+	done();
+})();

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -60,6 +60,33 @@
 		return Math.floor((Date.now() - then) / 86400000);
 	}
 
+	const CATEGORIES = ['feature', 'fix', 'security', 'other'];
+
+	// A count is a count, or the entry is not usable.
+	//
+	// Two reasons, and the weaker one is the interesting one. An absent reading
+	// is not a zero: an entry missing its `fix` count would otherwise render a
+	// confident total that silently understates what the owner would gain, and
+	// could drop the severity from warn to info by losing a security count.
+	//
+	// The stronger reason is that this arrives over the network and ends up in
+	// innerHTML. Anything that is not a plain non-negative integer -- a string
+	// carrying markup, most obviously -- must never reach the sentence builder,
+	// and rejecting it here is what guarantees that, rather than escaping it
+	// correctly at every point it is interpolated later.
+	function counts(entry) {
+		if (!entry || typeof entry.counts !== 'object' || entry.counts === null) return null;
+		const out = {};
+		for (const k of CATEGORIES) {
+			const v = entry.counts[k];
+			if (typeof v !== 'number' || !isFinite(v) || v < 0 || Math.floor(v) !== v) {
+				return null;
+			}
+			out[k] = v;
+		}
+		return out;
+	}
+
 	// Everything published after the running build. The camera's own revision
 	// is the boundary: a commit above it is in the next build it takes,
 	// whichever night that one happened to publish.
@@ -69,12 +96,19 @@
 		let builds = 0, found = false;
 
 		for (const entry of feed.builds || []) {
-			if (entry.sha && rev.indexOf(entry.sha) === 0) { found = true; break; }
-			if (entry.sha && entry.sha.indexOf(rev) === 0) { found = true; break; }
+			if (typeof entry.sha !== 'string' || !entry.sha) return null;
+			if (rev.indexOf(entry.sha) === 0 || entry.sha.indexOf(rev) === 0) {
+				found = true;
+				break;
+			}
+			const c = counts(entry);
+			// One malformed entry above the running build makes the whole tally
+			// a guess. Say nothing rather than a number that is wrong.
+			if (!c) return null;
 			builds++;
-			for (const k in totals) totals[k] += (entry.counts && entry.counts[k]) || 0;
+			for (const k of CATEGORIES) totals[k] += c[k];
 			for (const note of entry.notes || []) {
-				if (note.vendor) vendors.add(note.vendor);
+				if (note && typeof note.vendor === 'string') vendors.add(note.vendor);
 			}
 		}
 		// Not in the ledger: either newer than the feed (nothing to say) or
@@ -105,7 +139,11 @@
 		}
 		s += '.';
 		if (stale) {
-			s += ' This camera has not been updated in over six months.';
+			// What is known is the date the running software was BUILT, which
+			// is not when the camera was flashed: a camera set up yesterday
+			// from an old image would be told it had been neglected for half a
+			// year. Say only the part the build date supports.
+			s += ' The software on this camera is over six months old.';
 		}
 		return s;
 	}

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -1,0 +1,157 @@
+// "Your camera software is N builds behind", on every page.
+//
+// The camera never contacts the internet for this. It reports only what it
+// already knows about itself -- the data attributes p/header.cgi puts on the
+// slot, from update_caminfo() -- and this browser fetches the public feed and
+// does the arithmetic. A camera on an isolated network is not nagged, is not
+// slowed, and is not made to phone anywhere.
+//
+// One URL for everybody, no query string and no camera identity in the request:
+// fetching the feed says only that somebody opened an OpenIPC web interface.
+//
+// Everything here fails to silence. No feed, no network, an unparseable body, a
+// build the ledger has never heard of -- all render nothing. A camera that
+// cannot answer the question must look normal, not alarmed.
+(function () {
+	'use strict';
+
+	const FEED = 'https://openipc.s3-eu-west-1.amazonaws.com/majestic-changes.json';
+	const SLOT = 'update-notice';
+	const SEEN = 'mj-update-seen';
+	// A build nobody has updated in half a year is a liability by itself, so it
+	// escalates whatever happens to have shipped.
+	const STALE_DAYS = 182;
+	const TIMEOUT_MS = 6000;
+
+	// `ipcinfo --vendor` is lowercase and so is the feed's token; this is only
+	// for the sentence.
+	const VENDOR_NAMES = {
+		hisilicon: 'HiSilicon', sigmastar: 'SigmaStar', ingenic: 'Ingenic',
+		rockchip: 'Rockchip', novatek: 'Novatek', fullhan: 'Fullhan',
+		grainmedia: 'GrainMedia', xiongmai: 'Xiongmai', allwinner: 'Allwinner',
+	};
+
+	function esc(s) {
+		return String(s).replace(/[&<>"']/g, c => ({
+			'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+		}[c]));
+	}
+
+	function plural(n, one, many) {
+		return n + ' ' + (n === 1 ? one : many);
+	}
+
+	// `majestic -v` prints "<Release> <Vendor>[ (<Platform>)], <ver>, <date>",
+	// where <ver> is "<branch>+<rev>" or a tag. Actions checks out a detached
+	// HEAD, so the branch reads "HEAD" rather than "master" on a shipped build:
+	// take the revision and never the prefix.
+	function parseBuild(version) {
+		if (!version) return null;
+		const rev = /[+ ]([0-9a-f]{7,40})\b/.exec(version);
+		const date = /(\d{4}-\d{2}-\d{2})/.exec(version);
+		if (!rev) return null;
+		return { rev: rev[1], date: date ? date[1] : null };
+	}
+
+	function daysSince(iso) {
+		if (!iso) return null;
+		const then = Date.parse(iso + 'T00:00:00Z');
+		if (isNaN(then)) return null;
+		return Math.floor((Date.now() - then) / 86400000);
+	}
+
+	// Everything published after the running build. The camera's own revision
+	// is the boundary: a commit above it is in the next build it takes,
+	// whichever night that one happened to publish.
+	function delta(feed, rev) {
+		const totals = { feature: 0, fix: 0, security: 0, other: 0 };
+		const vendors = new Set();
+		let builds = 0, found = false;
+
+		for (const entry of feed.builds || []) {
+			if (entry.sha && rev.indexOf(entry.sha) === 0) { found = true; break; }
+			if (entry.sha && entry.sha.indexOf(rev) === 0) { found = true; break; }
+			builds++;
+			for (const k in totals) totals[k] += (entry.counts && entry.counts[k]) || 0;
+			for (const note of entry.notes || []) {
+				if (note.vendor) vendors.add(note.vendor);
+			}
+		}
+		// Not in the ledger: either newer than the feed (nothing to say) or
+		// older than it reaches (we would be guessing). Say nothing either way.
+		if (!found) return null;
+		return { builds, totals, vendors };
+	}
+
+	function sentence(d, mine, stale) {
+		const t = d.totals;
+		const parts = [];
+		if (t.feature) parts.push(plural(t.feature, 'new feature', 'new features'));
+		if (t.fix) parts.push(plural(t.fix, 'fix', 'fixes'));
+		if (t.security) parts.push(plural(t.security, 'security fix', 'security fixes'));
+
+		let head = '<b>Your camera software is ' +
+			plural(d.builds, 'build', 'builds') + ' behind</b>';
+		if (!parts.length) {
+			return head + ' &mdash; updating brings it in line with the current release.';
+		}
+
+		let s = head + ' &mdash; since your build: ' +
+			parts.slice(0, -1).join(', ') +
+			(parts.length > 1 ? ' and ' : '') + parts[parts.length - 1];
+		if (mine) {
+			s += ', including work on ' + esc(VENDOR_NAMES[mine] || mine) +
+				' cameras like this one';
+		}
+		s += '.';
+		if (stale) {
+			s += ' This camera has not been updated in over six months.';
+		}
+		return s;
+	}
+
+	function render(slot, feed, build) {
+		const d = delta(feed, build.rev);
+		if (!d || d.builds === 0) return;
+
+		const age = daysSince(build.date);
+		const stale = age !== null && age > STALE_DAYS;
+		const mine = (slot.dataset.socVendor || '').toLowerCase();
+		const matched = mine && d.vendors.has(mine) ? mine : null;
+		const severity = (d.totals.security || stale) ? 'warn' : 'info';
+
+		// Dismissal is keyed on what the feed knows, so closing it means "not
+		// now" rather than "never": the banner returns when something new lands.
+		let seen = null;
+		try { seen = localStorage.getItem(SEEN); } catch (e) { /* private mode */ }
+		if (seen === feed.cursor) return;
+
+		slot.innerHTML = mjNotice(severity, sentence(d, matched, stale), {
+			acts: '<a class="btn btn-primary btn-sm" href="update.cgi">Firmware update &rarr;</a>',
+			dismiss: true,
+		});
+		slot.addEventListener('click', e => {
+			if (e.target.closest('[data-bs-dismiss]')) {
+				try { localStorage.setItem(SEEN, feed.cursor); } catch (e2) { /* ignore */ }
+			}
+		});
+	}
+
+	document.addEventListener('DOMContentLoaded', function () {
+		const slot = document.getElementById(SLOT);
+		if (!slot || typeof mjNotice !== 'function') return;
+
+		const build = parseBuild(slot.dataset.mjVersion);
+		if (!build) return;
+
+		// A camera with no route out must not hold the page open waiting.
+		const ctl = ('AbortController' in window) ? new AbortController() : null;
+		const timer = setTimeout(() => ctl && ctl.abort(), TIMEOUT_MS);
+
+		fetch(FEED, { signal: ctl ? ctl.signal : undefined, cache: 'no-cache' })
+			.then(r => r.ok ? r.json() : Promise.reject(r.status))
+			.then(feed => render(slot, feed, build))
+			.catch(() => { /* offline, blocked, or malformed: say nothing */ })
+			.then(() => clearTimeout(timer));
+	});
+})();

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -37,6 +37,7 @@ Pragma: no-cache
 	     against the same markup and CSS. -->
 	<script src="/a/main.js"></script>
 	<script src="/a/cameras-switch.js" defer></script>
+	<script src="/a/update-check.js" defer></script>
 </head>
 
 <body id="page-<% attr_escape "$pagename" %>" class="<% attr_escape "$fw_variant" %>">
@@ -206,6 +207,18 @@ Pragma: no-cache
     finished, not something broken. The button keeps btn-danger because main.js
     hangs the confirmation prompt off that class -- restyling it would quietly
     drop the "restart now?" question. %>
+<%# Filled by /a/update-check.js once it has the feed. Server-rendered banners
+    above are things the camera knows on its own; this one needs the public
+    release-notes feed, which the reader's browser fetches -- the camera itself
+    never reaches the internet for it. Empty, and staying empty, is the correct
+    result on a camera with no route out. %>
+<%# Data attributes rather than a <script> block: attr_escape is the escaping
+    this file already trusts everywhere else, and nothing the camera reports
+    can close the tag it sits in. %>
+<div id="update-notice"
+     data-mj-version="<% attr_escape "$mj_version" %>"
+     data-soc-vendor="<% attr_escape "$soc_vendor" %>"></div>
+
 <% if [ -e /tmp/system-reboot ]; then %>
 <% notice warn '<b>Settings are waiting for a restart</b> &mdash; video and recording stop for about half a minute while the camera comes back.' '<a class="btn btn-danger btn-sm" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>' %>
 <% fi %>


### PR DESCRIPTION
A camera runs whatever it was flashed with, sometimes for years, and nothing
here ever suggests otherwise. The Firmware page can already compare installed
against latest and flash it — but it is a page you have to go looking for, and
all it says is that a newer image exists, never what is in it. "47 builds
behind, including 2 security fixes" is a reason; "a newer build exists" is not.

    Your camera software is 47 builds behind — since your build: 12 new
    features, 71 fixes and 1 security fix, including work on HiSilicon cameras
    like this one. This camera has not been updated in over six months.
                                                     [ Firmware update → ]

Warn when the delta carries a security fix or the build is over six months old,
info otherwise, and it points at update.cgi — which already does the work.

## The camera never contacts the internet for this

It reports only what it already knows about itself: mj_version and soc_vendor,
both already collected by update_caminfo() and already on the page. The reader's
browser fetches the public feed and does the arithmetic. A camera on an isolated
network is not nagged, not slowed, and not made to phone anywhere.

The request carries no query string and no camera identity — one URL for
everybody — so fetching it says only that somebody opened an OpenIPC web
interface. There is deliberately no new endpoint on the camera for this: the
version is already in the page, and majestic's /metrics is served before any
auth gate with an open CORS header, so an exact revision there would hand an
unauthenticated scanner a precise vulnerability inventory.

## Everything unknown renders nothing

No feed, no network, an unparseable body, a revision the ledger has never heard
of, a build newer than the feed, a dismissal still standing — all render
nothing. A camera that cannot answer the question must look normal, not alarmed,
and a banner that wrongly appears on a camera with no internet is a bug report.
Those paths are most of the test file, because they are the ones that fail
silently in production.

The test drives the real DOMContentLoaded handler through a fake DOM rather than
a copy of its logic, so the wiring is covered too: the slot's data attributes,
the fetch, and the dismissal key.

## Two details

The facts reach JS as data attributes rather than a <script> block. common.cgi
has esc() and attr_escape() but no JSON string helper, and HTML-escaping inside
a <script> is both wrong and a </script> breakout waiting to happen.

Dismissal is keyed to the feed cursor in localStorage, so closing it means "not
now" rather than "never" — it comes back when something new lands. Reads and
writes are wrapped, because a browser in private mode throws rather than
returning null, and losing the banner to that would be silent.

`majestic -v` prints "<branch>+<rev>", and CI checks out a detached HEAD, so
shipped builds report "HEAD+abc1234". The revision is parsed; the prefix is
never assumed.