### PR TITLE
Notices: a build older than the ledger is the case that matters most

### DIFF
--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -210,6 +210,38 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 			feed: feedOf([entry('aaaaaaaaa', { fix: 9 })]),
 		})) === null);
 
+	group('a date that is not a date is not evidence');
+
+	// The pre-ledger path decides "older" by comparing two dates, and a raw
+	// string comparison ranks "z" after every real date. Both sides are
+	// untrusted: the feed comes over the network, and the camera's date is
+	// lifted out of a version string by shape alone.
+	const badFeedDates = ['z', '2026-13-45', '2026-02-31', '', '20260905', 'yesterday'];
+	for (const bad of badFeedDates) {
+		check('a ledger dated ' + JSON.stringify(bad) + ' proves nothing',
+			(await run({
+				version: VER('deadbeef1', iso(400)),
+				feed: feedOf([{ sha: 'aaaaaaaaa', date: bad,
+					counts: { feature: 1, fix: 2, security: 1, other: 0 }, notes: [] }]),
+			})) === null);
+	}
+	check('a ledger date of the wrong type proves nothing',
+		(await run({
+			version: VER('deadbeef1', iso(400)),
+			feed: feedOf([{ sha: 'aaaaaaaaa', date: 20260905,
+				counts: { feature: 1, fix: 2, security: 1, other: 0 }, notes: [] }]),
+		})) === null);
+	check('a camera date of 0000-00-00 is not an ancient camera',
+		(await run({
+			version: 'Lite HiSilicon (hi3516ev300), HEAD+deadbeef1, 0000-00-00 07:14',
+			feed: feedOf([entry('aaaaaaaaa', { fix: 3 })]),
+		})) === null);
+	check('and a real pair still works',
+		(await run({
+			version: VER('deadbeef1', iso(400)),
+			feed: feedOf([entry('aaaaaaaaa', { fix: 3 })]),
+		})) !== null);
+
 	group('a feed it cannot trust is not a feed');
 
 	// An absent reading is not a zero, and these arrive over the network and end

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -158,9 +158,9 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 			version: VER(MINE, iso(1)),
 			feed: feedOf([entry(MINE, { fix: 3 })]),
 		})) === null);
-	check('a revision the ledger has never heard of: no guess',
+	check('a revision the ledger has never heard of, same age as it: no guess',
 		(await run({
-			version: VER('deadbeef1', iso(30)),
+			version: VER('deadbeef1', iso(1)),
 			feed: feedOf([entry('aaaaaaaaa', { fix: 9 }), entry('bbbbbbbbb', {})]),
 		})) === null);
 	check('a build newer than the feed: no banner',
@@ -175,6 +175,40 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 		})) === null);
 	check('an empty feed: no banner',
 		(await run({ version: VER(MINE, iso(30)), feed: feedOf([]) })) === null);
+
+	group('a build older than the ledger reaches');
+
+	// The ledger starts somewhere, and every camera flashed before that point
+	// falls off the end of it. Those owners are the furthest behind and the ones
+	// the banner most needs to reach, so "not in the ledger" must not mean
+	// "silent" when the build date proves the camera has been passed by.
+	let older = await run({
+		version: VER('deadbeef1', iso(400)),
+		feed: feedOf([
+			entry('aaaaaaaaa', { feature: 2, fix: 5, security: 1 }),
+			entry('bbbbbbbbb', { fix: 3 }),
+		]),
+	});
+	check('a build predating the whole ledger still gets a banner',
+		older !== null, 'silent for exactly the owners furthest behind');
+	check('and the tally is stated as a floor, not a count',
+		older && /at least 2 builds behind/.test(older.html), older && older.html);
+	check('and the wording does not claim to start from their build',
+		older && !/since your build/.test(older.html) && /changes we can see/.test(older.html),
+		older && older.html);
+	check('a security fix below the horizon still escalates',
+		older && older.sev === 'warn', older && older.sev);
+
+	check('a build NEWER than the feed is still silent',
+		(await run({
+			version: VER('99999999b', iso(0)),
+			feed: feedOf([entry('aaaaaaaaa', { fix: 9 }, [])]),
+		})) === null);
+	check('no build date means no claim about being older',
+		(await run({
+			version: 'Lite HiSilicon (hi3516ev300), HEAD+deadbeef1',
+			feed: feedOf([entry('aaaaaaaaa', { fix: 9 })]),
+		})) === null);
 
 	group('a feed it cannot trust is not a feed');
 

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -90,7 +90,7 @@
 	// Everything published after the running build. The camera's own revision
 	// is the boundary: a commit above it is in the next build it takes,
 	// whichever night that one happened to publish.
-	function delta(feed, rev) {
+	function delta(feed, rev, buildDate) {
 		const totals = { feature: 0, fix: 0, security: 0, other: 0 };
 		const vendors = new Set();
 		let builds = 0, found = false;
@@ -111,10 +111,29 @@
 				if (note && typeof note.vendor === 'string') vendors.add(note.vendor);
 			}
 		}
-		// Not in the ledger: either newer than the feed (nothing to say) or
-		// older than it reaches (we would be guessing). Say nothing either way.
-		if (!found) return null;
-		return { builds, totals, vendors };
+		if (found) return { builds, totals, vendors, atLeast: false };
+
+		// Not in the ledger, which is two very different situations.
+		//
+		// A build NEWER than the feed -- a development build, or a nightly the
+		// feed has not caught up with -- has nothing to be told.
+		//
+		// A build OLDER than the ledger reaches is the common case and the one
+		// that matters: the ledger starts somewhere, and every camera flashed
+		// before that point falls off the end of it. Saying nothing to those
+		// would leave the banner permanently silent for exactly the owners
+		// furthest behind, which is the opposite of the point.
+		//
+		// The build date separates the two. Only when it is strictly older than
+		// the oldest entry has the camera provably been passed by, and even then
+		// the totals are a floor rather than a count, so the sentence says "at
+		// least". Same-day is not evidence either way, and stays silent.
+		const eldest = feed.builds[feed.builds.length - 1];
+		if (buildDate && eldest && typeof eldest.date === 'string' &&
+			buildDate < eldest.date) {
+			return { builds, totals, vendors, atLeast: true };
+		}
+		return null;
 	}
 
 	function sentence(d, mine, stale) {
@@ -124,13 +143,14 @@
 		if (t.fix) parts.push(plural(t.fix, 'fix', 'fixes'));
 		if (t.security) parts.push(plural(t.security, 'security fix', 'security fixes'));
 
-		let head = '<b>Your camera software is ' +
+		let head = '<b>Your camera software is ' + (d.atLeast ? 'at least ' : '') +
 			plural(d.builds, 'build', 'builds') + ' behind</b>';
 		if (!parts.length) {
 			return head + ' &mdash; updating brings it in line with the current release.';
 		}
 
-		let s = head + ' &mdash; since your build: ' +
+		let s = head + (d.atLeast ? ' &mdash; in the changes we can see: '
+			: ' &mdash; since your build: ') +
 			parts.slice(0, -1).join(', ') +
 			(parts.length > 1 ? ' and ' : '') + parts[parts.length - 1];
 		if (mine) {
@@ -149,7 +169,7 @@
 	}
 
 	function render(slot, feed, build) {
-		const d = delta(feed, build.rev);
+		const d = delta(feed, build.rev, build.date);
 		if (!d || d.builds === 0) return;
 
 		const age = daysSince(build.date);

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -37,6 +37,22 @@
 		}[c]));
 	}
 
+	// A date is a date, or it is not evidence.
+	//
+	// Both inputs here are untrusted in different ways. The feed arrives over
+	// the network, and parseBuild lifts any YYYY-MM-DD-shaped run of digits out
+	// of a version string without checking it names a real day. Comparing either
+	// as a raw string would rank "z" after every real date and "0000-00-00"
+	// before them, turning nonsense into a confident "at least N builds behind".
+	function isDate(s) {
+		if (typeof s !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+		const t = Date.parse(s + 'T00:00:00Z');
+		if (isNaN(t)) return false;
+		// Round-trip, because Date.parse rolls 2026-02-31 forward into March
+		// rather than rejecting it.
+		return new Date(t).toISOString().slice(0, 10) === s;
+	}
+
 	function plural(n, one, many) {
 		return n + ' ' + (n === 1 ? one : many);
 	}
@@ -50,11 +66,13 @@
 		const rev = /[+ ]([0-9a-f]{7,40})\b/.exec(version);
 		const date = /(\d{4}-\d{2}-\d{2})/.exec(version);
 		if (!rev) return null;
-		return { rev: rev[1], date: date ? date[1] : null };
+		// A date that is not a real day is no date at all: nothing downstream
+		// should have to ask twice.
+		return { rev: rev[1], date: (date && isDate(date[1])) ? date[1] : null };
 	}
 
 	function daysSince(iso) {
-		if (!iso) return null;
+		if (!isDate(iso)) return null;
 		const then = Date.parse(iso + 'T00:00:00Z');
 		if (isNaN(then)) return null;
 		return Math.floor((Date.now() - then) / 86400000);
@@ -129,7 +147,7 @@
 		// the totals are a floor rather than a count, so the sentence says "at
 		// least". Same-day is not evidence either way, and stays silent.
 		const eldest = feed.builds[feed.builds.length - 1];
-		if (buildDate && eldest && typeof eldest.date === 'string' &&
+		if (isDate(buildDate) && eldest && isDate(eldest.date) &&
 			buildDate < eldest.date) {
 			return { builds, totals, vendors, atLeast: true };
 		}


### PR DESCRIPTION
The banner was silent for every camera in the field, and would have stayed
silent indefinitely.

The feed is a ledger that starts somewhere. `delta()` walked it looking for the
running revision and returned null when it did not find one, on the grounds that
guessing is worse than saying nothing. That is right for a build NEWER than the
feed — a development build has nothing to be told. It is exactly wrong for a
build OLDER than the ledger reaches, which is every camera flashed before the
ledger began: they fall off the end of it and are told nothing, forever. Those
owners are the furthest behind and are the entire reason the banner exists.

Found on hardware, not in the tests. Against the live feed a lab hi3516ev300
rendered nothing, and the unit tests could not have caught it: they all used
fixtures whose ledger happened to contain the camera's revision.

The build date separates the two cases. Only when it is strictly older than the
oldest entry has the camera provably been passed by, and even then what the feed
can see is a floor rather than a total — so the sentence says "at least N builds
behind" and "in the changes we can see" rather than "since your build", which
would claim a starting point the feed does not have. Same-day is not evidence
either way and stays silent, as does a version string carrying no date.

Verified on a lab hi3516ev300 through a real browser: a ledger whose oldest
entry postdates the camera now renders "at least 2 builds behind", escalating to
warn for a security fix below the horizon, while the same-day case stays silent.