### PR TITLE
Notices: a link goes to a page, a button acts, and nothing said so (#347)

### DIFF
--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -142,6 +142,7 @@ check('data-bs-dismiss reaches .mj-notice as well as .alert',
 	/closest\('\.alert, \.mj-notice'\)/.test(dismiss),
 	'a dismiss that only knows .alert is an inert x on every notice');
 
+
 group('one vocabulary for the actions, wherever they are written');
 
 // A notice points at the page that fixes what it reports, so its action is a
@@ -158,6 +159,31 @@ group('one vocabulary for the actions, wherever they are written');
 // that still renders, still links to the right place, and still looks like it
 // came from a different program than the banner above it.
 const ACTS_ON_GET = new Set(['restart.cgi']);
+
+// Every action in the tree, named. Named rather than counted, because the
+// failure this scan exists to catch is an action written in a spelling
+// actionGroups() cannot read: it then escapes every check below and the run
+// looks exactly like a passing one. A floor — "at least eight" — is green in
+// precisely that case, so it protects nothing. Against this list an action
+// that stops being recognised is a line that went missing.
+//
+// The cost is that adding a notice action edits this list, and that is the
+// point: it is the review the vocabulary did not have.
+const EXPECTED = [
+	'a/recordings.js sdcard.cgi "Open the SD card page &rarr;"',
+	'a/update-check.js update.cgi "Firmware update &rarr;"',
+	'cgi-bin/camera.cgi logs.cgi "Open the log &rarr;"',
+	'cgi-bin/camera.cgi restart.cgi "Restart camera"',
+	'cgi-bin/dashboard.cgi camera.cgi "Open Day / Night &rarr;"',
+	// The two on the no-video banner are empty here and filled by dashboard.js.
+	'cgi-bin/dashboard.cgi camera.cgi ""',
+	'cgi-bin/dashboard.cgi logs.cgi ""',
+	'cgi-bin/dashboard.cgi live.cgi "Open Live &rarr;"',
+	'cgi-bin/p/header.cgi config.cgi "Configuration file &rarr;"',
+	'cgi-bin/p/header.cgi network.cgi "Network settings &rarr;"',
+	'cgi-bin/p/header.cgi network.cgi "Set the MAC address &rarr;"',
+	'cgi-bin/p/header.cgi restart.cgi "Restart camera"',
+];
 
 // The shell words of a `<% notice ... %>` call, quoted the way sh reads them.
 // The sentences carry apostrophes and the actions carry double-quoted
@@ -184,6 +210,12 @@ function shellWords(line) {
 	return out;
 }
 
+// common.cgi's notice() and main.js's mjNotice() BUILD the action span, so the
+// hit inside each of them is the component itself rather than somewhere an
+// action was written. Matched by the exact placeholder each one interpolates,
+// so a real group can never be mistaken for one of these.
+const EMITTERS = ['%s', "' + o.acts + '"];
+
 // Every action group in the tree, in the three shapes one gets written in.
 function actionGroups(file, src) {
 	const out = [];
@@ -194,7 +226,9 @@ function actionGroups(file, src) {
 	while ((m = haserl.exec(src))) add(shellWords(m[1])[2]);
 
 	const markup = /<span class="mj-notice-acts">([\s\S]*?)<\/span>/g;
-	while ((m = markup.exec(src))) add(m[1]);
+	while ((m = markup.exec(src))) {
+		if (EMITTERS.indexOf(m[1]) < 0) add(m[1]);
+	}
 
 	// Written as `acts: '<a …>'`. Anything else is not skipped quietly: a call
 	// site this cannot read is a call site the rule stops covering.
@@ -226,22 +260,18 @@ const WWW = path.join(__dirname, '..', 'www');
 const groups = walk(WWW).flatMap((f) =>
 	actionGroups(path.relative(WWW, f), fs.readFileSync(f, 'utf8')));
 
-// A scanner that matched nothing would pass every check under it.
-check('the scan found the notices that actually carry actions',
-	groups.length >= 8, 'found ' + groups.length);
-
-let anchors = 0;
+const found = [];
 groups.forEach((g) => {
 	const re = /<a\b([^>]*)>([\s\S]*?)<\/a>/g;
 	let a;
 	while ((a = re.exec(g.html))) {
-		anchors++;
 		const attrs = a[1], text = a[2].trim();
 		const cls = (/\bclass="([^"]*)"/.exec(attrs) || ['', ''])[1];
 		const href = (/\bhref="([^"]*)"/.exec(attrs) || ['', ''])[1];
 		const page = href.split(/[?#]/)[0].replace(/^.*\//, '');
 		const isBtn = /(^|\s)btn(\s|$)/.test(cls);
 		const where = g.file + ': ' + a[0];
+		found.push(g.file + ' ' + page + ' "' + text + '"');
 
 		check(page + ' in ' + g.file + ' is drawn as what pressing it does',
 			isBtn === ACTS_ON_GET.has(page),
@@ -256,8 +286,15 @@ groups.forEach((g) => {
 		}
 	}
 });
-check('every action group in the tree holds at least one link', anchors >= 8,
-	'found ' + anchors);
+
+const missing = EXPECTED.filter((e) => found.indexOf(e) < 0);
+const extra = found.filter((f) => EXPECTED.indexOf(f) < 0);
+check('every notice action the tree holds is one the scan can read',
+	missing.length === 0,
+	'no longer found, so no longer checked:\n    ' + missing.join('\n    '));
+check('and the scan reads nothing this list has not been told about',
+	extra.length === 0,
+	'add it to EXPECTED once its shape is right:\n    ' + extra.join('\n    '));
 
 // dashboard.js writes two of those labels at runtime, and has to add the same
 // arrow the static ones are typed with.

--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -142,4 +142,128 @@ check('data-bs-dismiss reaches .mj-notice as well as .alert',
 	/closest\('\.alert, \.mj-notice'\)/.test(dismiss),
 	'a dismiss that only knows .alert is an inert x on every notice');
 
+group('one vocabulary for the actions, wherever they are written');
+
+// A notice points at the page that fixes what it reports, so its action is a
+// plain link ending in an arrow. A filled .btn is for the press that acts on
+// the camera where it stands — today exactly one href, restart.cgi, which
+// reboots on GET.
+//
+// The rule is worth a test rather than a paragraph because it is written in
+// four places at once: two haserl banners, three blocks of Dashboard markup
+// and two browser-built notices. It had already drifted — the firmware-behind
+// banner and the recordings banner both drew navigation as a filled button, so
+// the Dashboard offered "go to a page" in two shapes at the same time (#347) —
+// and nothing anywhere would have said so. Every way this breaks is a banner
+// that still renders, still links to the right place, and still looks like it
+// came from a different program than the banner above it.
+const ACTS_ON_GET = new Set(['restart.cgi']);
+
+// The shell words of a `<% notice ... %>` call, quoted the way sh reads them.
+// The sentences carry apostrophes and the actions carry double-quoted
+// attributes, so both quote styles are in use and splitting on whitespace is
+// not enough.
+function shellWords(line) {
+	const out = [];
+	let cur = '', q = null, started = false;
+	for (const ch of line) {
+		if (q) {
+			if (ch === q) q = null;
+			else cur += ch;
+			continue;
+		}
+		if (ch === "'" || ch === '"') { q = ch; started = true; continue; }
+		if (/\s/.test(ch)) {
+			if (started || cur) out.push(cur);
+			cur = ''; started = false;
+			continue;
+		}
+		cur += ch;
+	}
+	if (started || cur) out.push(cur);
+	return out;
+}
+
+// Every action group in the tree, in the three shapes one gets written in.
+function actionGroups(file, src) {
+	const out = [];
+	const add = (html) => { if (html && html.trim()) out.push({ file, html }); };
+	let m;
+
+	const haserl = /<%\s*notice\s+([\s\S]*?)%>/g;
+	while ((m = haserl.exec(src))) add(shellWords(m[1])[2]);
+
+	const markup = /<span class="mj-notice-acts">([\s\S]*?)<\/span>/g;
+	while ((m = markup.exec(src))) add(m[1]);
+
+	// Written as `acts: '<a …>'`. Anything else is not skipped quietly: a call
+	// site this cannot read is a call site the rule stops covering.
+	const key = /\bacts:\s*/g;
+	while ((m = key.exec(src))) {
+		// Not the one in main.js's own usage note: a comment emits nothing, and
+		// it spells its arrow as an escape, which is not what a page renders.
+		const bol = src.lastIndexOf('\n', m.index) + 1;
+		if (/^\s*(\/\/|\*)/.test(src.slice(bol, m.index))) continue;
+		const lit = /^'((?:[^'\\]|\\.)*)'/.exec(src.slice(m.index + m[0].length));
+		check('the acts: in ' + file + ' is a literal this test can read',
+			!!lit, src.slice(m.index, m.index + 80));
+		if (lit) add(lit[1]);
+	}
+	return out;
+}
+
+function walk(dir) {
+	const out = [];
+	for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+		const f = path.join(dir, e.name);
+		if (e.isDirectory()) out.push(...walk(f));
+		else if (/\.(cgi|js)$/.test(e.name)) out.push(f);
+	}
+	return out;
+}
+
+const WWW = path.join(__dirname, '..', 'www');
+const groups = walk(WWW).flatMap((f) =>
+	actionGroups(path.relative(WWW, f), fs.readFileSync(f, 'utf8')));
+
+// A scanner that matched nothing would pass every check under it.
+check('the scan found the notices that actually carry actions',
+	groups.length >= 8, 'found ' + groups.length);
+
+let anchors = 0;
+groups.forEach((g) => {
+	const re = /<a\b([^>]*)>([\s\S]*?)<\/a>/g;
+	let a;
+	while ((a = re.exec(g.html))) {
+		anchors++;
+		const attrs = a[1], text = a[2].trim();
+		const cls = (/\bclass="([^"]*)"/.exec(attrs) || ['', ''])[1];
+		const href = (/\bhref="([^"]*)"/.exec(attrs) || ['', ''])[1];
+		const page = href.split(/[?#]/)[0].replace(/^.*\//, '');
+		const isBtn = /(^|\s)btn(\s|$)/.test(cls);
+		const where = g.file + ': ' + a[0];
+
+		check(page + ' in ' + g.file + ' is drawn as what pressing it does',
+			isBtn === ACTS_ON_GET.has(page),
+			isBtn ? where + '\n    a .btn that only navigates'
+				: where + '\n    an action that acts on GET, drawn as a link');
+
+		// The two on the Dashboard's no-video banner are empty here and filled
+		// by dashboard.js, so their arrow is checked where it is written.
+		if (text) {
+			check('"' + text + '" ends the way its shape says it should',
+				/(&rarr;|→)$/.test(text) === !isBtn, where);
+		}
+	}
+});
+check('every action group in the tree holds at least one link', anchors >= 8,
+	'found ' + anchors);
+
+// dashboard.js writes two of those labels at runtime, and has to add the same
+// arrow the static ones are typed with.
+const dash = fs.readFileSync(A('dashboard.js'), 'utf8');
+check('the runtime-filled actions carry the arrow too',
+	(dash.match(/\.label \+ ' →'/g) || []).length === 2,
+	'dashboard.js fills #st-alert-novideo-a and -h');
+
 done();

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -627,9 +627,15 @@ function mjNoticeIcon(sev) {
 		(MJ_NOTICE_ICONS[sev] || MJ_NOTICE_ICONS.info) + '</svg>';
 }
 
-// mjNotice('danger', '<b>Title</b> \u2014 sentence.', {acts: '<a \u2026>Fix it \u2192</a>'})
+// mjNotice('danger', '<b>Title</b> \u2014 sentence.', {acts: '<a href="network.cgi">Fix it \u2192</a>'})
 // returns the notice's outer HTML as a string, because every caller here is
 // building innerHTML for a container it owns.
+//
+// The action is a plain link ending in an arrow, because a notice points at the
+// page that fixes what it reports rather than carrying the fix. A filled .btn
+// is only for a press that acts on the camera where it stands. p/common.cgi's
+// `notice` states the rule in full and tests/notice.test.js holds it across
+// every call site in the tree.
 function mjNotice(sev, html, opts) {
 	const o = opts || {};
 	return '<div class="mj-notice mj-notice-' + sev + '"' +

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -840,9 +840,12 @@
 		const msg = cardTrouble();
 		if (!msg) { el.className = 'd-none'; el.innerHTML = ''; return; }
 		el.className = '';
+		// A link, not a button: it goes to a page (#347). It wore btn-danger,
+		// which also put it one initAll() timing accident away from asking
+		// "Are you sure?" before letting anyone read the card's own page.
 		el.innerHTML = mjNotice('danger', msg, {
 			body: cardKernelLines(),
-			acts: '<a class="btn btn-sm btn-danger" href="sdcard.cgi">Open the SD card page</a>',
+			acts: '<a href="sdcard.cgi">Open the SD card page &rarr;</a>',
 		});
 	}
 

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -202,8 +202,13 @@
 		try { seen = localStorage.getItem(SEEN); } catch (e) { /* private mode */ }
 		if (seen === feed.cursor) return;
 
+		// A plain link, like every other notice that points at a page. This
+		// was a filled btn-primary, which put two notices side by side on the
+		// Dashboard making the same offer -- go to a page -- in two different
+		// shapes (#347). A .btn in a notice means the press acts on the camera
+		// then and there; this one navigates.
 		slot.innerHTML = mjNotice(severity, sentence(d, matched, stale), {
-			acts: '<a class="btn btn-primary btn-sm" href="update.cgi">Firmware update &rarr;</a>',
+			acts: '<a href="update.cgi">Firmware update &rarr;</a>',
 			dismiss: true,
 		});
 		slot.addEventListener('click', e => {

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -322,6 +322,23 @@ log_create() {
 # The marks are drawn rather than typed, and are the same five paths main.js
 # emits for the pages that build a notice in the browser -- a severity mark
 # that differs between two pages is worse than no mark at all.
+#
+# The actions have one vocabulary, and it is about what pressing them DOES
+# rather than about how important the notice is (#347). A notice says what is
+# wrong and points at the page that fixes it, so its ordinary action is a plain
+# link ending in an arrow -- "Open Day / Night ->" -- and it is a link for the
+# same reason the sentence is a sentence: nothing has happened yet. A filled
+# .btn is reserved for the rare action that happens where it stands, and today
+# that is exactly one href, restart.cgi, which reboots the camera on GET. Both
+# spellings sit side by side in camera.cgi's stopped-daemon banner, which is
+# what the pair is for: one goes to the log, the other restarts the camera.
+#
+# It went wrong the way one vocabulary with two writers always does. The
+# firmware-behind banner drew "Firmware update ->" as a filled btn-primary and
+# the recordings banner drew "Open the SD card page" as a btn-danger, both of
+# them navigation, so the Dashboard showed two notices making the same offer in
+# two different shapes. tests/notice.test.js walks every action group in the
+# tree and holds the rule.
 notice_icon() {
 	local d
 	case "$1" in


### PR DESCRIPTION
Fixes #347.

Two notices on the Dashboard offered the same thing in two different shapes: the firmware-behind banner drew **Firmware update →** as a filled `btn-primary`, and the day/night finding under it drew **Open Day / Night →** as a plain link. Both go to a page.

## The rule was already there, unwritten

Every notice action in the tree:

| notice | action | shape |
| --- | --- | --- |
| header — no default gateway | `Network settings →` | link |
| header — MAC is a placeholder | `Set the MAC address →` | link |
| header — no configuration found | `Configuration file →` | link |
| header — settings waiting for a restart | `Restart camera` | **btn-danger** |
| settings — majestic is not running | `Open the log →` **and** `Restart camera` | link **and btn-danger** |
| dashboard — day / night finding | `Open Day / Night →` | link |
| dashboard — no video | filled at runtime, `… →` | link |
| dashboard — you were brought here | `Open Live →` | link |
| **header — camera software is behind** | `Firmware update →` | **btn-primary** |
| **recordings — card trouble** | `Open the SD card page` | **btn-danger** |

Six of eight navigation actions were plain links ending in an arrow. The two that were not are the two changed here. The one action that genuinely *does* something where it stands — `restart.cgi`, which reboots the camera on GET — was a button in both of its call sites, and the stopped-daemon banner states the rule by example by carrying both spellings in one action group.

So the vocabulary is about what pressing does, not about how serious the notice is. A notice says what is wrong and points at the page that fixes it; pointing is a link, for the same reason the sentence beside it is a sentence — nothing has happened yet. A filled `.btn` is the press that acts on the camera now.

## What changed

- `update-check.js` and `recordings.js` drop their `.btn` classes; the recordings action gains the arrow the others carry.
- The rule is written down at `notice()` in `p/common.cgi` and at `mjNotice()` in `main.js` — both emitters, because a caller of one never reads the other.
- `tests/notice.test.js` gains the scan that holds it.

Nothing else moves. `Restart camera` stays a filled button in both places, and the per-finding dismiss `✕` is unchanged — a live misconfiguration should not be waveable away, while "your camera is behind" should.

## Why a test rather than a paragraph

The existing test pins the notice box byte-for-byte across both emitters, which is why the *box* has not drifted. What drifted is the hole the box leaves for its callers: it is owned by nobody and written in three spellings — a haserl `<% notice … %>` argument, hand-written `.mj-notice-acts` markup, and an `acts:` literal in JS. Every way it goes wrong renders perfectly: right link, right destination, wrong shape.

So the test walks `www/` for all three spellings and fails when a `.btn` only navigates, or a navigating link has lost its arrow. It also asserts the scan matched a plausible number of call sites — a scanner that quietly matches nothing passes every check under it. Confirmed it fails on the pre-fix markup before it was accepted.

## Also found

`recordings.js`'s action wore `btn-danger`, and `initAll` in `main.js` wires `.btn-danger` to a `confirm()`. It escaped only because that notice is built after the `load` event, so the static query never saw it — one timing accident away from asking "Are you sure?" before letting somebody read the SD card page.

## Verification

Full suite green; `tools/regen-bootstrap-css.sh` reproduces the committed `bootstrap.min.css` unchanged. Rendered on an hi3516ev200 with both banners of the report up — raising the first one needs a build older than the release feed's eldest entry — and the two now read as one shape:

```
ⓘ  Your camera software is at least 1 build behind — in the changes we can see: 1 new feature.     Firmware update →   ✕
⊗  Majestic cannot move the IR-cut filter — Nothing is connected to the filter, so nothing moves    Open Day / Night →  ✕
   it and it stays wherever it powered up. Left open in daylight it makes the whole picture magenta.
```
