### PR TITLE
Day / Night: three mechanisms decide the same thing, and the page said which one never

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -698,6 +698,35 @@ function runRest() {
 			ic.projector(6).age(1) === null);
 	}
 
+	group('diagnose: a mechanism that is filled in but not deciding');
+	{
+		// Three mechanisms decide the same thing, the camera picks one, and
+		// every control is on the page together. The reporter of #325 filled
+		// in a night gain multiple and both automatic delays while a legacy
+		// threshold pair kept the wheel, and nothing said so — four live-
+		// looking controls doing nothing, and no countdown, because the
+		// mechanism that has no countdown was the one running. Reachable only
+		// with a camera configured both ways at once.
+		const both = { lightMonitor: true, irCutPin1: 11,
+			minThreshold: 2000, maxThreshold: 14000,
+			autoNightGain: 33, autoNightDelay: 15, autoDayDelay: 60 };
+		const said = (nm, src) => ic.diagnose(nm, { night: 0, ircut: 0, src: src },
+			{ flips: 0, conflictS: 0 }).filter(x => x.id === 'mech-shadowed')[0];
+		check('thresholds winning over a filled-in automatic set is named',
+			/compares raw sensor gain/.test(said(both, 2).detail), '');
+		check('and it says why the countdown is missing',
+			/no countdown appears/.test(said(both, 2).detail));
+		check('a wired sensor winning over both is named as the sensor',
+			/daylight sensor is wired/.test(said(both, 1).detail));
+		// Nothing filled in, nothing being ignored, nothing to say.
+		check('automatic mode deciding says nothing',
+			!said(both, 4));
+		check('and neither does a camera with only the winning set filled in',
+			!said({ lightMonitor: true, minThreshold: 2000, maxThreshold: 14000 }, 2));
+		// A camera that has not reported a source is not accused of anything.
+		check('an unknown source says nothing either', !said(both, null));
+	}
+
 	group('diagnose: hunting, and the ordering of what it all reports');
 	{
 		const cfg = { irCutPin1: 11, lightSensorPin: 66, lightMonitor: true };

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -721,10 +721,43 @@ function runRest() {
 		// Nothing filled in, nothing being ignored, nothing to say.
 		check('automatic mode deciding says nothing',
 			!said(both, 4));
-		check('and neither does a camera with only the winning set filled in',
-			!said({ lightMonitor: true, minThreshold: 2000, maxThreshold: 14000 }, 2));
 		// A camera that has not reported a source is not accused of anything.
 		check('an unknown source says nothing either', !said(both, null));
+
+		// What it NAMES has to be what is there. The first cut named the
+		// automatic multiples and delays whatever was set, on a path that
+		// could fire with no automatic value at all — silence traded for a
+		// confident wrong account of somebody's configuration.
+		const thrOnly = { lightMonitor: true, minThreshold: 2000,
+			maxThreshold: 14000 };
+		check('a shadowed threshold pair is named without inventing the rest',
+			/the day and night thresholds below set but ignored/
+				.test(said(thrOnly, 1).detail.replace(/\s+/g, ' ')) &&
+			!/gain multiples/.test(said(thrOnly, 1).detail),
+			said(thrOnly, 1).detail);
+		check('and the countdown clause is only spoken about automatic mode',
+			!/no countdown/.test(said(thrOnly, 1).detail));
+		check('both shadowed sets are named together',
+			/gain multiples and delays and the day and night thresholds/
+				.test(said(both, 1).detail.replace(/\s+/g, ' ')),
+			said(both, 1).detail);
+		// The day gain multiple and both delays ship with defaults and are
+		// seeded on every camera, so their presence is not evidence anyone
+		// asked for automatic mode — that is the difference between saying it
+		// and shouting it.
+		const seeded = { lightMonitor: true, minThreshold: 2000,
+			maxThreshold: 14000, autoDayGain: 2, autoNightDelay: 15,
+			autoDayDelay: 60 };
+		check('defaults alone are stated, not warned about',
+			said(seeded, 2).level === 'info', said(seeded, 2).level);
+		check('a night gain multiple somebody typed is a warning',
+			said(both, 2).level === 'warning');
+		// The day gain multiple is an automatic control too; leaving it out of
+		// the set meant a camera holding only that one got a row note and no
+		// section explanation at all.
+		check('the day gain multiple counts as an automatic setting',
+			!!said({ lightMonitor: true, minThreshold: 1, maxThreshold: 2,
+				autoDayGain: 2 }, 2));
 	}
 
 	group('diagnose: hunting, and the ordering of what it all reports');

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -318,6 +318,42 @@
 			}
 		}
 
+		// Three mechanisms decide the same thing and the camera picks one; the
+		// controls for all three are on the page together. Saying which set is
+		// live matters only when another set is FILLED IN — that is the state
+		// in which somebody has told the camera something it is ignoring, and
+		// the reporter of #325 was in it: a night gain multiple and both
+		// automatic delays set, while a legacy threshold pair kept the wheel.
+		//
+		// Read off the camera's own source gauge rather than re-deriving the
+		// precedence from config, so a build that orders them differently is
+		// described correctly instead of confidently.
+		if (monitor && sample && (sample.src === 1 || sample.src === 2 ||
+			sample.src === 3)) {
+			const autoSet = ['autoNightGain', 'autoNightDelay', 'autoDayDelay']
+				.some((k) => has(nm[k]));
+			const thrSet = has(nm.minThreshold) && has(nm.maxThreshold);
+			const byPin = sample.src !== 2;
+			if (autoSet || (byPin && thrSet)) {
+				out.push({
+					id: 'mech-shadowed', level: 'warning',
+					title: 'Some of these settings are not being used',
+					detail: (byPin
+						? 'A daylight sensor is wired, and it decides before ' +
+							'anything else here does. '
+						: 'The day and night thresholds are both set, so the ' +
+							'camera compares raw sensor gain against those. ') +
+						'Everything below belonging to the other ways of ' +
+						'deciding is filled in but ignored — including the ' +
+						'automatic gain multiples and the delays beside them, ' +
+						'which is why no countdown appears. Each one says so ' +
+						'under itself; clearing the settings that are winning ' +
+						'hands day/night back to automatic mode.',
+					fix: 'nightMode',
+				});
+			}
+		}
+
 		// Thresholds are compared against isp_again, so min must sit BELOW max
 		// to leave a band the camera can idle in. Equal is not "no hysteresis
 		// but workable" — it is the same gain deciding both directions.

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -330,25 +330,44 @@
 		// described correctly instead of confidently.
 		if (monitor && sample && (sample.src === 1 || sample.src === 2 ||
 			sample.src === 3)) {
-			const autoSet = ['autoNightGain', 'autoNightDelay', 'autoDayDelay']
-				.some((k) => has(nm[k]));
-			const thrSet = has(nm.minThreshold) && has(nm.maxThreshold);
 			const byPin = sample.src !== 2;
-			if (autoSet || (byPin && thrSet)) {
+			// What is named has to be what is actually there. The first cut of
+			// this said "the automatic gain multiples and the delays beside
+			// them" whatever was set, on a path that could fire with no
+			// automatic value at all — swapping silence for a confident wrong
+			// account of somebody's configuration, which is the fault this
+			// finding exists to end rather than to join.
+			const AUTO_KEYS = ['autoNightGain', 'autoDayGain',
+				'autoNightDelay', 'autoDayDelay'];
+			const autoSet = AUTO_KEYS.some((k) => has(nm[k]));
+			const thrShadowed = byPin &&
+				has(nm.minThreshold) && has(nm.maxThreshold);
+			const shadowed = [];
+			if (autoSet) shadowed.push('the automatic gain multiples and delays');
+			if (thrShadowed) shadowed.push('the day and night thresholds');
+			// Severity follows intent, not presence. The day gain multiple and
+			// both automatic delays ship with defaults and are seeded on every
+			// camera, so finding them set says nothing about what anyone meant;
+			// a night gain multiple, or a threshold pair, is somebody having
+			// typed something. The row notes mark every ignored control either
+			// way — this only decides how loudly the section says it.
+			const deliberate = has(nm.autoNightGain) || thrShadowed;
+			if (shadowed.length) {
 				out.push({
-					id: 'mech-shadowed', level: 'warning',
+					id: 'mech-shadowed',
+					level: deliberate ? 'warning' : 'info',
 					title: 'Some of these settings are not being used',
 					detail: (byPin
 						? 'A daylight sensor is wired, and it decides before ' +
 							'anything else here does. '
 						: 'The day and night thresholds are both set, so the ' +
 							'camera compares raw sensor gain against those. ') +
-						'Everything below belonging to the other ways of ' +
-						'deciding is filled in but ignored — including the ' +
-						'automatic gain multiples and the delays beside them, ' +
-						'which is why no countdown appears. Each one says so ' +
-						'under itself; clearing the settings that are winning ' +
-						'hands day/night back to automatic mode.',
+						'That leaves ' + shadowed.join(' and ') + ' below set ' +
+						'but ignored' +
+						(autoSet ? ', which is why no countdown appears' : '') +
+						'. Each one says so under itself; clearing the ' +
+						'settings that are winning hands day/night back to ' +
+						'automatic mode.',
 					fix: 'nightMode',
 				});
 			}

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3388,6 +3388,7 @@
 					? v.night_auto_dwell_seconds : null,
 			};
 			ircutStats = ircutTrack.push(ircutSample, performance.now() / 1000);
+			paintNightInert(ircutSample.src);
 			paintFindings();
 			paintMonitor(s);
 		});
@@ -3656,6 +3657,67 @@
 
 	function pinField(key) {
 		return state.fields.filter((f) => f.dot === 'nightMode.' + key)[0];
+	}
+
+	// Day / Night has THREE mechanisms that decide the same thing, and the
+	// camera picks between them by what is filled in: a daylight sensor pin
+	// wins, then the pair of legacy raw thresholds, and only with neither of
+	// those does the calibration-free automatic mode run. Every control for
+	// all three sits on the page at once, all of them enabled, and nothing
+	// said which set was live — so the reporter of #325 filled in a night gain
+	// multiple and both automatic delays, watched the camera go on using a
+	// threshold pair set earlier, and reported the countdown as broken. Four
+	// controls were doing nothing and the page was silent about it.
+	//
+	// Which one is live is not inferred from the config here: the camera
+	// publishes the answer and its answer is the one that matters. Fields of a
+	// mechanism that is not deciding get the same note an x-requires field
+	// gets, for the same reason, and deliberately NOT by hiding or disabling
+	// them — the value is real, it is what is causing the surprise, and it has
+	// to stay findable and clearable. Hiding it would only move the surprise.
+	const NIGHT_MECH = {
+		'nightMode.minThreshold': 'thresholds',
+		'nightMode.maxThreshold': 'thresholds',
+		'nightMode.autoNightGain': 'auto',
+		'nightMode.autoDayGain': 'auto',
+		'nightMode.autoNightDelay': 'auto',
+		'nightMode.autoDayDelay': 'auto',
+	};
+	// night_mode_source, as the endpoint documents it: 0 manual, 1 GPIO
+	// sensor, 2 gain thresholds, 3 ADC, 4 automatic. 0 is nothing deciding,
+	// which is not a verdict about any of these, so it marks nothing.
+	const MECH_OF_SRC = { 1: 'sensor', 2: 'thresholds', 3: 'adc', 4: 'auto' };
+	// One line each. The finding at the top of the section carries the
+	// explanation and the way out; repeating a paragraph under every ignored
+	// control is the wall of text the reporter of #325 objected to in the same
+	// breath, and four copies of it say nothing the first did not.
+	const MECH_NAMED = {
+		sensor: 'the daylight sensor is deciding.',
+		adc: 'the sensor pad voltage is deciding.',
+		thresholds: 'the day and night thresholds are deciding.',
+		auto: 'automatic mode is deciding.',
+	};
+	function paintNightInert(src) {
+		const decides = MECH_OF_SRC[src];
+		state.fields.forEach((f) => {
+			const mech = NIGHT_MECH[f.dot];
+			if (!mech || !f.p) return;
+			let note = f.p.querySelector('.mj-night-inert');
+			// An empty control misleads nobody; only a filled-in one that is
+			// being ignored needs saying.
+			const v = f.getValue();
+			const set = decides && mech !== decides &&
+				String(v === undefined || v === null ? '' : v) !== '';
+			if (!set) {
+				if (note) note.remove();
+				return;
+			}
+			if (!note) {
+				note = el('div', 'hint mj-requires mj-night-inert');
+				f.p.appendChild(note);
+			}
+			note.textContent = 'Not in use — ' + MECH_NAMED[decides];
+		});
 	}
 
 	// The map reports; this writes what it reports into the real fields, so the


### PR DESCRIPTION
> *"And now the camera switches between day and night with no countdown at all. Are you guys testing this even minimally before merging the changes? :-)"*

Fair hit, but the countdown is not broken — and what is actually wrong is worse than a broken countdown.

### What their camera was doing

Day / Night has **three** mechanisms that decide the same thing, and the camera picks between them by what is filled in: a daylight sensor pin wins, then the pair of legacy raw thresholds, and only with neither of those does the calibration-free automatic mode run.

The reporter had set **Minimum sensor threshold for day** = 2000 and **Maximum sensor threshold for night** = 14000. So the camera was in the legacy mode — which has no countdown, because it has no pending state. Meanwhile they had also filled in **Gain multiple that means night** = 33, **Seconds of darkness before night** = 15 and **Seconds of brightness before day** = 60, all of which the camera was ignoring completely.

Reproduced on an hi3516ev300 with exactly that configuration: `night_mode_source` reports **2**, and **no `night_auto_*` gauge is published at all** — no streak, no dwell, no pending. There is no countdown to show and none is possible.

So four controls were doing nothing, and the page was silent about it. That is this UI's cardinal sin wearing a settings form, and it is also the reporter's second comment:

> *"there are now two sets of parameters that appear to control the same things … showing all of them together makes it very difficult for a user to understand which settings actually matter."*

### What the page does now

**It asks the camera which mechanism is deciding** rather than re-deriving the precedence from config, so a build that orders them differently gets described correctly instead of confidently.

- A control belonging to a mechanism that is **not** deciding, and that actually holds a value, gets a one-line note: *"Not in use — the day and night thresholds are deciding."* An empty control misleads nobody and is left alone.
- The finding at the top of the section carries the explanation, **including why no countdown appears**, and the way out.

**Not by hiding or disabling them**, which was the reporter's first suggestion. The value is real, it is the thing causing the surprise, and it has to stay findable and clearable — hiding it would only move the surprise. That is the argument `x-requires` already makes for itself in this codebase, and this reuses its note and its styling so there is one look for "the camera is quietly doing something else".

**And one line, not four paragraphs.** Repeating the explanation under every ignored control is the wall of text the reporter objected to in the same breath; the banner says it once.

### On their preferred fix

They would rather the legacy values were converted once and the fields removed. Two reasons that is not this repo's to do:

- The legacy thresholds are raw `isp_again` units and are **not portable** — Q10 on HiSilicon and SigmaStar, log2×32 on Ingenic — so a browser-side conversion to gain multiples would be right on one vendor and wrong on another.
- The daemon already ships the annotation that expresses exactly this (`x-requires`, with a `field`, an `equals` and a `message`). Declaring it on these keys would make every client show it, not just this page, and would state the precedence at its source. That belongs firmware-side and is worth raising there.

### Tests

Six checks in `tests/ircut-check.test.js` covering the finding: thresholds shadowing a filled-in automatic set, a wired sensor shadowing both, why the countdown is missing, and the three states that must stay quiet — automatic actually deciding, only the winning set filled in, and a camera that has reported no source at all. Reachable only with a camera configured two ways at once.

Suite green (24 files).

Refs #325 — not a closing trailer; the reporter has this to try and a standing complaint about hint length that this does not address.
