### PR TITLE
Notices: the reporter wanted buttons, and a button needs no arrow (#347)

### DIFF
--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -145,20 +145,26 @@ check('data-bs-dismiss reaches .mj-notice as well as .alert',
 
 group('one vocabulary for the actions, wherever they are written');
 
-// A notice points at the page that fixes what it reports, so its action is a
-// plain link ending in an arrow. A filled .btn is for the press that acts on
-// the camera where it stands — today exactly one href, restart.cgi, which
-// reboots on GET.
+// A notice is read the way a system dialog is, so the thing to press is shaped
+// like one: every action is a button, and the colour says what pressing costs.
+// btn-primary goes to the page that fixes the finding, btn-secondary is a
+// second diagnostic destination beside it, and btn-danger is the press that
+// acts on the camera rather than going anywhere — today one href, restart.cgi,
+// which reboots on GET.
+//
+// btn-danger is the load-bearing one. main.js hangs its confirm() off
+// .btn-danger and .btn-warning, so wearing that class is a promise that
+// pressing does something worth asking about; the recordings banner wore it
+// over a plain navigation and came within one initAll() timing accident of
+// asking "Are you sure?" before letting somebody read a page.
 //
 // The rule is worth a test rather than a paragraph because it is written in
-// four places at once: two haserl banners, three blocks of Dashboard markup
-// and two browser-built notices. It had already drifted — the firmware-behind
-// banner and the recordings banner both drew navigation as a filled button, so
-// the Dashboard offered "go to a page" in two shapes at the same time (#347) —
-// and nothing anywhere would have said so. Every way this breaks is a banner
-// that still renders, still links to the right place, and still looks like it
-// came from a different program than the banner above it.
-const ACTS_ON_GET = new Set(['restart.cgi']);
+// three languages at once — a haserl argument, hand-written .mj-notice-acts
+// markup, and an `acts:` literal in JS — and nothing compared them, so it
+// drifted: two banners on one Dashboard offered the same thing in two shapes
+// (#347). Every way this breaks renders perfectly. Right link, right
+// destination, wrong shape.
+const ACTS_ON_CAMERA = new Set(['restart.cgi']);
 
 // Every action in the tree, named. Named rather than counted, because the
 // failure this scan exists to catch is an action written in a spelling
@@ -170,18 +176,18 @@ const ACTS_ON_GET = new Set(['restart.cgi']);
 // The cost is that adding a notice action edits this list, and that is the
 // point: it is the review the vocabulary did not have.
 const EXPECTED = [
-	'a/recordings.js sdcard.cgi "Open the SD card page &rarr;"',
-	'a/update-check.js update.cgi "Firmware update &rarr;"',
-	'cgi-bin/camera.cgi logs.cgi "Open the log &rarr;"',
+	'a/recordings.js sdcard.cgi "Open the SD card page"',
+	'a/update-check.js update.cgi "Firmware update"',
+	'cgi-bin/camera.cgi logs.cgi "Open the log"',
 	'cgi-bin/camera.cgi restart.cgi "Restart camera"',
-	'cgi-bin/dashboard.cgi camera.cgi "Open Day / Night &rarr;"',
+	'cgi-bin/dashboard.cgi camera.cgi "Open Day / Night"',
 	// The two on the no-video banner are empty here and filled by dashboard.js.
 	'cgi-bin/dashboard.cgi camera.cgi ""',
 	'cgi-bin/dashboard.cgi logs.cgi ""',
-	'cgi-bin/dashboard.cgi live.cgi "Open Live &rarr;"',
-	'cgi-bin/p/header.cgi config.cgi "Configuration file &rarr;"',
-	'cgi-bin/p/header.cgi network.cgi "Network settings &rarr;"',
-	'cgi-bin/p/header.cgi network.cgi "Set the MAC address &rarr;"',
+	'cgi-bin/dashboard.cgi live.cgi "Open Live"',
+	'cgi-bin/p/header.cgi config.cgi "Configuration file"',
+	'cgi-bin/p/header.cgi network.cgi "Network settings"',
+	'cgi-bin/p/header.cgi network.cgi "Set the MAC address"',
 	'cgi-bin/p/header.cgi restart.cgi "Restart camera"',
 ];
 
@@ -234,10 +240,11 @@ function actionGroups(file, src) {
 	// site this cannot read is a call site the rule stops covering.
 	const key = /\bacts:\s*/g;
 	while ((m = key.exec(src))) {
-		// Not the one in main.js's own usage note: a comment emits nothing, and
-		// it spells its arrow as an escape, which is not what a page renders.
+		// Not the ones in the two emitters' own usage notes: a comment emits
+		// nothing. Three prefixes because the files scanned are written in two
+		// languages -- // and * for JS, # for the haserl shell.
 		const bol = src.lastIndexOf('\n', m.index) + 1;
-		if (/^\s*(\/\/|\*)/.test(src.slice(bol, m.index))) continue;
+		if (/^\s*(\/\/|\*|#)/.test(src.slice(bol, m.index))) continue;
 		const lit = /^'((?:[^'\\]|\\.)*)'/.exec(src.slice(m.index + m[0].length));
 		check('the acts: in ' + file + ' is a literal this test can read',
 			!!lit, src.slice(m.index, m.index + 80));
@@ -266,24 +273,27 @@ groups.forEach((g) => {
 	let a;
 	while ((a = re.exec(g.html))) {
 		const attrs = a[1], text = a[2].trim();
-		const cls = (/\bclass="([^"]*)"/.exec(attrs) || ['', ''])[1];
+		const cls = (/\bclass="([^"]*)"/.exec(attrs) || ['', ''])[1].split(/\s+/);
 		const href = (/\bhref="([^"]*)"/.exec(attrs) || ['', ''])[1];
 		const page = href.split(/[?#]/)[0].replace(/^.*\//, '');
-		const isBtn = /(^|\s)btn(\s|$)/.test(cls);
 		const where = g.file + ': ' + a[0];
+		const has = (c) => cls.indexOf(c) >= 0;
 		found.push(g.file + ' ' + page + ' "' + text + '"');
 
-		check(page + ' in ' + g.file + ' is drawn as what pressing it does',
-			isBtn === ACTS_ON_GET.has(page),
-			isBtn ? where + '\n    a .btn that only navigates'
-				: where + '\n    an action that acts on GET, drawn as a link');
+		check(page + ' in ' + g.file + ' is a button', has('btn'),
+			where + '\n    a bare link among banners of buttons');
 
-		// The two on the Dashboard's no-video banner are empty here and filled
-		// by dashboard.js, so their arrow is checked where it is written.
-		if (text) {
-			check('"' + text + '" ends the way its shape says it should',
-				/(&rarr;|→)$/.test(text) === !isBtn, where);
-		}
+		// The confirm() class, spent only where pressing really does something.
+		check(page + ' in ' + g.file + ' asks before it acts, or does not claim to',
+			(has('btn-danger') || has('btn-warning')) === ACTS_ON_CAMERA.has(page),
+			ACTS_ON_CAMERA.has(page)
+				? where + '\n    acts on the camera without the class that asks first'
+				: where + '\n    navigation wearing the class main.js hangs confirm() off');
+
+		// An arrow said what the button shape already says. Dropped at the
+		// reporter's request, and pinned so it cannot creep back one banner at
+		// a time.
+		check('"' + text + '" carries no arrow', !/(&rarr;|→)$/.test(text), where);
 	}
 });
 
@@ -296,11 +306,11 @@ check('and the scan reads nothing this list has not been told about',
 	extra.length === 0,
 	'add it to EXPECTED once its shape is right:\n    ' + extra.join('\n    '));
 
-// dashboard.js writes two of those labels at runtime, and has to add the same
-// arrow the static ones are typed with.
+// dashboard.js writes two of those labels at runtime, into anchors the markup
+// has already given the right classes. It must not append an arrow to either.
 const dash = fs.readFileSync(A('dashboard.js'), 'utf8');
-check('the runtime-filled actions carry the arrow too',
-	(dash.match(/\.label \+ ' →'/g) || []).length === 2,
+check('the runtime-filled labels carry no arrow either',
+	!/\.label \+ ' →'/.test(dash),
 	'dashboard.js fills #st-alert-novideo-a and -h');
 
 done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3378,17 +3378,22 @@ mark {
 }
 
 /* The sentence is the part that wraps; the actions after it never do. They are
-   two or three words each and one of them is a link that reads as a label, so
-   "Open Day / Night" broken across two lines looks like a stray fragment of
-   the paragraph rather than the thing to press. The row itself stays one row
-   at every width above sm — wrapping it puts the mark, the sentence and the
-   actions on three lines each of which is mostly empty, because the sentence
-   is a flex item that will not shrink past its longest word. */
+   two or three words each and they are buttons, so "Open Day / Night" broken
+   across two lines is a button with a ragged label rather than the thing to
+   press. The row itself stays one row at every width above sm — wrapping it
+   puts the mark, the sentence and the actions on three lines each of which is
+   mostly empty, because the sentence is a flex item that will not shrink past
+   its longest word.
+
+   The gap is 0.5rem rather than the 0.875rem it was while these were bare
+   links. Text needs the air to read as two separate labels; two buttons carry
+   their own edges, and at 14px apart they read as two unrelated controls that
+   happen to be near each other rather than as the pair of choices they are. */
 .mj-notice-acts {
 	flex: 0 0 auto;
 	display: flex;
 	align-items: center;
-	gap: 0.875rem;
+	gap: 0.5rem;
 	margin-left: auto;
 	white-space: nowrap;
 	font-size: 0.875rem;

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -118,7 +118,7 @@
 			if (t) t.textContent = f.title;
 			if (d) d.textContent = f.detail;
 			if (a) {
-				a.textContent = f.act.label + ' →';
+				a.textContent = f.act.label;
 				a.href = f.act.href;
 				// Assigned, not added: this anchor is rewritten on every
 				// finding and addEventListener would stack a prompt per
@@ -132,7 +132,7 @@
 			const h = $('#st-alert-novideo-h');
 			if (h) {
 				h.hidden = !f.help;
-				if (f.help) { h.textContent = f.help.label + ' →'; h.href = f.help.href; }
+				if (f.help) { h.textContent = f.help.label; h.href = f.help.href; }
 			}
 		}
 		setAlert('#st-alert-novideo', !!f);

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -627,15 +627,17 @@ function mjNoticeIcon(sev) {
 		(MJ_NOTICE_ICONS[sev] || MJ_NOTICE_ICONS.info) + '</svg>';
 }
 
-// mjNotice('danger', '<b>Title</b> \u2014 sentence.', {acts: '<a href="network.cgi">Fix it \u2192</a>'})
+// mjNotice('danger', '<b>Title</b> \u2014 sentence.',
+//          {acts: '<a class="btn btn-sm btn-primary" href="network.cgi">Fix it</a>'})
 // returns the notice's outer HTML as a string, because every caller here is
 // building innerHTML for a container it owns.
 //
-// The action is a plain link ending in an arrow, because a notice points at the
-// page that fixes what it reports rather than carrying the fix. A filled .btn
-// is only for a press that acts on the camera where it stands. p/common.cgi's
-// `notice` states the rule in full and tests/notice.test.js holds it across
-// every call site in the tree.
+// The action is a button and carries no arrow: btn-primary for the page that
+// fixes this, btn-secondary for a second destination beside it, and
+// btn-danger only where pressing acts on the camera rather than going
+// somewhere -- that class is what this file hangs a confirm() off, so it must
+// not be spent on navigation. p/common.cgi's `notice` states the rule in full
+// and tests/notice.test.js holds it across every call site in the tree.
 function mjNotice(sev, html, opts) {
 	const o = opts || {};
 	return '<div class="mj-notice mj-notice-' + sev + '"' +

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -840,12 +840,13 @@
 		const msg = cardTrouble();
 		if (!msg) { el.className = 'd-none'; el.innerHTML = ''; return; }
 		el.className = '';
-		// A link, not a button: it goes to a page (#347). It wore btn-danger,
-		// which also put it one initAll() timing accident away from asking
-		// "Are you sure?" before letting anyone read the card's own page.
+		// btn-primary rather than the btn-danger it used to wear: this goes to
+		// a page, and btn-danger is the class main.js hangs a confirm() off, so
+		// it was one initAll() timing accident away from asking "Are you sure?"
+		// before letting anyone read the card's own page.
 		el.innerHTML = mjNotice('danger', msg, {
 			body: cardKernelLines(),
-			acts: '<a href="sdcard.cgi">Open the SD card page &rarr;</a>',
+			acts: '<a class="btn btn-sm btn-primary" href="sdcard.cgi">Open the SD card page</a>',
 		});
 	}
 

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -202,13 +202,8 @@
 		try { seen = localStorage.getItem(SEEN); } catch (e) { /* private mode */ }
 		if (seen === feed.cursor) return;
 
-		// A plain link, like every other notice that points at a page. This
-		// was a filled btn-primary, which put two notices side by side on the
-		// Dashboard making the same offer -- go to a page -- in two different
-		// shapes (#347). A .btn in a notice means the press acts on the camera
-		// then and there; this one navigates.
 		slot.innerHTML = mjNotice(severity, sentence(d, matched, stale), {
-			acts: '<a href="update.cgi">Firmware update &rarr;</a>',
+			acts: '<a class="btn btn-sm btn-primary" href="update.cgi">Firmware update</a>',
 			dismiss: true,
 		});
 		slot.addEventListener('click', e => {

--- a/www/cgi-bin/camera.cgi
+++ b/www/cgi-bin/camera.cgi
@@ -48,7 +48,7 @@ fi
     plain text rather than a link, about a daemon that has stopped. The log is
     where majestic says why it died -- and it is what an owner can screenshot
     for whoever sold them the camera -- and a restart is the thing to try. %>
-<% notice danger '<b>Majestic is not running</b> &mdash; the daemon that streams the video and answers for every setting on this page is stopped, so there is nothing here to configure.' '<a href="logs.cgi">Open the log &rarr;</a><a class="btn btn-danger btn-sm" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. The camera is unreachable for about half a minute while it comes back.">Restart camera</a>' %>
+<% notice danger '<b>Majestic is not running</b> &mdash; the daemon that streams the video and answers for every setting on this page is stopped, so there is nothing here to configure.' '<a class="btn btn-sm btn-secondary" href="logs.cgi">Open the log</a><a class="btn btn-sm btn-danger" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. The camera is unreachable for about half a minute while it comes back.">Restart camera</a>' %>
 
 <% else %>
 

--- a/www/cgi-bin/dashboard.cgi
+++ b/www/cgi-bin/dashboard.cgi
@@ -60,7 +60,7 @@ done) %>
 	<div class="mj-notice mj-notice-warn" id="st-alert-ircut" hidden>
 		<svg class="mj-notice-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4.6 21.2 19.4H2.8z"/><path d="M12 10.2v4"/><path d="M12 17.1h.01"/></svg>
 		<div class="mj-notice-txt"><b id="st-alert-ircut-t"></b> &mdash; <span id="st-alert-ircut-d"></span></div>
-		<span class="mj-notice-acts"><a href="camera.cgi?tab=nightMode">Open Day / Night &rarr;</a></span>
+		<span class="mj-notice-acts"><a class="btn btn-sm btn-primary" href="camera.cgi?tab=nightMode">Open Day / Night</a></span>
 		<!-- A bare ×, and it has been three things. "No filter here" read as
 		     something the page was ASSERTING rather than a button; "Dismiss"
 		     fixed that but put a second link-styled phrase beside "Open Day /
@@ -84,12 +84,12 @@ done) %>
 	<div class="mj-notice mj-notice-warn" id="st-alert-novideo" hidden>
 		<svg class="mj-notice-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4.6 21.2 19.4H2.8z"/><path d="M12 10.2v4"/><path d="M12 17.1h.01"/></svg>
 		<div class="mj-notice-txt"><b id="st-alert-novideo-t"></b> &mdash; <span id="st-alert-novideo-d"></span></div>
-		<span class="mj-notice-acts"><a id="st-alert-novideo-a" href="camera.cgi?tab=isp"></a>
+		<span class="mj-notice-acts"><a class="btn btn-sm btn-primary" id="st-alert-novideo-a" href="camera.cgi?tab=isp"></a>
 		<!-- Only on a hardware finding. What this page can say is worked out
 		     from two gauges; the log is where majestic says what happened when
 		     it brought the sensor up, and it is what an owner can screenshot
 		     for whoever sold them the camera. -->
-		<a id="st-alert-novideo-h" href="logs.cgi" hidden></a></span>
+		<a class="btn btn-sm btn-secondary" id="st-alert-novideo-h" href="logs.cgi" hidden></a></span>
 	</div>
 	<!-- Why you are here, when the Live page sent you and the fault has since
 	     cleared. Being moved to another page for no visible reason is worse
@@ -104,7 +104,7 @@ done) %>
 		     sentence starts as the bare fact of the hand-off and only earns its
 		     second half (status.js) once the check has run and found nothing. -->
 		<div class="mj-notice-txt">Live video was not available a moment ago, so you were brought here.<span id="st-alert-wasnovideo-ok"></span></div>
-		<span class="mj-notice-acts"><a href="live.cgi">Open Live &rarr;</a></span>
+		<span class="mj-notice-acts"><a class="btn btn-sm btn-primary" href="live.cgi">Open Live</a></span>
 	</div>
 </div>
 

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -323,22 +323,35 @@ log_create() {
 # emits for the pages that build a notice in the browser -- a severity mark
 # that differs between two pages is worse than no mark at all.
 #
-# The actions have one vocabulary, and it is about what pressing them DOES
-# rather than about how important the notice is (#347). A notice says what is
-# wrong and points at the page that fixes it, so its ordinary action is a plain
-# link ending in an arrow -- "Open Day / Night ->" -- and it is a link for the
-# same reason the sentence is a sentence: nothing has happened yet. A filled
-# .btn is reserved for the rare action that happens where it stands, and today
-# that is exactly one href, restart.cgi, which reboots the camera on GET. Both
-# spellings sit side by side in camera.cgi's stopped-daemon banner, which is
-# what the pair is for: one goes to the log, the other restarts the camera.
+# EVERY action is a button, and the colour says what pressing it costs (#347).
+# A notice is read the way a system dialog is -- a sentence, a way out in the
+# corner, and the thing to press -- so the thing to press is shaped like one.
+# The reporter of #347 put it plainly after seeing the alternative: a bare link
+# among banners of buttons is the odd one out, and an arrow after it says only
+# what the underline already said.
 #
-# It went wrong the way one vocabulary with two writers always does. The
-# firmware-behind banner drew "Firmware update ->" as a filled btn-primary and
-# the recordings banner drew "Open the SD card page" as a btn-danger, both of
-# them navigation, so the Dashboard showed two notices making the same offer in
-# two different shapes. tests/notice.test.js walks every action group in the
-# tree and holds the rule.
+#   btn-primary    go to the page that fixes this
+#   btn-secondary  a second, diagnostic destination beside a primary
+#   btn-danger     acts on the camera when pressed, not a destination
+#
+# btn-secondary rather than btn-outline-secondary, which is the more obvious
+# reading of "the quieter one", because the outline's label is the SAME grey
+# as its border: measured on this card it is 3.51:1 on the dark theme, where
+# the filled one puts white on that grey and reaches 4.69:1 in both themes. A
+# filled grey is quieter than a filled blue or red anyway -- it is the least
+# saturated thing in the row -- so nothing is lost by taking the legible one.
+#
+# The last one is not decoration. main.js hangs its confirm() off .btn-danger
+# and .btn-warning, so that class is a promise that pressing does something
+# worth asking about; today exactly one href earns it, restart.cgi, which
+# reboots the camera on GET. Putting it on a link that merely navigates is how
+# the recordings banner came within one initAll() timing accident of asking
+# "Are you sure?" before letting somebody read a page.
+#
+# The vocabulary drifted once already, because it is written in three languages
+# -- this argument, hand-written .mj-notice-acts markup, and an `acts:` literal
+# in JS -- and nothing compared them. tests/notice.test.js now does, over every
+# action in the tree, by name.
 notice_icon() {
 	local d
 	case "$1" in

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -188,7 +188,7 @@ Pragma: no-cache
     an NTP server on the camera's own subnet is reachable with no gateway at
     all, and a static-network camera pointed at one would have been told every
     page that its clock was broken when it was not. %>
-<% notice warn '<b>No default gateway</b> &mdash; nothing outside the local network is reachable from this camera.' '<a href="network.cgi">Network settings &rarr;</a>' %>
+<% notice warn '<b>No default gateway</b> &mdash; nothing outside the local network is reachable from this camera.' '<a class="btn btn-sm btn-primary" href="network.cgi">Network settings</a>' %>
 <% fi %>
 
 <%# The address the firmware falls back to when the camera's own was not put
@@ -196,11 +196,11 @@ Pragma: no-cache
     card, which has been there all along -- the banner used to carry a second
     copy of that form, on every page, until somebody used one of them. %>
 <% if [ "$network_macaddr" = "00:00:23:34:45:66" ] && [ -f /etc/shadow- ] && [ -n $(grep root /etc/shadow- | cut -d: -f2) ]; then %>
-<% notice danger "<b>This camera's MAC address is a placeholder</b> &mdash; <code>00:00:23:34:45:66</code> is what the firmware falls back to when the camera's own address was not put back after flashing, and two cameras carrying it on one network will collide." '<a href="network.cgi#mac">Set the MAC address &rarr;</a>' %>
+<% notice danger "<b>This camera's MAC address is a placeholder</b> &mdash; <code>00:00:23:34:45:66</code> is what the firmware falls back to when the camera's own address was not put back after flashing, and two cameras carrying it on one network will collide." '<a class="btn btn-sm btn-primary" href="network.cgi#mac">Set the MAC address</a>' %>
 <% fi %>
 
 <% if [ ! -e $(get_config) ]; then %>
-<% notice danger '<b>No camera configuration found</b> &mdash; there is no settings file for the camera to read.' '<a href="config.cgi">Configuration file &rarr;</a>' %>
+<% notice danger '<b>No camera configuration found</b> &mdash; there is no settings file for the camera to read.' '<a class="btn btn-sm btn-primary" href="config.cgi">Configuration file</a>' %>
 <% fi %>
 
 <%# Warning rather than danger: it reports something you asked for and have not
@@ -220,7 +220,7 @@ Pragma: no-cache
      data-soc-vendor="<% attr_escape "$soc_vendor" %>"></div>
 
 <% if [ -e /tmp/system-reboot ]; then %>
-<% notice warn '<b>Settings are waiting for a restart</b> &mdash; video and recording stop for about half a minute while the camera comes back.' '<a class="btn btn-danger btn-sm" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>' %>
+<% notice warn '<b>Settings are waiting for a restart</b> &mdash; video and recording stop for about half a minute while the camera comes back.' '<a class="btn btn-sm btn-danger" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>' %>
 <% fi %>
 
 <% if [ -z "$hide_title" ]; then %><h2><%= $page_title %></h2><% fi %>


### PR DESCRIPTION
Fixes #347, again — this is the reporter's answer to the first round.

@usa- looked at #350 and said two things: the arrow is redundant (an underlined link already says it navigates), and they had preferred the buttons — a notice reads as a system dialog, sentence plus a close in the corner, so the thing to press should look like the thing to press. Both halves are one change, because a button takes no arrow.

## Every action is a button, and the colour says what pressing costs

| class | meaning | where |
| --- | --- | --- |
| `btn-primary` | go to the page that fixes this | seven of them |
| `btn-secondary` | a second, diagnostic destination beside a primary | *Open the log*, *Camera log* |
| `btn-danger` | acts on the camera when pressed, not a destination | *Restart camera*, twice |

The last row has to survive this change. `main.js` hangs its `confirm()` off `.btn-danger` and `.btn-warning`, so that class is a promise that pressing does something worth asking about, and exactly one href earns it — `restart.cgi`, which reboots on GET. With everything else also a button, red is now the *only* thing separating "look at this" from "reboot this", so the test pins it rather than leaving it to whoever writes the next banner.

## Two things decided by measurement rather than by eye

**`btn-secondary`, not `btn-outline-secondary`.** The outline is the more obvious reading of "the quieter one", but its label is the same grey as its border and measures **3.51:1** against the notice card on the dark theme — short of AA for text. The filled one puts white on that grey and reaches **4.69:1 in both themes**. A filled grey is the least saturated thing in the row and reads as the quieter one anyway. `btn-outline-primary` and `btn-outline-light` were measured too and are not options at all: purgecss has stripped both, so they render as unstyled text — which is also why `bootstrap.min.css` needs no regeneration here, both classes used are already in the subset.

**The action gap drops from `0.875rem` to `0.5rem`.** Text needs the air to read as two separate labels; two buttons carry their own edges, and 14px apart they read as two unrelated controls that happen to be near each other rather than as the pair of choices they are.

## Test

`tests/notice.test.js` keeps the named inventory of every action in the tree from the last round and changes what it asks of each one: that it is a `.btn` at all, that the `confirm()` class is on the one href that acts and on nothing else, and that no label ends in an arrow — pinned so the arrow cannot creep back one banner at a time. Its comment-skip learnt `#`, because the rule is now stated in a shell comment that says the word `acts:` in prose.

## Verification

Full suite green, template lint clean, `bootstrap.min.css` reproduces unchanged. Rendered on an hi3516ev200. Three banners stacked, one of each colour:

```
ⓘ  Your camera software is at least 1 build behind — …           [ Firmware update ]   ✕
⚠  Settings are waiting for a restart — …                        [ Restart camera  ]
⊗  Majestic cannot move the IR-cut filter — …                    [ Open Day / Night ]  ✕
```

and both two-action pairings, in both orders:

```
⊗  Majestic is not running — …              [ Open the log ] [ Restart camera ]
⚠  Nothing to see — …                       [ Open image settings ] [ Camera log ]
```

One thing I saw and left alone: a notice with a dismiss `✕` puts its button ~24px further left than one without, so a stack of banners has a slightly ragged button edge. It was there with links too and the boxes themselves align. Reserving the close slot would need a `:has()` rule carrying a hardcoded `.btn-close` width, which is the kind of threshold that breaks silently when Bootstrap changes it, so it is not worth the trade unless someone says it reads badly.
