### PR TITLE
Notices: show what actually changed, not just how much

### DIFF
--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -64,7 +64,14 @@ function run(opts) {
 			getItem() { if (opts.storageThrows) throw new Error('denied'); return stored; },
 			setItem(k, v) { if (opts.storageThrows) throw new Error('denied'); stored = v; },
 		},
-		mjNotice(sev, html) { painted = { sev, html }; return '<div>' + html + '</div>'; },
+		// Mirrors what main.js composes, so a test can see the body and the
+		// actions and not just the sentence.
+		mjNotice(sev, html, opts) {
+			const o = opts || {};
+			const full = html + (o.body || '') + (o.acts || '');
+			painted = { sev, html: full, sentence: html, body: o.body || '' };
+			return '<div>' + full + '</div>';
+		},
 		// Two endpoints now: the public feed, and the camera's own answer about
 		// whether an image it can install exists. Tests that do not care about
 		// the second get "yes, there is one", so they keep testing the first.
@@ -219,6 +226,61 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 			version: 'Lite HiSilicon (hi3516ev300), HEAD+deadbeef1',
 			feed: feedOf([entry('aaaaaaaaa', { fix: 9 })]),
 		})) === null);
+
+	group('the sentences, which were fetched and thrown away');
+
+	const withNotes = (notes) => ({
+		version: VER(MINE, iso(30)),
+		feed: feedOf([
+			{ sha: 'aaaaaaaaa', date: iso(1),
+			  counts: { feature: 1, fix: 2, security: 1, other: 5 }, notes: notes },
+			entry(MINE, {}),
+		]),
+	});
+
+	let n = await run(withNotes([
+		{ cat: 'fix', vendor: null, text: 'Recording no longer stops on its own.' },
+		{ cat: 'security', vendor: null, text: 'Who may call the camera is now checked.' },
+		{ cat: 'feature', vendor: null, text: 'Streaming can come from both channels.' },
+	]));
+	check('the changelog is rendered, not discarded',
+		n && /What\u2019s new/.test(n.html) && /Recording no longer stops/.test(n.html),
+		n && n.html);
+	check('security is listed first and marked',
+		n && n.html.indexOf('Who may call') < n.html.indexOf('Streaming can come') &&
+		     /<b>Security<\/b>/.test(n.html), n && n.html);
+	check('and it is collapsed, not shouting',
+		n && /<details class="mj-whatsnew"><summary>/.test(n.html) && !/<details open/.test(n.html),
+		n && n.html);
+	check('the counts stay the headline',
+		n && /1 new feature, 2 fixes and 1 security fix/.test(n.html), n && n.html);
+
+	// The disclosure gate withholds sentences it will not publish, so the list
+	// is routinely shorter than the counts. Nothing should draw attention to it.
+	n = await run(withNotes([{ cat: 'fix', vendor: null, text: 'One described change.' }]));
+	check('a list shorter than the counts says nothing about the gap',
+		n && !/not described|withheld|some changes/i.test(n.html), n && n.html);
+
+	n = await run(withNotes([]));
+	check('no sentences at all means no expander, just the counts',
+		n && !/mj-whatsnew/.test(n.html) && /2 fixes/.test(n.html), n && n.html);
+
+	const many = [];
+	for (let i = 0; i < 12; i++) many.push({ cat: 'fix', vendor: null, text: 'Fix number ' + i + '.' });
+	n = await run(withNotes(many));
+	check('a long list is capped and says how many are left',
+		n && /and 4 more/.test(n.html) && !/Fix number 8\./.test(n.html), n && n.html);
+
+	// These sentences are model-written and published with nobody reading them,
+	// so they get the same treatment as any other remote string.
+	n = await run(withNotes([
+		{ cat: 'fix', vendor: null, text: '<img src=x onerror=alert(1)> & "quoted"' },
+	]));
+	check('a sentence carrying markup is escaped, not executed',
+		n && n.html.indexOf('<img src=x') === -1 && /&lt;img/.test(n.html), n && n.html);
+	check('a non-string sentence is ignored rather than printed',
+		(await run(withNotes([{ cat: 'fix', vendor: null, text: { evil: 1 } }])))
+			.html.indexOf('mj-whatsnew') === -1);
 
 	group('nothing to install means nothing to say');
 

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -282,6 +282,51 @@ const VER = (rev, date) => 'Lite HiSilicon (hi3516ev300), HEAD+' + rev + ', ' + 
 		(await run(withNotes([{ cat: 'fix', vendor: null, text: { evil: 1 } }])))
 			.html.indexOf('mj-whatsnew') === -1);
 
+	group('a note belongs to the cameras it was written for');
+
+	const mixed = (vendor) => run({
+		version: VER(MINE, iso(30)), vendor: vendor,
+		feed: feedOf([
+			{ sha: 'aaaaaaaaa', date: iso(1),
+			  counts: { feature: 0, fix: 3, security: 0, other: 0 }, notes: [
+				{ cat: 'fix', vendor: null, text: 'Everyone gets this one.' },
+				{ cat: 'fix', vendor: 'hisilicon', text: 'A HiSilicon-only repair.' },
+				{ cat: 'fix', vendor: 'sigmastar', text: 'A SigmaStar-only repair.' },
+			] },
+			entry(MINE, {}),
+		]),
+	});
+
+	let m = await mixed('hisilicon');
+	check('a camera sees the global note and its own vendor\'s',
+		m && /Everyone gets this one/.test(m.html) && /HiSilicon-only repair/.test(m.html),
+		m && m.body);
+	check('and never another vendor\'s',
+		m && !/SigmaStar-only repair/.test(m.html), m && m.body);
+
+	m = await mixed('sigmastar');
+	check('the same feed shows the other vendor theirs instead',
+		m && /SigmaStar-only repair/.test(m.html) && !/HiSilicon-only repair/.test(m.html),
+		m && m.body);
+
+	m = await mixed('novatek');
+	check('a vendor with nothing of its own still sees the global note',
+		m && /Everyone gets this one/.test(m.html) &&
+		     !/HiSilicon-only/.test(m.html) && !/SigmaStar-only/.test(m.html), m && m.body);
+
+	m = await run({
+		version: VER(MINE, iso(30)), vendor: 'novatek',
+		feed: feedOf([
+			{ sha: 'aaaaaaaaa', date: iso(1),
+			  counts: { feature: 0, fix: 2, security: 0, other: 0 }, notes: [
+				{ cat: 'fix', vendor: 'hisilicon', text: 'Not for this camera.' },
+			] },
+			entry(MINE, {}),
+		]),
+	});
+	check('nothing applicable means no expander at all, counts unchanged',
+		m && !/mj-whatsnew/.test(m.html) && /2 fixes/.test(m.html), m && m.html);
+
 	group('nothing to install means nothing to say');
 
 	// majestic-webui#348: the notice said a camera was behind while the Firmware

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3377,6 +3377,26 @@ mark {
 	margin-top: 0.7rem;
 }
 
+/* The changelog inside a notice. A <details> rather than a button and a class,
+   because the browser already knows how to open and close one and remembers
+   nothing between page loads — which is what we want: this reopens closed on
+   every page, so it never becomes a thing to scroll past.
+   The marker is the summary's own, left alone; restyling it is how disclosure
+   widgets stop looking clickable. */
+.mj-whatsnew > summary {
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.mj-whatsnew > ul {
+	margin-top: 0.45rem;
+	padding-left: 1.1rem;
+}
+
+.mj-whatsnew > ul > li + li {
+	margin-top: 0.25rem;
+}
+
 /* The sentence is the part that wraps; the actions after it never do. They are
    two or three words each and they are buttons, so "Open Day / Night" broken
    across two lines is a button with a ragged label rather than the thing to

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -136,7 +136,11 @@
 				// escaped where it is written, like every other string the feed
 				// supplies.
 				if (typeof note.text === 'string' && note.text) {
-					said.push({ cat: note.cat, text: note.text });
+					// The vendor comes too. It is this note's SCOPE, which is
+					// already how the sentence above uses it, and a list that
+					// drops it offers one vendor's fix to every other vendor's
+					// camera.
+					said.push({ cat: note.cat, vendor: note.vendor, text: note.text });
 				}
 			}
 		}
@@ -217,10 +221,17 @@
 	const CAT_RANK = { security: 0, feature: 1, fix: 2 };
 	const MAX_SHOWN = 8;
 
-	function whatsNew(said) {
+	function whatsNew(said, mine) {
 		if (!said || !said.length) return '';
+		// A note carrying a vendor applies to that vendor's cameras and no
+		// others; one carrying none applies everywhere. Listing another
+		// vendor's work here would promise this owner something their camera
+		// will never do — the same mistake the sentence above already avoids by
+		// only claiming "cameras like this one" on a match.
+		const applies = said.filter(n => !n.vendor || n.vendor === mine);
+		if (!applies.length) return '';
 		const rank = (c) => (c in CAT_RANK) ? CAT_RANK[c] : 3;
-		const sorted = said.slice().sort((a, b) => rank(a.cat) - rank(b.cat));
+		const sorted = applies.slice().sort((a, b) => rank(a.cat) - rank(b.cat));
 		const items = sorted.slice(0, MAX_SHOWN).map(n =>
 			'<li>' + (n.cat === 'security' ? '<b>Security</b> &mdash; ' : '') +
 			esc(n.text) + '</li>').join('');
@@ -249,7 +260,7 @@
 		if (seen === feed.cursor) return;
 
 		slot.innerHTML = mjNotice(severity, sentence(d, matched, stale), {
-			body: whatsNew(d.said),
+			body: whatsNew(d.said, mine),
 			acts: '<a class="btn btn-sm btn-primary" href="update.cgi">Firmware update</a>',
 			dismiss: true,
 		});

--- a/www/a/update-check.js
+++ b/www/a/update-check.js
@@ -114,6 +114,7 @@
 	function delta(feed, rev, buildDate) {
 		const totals = { feature: 0, fix: 0, security: 0, other: 0 };
 		const vendors = new Set();
+		const said = [];
 		let builds = 0, found = false;
 
 		for (const entry of feed.builds || []) {
@@ -129,10 +130,17 @@
 			builds++;
 			for (const k of CATEGORIES) totals[k] += c[k];
 			for (const note of entry.notes || []) {
-				if (note && typeof note.vendor === 'string') vendors.add(note.vendor);
+				if (!note) continue;
+				if (typeof note.vendor === 'string') vendors.add(note.vendor);
+				// Remote text, bound for innerHTML. Kept as data here and
+				// escaped where it is written, like every other string the feed
+				// supplies.
+				if (typeof note.text === 'string' && note.text) {
+					said.push({ cat: note.cat, text: note.text });
+				}
 			}
 		}
-		if (found) return { builds, totals, vendors, atLeast: false };
+		if (found) return { builds, totals, vendors, said, atLeast: false };
 
 		// Not in the ledger, which is two very different situations.
 		//
@@ -152,7 +160,7 @@
 		const eldest = feed.builds[feed.builds.length - 1];
 		if (isDate(buildDate) && eldest && isDate(eldest.date) &&
 			buildDate < eldest.date) {
-			return { builds, totals, vendors, atLeast: true };
+			return { builds, totals, vendors, said, atLeast: true };
 		}
 		return null;
 	}
@@ -189,6 +197,41 @@
 		return s;
 	}
 
+	// The counts are the headline because they are what makes the banner
+	// scannable, but they are also the least useful thing in it: "11 fixes" does
+	// not tell an owner whether any of them is theirs. The sentences do, and
+	// until now they were fetched and thrown away.
+	//
+	// Collapsed by default. This sits on every page, and a banner that pushes
+	// the page down to list a fortnight of changes is one people learn to close
+	// rather than read.
+	//
+	// SECURITY FIRST, then features, then fixes: it is the ordering an owner
+	// deciding whether to update now rather than at the weekend actually needs.
+	//
+	// The list is deliberately allowed to be shorter than the counts imply. A
+	// change whose sentence was withheld is still counted and simply not
+	// described, and nothing here draws attention to the gap — saying "some
+	// changes are not described" invites exactly the question the withholding
+	// existed to avoid.
+	const CAT_RANK = { security: 0, feature: 1, fix: 2 };
+	const MAX_SHOWN = 8;
+
+	function whatsNew(said) {
+		if (!said || !said.length) return '';
+		const rank = (c) => (c in CAT_RANK) ? CAT_RANK[c] : 3;
+		const sorted = said.slice().sort((a, b) => rank(a.cat) - rank(b.cat));
+		const items = sorted.slice(0, MAX_SHOWN).map(n =>
+			'<li>' + (n.cat === 'security' ? '<b>Security</b> &mdash; ' : '') +
+			esc(n.text) + '</li>').join('');
+		const rest = sorted.length - MAX_SHOWN;
+		const more = rest > 0
+			? '<p class="small text-secondary mb-0">and ' + rest + ' more</p>'
+			: '';
+		return '<details class="mj-whatsnew"><summary>What\u2019s new</summary>' +
+			'<ul class="small mb-1">' + items + '</ul>' + more + '</details>';
+	}
+
 	function render(slot, feed, build) {
 		const d = delta(feed, build.rev, build.date);
 		if (!d || d.builds === 0) return;
@@ -206,6 +249,7 @@
 		if (seen === feed.cursor) return;
 
 		slot.innerHTML = mjNotice(severity, sentence(d, matched, stale), {
+			body: whatsNew(d.said),
 			acts: '<a class="btn btn-sm btn-primary" href="update.cgi">Firmware update</a>',
 			dismiss: true,
 		});


### PR DESCRIPTION
The banner counted changes and then threw away the description of every one of
them. The feed carries a sentence per user-visible change, written for owners
and put through a disclosure gate before publication; the browser fetched them,
read the vendor field off each one to decide whether to say "cameras like this
one", and discarded the text. "11 fixes" does not tell anyone whether any of
them is theirs.

So the sentences now appear, in the notice body slot that already existed and
was already styled, behind a "What's new" disclosure.

Collapsed by default. This sits on every page, and a banner that pushes the page
down to list a fortnight of changes is one people learn to close rather than
read. A <details> rather than a button and a class, because the browser already
knows how to work one, and because it remembers nothing between page loads —
which is what we want here: it reopens closed, so it never becomes furniture.

Security first, then features, then fixes, capped at eight with a count of the
rest. That is the order someone deciding whether to update now rather than at
the weekend actually needs.

The list is allowed to be shorter than the counts, and nothing points at the
gap. A change whose sentence the disclosure gate withheld is still counted and
simply not described; a line saying "some changes are not described here" would
invite exactly the question the withholding exists to avoid.

The sentences are escaped where they are written. They are model-written and
published with nobody reading them first, so they get the same treatment as
every other string the feed supplies — the counts are already refused unless
they are plain integers, and the prose gets escaping rather than trust. A test
covers a sentence carrying markup, and the fake mjNotice in the suite now
composes the body and actions the way main.js does, so a test can see what the
page would show rather than the sentence alone.

Verified on a lab hi3516ev200 against the feed the nightly actually generated:
fifteen sentences, collapsed by default, no raw markup in the DOM.