### PR TITLE
Settings: an emptied number field means "not set", and the pin map was two pads short

### DIFF
--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -113,9 +113,20 @@
 		// OpenIPC is majestic's, and majestic never releases a pad when its
 		// nightMode key is deleted; treating that as ownership would lock a
 		// camera out of the pad a rescan needs most.
+		//
+		// The roles here are the ones majestic and U-Boot assign OUTSIDE this
+		// section. The four Day / Night roles are excluded because they are
+		// drawn as roles, in their own colours; these have no row of their own
+		// on this page, so without a word here their pads would read as free
+		// to anyone picking one.
+		const FOREIGN = {
+			ptz: 'used by the PTZ driver',
+			speaker: 'used by the speaker',
+			button: 'used by the doorbell button',
+		};
 		const owned = {};
 		(info.assigned || []).forEach((a) => {
-			if (a.role === 'ptz') owned[a.pin] = 'used by the PTZ driver';
+			if (FOREIGN[a.role]) owned[a.pin] = FOREIGN[a.role];
 		});
 		(info.held || []).forEach((h) => {
 			if (h.owner && h.owner !== 'sysfs') owned[h.pin] = 'held by ' + h.owner;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3787,12 +3787,34 @@
 		return r ? r.label : '';
 	}
 
+	// What this field is called on screen. A Day / Night pin has a role on the
+	// map — "IR-cut filter, closing coil" — which is what every sentence in
+	// that panel calls it; anything else is named by the caption printed above
+	// its own control, derived exactly as renderField derives it. Never the
+	// dotted key: a name readable only by someone who already knows the answer
+	// is not a name.
+	function fieldName(f) {
+		const key = f.dot.slice(f.dot.lastIndexOf('.') + 1);
+		const role = f.dot.indexOf('nightMode.') === 0 ? roleName(key) : '';
+		return role || (f.schema && f.schema.title) || titleCase(key);
+	}
+
+	// Which of the fields this save asked the camera to REMOVE are still
+	// configured afterwards. Asked of the refreshed config, so it is the
+	// camera answering and not the form: an older majestic accepts a null,
+	// answers 202 and ignores it, and nothing else on the page would ever say
+	// that a clear did not take.
+	//
+	// It used to look only under nightMode and only at pins, which was right
+	// while pins were the only thing that could be cleared. Once any numeric
+	// field with no default could be, that shape quietly stopped covering the
+	// cases it was written for — a threshold or a speaker pad whose removal
+	// was ignored would have been reported as a clean save, which is the exact
+	// opposite of what this exists to guarantee.
 	function stillSet(cleared) {
 		return (cleared || [])
-			.map((f) => f.dot.slice('nightMode.'.length))
-			.filter((k) => isNumish(getDotted(state.config, 'nightMode.' + k)))
-			.map(roleName)
-			.filter(Boolean);
+			.filter((f) => isNumish(getDotted(state.config, f.dot)))
+			.map(fieldName);
 	}
 
 	// The filter test's verdict names a wiring and a fix for it ("swap the two
@@ -5285,9 +5307,9 @@
 				// Joined with semicolons, because the role names have commas in
 				// them: "IR-cut filter, closing coil, IR-cut filter, opening
 				// coil" reads as four things and names none of them.
-				showError('Saved, but these could not be disconnected: ' +
-					kept.join('; ') + '. The camera is still configured to ' +
-					'drive them; its firmware may be too old to clear a setting.');
+				showError('Saved, but these could not be cleared: ' +
+					kept.join('; ') + '. The camera is still configured with ' +
+					'them; its firmware may be too old to clear a setting.');
 			// Ask the camera what this cost rather than assuming the worst.
 			// Only a pipeline-class change is still owed a reload; a service
 			// restart or a channel rebuild already happened inside the save,

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -5179,14 +5179,42 @@
 		return fields.some(f => changeCost(f) === 'inplace');
 	}
 
+	// Does emptying this control mean "remove this key"?
+	//
+	// A NUMBER field has no way to say "empty" other than by being empty: an
+	// empty string reaches the config walker and an integer key stores ZERO,
+	// which is a real value and a different statement. The reporter of #325
+	// found that the hard way — told by this very page to clear the day and
+	// night thresholds to hand day/night back to automatic mode, they cleared
+	// both, and the save wrote 0 and 0. Measured on an hi3516ev300: the
+	// camera goes on reporting the threshold mechanism, so the advice could
+	// not be followed at all. Sent as null instead, both keys are removed and
+	// the camera returns to automatic on the same save.
+	//
+	// Only where the schema declares no `default`. A key with one has a
+	// defined unconfigured state that is not absence — it is re-seeded on
+	// every load — so removing it would read as absent now and as the default
+	// after the next restart, which is what the reset control is for.
+	//
+	// Strings are deliberately left alone: an empty string is a value someone
+	// can mean, and an overlay line cleared to nothing is not the same request
+	// as an overlay key that does not exist.
+	function clearsToNull(f) {
+		if (String(f.getValue()) !== '') return false;
+		if (PIN_DOTS[f.dot]) return true;
+		const sch = f.schema || {};
+		if (sch.type !== 'integer' && sch.type !== 'number') return false;
+		return sch.default === undefined || sch.default === null;
+	}
+
 	async function onSubmit(ev) {
 		ev.preventDefault();
 		const all = state.fields.filter(f => f.getValue() !== state.initial[f.dot]);
-		// A cleared pin rides the same batch as everything else, as a null —
+		// A cleared field rides the same batch as everything else, as a null —
 		// which majestic removes rather than stores. Withholding it and tidying
 		// up afterwards was the older shape, and it left the two halves of one
 		// save able to disagree.
-		const cleared = all.filter(f => PIN_DOTS[f.dot] && String(f.getValue()) === '');
+		const cleared = all.filter(clearsToNull);
 		const dirty = all;
 		if (!all.length) return;
 
@@ -5203,8 +5231,8 @@
 			// list of strings, not a comma-joined scalar.
 			if (f.schema && f.schema.type === 'array')
 				val = String(val).split(',').map(s => s.trim()).filter(s => s.length);
-			// null is "remove this key". Only a cleared pin means it — an empty
-			// string field is an empty string, which is a value someone chose.
+			// null is "remove this key" — see clearsToNull for which emptied
+			// controls mean it and which mean an empty string someone chose.
 			else if (cleared.indexOf(f) >= 0)
 				val = null;
 			setDotted(body, f.dot, val);

--- a/www/cgi-bin/j/gpio.cgi
+++ b/www/cgi-bin/j/gpio.cgi
@@ -147,6 +147,17 @@ assigned() {
 		v=$(yaml-cli -g ".nightMode.$k" 2>/dev/null)
 		echo "$v" | grep -qE '^[0-9]+$' && echo "$v $k"
 	done
+	# Pads majestic has been given elsewhere in its own config. Day / Night is
+	# not the only section that assigns one, and a pad the speaker or the
+	# doorbell button is on is neither free to hand an IR-cut coil nor
+	# something a sweep may drive — the scan raises a pad against another and
+	# brakes both, which on a speaker enable or a button line is not a
+	# measurement anybody asked for. They were invisible here, so the map drew
+	# them as free and the sweep treated them as candidates.
+	for kv in "audio.speakerPin speaker" "sip.buttonPin button"; do
+		v=$(yaml-cli -g ".${kv%% *}" 2>/dev/null)
+		echo "$v" | grep -qE '^[0-9]+$' && echo "$v ${kv##* }"
+	done
 	for e in ptz_gpio gpio_motors; do
 		for v in $(fw_printenv -n "$e" 2>/dev/null | tr ',' ' '); do
 			echo "$v" | grep -qE '^[0-9]+$' && echo "$v ptz"
@@ -228,7 +239,19 @@ if [ -n "$DRIVE" ] && [ -n "$LOWPAD" ]; then
 		for line in $(assigned | sed 's/ /:/'); do
 			pv="${line%%:*}"; role="${line#*:}"
 			case "$role" in irCutPin1|irCutPin2) continue ;; esac
-			if [ "$pv" = "$pad" ]; then deny "pad $pad is already assigned"; fi
+			# Named, not just refused. "already assigned" leaves the reader to
+			# go and find out what to, which on a page whose whole subject is
+			# which pad does what is the one thing not to make them do — and
+			# the names are the ones on screen, never the config keys.
+			case "$role" in
+				backlightPin)   what='the night illuminator' ;;
+				lightSensorPin) what='the daylight sensor' ;;
+				ptz)            what='the PTZ driver' ;;
+				speaker)        what='the speaker' ;;
+				button)         what='the doorbell button' ;;
+				*)              what='something else' ;;
+			esac
+			if [ "$pv" = "$pad" ]; then deny "pad $pad is already used by $what"; fi
 		done
 	done
 	COILS=$(coil_pads)


### PR DESCRIPTION
> *"I can't clear these thresholds because after saving, empty fields are automatically set back to `0`. This should be fixed, preferably for all settings fields in all categories where an empty value is a valid state."*

Correct, and worse than it looks: #343 added a banner telling this reporter to clear the day and night thresholds to hand day/night back to automatic mode — and the page could not do it. It had trapped them in the state it was telling them to leave.

### Measured

On an hi3516ev300 + imx335, driving the config API directly:

| what is sent for `nightMode.minThreshold` | what lands in the config | `night_mode_source` |
|---|---|---|
| `""` (what the page sent) | `minThreshold: 0` | **2** — still the threshold mechanism |
| `null` | key removed | **4** — automatic, `night_auto_*` gauges return |

A number field has no way to say "empty" other than by being empty. An empty string reaches the config walker and an integer key stores **zero**, which is a real value and a different statement. Only `null` removes a key, and until now only the four IR-cut pins sent it.

### The rule

An emptied **numeric** control sends `null` whenever the schema declares **no `default`** for it.

- A key *with* a default has a defined unconfigured state that is not absence — it is re-seeded on every load — so removing it would read as absent now and as the default after the next restart. That is what the per-field reset control is for.
- **Strings are deliberately left alone.** An empty string is a value someone can mean; an overlay line cleared to nothing is not the same request as an overlay key that does not exist.

### What it covers

Fourteen keys, and every one is a setting whose empty state is real:

`isp.drc`, `nightMode.overrideDrc`, `video0.refEnhance`, `usbcam.bitrate`, `netip.port`, `nightMode.minThreshold`, `nightMode.maxThreshold`, `nightMode.autoNightGain`, and six GPIO pads — `nightMode.irCutPin1`, `irCutPin2`, `backlightPin`, `lightSensorPin`, plus **`audio.speakerPin` and `sip.buttonPin`**.

Those last two are worth calling out. The pads are the reason this pattern exists at all — 0 is a real pin, listed as RESET on several XiongMai boards — and they had exactly the fault the IR-cut pins were fixed for, unnoticed, in two other sections of the same page.

### Verified end to end, not in the abstract

Driving the real form in a browser against a camera: emptying both threshold controls and pressing Save posts `{"nightMode":{"minThreshold":null,"maxThreshold":null}}`, both keys leave the config rather than becoming zero, and the camera returns to automatic mode with its countdown gauges back on the same save.

No test is added. The predicate lives in `mj-settings.js`, which has no harness, and extracting a module for six lines would be the tail wagging the dog — the check that matters is the one above, which exercises the form, the batch shape, the daemon and the resulting camera state together.

Suite green (25 files).

Refs #325 — the reporter's two other points on that issue (the page has become text-heavy, and they would rather see only the active set of parameters) are not addressed here and are answered on the issue.


---

## Second commit: the pin map knew about four pads, and there are six

Enumerating the fields above turned up `audio.speakerPin` and `sip.buttonPin` as GPIO pads with the same clearing bug. Which raised a better question, and this is the answer to it.

The Day / Night pin map draws every pad on the SoC and dresses the ones already spoken for, so somebody assigning an IR-cut coil can see what is free. It read the four Day / Night pins and the PTZ lines from U-Boot — and **nothing else majestic's own config assigns**. The speaker's pad and the doorbell button's pad were drawn as free, on a page whose entire subject is which pad does what.

The second consequence is the one that matters: `assigned` is also the sweep's refusal list, so **"Find them for me" treated both as candidates** — raising one against another and braking both. On a speaker enable or a button line that is not a measurement anybody asked for.

Verified on an hi3516ev300 with both pins set:

| request | before | after |
|---|---|---|
| drive the speaker's pad | `done: true` — pad driven | `pad 52 is already used by the speaker` |
| drive the doorbell's pad | `done: true` — pad driven | `pad 53 is already used by the doorbell button` |
| drive a genuinely free pair | `done: true` | `done: true` |

The refusal **names what the pad is used by** rather than saying "already assigned" — leaving the reader to go and find out what to is the one thing not to make them do here — and the names are the ones on screen: the night illuminator, the daylight sensor, the speaker, the doorbell button. Never the config keys behind them.

No new UI: `mj-pin-owned` already dims the pad, disables it, and names its owner in the tooltip and in the pad's popover. These two were simply not in the list.
