### PR TITLE
Live: recover the software-decode rung from a socket drop, don't strand it on MJPEG

### DIFF
--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -671,6 +671,30 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			'made=' + env.made.length);
 	}
 
+	// A retry scheduled from a superseded session must not fire a software
+	// player over a newer one the viewer just chose (#288).
+	group('a pending software retry does not override a transport change');
+	{
+		const env = load('mse',
+			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');   // -> wasm made[1]
+		env.made[1].say('playing');
+		env.made[1].say('mjpeg', 'unreachable');  // schedules a wasm retry
+		const before = env.made.length;
+		// The viewer picks WebRTC while that retry is pending.
+		pickWebRTC(env);
+		const afterPick = env.made[env.made.length - 1];
+		check('the transport choice attached its own player',
+			afterPick && afterPick.kind === 'webrtc', afterPick && afterPick.kind);
+		// Long enough that the stale retry timer would have fired.
+		await new Promise((r) => setTimeout(r, 1400));
+		check('the stale retry did not start another software player',
+			env.made.length === before + 1 &&
+			env.made[env.made.length - 1].kind === 'webrtc',
+			'made=' + env.made.length + ' last=' + env.made[env.made.length - 1].kind);
+	}
+
 	group('the rescue needs the decoder to actually be present');
 	{
 		// Same unreachable H.265 channel, but no software decoder in the page

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -615,7 +615,12 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			env.el('mj-transport-m').checked === true);
 	}
 
-	group('a rescue that also fails does not loop back');
+	// #288: the software rung has a reconnect ladder of its own now — a dropped
+	// socket is retried, not read as "software decode is done" and dropped to
+	// MJPEG. A working player was the whole point of the rung; one blip must not
+	// end it. (The worker retries internally too, hevc-wasm@v0.1.1; this page
+	// ladder backs an older pinned worker that gives up on the first drop.)
+	group('a software socket drop retries the rung before MJPEG');
 	{
 		const env = load('mse',
 			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 0, true);
@@ -623,10 +628,46 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		env.made[0].say('mjpeg', 'unreachable');
 		const wasm = env.made[1];
 		check('the decoder was tried', wasm && wasm.kind === 'wasm');
-		// Its worker could not hold the socket either — same flaky link.
+		wasm.say('playing');           // it was working
+		// Its socket drops mid-session. The old behaviour fell straight to MJPEG.
 		wasm.say('mjpeg', 'unreachable');
-		check('it falls to MJPEG rather than round again',
-			env.made.length === 2 && env.el('live-mjpeg').src === '/mjpeg',
+		check('no MJPEG yet — the drop is being retried',
+			env.el('live-mjpeg').src === '', env.el('live-mjpeg').src);
+		await new Promise((r) => setTimeout(r, 1200));
+		check('a fresh software player was made for the retry',
+			env.made.length === 3 && env.made[2].kind === 'wasm',
+			'made=' + env.made.length);
+		// The retry catches: a picture is back, and the ladder resets so the
+		// next drop gets the full budget again.
+		env.made[2].say('playing');
+		check('the recovered picture is on the stage, not MJPEG',
+			env.el('live-mjpeg').src === '');
+	}
+
+	group('a software rung that keeps dropping falls to MJPEG, bounded');
+	{
+		const env = load('mse',
+			{ 'jpeg.enabled': true, 'video0.codec': 'h265' }, 0, true);
+		await tick();
+		env.made[0].say('mjpeg', 'unreachable');   // -> wasm made[1]
+		// Every retry also drops, before ever showing a picture. The ladder is
+		// five deep (1s..5s) — long enough to outlast a daemon restart — so drive
+		// that many drops and let each timer fire, then one more to spend it.
+		let made = 2;
+		for (let i = 1; i <= 5; i++) {
+			env.made[env.made.length - 1].say('mjpeg', 'unreachable');
+			await new Promise((r) => setTimeout(r, 1000 * i + 200));
+			check('retry ' + i + ' made a fresh software player',
+				env.made.length === made + 1 && env.made[made].kind === 'wasm',
+				'made=' + env.made.length);
+			made = env.made.length;
+		}
+		// The fourth drop is past the budget: now it gives up to MJPEG rather
+		// than retry for ever.
+		env.made[env.made.length - 1].say('mjpeg', 'unreachable');
+		check('the ladder is spent, so MJPEG takes the stage',
+			env.el('live-mjpeg').src === '/mjpeg', env.el('live-mjpeg').src);
+		check('and it stopped making players', env.made.length === made,
 			'made=' + env.made.length);
 	}
 

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -193,6 +193,19 @@ window.MajesticPreview = (function () {
 		const WASM_MAX_RETRIES = 5;
 		const WASM_RETRY_MS = 1000;
 		let wasmRetries = 0;
+		// A pending retry, a "played long enough to count as recovered" timer,
+		// and the generation they belong to. A channel change bumps the
+		// generation so a superseded retry cannot start a wasm player over the
+		// newer session, and `destroyed` stops a retry firing after the panel
+		// closes and leaking a worker/socket.
+		let wasmRetryTimer = null;
+		let wasmHealthyTimer = null;
+		let wasmGen = 0;
+		let destroyed = false;
+		function cancelWasmTimers() {
+			if (wasmRetryTimer) { clearTimeout(wasmRetryTimer); wasmRetryTimer = null; }
+			if (wasmHealthyTimer) { clearTimeout(wasmHealthyTimer); wasmHealthyTimer = null; }
+		}
 		let frame = null;
 		// Bumped whenever the picture stops being what it was — a channel
 		// change, a dropped chain. An async consumer (the luma sampler reads a
@@ -258,12 +271,6 @@ window.MajesticPreview = (function () {
 			const p = pending;
 			pending = null;
 			if (!p.w || !p.h) return;
-			// A real decoded frame is on screen, so the software rung recovered:
-			// reset its page-level reconnect ladder here rather than in
-			// onPromoted, which also fires for an unproven promotion still
-			// connecting — resetting there would let the #288 backstop retry
-			// without bound instead of a bounded few times.
-			wasmRetries = 0;
 			const same = frame && frame.w === p.w && frame.h === p.h &&
 				frame.codec === p.codec;
 			frame = { w: p.w, h: p.h, codec: p.codec };
@@ -342,8 +349,14 @@ window.MajesticPreview = (function () {
 			if (kind === 'wasm' && String(detail || '').split(' ')[0] === 'unreachable' &&
 				wasmRetries < WASM_MAX_RETRIES) {
 				wasmRetries++;
-				setTimeout(function () {
-					if (!exhausted) swap.start('wasm');
+				cancelWasmTimers();
+				const g = wasmGen;
+				wasmRetryTimer = setTimeout(function () {
+					wasmRetryTimer = null;
+					// Not after teardown (would leak a worker), not for a stale
+					// generation (a channel change superseded it), not once the
+					// chain has already given up.
+					if (!destroyed && !exhausted && wasmGen === g) swap.start('wasm');
 				}, WASM_RETRY_MS * wasmRetries);
 				return;
 			}
@@ -447,7 +460,24 @@ window.MajesticPreview = (function () {
 				// only place a FIRST attach can say so — it was promoted before
 				// it had anything, so its picture arrives here rather than as a
 				// second promotion.
-				if (st === 'playing') announcePlaying(kind);
+				if (st === 'playing') {
+					announcePlaying(kind);
+					// A software session that keeps playing for a moment (not just
+					// one decoded frame) is a genuine recovery, so the retry
+					// budget resets and the next drop gets a fresh ladder. A
+					// decoder that plays a frame and immediately drops never arms
+					// this, so it still exhausts to the alert. No
+					// per-frame stats reach this panel, hence the short timer.
+					if (kind === 'wasm') {
+						if (wasmHealthyTimer) clearTimeout(wasmHealthyTimer);
+						const hg = wasmGen;
+						wasmHealthyTimer = setTimeout(function () {
+							wasmHealthyTimer = null;
+							if (!destroyed && wasmGen === hg && swap.playing() === 'wasm')
+								wasmRetries = 0;
+						}, 1500);
+					}
+				}
 				if (kind !== 'webrtc') {
 					// MSE is the last thing to try, so its giving up ends the
 					// chain — and it says so on the live player's own channel
@@ -564,6 +594,10 @@ window.MajesticPreview = (function () {
 		// ── The handle ───────────────────────────────────────────────────────
 
 		function goToStream(n) {
+			// A channel change supersedes any pending software-rung retry or
+			// recovery timer: they belonged to the channel being left.
+			wasmGen++;
+			cancelWasmTimers();
 			// Only when it actually moves. The channels are different pictures —
 			// different size, often a different codec — so what was true of the
 			// old one is not a description of the new one, it is a wrong
@@ -680,6 +714,10 @@ window.MajesticPreview = (function () {
 			setStream: goToStream,
 
 			destroy: function () {
+				// A pending software-rung retry must not fire after teardown and
+				// recreate a worker/socket against the detached stage.
+				destroyed = true;
+				cancelWasmTimers();
 				// Through the swap, which closes the trial as well as the player
 				// on screen. Destroying only the live player would leave a
 				// transport still being judged behind on every teardown — a live

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -184,6 +184,15 @@ window.MajesticPreview = (function () {
 		// channel is still a request worth honouring — an H.264 substream plays
 		// in a browser that refused an H.265 main.
 		let exhausted = false;
+		// A page-level reconnect ladder for the software rung, matching
+		// preview-page.js and backing the worker's own (hevc-wasm@v0.1.1): a
+		// pinned worker older than that gives up on the first dropped socket,
+		// and this panel — which has no MJPEG fallback — then shows its "could
+		// not be played" alert for good, the #288 dead-end on the settings page.
+		// Retry the rung a few times before the alert; reset by a promotion.
+		const WASM_MAX_RETRIES = 5;
+		const WASM_RETRY_MS = 1000;
+		let wasmRetries = 0;
 		let frame = null;
 		// Bumped whenever the picture stops being what it was — a channel
 		// change, a dropped chain. An async consumer (the luma sampler reads a
@@ -249,6 +258,12 @@ window.MajesticPreview = (function () {
 			const p = pending;
 			pending = null;
 			if (!p.w || !p.h) return;
+			// A real decoded frame is on screen, so the software rung recovered:
+			// reset its page-level reconnect ladder here rather than in
+			// onPromoted, which also fires for an unproven promotion still
+			// connecting — resetting there would let the #288 backstop retry
+			// without bound instead of a bounded few times.
+			wasmRetries = 0;
 			const same = frame && frame.w === p.w && frame.h === p.h &&
 				frame.codec === p.codec;
 			frame = { w: p.w, h: p.h, codec: p.codec };
@@ -318,6 +333,18 @@ window.MajesticPreview = (function () {
 			if (kind === 'mse' && window.MajesticTransport.softwareRungForCodec(
 				detail, get(stream ? 'video1.codec' : 'video0.codec'))) {
 				swap.start('wasm');
+				return;
+			}
+			// The software rung dropped its socket. Retry it a bounded few times
+			// before the alert, so a transient blip does not end a working H.265
+			// preview here (#288). Reset by a promotion (onPromoted); only a
+			// socket drop reports 'unreachable', so this cannot loop.
+			if (kind === 'wasm' && String(detail || '').split(' ')[0] === 'unreachable' &&
+				wasmRetries < WASM_MAX_RETRIES) {
+				wasmRetries++;
+				setTimeout(function () {
+					if (!exhausted) swap.start('wasm');
+				}, WASM_RETRY_MS * wasmRetries);
 				return;
 			}
 			exhausted = true;

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -120,6 +120,19 @@
 	// They part company for the length of that retry, and that gap is the
 	// point: the picture stays until the replacement has one of its own.
 	let holdingFallback = null;
+	// A page-level reconnect ladder for the software-decode rung, and a belt to
+	// the worker's own braces (hevc-wasm@v0.1.1). A pinned worker older than
+	// that gives up on the FIRST dropped socket, and the chain reads that one
+	// `unreachable` as "software decode is done" and falls to MJPEG with no way
+	// back — the #288 dead-end, where a transient blip stranded a working H.265
+	// preview until the tab was reloaded. So a wasm socket drop is retried here
+	// a few times before MJPEG, reset by a picture reaching the stage
+	// (showVideo). It cannot loop: only a socket drop reports `unreachable`; a
+	// codec the decoder cannot take reports `codec-changed`, and a missing
+	// decoder `decoder-unavailable`, both of which terminate the chain instead.
+	const WASM_MAX_RETRIES = 5;
+	const WASM_RETRY_MS = 1000;
+	let wasmRetries = 0;
 	function showVideo() {
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = '#000'; }
@@ -903,6 +916,24 @@
 			attachPlayer('wasm');
 			return;
 		}
+		// The software rung itself dropped its socket. A current worker has
+		// already retried six times before saying so; an older pinned one gave
+		// up on the first drop. Either way, retry the rung a bounded few times
+		// before MJPEG rather than ending a working H.265 preview on one blip
+		// (#288). Reset by a picture (showVideo); terminates on anything but a
+		// socket drop, so it cannot loop.
+		if (kind === 'wasm' && String(detail || '').split(' ')[0] === 'unreachable' &&
+			wasmRetries < WASM_MAX_RETRIES) {
+			wasmRetries++;
+			// The caller has already retired the live player (or it was a failed
+			// trial), so its last frame stays on the stage through the wait
+			// rather than blanking it — the same picture-holding rule as a
+			// transport switch.
+			setTimeout(function () {
+				if (fellBack === null) attachPlayer('wasm');
+			}, WASM_RETRY_MS * wasmRetries);
+			return;
+		}
 		showFallback(detail);
 	}
 
@@ -921,6 +952,12 @@
 	// `inset: 0` and letterbox, which is Fit.
 	function applyMedia(m) {
 		chipMedia = m;
+		// A real decoded frame reached the stage, so the software rung is
+		// genuinely playing again: reset its page-level reconnect ladder. This
+		// is the "recovered" signal, not showVideo() — that also runs for an
+		// unproven promotion still connecting, and resetting there would let the
+		// #288 backstop retry for ever instead of a bounded few times.
+		wasmRetries = 0;
 		if (window.MajesticZoom) window.MajesticZoom.setFrame(m.w, m.h);
 		setChip();
 	}

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -132,7 +132,21 @@
 	// decoder `decoder-unavailable`, both of which terminate the chain instead.
 	const WASM_MAX_RETRIES = 5;
 	const WASM_RETRY_MS = 1000;
+	// Frames a software session must decode before it counts as recovered and
+	// the retry budget resets — proof of sustained play, not the mere codec
+	// announcement (~1s at 8fps).
+	const WASM_HEALTHY_FRAMES = 8;
 	let wasmRetries = 0;
+	// A pending page-level retry and the generation it belongs to. Any fresh
+	// attach, channel change or transport change bumps the generation, so a
+	// retry scheduled by a superseded session cannot fire attachPlayer('wasm')
+	// over the newer player and override the viewer's choice. The timer is held
+	// so it can be cancelled outright.
+	let wasmRetryTimer = null;
+	let wasmGen = 0;
+	function cancelWasmRetry() {
+		if (wasmRetryTimer) { clearTimeout(wasmRetryTimer); wasmRetryTimer = null; }
+	}
 	function showVideo() {
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = '#000'; }
@@ -872,6 +886,11 @@
 		: MajesticVideo;
 
 	function attachPlayer(kind) {
+		// Any fresh attach supersedes a pending software-rung retry: it belongs
+		// to a session that is being replaced, and firing it now would stage a
+		// wasm player over the new one.
+		wasmGen++;
+		cancelWasmRetry();
 		swap.start(kind === true ? 'webrtc' : kind === false ? 'mse' : kind);
 	}
 
@@ -928,9 +947,13 @@
 			// The caller has already retired the live player (or it was a failed
 			// trial), so its last frame stays on the stage through the wait
 			// rather than blanking it — the same picture-holding rule as a
-			// transport switch.
-			setTimeout(function () {
-				if (fellBack === null) attachPlayer('wasm');
+			// transport switch. Guarded by the generation captured now: a channel
+			// or transport change in the meantime bumps it and this does nothing.
+			cancelWasmRetry();
+			const retryGen = wasmGen;
+			wasmRetryTimer = setTimeout(function () {
+				wasmRetryTimer = null;
+				if (wasmGen === retryGen && fellBack === null) attachPlayer('wasm');
 			}, WASM_RETRY_MS * wasmRetries);
 			return;
 		}
@@ -952,12 +975,6 @@
 	// `inset: 0` and letterbox, which is Fit.
 	function applyMedia(m) {
 		chipMedia = m;
-		// A real decoded frame reached the stage, so the software rung is
-		// genuinely playing again: reset its page-level reconnect ladder. This
-		// is the "recovered" signal, not showVideo() — that also runs for an
-		// unproven promotion still connecting, and resetting there would let the
-		// #288 backstop retry for ever instead of a bounded few times.
-		wasmRetries = 0;
 		if (window.MajesticZoom) window.MajesticZoom.setFrame(m.w, m.h);
 		setChip();
 	}
@@ -1065,7 +1082,15 @@
 			},
 			onStats: (s) => {
 				if (!isLive()) return;
-				if (s.transport === 'wasm') softwareNote(s);
+				if (s.transport === 'wasm') {
+					softwareNote(s);
+					// Sustained software playback resets the retry budget so the
+					// NEXT drop gets a fresh ladder — gated on frames actually
+					// decoded, not the codec announcement, so a decoder that
+					// announces its codec and immediately drops still exhausts to
+					// MJPEG rather than resetting on every attempt.
+					if ((s.framesDecoded | 0) >= WASM_HEALTHY_FRAMES) wasmRetries = 0;
+				}
 				// The chip rides every tick, not just when the panel is open —
 				// this is where its fps comes from, and a fresh write also
 				// heals it after a transient "reconnecting…" state. The panel
@@ -1320,6 +1345,10 @@
 	// it would be promoted onto the channel the viewer had already left — and
 	// the adaptation toast's baseline, which belongs to the channel being left.
 	function goToStream(n) {
+		// The viewer changed channel: a software-rung retry pending from the
+		// channel being left must not fire onto the new one.
+		wasmGen++;
+		cancelWasmRetry();
 		stream = n;
 		// The two channels are two encoders; the baseline and any toast on
 		// screen describe the one being left.

--- a/www/a/preview-wasm.js
+++ b/www/a/preview-wasm.js
@@ -34,7 +34,7 @@ window.MajesticWasm = (function () {
 	// MJ_WASM_BASE overrides it, for a development build or an operator who
 	// would rather host it themselves.
 	const BASE = (window.MJ_WASM_BASE ||
-		'https://cdn.jsdelivr.net/gh/OpenIPC/hevc-wasm@v0.1.0/dist/');
+		'https://cdn.jsdelivr.net/gh/OpenIPC/hevc-wasm@v0.1.1/dist/');
 	const LOAD_TIMEOUT_MS = 8000;
 
 	// A Worker cannot be constructed from a cross-origin URL, so the worker


### PR DESCRIPTION
## The bug

On the Live page, a camera whose stream this browser can't decode natively (H.265 with no HEVC decoder) falls to the software decode rung. That rung had **no reconnect**: the decoder worker treated a dropped `/ws/video` socket as fatal, and `nextRung` read that one `unreachable` as "software decode is done" and fell straight to **MJPEG** — and to the "could not be played" alert on the **Live adjustments** panel, which has no MJPEG fallback. Nothing retried it, so only a page reload recovered it.

So a transient drop — a camera reload, a lost packet on a remote link, a rapid Main→Sub→Main reopen — stranded a working H.265 preview on MJPEG. This is the standing half of #288; #307 and #309 hardened the MSE→wasm handoff but left the wasm socket itself as fragile as before.

## The fix

The real fix is the worker's own reconnect ladder — `OpenIPC/hevc-wasm#1`, released as **v0.1.1** — and this bumps the pin from `@v0.1.0` to `@v0.1.1`.

This PR adds the **page-level backstop** so a camera still serving an older worker does not dead-end either:

- a wasm socket drop (`unreachable`) retries the rung a bounded **five times** before MJPEG, spaced 1→5 s (long enough to outlast a daemon restart);
- the ladder is reset by a **real decoded frame**, never by an unproven promotion, so it cannot loop;
- it terminates on anything but a socket drop — a codec the decoder can't take reports `codec-changed`, a missing decoder `decoder-unavailable`.

`tests/staging.test.js` gains two cases: a socket drop retries the rung and re-engages software H.265, and a rung that keeps dropping gives up to MJPEG in a bounded number of tries.

## Verification

- `npm test` green, including the new staging cases.
- Measured end-to-end on a hi3516ev300 (H.265 main) driven from a Raspberry Pi 4: with the v0.1.1 worker, software H.265 rides straight through a `/ws/video` drop; with an older worker, the page backstop re-engages software H.265 instead of stranding on MJPEG. The previous behaviour dropped to MJPEG and stayed.

The dropped socket that triggers this in the field is a WebSocket close/data ordering issue tracked and fixed in `OpenIPC/libevent#2`; the reconnect here makes the client resilient to a drop of any source regardless.

Requires `hevc-wasm@v0.1.1` to be tagged (from `OpenIPC/hevc-wasm#1`) before the bumped pin resolves.
