### PR TITLE
Notices: say nothing until there is an image the camera can install

### DIFF
--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -65,7 +65,17 @@ function run(opts) {
 			setItem(k, v) { if (opts.storageThrows) throw new Error('denied'); stored = v; },
 		},
 		mjNotice(sev, html) { painted = { sev, html }; return '<div>' + html + '</div>'; },
-		fetch() {
+		// Two endpoints now: the public feed, and the camera's own answer about
+		// whether an image it can install exists. Tests that do not care about
+		// the second get "yes, there is one", so they keep testing the first.
+		fetch(url) {
+			const isFw = String(url).indexOf('fw-latest') !== -1;
+			if (isFw) {
+				if (opts.fwFails) return Promise.reject(new Error('no updater'));
+				const fw = ('fw' in opts) ? opts.fw : { newer: true };
+				if (fw === null) return Promise.resolve({ ok: false, status: 500 });
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(fw) });
+			}
 			if (opts.netFails) return Promise.reject(new Error('offline'));
 			if (opts.httpStatus) return Promise.resolve({ ok: false, status: opts.httpStatus });
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.feed) });
@@ -209,6 +219,31 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 			version: 'Lite HiSilicon (hi3516ev300), HEAD+deadbeef1',
 			feed: feedOf([entry('aaaaaaaaa', { fix: 9 })]),
 		})) === null);
+
+	group('nothing to install means nothing to say');
+
+	// majestic-webui#348: the notice said a camera was behind while the Firmware
+	// page correctly offered nothing to install. The software and the image it
+	// ships in do not become available at the same moment, so the notice has to
+	// wait for the image.
+	const behind = {
+		version: VER(MINE, iso(30)),
+		feed: feedOf([entry('aaaaaaaaa', { feature: 2, fix: 6, security: 1 }), entry(MINE, {})]),
+	};
+	check('with an installable image, it speaks',
+		(await run(Object.assign({}, behind, { fw: { newer: true } }))) !== null);
+	check('with no newer image, it stays silent even with a security fix',
+		(await run(Object.assign({}, behind, { fw: { newer: false } }))) === null);
+	check('"cannot tell" is not permission to speak',
+		(await run(Object.assign({}, behind, { fw: { newer: null } }))) === null);
+	check('a missing `newer` field is not permission either',
+		(await run(Object.assign({}, behind, { fw: {} }))) === null);
+	check('an updater that cannot be reached is not evidence of an update',
+		(await run(Object.assign({}, behind, { fwFails: true }))) === null);
+	check('nor is an endpoint that errors',
+		(await run(Object.assign({}, behind, { fw: null }))) === null);
+	check('and the string "true" is not the boolean',
+		(await run(Object.assign({}, behind, { fw: { newer: 'true' } }))) === null);
 
 	group('a date that is not a date is not evidence');
 

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -16,6 +16,9 @@
 	'use strict';
 
 	const FEED = 'https://openipc.s3-eu-west-1.amazonaws.com/majestic-changes.json';
+	// Whether an image this board can actually install exists. Same-origin, and
+	// the same question the Firmware page asks, through the same updater.
+	const FW_LATEST = '/cgi-bin/j/fw-latest.cgi';
 	const SLOT = 'update-notice';
 	const SEEN = 'mj-update-seen';
 	// A build nobody has updated in half a year is a liability by itself, so it
@@ -228,10 +231,24 @@
 		// A camera with no route out must not hold the page open waiting.
 		const ctl = ('AbortController' in window) ? new AbortController() : null;
 		const timer = setTimeout(() => ctl && ctl.abort(), TIMEOUT_MS);
-
-		fetch(FEED, { signal: ctl ? ctl.signal : undefined, cache: 'no-cache' })
+		const signal = ctl ? ctl.signal : undefined;
+		const grab = (url) => fetch(url, { signal: signal, cache: 'no-cache' })
 			.then(r => r.ok ? r.json() : Promise.reject(r.status))
-			.then(feed => render(slot, feed, build))
+			.catch(() => null);
+
+		// Both questions, because either one alone misleads. The feed says what
+		// changed in the camera's software; the endpoint says whether an image
+		// carrying it exists for this board. Telling an owner they are behind
+		// while the Firmware page offers them nothing to install is the
+		// contradiction this pair exists to make impossible.
+		Promise.all([grab(FEED), grab(FW_LATEST)])
+			.then(([feed, fw]) => {
+				// `newer` is true, false, or null for "cannot tell". Only true
+				// is permission to speak: an unreachable updater is not evidence
+				// that an update exists.
+				if (!feed || !fw || fw.newer !== true) return;
+				render(slot, feed, build);
+			})
 			.catch(() => { /* offline, blocked, or malformed: say nothing */ })
 			.then(() => clearTimeout(timer));
 	});

--- a/www/cgi-bin/j/fw-latest.cgi
+++ b/www/cgi-bin/j/fw-latest.cgi
@@ -25,8 +25,22 @@
 # a stale one is refreshed by whichever request notices first.
 
 CACHE=/tmp/fw-latest.json
-TTL=21600   # six hours: images appear daily at most, and a stale answer only
-            # ever delays the notice, never invents one.
+
+# The two answers are not equally safe to remember, so they are not cached for
+# the same length of time.
+#
+# "no image" is cheap to hold: the worst a stale one does is delay the notice,
+# and it is the common answer — most days there is nothing new, so this is what
+# keeps the query off the page.
+#
+# "there is an image" is the dangerous one. Held for hours it can outlive the
+# thing it describes: connectivity drops, or the build is withdrawn, and the
+# notice keeps insisting while the Firmware page — which asks live, every time —
+# offers nothing. That is the contradiction this endpoint exists to prevent,
+# arriving by a different road. So a yes is re-checked often, and the extra
+# queries only happen while an update is genuinely waiting to be installed.
+TTL_NO=21600    # six hours
+TTL_YES=900     # fifteen minutes
 
 json_hdr() { printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Control: no-store\n\n'; }
 
@@ -36,7 +50,11 @@ installed=$(sed -n 's/^GITHUB_VERSION="\?\([^",]*\).*/\1/p' /etc/os-release 2>/d
 fresh=0
 if [ -f "$CACHE" ]; then
     age=$(( $(date +%s) - $(date -r "$CACHE" +%s 2>/dev/null || echo 0) ))
-    [ "$age" -ge 0 ] && [ "$age" -lt "$TTL" ] && fresh=1
+    case "$(cat "$CACHE" 2>/dev/null)" in
+        *'"newer":true'*) ttl=$TTL_YES ;;
+        *) ttl=$TTL_NO ;;
+    esac
+    [ "$age" -ge 0 ] && [ "$age" -lt "$ttl" ] && fresh=1
 fi
 
 if [ "$fresh" = "1" ]; then
@@ -45,12 +63,23 @@ if [ "$fresh" = "1" ]; then
     exit 0
 fi
 
-# Same call, same scrape as the Firmware page: one source of truth for "what
-# could this board install". `timeout` bounds it so a dead network cannot hang
-# the request.
+# Same predicate as the Firmware page, deliberately down to the numbers: a
+# default route must exist, and `sysupgrade` gets the same fifteen seconds. A
+# longer timeout here, or asking without a route, would let this endpoint answer
+# where the page gives up — and two surfaces that disagree is the whole fault
+# this is fixing.
+#
+# The page reads $network_gateway from the shared shell prelude, which is a
+# haserl template this cannot include, so the one line that computes it is
+# repeated here verbatim rather than reimplemented — `ip route`, not
+# /proc/net/route, because a hand-rolled parse of that file is how this check
+# was wrong the first time: `grep -E` does not read \t as a tab, so it saw no
+# default route on a camera that plainly had one and switched the notice off
+# everywhere.
 latest=""
-if command -v sysupgrade >/dev/null 2>&1; then
-    latest=$(timeout 20 sysupgrade --list-builds 2>/dev/null \
+if [ -n "$(ip route 2>/dev/null | awk '/default/ {print $3}')" ] &&
+   command -v sysupgrade >/dev/null 2>&1; then
+    latest=$(timeout 15 sysupgrade --list-builds 2>/dev/null \
              | grep -Eo '[A-Za-z0-9._]+-[0-9]{8}-[0-9a-f]+' | head -1)
 fi
 

--- a/www/cgi-bin/j/fw-latest.cgi
+++ b/www/cgi-bin/j/fw-latest.cgi
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Is there a firmware image this board can actually install?
+#
+# GET -> {"installed":"<sha>","latest":"<build-id>","latestSha":"<sha>",
+#         "newer":true|false|null}
+#
+# `newer` is null for "cannot tell" — no updater, no network, a manifest that
+# did not answer. Callers must treat null as "say nothing", never as false and
+# never as true.
+#
+# WHY THIS EXISTS. The update notice counts what changed in the camera software,
+# but the button under it flashes a whole firmware image, and the two do not
+# become available at the same moment: the software publishes on its own
+# schedule, and an image carrying it appears later, per board, sometimes not for
+# days. A notice driven by the software alone therefore tells an owner they are
+# behind while the Firmware page — correctly — offers them nothing to install.
+# That contradiction is the whole of majestic-webui#348.
+#
+# So the notice asks this endpoint as well, and stays silent unless an image
+# exists. The comparison is deliberately the same one the Firmware page makes,
+# through the same updater, so the two cannot disagree.
+#
+# CACHED because `sysupgrade --list-builds` fetches a manifest over the network
+# and the notice is on every page. The cache is a plain file with an mtime TTL;
+# a stale one is refreshed by whichever request notices first.
+
+CACHE=/tmp/fw-latest.json
+TTL=21600   # six hours: images appear daily at most, and a stale answer only
+            # ever delays the notice, never invents one.
+
+json_hdr() { printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Control: no-store\n\n'; }
+
+installed=$(sed -n 's/^GITHUB_VERSION="\?\([^",]*\).*/\1/p' /etc/os-release 2>/dev/null \
+            | sed -n 's/.*+\([0-9a-f]\{7,\}\).*/\1/p' | head -1)
+
+fresh=0
+if [ -f "$CACHE" ]; then
+    age=$(( $(date +%s) - $(date -r "$CACHE" +%s 2>/dev/null || echo 0) ))
+    [ "$age" -ge 0 ] && [ "$age" -lt "$TTL" ] && fresh=1
+fi
+
+if [ "$fresh" = "1" ]; then
+    json_hdr
+    cat "$CACHE"
+    exit 0
+fi
+
+# Same call, same scrape as the Firmware page: one source of truth for "what
+# could this board install". `timeout` bounds it so a dead network cannot hang
+# the request.
+latest=""
+if command -v sysupgrade >/dev/null 2>&1; then
+    latest=$(timeout 20 sysupgrade --list-builds 2>/dev/null \
+             | grep -Eo '[A-Za-z0-9._]+-[0-9]{8}-[0-9a-f]+' | head -1)
+fi
+
+latest_sha=$(printf '%s' "$latest" | sed -n 's/.*-\([0-9a-f]\{7,\}\)$/\1/p')
+
+if [ -z "$latest" ] || [ -z "$latest_sha" ] || [ -z "$installed" ]; then
+    newer=null
+else
+    case "$latest_sha" in
+        "$installed"*) newer=false ;;
+        *) case "$installed" in "$latest_sha"*) newer=false ;; *) newer=true ;; esac ;;
+    esac
+fi
+
+body=$(printf '{"installed":"%s","latest":"%s","latestSha":"%s","newer":%s}' \
+        "$installed" "$latest" "$latest_sha" "$newer")
+
+# Only a real answer is worth caching; an unknown should be retried, not
+# remembered for six hours.
+[ "$newer" != "null" ] && printf '%s' "$body" > "$CACHE" 2>/dev/null
+
+json_hdr
+printf '%s' "$body"

--- a/www/cgi-bin/j/fw-latest.cgi
+++ b/www/cgi-bin/j/fw-latest.cgi
@@ -47,20 +47,31 @@ json_hdr() { printf 'HTTP/1.1 200 OK\nContent-Type: application/json\nCache-Cont
 installed=$(sed -n 's/^GITHUB_VERSION="\?\([^",]*\).*/\1/p' /etc/os-release 2>/dev/null \
             | sed -n 's/.*+\([0-9a-f]\{7,\}\).*/\1/p' | head -1)
 
-fresh=0
+# A half-written cache is not an answer. The file is replaced by rename below,
+# so a reader should never see one — but a crash mid-write, or a cache left by
+# an older build that wrote in place, would otherwise sit here being counted as
+# fresh for hours while serving JSON the browser cannot parse. Cheap to check,
+# and the check is what stops a bad file outliving the request that made it.
+cached=""
 if [ -f "$CACHE" ]; then
+    cached=$(cat "$CACHE" 2>/dev/null)
+    case "$cached" in
+        '{'*'}') ;;
+        *) cached="" ;;
+    esac
+fi
+
+if [ -n "$cached" ]; then
     age=$(( $(date +%s) - $(date -r "$CACHE" +%s 2>/dev/null || echo 0) ))
-    case "$(cat "$CACHE" 2>/dev/null)" in
+    case "$cached" in
         *'"newer":true'*) ttl=$TTL_YES ;;
         *) ttl=$TTL_NO ;;
     esac
-    [ "$age" -ge 0 ] && [ "$age" -lt "$ttl" ] && fresh=1
-fi
-
-if [ "$fresh" = "1" ]; then
-    json_hdr
-    cat "$CACHE"
-    exit 0
+    if [ "$age" -ge 0 ] && [ "$age" -lt "$ttl" ]; then
+        json_hdr
+        printf '%s' "$cached"
+        exit 0
+    fi
 fi
 
 # Same predicate as the Firmware page, deliberately down to the numbers: a
@@ -98,8 +109,21 @@ body=$(printf '{"installed":"%s","latest":"%s","latestSha":"%s","newer":%s}' \
         "$installed" "$latest" "$latest_sha" "$newer")
 
 # Only a real answer is worth caching; an unknown should be retried, not
-# remembered for six hours.
-[ "$newer" != "null" ] && printf '%s' "$body" > "$CACHE" 2>/dev/null
+# remembered.
+#
+# Written to a private name and renamed into place, because the notice is on
+# every page and these requests overlap: `> "$CACHE"` truncates the file first
+# and fills it after, so a reader arriving between the two gets an empty or
+# partial body, and the mtime the truncation just set makes it look fresh.
+# rename is atomic, so a reader sees either the old answer or the new one.
+if [ "$newer" != "null" ]; then
+    tmp="$CACHE.$$"
+    if printf '%s' "$body" > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$CACHE" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+fi
 
 json_hdr
 printf '%s' "$body"


### PR DESCRIPTION
Reported in #348: the notice said a camera was behind while the Firmware page,
correctly, offered nothing to install. Both were right about different things,
and the notice was the one making a claim the owner could not act on.

The notice counts what changed in the camera's software. The button under it
flashes a whole firmware image. Those do not become available at the same
moment: the software publishes on its own schedule, and an image carrying it
appears afterwards, per board, sometimes not for days. So a notice driven by the
software alone is guaranteed to spend part of every day contradicting the page it
links to — which is exactly what it did, within hours of shipping.

It now asks the camera as well, through a new endpoint that runs the same
`sysupgrade` query the Firmware page runs, so the two cannot disagree by
construction. The banner appears only when an image exists for this board.

The endpoint answers true, false, or null for "cannot tell" — no updater, no
network, a manifest that did not answer — and only true is permission to speak.
An unreachable updater is not evidence that an update exists, which is the same
rule the feed already follows and the reason a security fix nobody can install
now stays quiet rather than shouting.

Cached with a six-hour mtime TTL, because the notice is on every page and the
query fetches a manifest over the network. Only real answers are cached; an
unknown is retried rather than remembered. Measured on a lab hi3516ev200: 0.7 s
cold, nothing warm.

Verified on the board that produced the report, through a real browser: with its
true state the banner stays silent even against a feed carrying a security fix,
and appears when the updater is made to offer a newer build.

Fixes #348.