### PR TITLE
Settings: a requirement that two settings have to agree on

### DIFF
--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -223,4 +223,68 @@ group('renderField reads the widget hatches on call, not at declaration');
 	}
 }
 
+// A rule that only bites when two settings coincide.
+//
+// majestic refuses live HLS on a camera whose recorder is in motion mode,
+// because nothing is written between detections and the playlist has no new
+// bytes to describe. It does NOT refuse it when the recorder is switched off:
+// records.mode then describes nothing that is happening, and HLS serves out of
+// memory exactly as it does on a camera with no card.
+//
+// One controlling field cannot say that. Written as "HLS requires
+// records.mode continuous" the form would grey the switch out on a camera with
+// recording off and tell its owner to change a setting that is inert — a
+// warning about a configuration the camera deliberately allows, which nothing
+// on the page can clear. So the condition arrives as alternatives, satisfied
+// by either way out of the rule.
+group('a requirement satisfied by any one of several alternatives');
+{
+	// Exactly what majestic emits, including the absent top-level `field`.
+	const HLS = {
+		when: 'true',
+		any: [
+			{ field: 'records.enabled', equals: 'false' },
+			{ field: 'records.mode', notEquals: 'motion' },
+		],
+		message: 'Motion recording writes nothing between detections.',
+	};
+
+	const lookup = (hls, enabled, mode) => ({
+		self: () => hls,
+		saved: (dot) => dot === 'records.enabled' ? enabled
+			: dot === 'records.mode' ? mode : undefined,
+	});
+
+	check('recording on and in motion mode is the one combination refused',
+		req.met(HLS, lookup(true, true, 'motion')) === false);
+	check('and it is the only one that says anything',
+		req.notice(HLS, lookup(true, true, 'motion')) === HLS.message);
+
+	check('recording off leaves the mode inert, so HLS is fine',
+		req.met(HLS, lookup(true, false, 'motion')) === true);
+	check('continuous recording is fine',
+		req.met(HLS, lookup(true, true, 'continuous')) === true);
+	check('and so is recording off in continuous mode',
+		req.met(HLS, lookup(true, false, 'continuous')) === true);
+
+	// `when` still scopes it to this field's own value: a camera with HLS off
+	// must not be told anything about it.
+	check('nothing is said about a switch that is off',
+		req.met(HLS, lookup(false, true, 'motion')) === true);
+
+	// Same fail-open rule as a single condition, applied per alternative: an
+	// alternative whose field nothing can answer for satisfies the whole
+	// requirement, because a warning drawn from no data cannot be cleared.
+	check('an unresolvable alternative satisfies it',
+		req.met(HLS, { self: () => true, saved: (dot) =>
+			dot === 'records.mode' ? 'motion' : undefined }) === true);
+
+	// A malformed or empty list is satisfied rather than stuck on screen.
+	check('an empty list of alternatives is satisfied',
+		req.met({ when: 'true', any: [] }, { self: () => true }) === true);
+	check('a requirement with neither field nor any is satisfied',
+		req.met({ when: 'true', message: 'x' }, { self: () => true }) === true);
+}
+
+
 done();

--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -237,6 +237,14 @@ group('renderField reads the widget hatches on call, not at declaration');
 // warning about a configuration the camera deliberately allows, which nothing
 // on the page can clear. So the condition arrives as alternatives, satisfied
 // by either way out of the rule.
+// It fails the same silent way the single-field shape does, which is why these
+// belong beside those rather than in a suite of their own: get `any` wrong in
+// one direction and no warning draws on the camera that needs one; get it wrong
+// in the other and a warning sits on a valid camera with nothing on the page
+// able to clear it. Neither states an error anywhere. And neither can be
+// produced to order — seeing the real thing needs a camera recording on motion
+// with HLS switched on, and then the same camera with recording off to prove
+// the warning goes away again.
 group('a requirement satisfied by any one of several alternatives');
 {
 	// Exactly what majestic emits, including the absent top-level `field`.

--- a/www/a/mj-requires.js
+++ b/www/a/mj-requires.js
@@ -96,12 +96,36 @@
 	//   would be a definite claim made from no data, and nothing on the page
 	//   could clear it. Same reasoning as an unknown operator holding.
 	function met(req, lookup) {
-		if (!req || !req.field) return true;
+		if (!req || (!req.field && !Array.isArray(req.any))) return true;
 		lookup = lookup || {};
 		if (req.when !== undefined) {
 			const self = typeof lookup.self === 'function' ? lookup.self() : undefined;
 			if (self === undefined || String(self) !== String(req.when)) return true;
 		}
+
+		// A list of alternatives, satisfied when any one of them holds.
+		//
+		// Some rules only bite when two settings coincide, and one equality
+		// then says something broader than the camera enforces. Live HLS is
+		// the case this was added for: motion recording defeats it only when
+		// there IS a recorder running, so `records.mode` alone would grey the
+		// switch out on a camera with recording off and tell its owner to
+		// change a setting that is already inert.
+		//
+		// Same fail-open rule as everything else here, applied per
+		// alternative: one whose field cannot be resolved satisfies the
+		// requirement outright, because a warning drawn from no data is one
+		// nothing on the page can clear.
+		if (Array.isArray(req.any)) {
+			if (!req.any.length) return true;
+			return req.any.some(function (alt) {
+				if (!alt || !alt.field) return true;
+				const av = resolve(alt.field, lookup);
+				if (av === undefined) return true;
+				return matches(alt, av);
+			});
+		}
+
 		const v = resolve(req.field, lookup);
 		if (v === undefined) return true;
 		return matches(req, v);

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -4212,10 +4212,18 @@
 		// Where it does happen to share the page, an unsaved edit to it has to
 		// repaint the warning, exactly as it moves a visibleWhen row.
 		for (const u of state.reqUpdaters || []) {
-			const ctrl = byDot[u.req.field];
-			if (!ctrl || ctrl.dot === u.dot) continue;
-			ctrl.control.addEventListener('change', u.paint);
-			ctrl.control.addEventListener('input', u.paint);
+			// Every field the condition consults, since `any` names more than
+			// one. Missing the second of them would leave the warning correct
+			// on mount and stale under exactly the edit that clears it.
+			const fields = Array.isArray(u.req.any)
+				? u.req.any.map(a => a && a.field).filter(Boolean)
+				: [u.req.field];
+			for (const dot of fields) {
+				const ctrl = byDot[dot];
+				if (!ctrl || ctrl.dot === u.dot) continue;
+				ctrl.control.addEventListener('change', u.paint);
+				ctrl.control.addEventListener('input', u.paint);
+			}
 		}
 
 		// Flipping a controller changes which rows exist, so anything that counts
@@ -4850,7 +4858,12 @@
 		// disabling it: the setting is a legitimate thing to want, it is
 		// remembered, and it starts working the moment its requirement is met.
 		// Hiding it would only move the surprise.
-		if (!live && sub['x-requires'] && sub['x-requires'].field) {
+		// `.field` or `.any`: a requirement carries one controlling field, or a
+		// list of alternatives for a rule that only bites when two settings
+		// coincide. Both shapes are decided by mj-requires.js; this only has to
+		// recognise that there is a requirement to paint.
+		if (!live && sub['x-requires']
+			&& (sub['x-requires'].field || Array.isArray(sub['x-requires'].any))) {
 			const req = sub['x-requires'];
 			const warn = el('div', 'hint mj-requires');
 			const paint = () => {


### PR DESCRIPTION
`x-requires` names one controlling field. That is enough for the substitutions it was written for — `outgoing.substream` is inert exactly when `video1.enabled` is false, and nothing else bears on it.

Some rules are narrower than one equality can say. majestic now refuses live HLS on a camera whose recorder is in **motion** mode, because nothing is written between detections and the playlist has no new byte ranges to describe. It does **not** refuse it when the recorder is switched off: `records.mode` then describes nothing that is happening, and HLS serves out of memory exactly as it does on a camera with no card.

Written as "HLS requires `records.mode` continuous", the form would grey the switch out on that second camera and tell its owner to change a setting that is already inert — a warning about a configuration the camera deliberately allows, which nothing on the page can clear. That is the failure this module exists to prevent, arriving from the other direction.

### The shape

A condition may now carry `any`: a list of alternatives, satisfied when any one holds. That is what a requirement looks like when the rule it guards is a *coincidence* of two settings — the negation of "both are true" is "either is false".

```json
"x-requires": {
  "when": "true",
  "any": [
    { "field": "records.enabled", "equals": "false" },
    { "field": "records.mode", "notEquals": "motion" }
  ],
  "message": "Motion recording writes nothing between detections, so there is no live stream to serve."
}
```

majestic emits it with **no top-level `field`**, deliberately: this build reads a requirement without a controlling field as satisfied and stays silent, so a camera running the newer daemon against an older WebUI loses the hint rather than gaining a wrong one. The daemon enforces the rule regardless.

The existing fail-open rules apply per alternative — one whose field nothing can answer for satisfies the whole requirement, on the same reasoning as an unresolvable single field.

The repaint loop now follows every field a condition consults, not just `req.field`. With two controlling fields, watching one would leave the warning correct on mount and stale under exactly the edit that clears it.

### Tests

Nine new cases in `tests/requires.test.js` covering the one refused combination, the three permitted ones, `when` still scoping to the field's own value, an unresolvable alternative, an empty list, and a requirement carrying neither shape. Full suite green.

The camera-side change that emits this condition is already released; a camera running it serves the fragment above from `/api/v1/config.schema.json`.
