### PR TITLE
Review: first-party is about who controls the bytes, not the hostname

### DIFF
--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -112,17 +112,21 @@ pr_compliances:
     success_criteria: >
       New front-end code is vanilla JS in www/a/, loaded with a plain <script> tag, and
       any asset it needs is committed to this tree. A page may additionally read
-      OPTIONAL DATA over fetch from a first-party OpenIPC endpoint — data the page is
-      about, not a resource it is built from — provided it renders completely when that
-      fetch fails, is blocked, or returns nonsense, and provided the data is treated as
-      untrusted input rather than markup.
+      OPTIONAL DATA over fetch from an endpoint the project itself publishes — data the
+      page is about, not a resource it is built from. "The project publishes it" is a
+      question of who controls the bytes, not of whose name is in the hostname: a
+      release bucket or pages site the project uploads to counts, whoever rents the
+      metal under it. It must also render completely when that fetch fails, is blocked,
+      or returns nonsense, and treat what comes back as untrusted input rather than
+      markup.
     failure_criteria: >
       The diff adds a runtime npm dependency, a bundler or transpiler step, a framework,
       or a <script>/<link>/@import pointing at a third-party host; or a fetch of anything
       the page needs in order to render — a script, a style, a font, an image, a
-      template. A data fetch that is not first-party, or whose failure leaves the page
-      incomplete, broken or visibly waiting, fails this too: an offline camera must look
-      normal, not degraded.
+      template. A data fetch from an endpoint the project does not publish — somebody
+      else's API, CDN, analytics or telemetry — fails this too, as does one whose
+      failure leaves the page incomplete, broken or visibly waiting: an offline camera
+      must look normal, not degraded.
 
   - title: "A new page is registered, not named twice"
     compliance_label: true


### PR DESCRIPTION
The carve-out for reading optional data said "a first-party OpenIPC endpoint",
and the one endpoint it exists to permit is a release bucket whose hostname
belongs to the company renting out the storage. Read strictly — which is how a
gate should be read — that is a third-party host, so the rule could keep failing
the exact fetch it was amended to allow, on every future pull request touching
that file.

So the test is stated as ownership rather than hostname: an endpoint the project
publishes to and controls the contents of counts, whoever owns the metal
underneath. The failure side names what is actually meant to be excluded —
somebody else's API, CDN, analytics or telemetry — instead of leaning on
"not first-party" to carry it.

Nothing about the rule's reach changes. Assets must still be committed to this
tree, anything the page needs in order to render must still not be fetched, and
a data fetch whose failure leaves the page incomplete still fails.

Worth recording why this was nearly missed: the finding on the pull request that
introduced the carve-out quoted the rule's OLD wording, because the checklist is
read from the base branch — a pull request cannot weaken the rule that governs
it. That is correct behaviour, and it means an amendment is never exercised by
the change that makes it. The first pull request to test this one will be the
next that touches the fetch.