### PR TITLE
Notices: the buttons line up because the corner is always reserved (#347)

### DIFF
--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -91,6 +91,20 @@ const css = fs.readFileSync(A('bootstrap.override.css'), 'utf8');
 SEVS.forEach((s) => check('.mj-notice-' + s + ' is styled',
 	css.includes('.mj-notice-' + s + ' '), s));
 
+// What puts the actions in a column down a stack of banners (#347): the close
+// button is out of the flow, and every notice pays for its corner whether or
+// not it has one. As a flex item it shifted the actions left by its own width
+// on exactly the notices that could be dismissed, which is two right edges in
+// one column. A string check rather than a rendered one, because this suite is
+// plain node with no browser — but losing either half is silent.
+check('every notice reserves the close button its corner',
+	/--mj-notice-close:/.test(css) &&
+	/padding:[^;]*var\(--mj-notice-close\)/.test(css),
+	'the right inset no longer reserves the close slot');
+check('and the close button is out of the flow to sit in it',
+	/\.mj-notice > \.btn-close \{[^}]*position: absolute/.test(css),
+	'a close button back in the flow pushes the actions left again');
+
 const full = mjNotice('warn', 'sentence', {
 	body: 'body', acts: '<a href="#">Go</a>', dismiss: true,
 });

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3462,11 +3462,17 @@ mark {
 }
 
 /* Both right-hand controls go back to the first line where the notice has a
-   body row under its sentence. There the text column can be a paragraph, three
-   lines of dmesg and a control of its own, and the middle of that is nowhere:
-   the action belongs against the headline it answers. Only the SD-card health
-   banner is built this way. A browser without :has() centres them, which is the
-   request as asked and no worse than any other notice gets. */
+   body row under its sentence, because a body row is content that can GROW and
+   the action answers the headline rather than the block. Three notices carry
+   one: the firmware-behind banner, whose body is a "What's new" list that the
+   reader opens; the recordings page's card-trouble banner, which carries the
+   kernel's own messages; and the SD-card page's, which puts its repair button
+   down there rather than in this row. Measured on the first of those with its
+   list open, centring puts the button 63px down, level with the bullets and
+   clear of the sentence it belongs to; against the first line it stays at 26px
+   whether the list is open or shut, which is the point. A browser without
+   :has() centres them, which is the request as asked and no worse than any
+   other notice gets. */
 .mj-notice:has(.mj-notice-body) > .mj-notice-acts {
 	align-self: flex-start;
 }

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3348,11 +3348,23 @@ mark {
    var() is invalid at computed-value time, which unsets the property instead
    of falling back to the declaration above it. */
 .mj-notice {
+	--mj-notice-close: 1.5rem;
+	position: relative;
 	display: flex;
 	align-items: flex-start;
 	gap: 0.75rem;
 	margin-bottom: 0.5rem;
-	padding: 0.6rem 1rem;
+	/* The right inset ALWAYS holds the close button's slot, whether or not this
+	   notice has one (#347). As a flex item the x pushed the actions left by its
+	   own width plus the gap, so a stack of banners had its buttons at two
+	   different x positions depending on which of them could be dismissed —
+	   invisible while these were text links and impossible to miss once they
+	   were buttons. Reserving the corner on every notice is what puts them in a
+	   column. The width is .btn-close's own box, 1em of glyph in 0.25em of
+	   padding either side; getting it wrong costs a few pixels of inset rather
+	   than a broken row, which is why this is a plain reservation and not a
+	   :has() rule measuring the button that happens to be there. */
+	padding: 0.6rem calc(1rem + 0.75rem + var(--mj-notice-close)) 0.6rem 1rem;
 	background: var(--bs-card-bg);
 	border: 1px solid var(--bs-border-color);
 	border-radius: var(--bs-border-radius-lg);
@@ -3424,15 +3436,44 @@ mark {
 	flex: 0 0 auto;
 	display: flex;
 	align-items: center;
+	/* Centred against the whole notice, which on one or two lines is what the
+	   eye expects of a control beside a sentence (#347). The BOX stays
+	   flex-start, so the severity mark keeps its place against the first line
+	   whatever the sentence does — they are different items and only one of
+	   them is annotating the first word. */
+	align-self: center;
 	gap: 0.5rem;
 	margin-left: auto;
 	white-space: nowrap;
 	font-size: 0.875rem;
 }
 
+/* Out of the flow and into the slot the padding reserved for it. Centred with
+   the actions rather than pinned to the first line, because the two of them are
+   one cluster and a x sitting a line above the button it stands beside reads as
+   a misalignment rather than as a corner control — on the one-line notices that
+   is most of them, they are the same thing anyway. */
 .mj-notice > .btn-close {
-	flex: 0 0 auto;
-	margin-top: 0.15rem;
+	position: absolute;
+	top: 50%;
+	right: 1rem;
+	transform: translateY(-50%);
+	margin: 0;
+}
+
+/* Both right-hand controls go back to the first line where the notice has a
+   body row under its sentence. There the text column can be a paragraph, three
+   lines of dmesg and a control of its own, and the middle of that is nowhere:
+   the action belongs against the headline it answers. Only the SD-card health
+   banner is built this way. A browser without :has() centres them, which is the
+   request as asked and no worse than any other notice gets. */
+.mj-notice:has(.mj-notice-body) > .mj-notice-acts {
+	align-self: flex-start;
+}
+
+.mj-notice:has(.mj-notice-body) > .btn-close {
+	top: calc(0.6rem + 0.15rem);
+	transform: none;
 }
 
 .mj-notice-danger { border-color: rgba(var(--bs-danger-rgb), 0.45); }
@@ -3469,6 +3510,16 @@ mark {
 	.mj-notice-acts {
 		flex: 1 1 100%;
 		justify-content: flex-end;
+	}
+
+	/* Back to the corner. Centring the x against the notice is right while it
+	   stands beside the button on one row; here the actions have taken a row of
+	   their own below the sentence, so the middle of the box is a third of the
+	   way down the text — the x landed over the sentence it was meant to sit
+	   clear of. */
+	.mj-notice > .btn-close {
+		top: calc(0.6rem + 0.15rem);
+		transform: none;
 	}
 }
 


### PR DESCRIPTION
Fixes #347 — the reporter's third and last round, after #350 (one vocabulary) and #357 (buttons, no arrows).

@usa- asked for two things: line the buttons up on the right edge, and centre them vertically in the notice.

## The ragged edge

The close button was a flex item sitting after the actions, so on a dismissible notice it pushed them left by its own width plus the gap, and on one without it did not. Two right edges in a column of banners, decided by which of them happened to be dismissible. It was there while these were text links and nobody mentioned it; filled buttons made it obvious — which is a fair description of what changing the shape of a control does to the layout around it.

So the close comes out of the flow into the corner, and **every** notice reserves that corner in its right padding whether or not it has one. The reservation is `.btn-close`'s own box — 1em of glyph in 0.25em of padding either side — named `--mj-notice-close` so the arithmetic in the `padding` says what it is reserving. Getting that width wrong costs a few pixels of inset rather than a broken row, which is why it is a plain reservation and not a `:has()` rule measuring whichever button happens to be there.

Measured across all five shapes a notice comes in — one line and two, one action and two, dismissible and not — the action group now ends **53px from the box edge in every one**, in both themes:

```
                                          acts right-inset   acts vs centre
one line, dismissible                          53px              0.0px
one line, not dismissible                      53px              0.0px
two lines, dismissible                         53px              0.0px
two lines, two actions                         53px              0.0px
body row (SD-card health, 196px tall)          53px            -72.1px
```

## The vertical centring

`align-self` on the action group, not on the box. The box stays `flex-start` because the severity mark is annotating the first word and has to stay against the first line; the actions are a different item and answer the whole notice.

Two exceptions, both found by rendering rather than by reasoning:

- **A notice with a body row** can be a paragraph, three lines of `dmesg` and a control of its own, and the middle of that is nowhere — the action belongs against the headline it answers. Both right-hand controls go back to the first line there (the −72.1px row above). Only the SD-card health banner is built this way, and a browser without `:has()` centres them, which is the request as asked.
- **Below sm** the actions take a row of their own under the sentence, so the middle of the box is a third of the way down the text — the centred close landed on top of the sentence it is meant to sit clear of. It goes back to the corner at that width.

## Verification

Full suite green, template lint clean, `bootstrap.min.css` reproduces unchanged (no new Bootstrap classes). Rendered at 1300px in both themes and at 390px.

Rendered against the **built tree served locally**, not on a camera: this is a stylesheet question, and the lab board is shared — an earlier round of this work left a bind mount over its `/var/www` for an hour and a half and silently hid somebody else's in-progress deployment for the whole window. There was no reason to touch it to answer a CSS question.

`tests/notice.test.js` gains two string checks — that the padding still reserves `--mj-notice-close`, and that the close button is still out of the flow. Not a rendered test: this suite is plain node with no browser by policy. But losing either half puts the column back to two right edges with nothing to say so.
