### PR TITLE
Recordings: play a sealed clip, and hold the key that opens it

### DIFF
--- a/tests/mp4crypt.test.js
+++ b/tests/mp4crypt.test.js
@@ -434,6 +434,27 @@ group('reading the header');
 	check('and so is something that is not an MP4 at all',
 		notMp4.ok === false && !!notMp4.reason);
 
+	// A moov whose tracks this walk cannot take apart — a header shaped in a
+	// way this build has not seen — is a different case again. The bytes are
+	// here, so the question can be asked directly rather than assumed either
+	// way: no protection box anywhere inside them is a finding, and refusing
+	// such a clip would refuse a recording that plays today.
+	const bare = Buffer.concat([
+		box('ftyp', Buffer.alloc(16)),
+		box('moov', box('trak', box('mdia', box('mdhd', Buffer.alloc(24))))),
+	]);
+	const b = CRYPT.inspect(u8(bare), bare.length);
+	check('a header this walk cannot take a track out of, holding no protection at all, is clear',
+		b.ok === true && b.encrypted === false && b.reason === null);
+
+	const bareSealed = Buffer.concat([
+		box('ftyp', Buffer.alloc(16)),
+		box('moov', box('trak', box('mdia', box('minf', sinf('avc1', KID, {}))))),
+	]);
+	const bs = CRYPT.inspect(u8(bareSealed), bareSealed.length);
+	check('and the same header with protection in it is encrypted and unopenable, not clear',
+		bs.ok === true && bs.encrypted === true && /does not know/.test(bs.reason || ''));
+
 	// Signalled as protected and then declared not to be. It plays as it is,
 	// and demanding a passphrase for it would refuse a working clip.
 	const off = CRYPT.inspect(u8(initSegment({ isProtected: 0 })));

--- a/tests/mp4crypt.test.js
+++ b/tests/mp4crypt.test.js
@@ -447,6 +447,24 @@ group('reading the header');
 	check('a header this walk cannot take a track out of, holding no protection at all, is clear',
 		b.ok === true && b.encrypted === false && b.reason === null);
 
+	// The four letters are also ordinary bytes, and they turn up inside codec
+	// configuration by chance. A scan that matched one there would refuse a
+	// clear recording as a sealed one nothing can open — a worse failure than
+	// the one the fallback exists to prevent, so it reads box types at box
+	// boundaries and never looks inside a box it does not understand.
+	// A payload that happens to contain the letters, inside a box this walk has
+	// no business opening.
+	const gama = box('gama', Buffer.concat([
+		Buffer.from('xxsinf', 'ascii'), Buffer.from('tenc', 'ascii')]));
+	const stsdDecoy = box('stsd', Buffer.concat([Buffer.from([0, 0, 0, 0]), u32(1), gama]));
+	const decoy = Buffer.concat([
+		box('ftyp', Buffer.alloc(16)),
+		box('moov', box('trak', box('mdia', box('minf', box('stbl', stsdDecoy))))),
+	]);
+	const d = CRYPT.inspect(u8(decoy), decoy.length);
+	check('four letters inside a payload are not a protection box',
+		d.ok === true && d.encrypted === false && d.reason === null);
+
 	const bareSealed = Buffer.concat([
 		box('ftyp', Buffer.alloc(16)),
 		box('moov', box('trak', box('mdia', box('minf', sinf('avc1', KID, {}))))),

--- a/tests/recordings-health.test.js
+++ b/tests/recordings-health.test.js
@@ -176,7 +176,10 @@ function load(cardHealth, metrics, mode) {
 	};
 	ctx.window.document = ctx.document;
 	vm.createContext(ctx);
-	for (const f of ['timeline.js', 'mp4index.js', 'recordings.js']) {
+	// The page loads these in this order, and so does the browser: recordings.js
+	// takes the crypto modules at module scope, the way it takes the index.
+	for (const f of ['timeline.js', 'mp4index.js', 'mjcrypto.js', 'mp4crypt.js',
+		'reckeys.js', 'recordings.js']) {
 		vm.runInContext(fs.readFileSync(A(f), 'utf8'), ctx);
 	}
 	return env;

--- a/tests/recordings-pump.test.js
+++ b/tests/recordings-pump.test.js
@@ -155,7 +155,7 @@ function makeEl(id) {
 const CLIP_SECONDS = 120;
 const CLIP = clip(CLIP_SECONDS);
 
-function load() {
+function load(opts) {
 	const env = { appends: [], ranges: makeRanges(), reads: [], eos: false };
 	const els = {};
 	const $ = (id) => (els[id] = els[id] || makeEl(id));
@@ -188,7 +188,7 @@ function load() {
 					fire(ev) { (sb.handlers[ev] || []).slice().forEach((f) => f()); },
 					appendBuffer(bytes) {
 						const at = appendedAt(bytes);
-						env.appends.push({ at: at, bytes: bytes.length });
+						env.appends.push({ at: at, bytes: bytes.length, tag: bytes[0] });
 						if (at !== null) env.ranges.add(at, at + FRAG_SECONDS);
 						sb.updating = true;
 						// updateend lands on a later task, as it does in a
@@ -286,10 +286,53 @@ function load() {
 	};
 	ctx.window.document = ctx.document;
 	vm.createContext(ctx);
-	for (const f of ['timeline.js', 'mp4index.js', 'recordings.js']) {
+	// The page loads these in this order, and so does the browser: recordings.js
+	// takes the crypto modules at module scope, the way it takes the index.
+	for (const f of ['timeline.js', 'mp4index.js', 'mjcrypto.js', 'mp4crypt.js',
+		'reckeys.js']) {
 		vm.runInContext(fs.readFileSync(A(f), 'utf8'), ctx);
 	}
+	// A clip the page will treat as sealed, without building an encrypted one.
+	// What is under test here is the WIRING — that the transforms reach both
+	// append sites — and the format modules have their own suite for whether
+	// the bytes come out right. Stubbing at this seam is what lets this file
+	// keep using the fixture every other test in it uses.
+	if (opts && opts.sealed) {
+		env.transformed = { init: 0, fragment: 0 };
+		ctx.window.MajesticMp4Crypt = {
+			inspect: () => ({
+				ok: true, encrypted: true, wrapped: true,
+				tracks: { 1: { id: 1, protected: true, ivSize: 8, format: 'avc1' } },
+				keyBox: { kidHex: 'kid', modes: ['passphrase'], slots: [], pubkeyFp: null },
+				reason: null,
+			}),
+			// Marks what it touched, so an append that skipped a transform is
+			// visible rather than merely wrong-looking.
+			clearInit: (bytes) => { env.transformed.init++; return mark(bytes, 0xc1); },
+			decryptFragment: (bytes) => { env.transformed.fragment++; return mark(bytes, 0xd2); },
+			chipOnly: () => false,
+			openWithPassphrase: () => ({ material: new Uint8Array(48) }),
+			openWithPrivateKey: () => ({ reason: 'no' }),
+			chain: () => ({ genesis: () => {}, step: () => ({ ok: true }) }),
+		};
+		ctx.window.MajesticRecKeys = {
+			ui: { mount() {}, refresh: () => Promise.resolve(null), state: () => 'none' },
+			needFor: () => Promise.resolve(new Uint8Array(48)),
+			known: () => null, remember() {}, forgetAll() {},
+			heldKey: () => null, heldMeta: () => null,
+		};
+	}
+	vm.runInContext(fs.readFileSync(A('recordings.js'), 'utf8'), ctx);
 	return env;
+}
+
+// A copy with its first byte stamped, so a test can see which transform a
+// buffer went through — or that it went through none.
+function mark(bytes, tag) {
+	const out = new Uint8Array(bytes.length ? bytes : 1);
+	out.set(bytes);
+	out[0] = tag;
+	return out;
 }
 
 function bufferedEnd(env) {
@@ -450,6 +493,33 @@ async function playTo(env, sec) {
 		check('reopening really did run the open path again',
 			env.appends.length > 0 && env.reads.length > 4,
 			'reads=' + env.reads.length);
+	}
+
+	// ---- a sealed clip reaches the decoder decrypted ---------------------
+	//
+	// The wiring, and it is the kind that fails silently in both directions. A
+	// transform applied to the fragments but not the init segment gives a
+	// SourceBuffer an initialisation segment whose sample entries name a codec
+	// no decoder implements; one applied to the init but not the fragments
+	// gives it ciphertext. Neither raises anything. Both are a black frame and
+	// a page that looks like it is still loading.
+	{
+		group('a sealed clip is decrypted on its way to the decoder');
+		const env = load({ sealed: true });
+		await waitFor(() => env.appends.length > 2);
+		await quiesce(env);
+
+		check('the init segment went through the header rewrite',
+			env.transformed.init >= 1, 'init transforms: ' + env.transformed.init);
+		check('and every fragment through the decrypter',
+			env.transformed.fragment >= 2, 'fragment transforms: ' + env.transformed.fragment);
+
+		const stamps = env.appends.map((a) => a.tag);
+		check('every buffer the SourceBuffer was given carries a transform\'s mark',
+			stamps.length > 2 && stamps.every((t) => t === 0xc1 || t === 0xd2),
+			stamps.join(','));
+		check('the first of them is the rewritten header, not a fragment',
+			stamps[0] === 0xc1, 'first append tag ' + stamps[0]);
 	}
 
 	done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3569,6 +3569,38 @@ mark {
 	object-fit: contain;
 }
 
+/* The lock covers the picture rather than replacing it: the element keeps its
+   place in the layout, so unlocking a clip does not make the page jump. */
+.rec-lock {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.82);
+	color: var(--bs-body-color);
+	padding: 1rem;
+}
+
+.rec-stage.rec-locked .rec-video { visibility: hidden; }
+
+.rec-lock-box {
+	max-width: 30rem;
+	text-align: center;
+	color: #fff;
+}
+
+.rec-lock-icon {
+	font-size: 1.75rem;
+	line-height: 1;
+	margin-bottom: 0.5rem;
+}
+
+.rec-lock-in {
+	max-width: 22rem;
+	margin: 0 auto;
+}
+
 .rec-lbl {
 	display: block;
 	font-size: 0.6875rem;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -4899,6 +4899,31 @@
 				'<label for="' + id + '" class="form-label">' + labelHtml + '</label>' +
 				'<select class="form-select" id="' + id + '">' + opts + '</select>';
 			control = p.querySelector('select');
+		} else if (type === 'string' && (sub['x-secret'] || sub.writeOnly)) {
+			// A secret the camera has asked not to be shown. It is not hidden
+			// from anyone who can read this page — the value came down the same
+			// authenticated request as everything else — so this is about
+			// shoulders and screen shares, not about secrecy from the browser.
+			// The markup is the shape p/common.cgi's field_password emits, but
+			// the reveal toggle in main.js is wired once at page load and this
+			// form is built long after — so the handler is attached here, to
+			// the field that was just made, rather than relying on a scan that
+			// has already run.
+			p = el('p', 'string password mj-row');
+			const v = eff !== undefined && eff !== null ? String(eff) : '';
+			p.innerHTML =
+				'<label for="' + id + '" class="form-label">' + labelHtml + '</label>' +
+				'<div class="input-group">' +
+				'<input type="password" id="' + id + '" class="form-control" value="' + esc(v) +
+				'" autocomplete="off" spellcheck="false">' +
+				'<div class="input-group-text"><input class="form-check-input mt-0" type="checkbox"' +
+				' data-for="' + id + '" aria-label="Show"></div>' +
+				'</div>';
+			control = p.querySelector('input[type=password]');
+			const eye = p.querySelector('input[type=checkbox]');
+			if (eye) eye.addEventListener('change', () => {
+				control.type = eye.checked ? 'text' : 'password';
+			});
 		} else if (type === 'string') {
 			p = el('p', 'string mj-row');
 			const v = eff !== undefined && eff !== null ? String(eff) : '';

--- a/www/a/mp4crypt.js
+++ b/www/a/mp4crypt.js
@@ -295,14 +295,37 @@ window.MajesticMp4Crypt = (function () {
 	}
 
 	// Is there a protection box anywhere under here? Used only where the track
-	// walk came back empty, and deliberately a scan rather than a parse: the
-	// question is whether these bytes contain any of the boxes protection is
-	// signalled with, and a box tree this build could not walk is exactly the
-	// case where a parse cannot answer.
-	function protectionSomewhere(u8, from, to) {
-		for (let at = from; at + 8 <= to; at++) {
-			const t = fourcc(u8, at);
-			if (t === 'sinf' || t === 'encv' || t === 'enca' || t === 'tenc') return true;
+	// walk came back empty — a header shaped in a way this build has not seen.
+	//
+	// A structural walk, not a search for the four letters. `sinf`, `encv`,
+	// `enca` and `tenc` are ordinary byte sequences and appear inside codec
+	// configuration and metadata payloads by chance; a scan that matched one
+	// there would refuse a perfectly clear recording as an unopenable sealed
+	// one, which is a worse failure than the one this function exists to
+	// prevent. So it descends the containers it knows, reads box types at box
+	// boundaries only, and never looks inside a box it does not understand.
+	//
+	// A tree it cannot walk answers false, which is the same answer as before
+	// this existed: nothing here found protection. That is a statement about
+	// what was looked at, and the caller's sentence says as much.
+	const PROTECTION_PARENTS = {
+		moov: 8, trak: 8, mdia: 8, minf: 8, stbl: 8, stsd: 16, sinf: 8, schi: 8,
+	};
+
+	function protectionSomewhere(u8, from, to, depth) {
+		if ((depth || 0) > 8) return false;           // a tree this deep is not one of ours
+		let at = from;
+		while (at + 8 <= to) {
+			const size = be32(u8, at);
+			if (size < 8 || at + size > to) return false;
+			const type = fourcc(u8, at + 4);
+			if (type === 'sinf' || type === 'encv' || type === 'enca' || type === 'tenc')
+				return true;
+			const skip = PROTECTION_PARENTS[type];
+			if (skip !== undefined && at + skip <= at + size &&
+				protectionSomewhere(u8, at + skip, at + size, (depth || 0) + 1))
+				return true;
+			at += size;
 		}
 		return false;
 	}

--- a/www/a/mp4crypt.js
+++ b/www/a/mp4crypt.js
@@ -265,8 +265,25 @@ window.MajesticMp4Crypt = (function () {
 		// actually protected, which decides whether a key is needed at all — a
 		// track can be wrapped and declare itself unprotected, and demanding a
 		// passphrase for that would refuse a clip that plays.
-		if (!Object.keys(tracks).length)
-			return unreadable('the clip header carries no tracks this page can read');
+		// A moov this walk could not take a track out of. That is not the same
+		// as a header nobody saw: the bytes are here, so the question can be
+		// asked directly — is there a protection box anywhere inside them? If
+		// there is not, the clip is in the clear as a FINDING rather than an
+		// assumption, and refusing it would refuse a recording that plays
+		// today. If there is, this build cannot say how, and says that.
+		if (!Object.keys(tracks).length) {
+			const guard = protectionSomewhere(u8, moov[0] + 8, moov[1]);
+			if (guard)
+				return {
+					ok: true, encrypted: true, wrapped: true, tracks: {},
+					keyBox: keyBox(u8.subarray(0, end)),
+					reason: 'this recording is protected in a way this page does not know',
+				};
+			return {
+				ok: true, encrypted: false, wrapped: false,
+				tracks: {}, keyBox: null, reason: null,
+			};
+		}
 		return {
 			ok: true,
 			encrypted: encrypted,
@@ -275,6 +292,19 @@ window.MajesticMp4Crypt = (function () {
 			keyBox: wrapped ? keyBox(u8.subarray(0, end)) : null,
 			reason: reason,
 		};
+	}
+
+	// Is there a protection box anywhere under here? Used only where the track
+	// walk came back empty, and deliberately a scan rather than a parse: the
+	// question is whether these bytes contain any of the boxes protection is
+	// signalled with, and a box tree this build could not walk is exactly the
+	// case where a parse cannot answer.
+	function protectionSomewhere(u8, from, to) {
+		for (let at = from; at + 8 <= to; at++) {
+			const t = fourcc(u8, at);
+			if (t === 'sinf' || t === 'encv' || t === 'enca' || t === 'tenc') return true;
+		}
+		return false;
 	}
 
 	// `ok` false is a third answer beside clear and encrypted, and callers have

--- a/www/a/reckeys.js
+++ b/www/a/reckeys.js
@@ -549,13 +549,32 @@ window.MajesticRecKeys.ui = (function () {
 		say('Making a key…');
 		K.generate(pass).then(function (made) {
 			download('owner-' + made.meta.fingerprint.slice(0, 8) + '.pem', made.privatePem);
-			return K.save(made.record).then(refresh).then(function () {
-				say('Made, and the private half has downloaded. <strong>That file is the only other ' +
-					'copy</strong> — this browser’s is a convenience and goes when its storage does. ' +
-					'Now save the public key to the camera so it starts sealing recordings to it.', 'success');
-			});
+			return keep(made.record, made.key, made.meta,
+				'Made, and the private half has downloaded. <strong>That file is the only other ' +
+				'copy</strong> — this browser’s is a convenience and goes when its storage does. ' +
+				'Now save the public key to the camera so it starts sealing recordings to it.');
 		}).catch(function (e) {
 			say(esc(e.message || 'the key could not be made'), 'danger');
+		});
+	}
+
+	// Storing can simply not happen — a private window, blocked site data, a
+	// transaction that failed — and K.save() answers null when it did not. A
+	// page that says "saved" anyway sends somebody away believing they have a
+	// key here; the truthful answer is that it works for this visit and the
+	// PEM is the only copy that outlives it. Either way the key is held in
+	// memory, so the visit is usable rather than merely reported on.
+	function keep(rec, key, meta, kept) {
+		return K.save(rec).then(function (ok) {
+			K.holdKey(key, meta);
+			record = rec;
+			return refresh().then(function () {
+				say(storable === false || ok === null
+					? 'Loaded, and usable until this page is closed — this browser will not keep it ' +
+						'between visits, so the PEM file is the only copy. Private windows and blocked ' +
+						'site data both do this.'
+					: kept, storable === false || ok === null ? 'warning' : 'success');
+			});
 		});
 	}
 
@@ -568,9 +587,8 @@ window.MajesticRecKeys.ui = (function () {
 		} catch (e) {
 			return say(esc(e.message || 'that file is not a private key'), 'danger');
 		}
-		K.save(got.record).then(refresh).then(function () {
-			say('Loaded the key ending ' + esc(fp(got.meta.fingerprint.slice(-4))) + '.', 'success');
-		});
+		keep(got.record, got.key, got.meta,
+			'Loaded the key ending ' + esc(fp(got.meta.fingerprint.slice(-4))) + '.');
 	}
 
 	// Publishing is two writes and the second is not guessed at: the file goes
@@ -589,10 +607,21 @@ window.MajesticRecKeys.ui = (function () {
 		}).then(function (r) {
 			if (!r.ok) throw new Error('the camera answered ' + r.status);
 			return apiFetch('/api/v1/config.schema.json').then(function (s) {
-				return s.ok ? s.json() : null;
+				// A schema that did not arrive is not a schema without the
+				// setting in it. The two are reported apart below, because one
+				// is a fact about this firmware and the other is a fact about
+				// one HTTP request.
+				if (!s.ok) return { failed: s.status };
+				return s.json().then(function (j) { return { schema: j }; },
+					function () { return { failed: 'unreadable' }; });
 			});
-		}).then(function (schema) {
-			if (!settingExists(schema))
+		}).then(function (got) {
+			if (got.failed)
+				return say('The public key is on the camera at <code>' + esc(PUBLIC_PATH) + '</code>, ' +
+					'but its settings could not be read just now (' + esc(got.failed) + '), so nothing ' +
+					'else was changed. Point the recording settings at that file, or try again.',
+					'warning');
+			if (!settingExists(got.schema))
 				return say('The public key is on the camera at <code>' + esc(PUBLIC_PATH) + '</code>. ' +
 					'This firmware does not offer a setting to point at it, so nothing else was ' +
 					'changed — a newer build will.', 'warning');
@@ -613,15 +642,17 @@ window.MajesticRecKeys.ui = (function () {
 	function settingExists(schema) {
 		try {
 			const p = PUBLIC_KEY_SETTING.split('.');
-			let at = schema.properties;
+			let at = schema && schema.properties;
 			for (let i = 0; i < p.length; i++) {
 				if (!at || !at[p[i]]) return false;
 				at = i === p.length - 1 ? at[p[i]] : at[p[i]].properties;
 			}
 			return true;
 		} catch (e) {
-			// A schema that could not be read is not a schema that says no.
-			// Nothing is written on the strength of a failed fetch.
+			// A schema shaped in a way this walk did not expect. Reported the
+			// same as one without the setting, which is the safe half of the
+			// distinction: nothing is written. The other half — a schema that
+			// never arrived — is decided before this is called.
 			return false;
 		}
 	}

--- a/www/a/reckeys.js
+++ b/www/a/reckeys.js
@@ -581,6 +581,11 @@ window.MajesticRecKeys.ui = (function () {
 	function loadPem(text) {
 		const pass = window.prompt('Choose a passphrase for this browser’s copy of the key');
 		if (pass === null) return;
+		// The same guard generation has. A key stored under no passphrase is
+		// readable by anyone who reaches this browser profile, and an imported
+		// key is exactly as worth protecting as a generated one.
+		if (!pass) return say('A key kept without a passphrase is a key anyone using this ' +
+			'computer can read. Choose one.', 'warning');
 		let got;
 		try {
 			got = K.importPem(text, pass);
@@ -598,7 +603,25 @@ window.MajesticRecKeys.ui = (function () {
 	// the daemon ignores and calling it done is the failure this avoids.
 	function promptPublish() {
 		if (!record) return;
-		const pem = C.pemWrap('PUBLIC KEY', record.spki);
+		// The public half is derived from the unlocked private key, never read
+		// out of the stored record. The record's authentication tag covers the
+		// wrapped key and the parameters needed to unwrap it — not the public
+		// metadata beside them — so a record edited in place could pair a
+		// genuine private key with somebody else's public one, and the camera
+		// would seal every future recording to a key this operator does not
+		// hold. Deriving it means publishing proves possession, which is the
+		// property that matters here.
+		const key = K.heldKey();
+		if (!key) {
+			say('Unlock the key first: what gets sent to the camera is derived from the ' +
+				'key itself, not from what this browser has written down beside it.', 'warning');
+			return;
+		}
+		const meta = K.metaFor(key);
+		if (meta.fingerprint !== record.fingerprint)
+			say('The stored fingerprint did not match the key it sits beside; the key’s own ' +
+				'is what was sent, and the record has been corrected.', 'warning');
+		const pem = C.publicKeyPem(key);
 		say('Saving the public key to the camera…');
 		apiFetch('/upload', {
 			method: 'POST',

--- a/www/a/reckeys.js
+++ b/www/a/reckeys.js
@@ -278,3 +278,399 @@ window.MajesticRecKeys = (function () {
 	if (typeof module === 'object' && module.exports) module.exports = api;
 	return api;
 })();
+
+// ---------------------------------------------------------------------------
+// The panel, and the one question the recordings page asks it.
+//
+// Kept in the same file as the store it drives, because everything here is
+// about presenting that store's four states — no key, locked, unlocked, cannot
+// store one — and a second file would only move the state machine away from
+// the thing it describes.
+window.MajesticRecKeys.ui = (function () {
+	'use strict';
+
+	const K = window.MajesticRecKeys;
+	const C = window.MajesticCrypto;
+
+	// Where the public half goes on the camera, and the setting that points at
+	// it. One place, because the panel writes both and a disagreement between
+	// them is a camera that seals recordings to a file it cannot read.
+	const PUBLIC_PATH = '/etc/records-owner.pub';
+	const PUBLIC_KEY_SETTING = 'records.publicKey';
+
+	let record = null;          // what storage holds, or null
+	let storable = null;        // whether this browser can store anything
+	let pending = null;         // the question the lock panel is asking
+
+	function $id(id) { return document.getElementById(id); }
+
+	function esc(t) {
+		return String(t == null ? '' : t)
+			.replace(/&/g, '&amp;').replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+	}
+
+	// A fingerprint people are meant to compare by eye, not read as a number.
+	function fp(hex) {
+		return String(hex || '').replace(/(..)(?=.)/g, '$1 ').toUpperCase();
+	}
+
+	function refresh() {
+		return K.available().then(function (ok) {
+			storable = ok;
+			return ok ? K.load() : null;
+		}).then(function (rec) {
+			record = rec || null;
+			render();
+			return record;
+		});
+	}
+
+	function state() {
+		if (storable === false) return 'unstorable';
+		if (!record) return 'none';
+		return K.heldKey() ? 'unlocked' : 'locked';
+	}
+
+	function chip() {
+		switch (state()) {
+		case 'unlocked': return '<span class="badge text-bg-success">Key unlocked</span>';
+		case 'locked': return '<span class="badge text-bg-secondary">Key locked</span>';
+		case 'unstorable': return '<span class="badge text-bg-warning">This browser cannot store keys</span>';
+		default: return '<span class="badge text-bg-secondary">No key on this device</span>';
+		}
+	}
+
+	function render() {
+		const body = $id('rec-keys-body');
+		const head = $id('rec-keys-chip');
+		if (head) head.innerHTML = chip();
+		if (!body) return;
+
+		let h = '';
+		if (record) {
+			h += '<div class="mb-3"><div class="fw-semibold">This device’s key</div>' +
+				'<div class="font-monospace small">' + esc(fp(record.fingerprint)) + '</div>' +
+				'<div class="x-small text-secondary">RSA-' + esc(record.bits) +
+				(record.createdAt ? ', added ' + esc(String(record.createdAt).slice(0, 10)) : '') +
+				'</div></div>';
+			h += '<div class="d-flex flex-wrap gap-2 mb-3">' +
+				(K.heldKey()
+					? '<button class="btn btn-sm btn-outline-secondary" id="rec-keys-lock" type="button">Lock</button>'
+					: '<button class="btn btn-sm btn-primary" id="rec-keys-unlock" type="button">Unlock</button>') +
+				'<button class="btn btn-sm btn-outline-secondary" id="rec-keys-backup" type="button">Download a backup</button>' +
+				'<button class="btn btn-sm btn-outline-secondary" id="rec-keys-publish" type="button">Save the public key to the camera</button>' +
+				'<button class="btn btn-sm btn-outline-danger" id="rec-keys-forget" type="button">Remove</button>' +
+				'</div>';
+		} else {
+			h += '<p class="small mb-3">No key on this device. A key is what opens recordings ' +
+				'the camera sealed to its public half — the camera never holds the private one, ' +
+				'which is why those recordings survive the camera being stolen.</p>';
+		}
+
+		if (!record || state() === 'none') {
+			h += K.canGenerate()
+				? '<div class="mb-3"><button class="btn btn-sm btn-primary" id="rec-keys-generate" type="button">Generate a key</button>' +
+					'<div class="x-small text-secondary mt-1">Made in this browser. The private half never leaves it, ' +
+					'and the backup you download is the only other copy.</div></div>'
+				: '<div class="mb-3"><div class="small">This page is served over a connection the browser ' +
+					'will not make keys on, so make one yourself and bring it here:</div>' +
+					'<pre class="x-small mb-2">openssl genrsa -out owner.pem 2048\nopenssl rsa -in owner.pem -pubout -out owner.pub</pre></div>';
+			h += '<div class="mb-2"><label class="form-label small" for="rec-keys-file">Or load a private key you already have</label>' +
+				'<input class="form-control form-control-sm" type="file" id="rec-keys-file" accept=".pem,.key,text/plain"></div>';
+		}
+
+		if (storable === false)
+			h += '<div class="x-small text-secondary">Nothing can be kept between visits here — a key you ' +
+				'load will work until this page is closed. Private windows and blocked site data both do this.</div>';
+
+		body.innerHTML = h;
+		wire();
+	}
+
+	function ask(title, sentence, label, onGo) {
+		pending = onGo;
+		return '<div class="rec-lock-box"><div class="rec-lock-icon">🔒</div>' +
+			'<p class="fw-semibold mb-1">' + esc(title) + '</p>' +
+			'<p class="small">' + sentence + '</p>' +
+			'<div class="input-group input-group-sm rec-lock-in">' +
+			'<input type="password" class="form-control" id="rec-lock-pass" autocomplete="off">' +
+			'<button class="btn btn-primary" id="rec-lock-go" type="button">' + esc(label) + '</button>' +
+			'</div><div class="x-small text-secondary mt-2" id="rec-lock-why"></div></div>';
+	}
+
+	// The recordings page's one question: give me this clip's keys, or tell me
+	// nothing here can. Resolves with the 48 bytes or with null, and null is an
+	// answer — the panel has already said which of the several reasons it is.
+	function needFor(box, opts) {
+		const show = opts.show;
+		const held = K.known(box.kidHex);
+		if (held) return Promise.resolve(held);
+
+		return refresh().then(function () {
+			// A key already unlocked in this visit, and the clip sealed to it.
+			const key = K.heldKey();
+			const meta = K.heldMeta();
+			if (key && box.pubkeyFp && meta && meta.fingerprint === box.pubkeyFp) {
+				const got = window.MajesticMp4Crypt.openWithPrivateKey(box, key, meta.fingerprint);
+				if (got.material) { K.remember(box.kidHex, got.material); show(''); return got.material; }
+			}
+
+			// Nothing in a browser opens a chip-bound recording: the key
+			// unwraps inside the camera's own silicon and nowhere else. Said
+			// plainly, with what to change so the next one can be opened.
+			if (window.MajesticMp4Crypt.chipOnly(box))
+				return refuse(show, 'Only the camera that recorded it can open this.',
+					'This recording is bound to that camera’s hardware. Nothing in a browser can ' +
+					'decode it, on this machine or any other. To be able to open future recordings ' +
+					'here, add a recovery key or a passphrase in the recording settings.', opts);
+
+			// Sealed to a key that is not this one. Naming the fingerprint is
+			// what makes that sentence actionable rather than a dead end.
+			if (box.pubkeyFp && record && record.fingerprint !== box.pubkeyFp && !hasPassphraseSlot(box))
+				return refuse(show, 'This recording is locked to another key.',
+					'It was sealed to the key ending ' + esc(fp(box.pubkeyFp.slice(-4))) +
+					'; this device holds ' + esc(fp(record.fingerprint.slice(-4))) + '.', opts);
+
+			if (box.pubkeyFp && record && record.fingerprint === box.pubkeyFp && !K.heldKey())
+				return new Promise(function (resolve) {
+					show(ask('This recording is sealed to your key.',
+						'Unlock the key on this device to play it. The passphrase is the one you ' +
+						'chose for this browser, not the camera’s.',
+						'Unlock', function (pass, why) {
+							const der = K.unwrap(record, pass);
+							if (!der) return why('That passphrase does not unlock the key on this device.');
+							const key2 = K.keyFromDer(der, record.form);
+							K.holdKey(key2, { fingerprint: record.fingerprint });
+							const got = window.MajesticMp4Crypt.openWithPrivateKey(box, key2, record.fingerprint);
+							if (!got.material) return why(got.reason);
+							K.remember(box.kidHex, got.material);
+							show('');
+							render();
+							resolve(got.material);
+						}));
+				});
+
+			if (hasPassphraseSlot(box))
+				return new Promise(function (resolve) {
+					show(ask('This recording is sealed.',
+						'Enter the recording passphrase — the one set on the camera, in the ' +
+						'recording settings. It opens every clip made while it was in force.',
+						'Unlock', function (pass, why) {
+							const got = window.MajesticMp4Crypt.openWithPassphrase(box, pass);
+							if (!got.material) return why(got.reason);
+							K.remember(box.kidHex, got.material);
+							show('');
+							resolve(got.material);
+						}));
+				});
+
+			return refuse(show, 'Nothing on this device opens this recording.',
+				'It carries no passphrase, and no key here matches the one it was sealed to.', opts);
+		});
+	}
+
+	function hasPassphraseSlot(box) {
+		return box.modes.indexOf('passphrase') >= 0;
+	}
+
+	function refuse(show, title, sentence, opts) {
+		show('<div class="rec-lock-box"><div class="rec-lock-icon">🔒</div>' +
+			'<p class="fw-semibold mb-1">' + esc(title) + '</p>' +
+			'<p class="small">' + sentence + '</p>' +
+			(opts && opts.download
+				? '<a class="btn btn-sm btn-outline-secondary" download href="' + esc(opts.download) +
+					'">Save the clip as recorded</a>'
+				: '') +
+			'</div>');
+		return null;
+	}
+
+	// ---- the panel's own buttons -----------------------------------------
+
+	function wire() {
+		const on = function (id, fn) {
+			const el = $id(id);
+			if (el) el.addEventListener('click', fn);
+		};
+		on('rec-keys-unlock', function () { promptUnlock(); });
+		on('rec-keys-lock', function () { K.forgetAll(); render(); });
+		on('rec-keys-backup', function () { promptBackup(); });
+		on('rec-keys-forget', function () { promptForget(); });
+		on('rec-keys-generate', function () { promptGenerate(); });
+		const file = $id('rec-keys-file');
+		if (file) file.addEventListener('change', function () {
+			const f = file.files && file.files[0];
+			if (f) f.text().then(loadPem);
+		});
+	}
+
+	function say(html, kind) {
+		const el = $id('rec-keys-say');
+		if (!el) return;
+		el.className = html ? 'alert alert-' + (kind || 'secondary') + ' py-2 px-3 small mt-3' : 'd-none';
+		el.innerHTML = html || '';
+	}
+
+	function promptUnlock() {
+		const pass = window.prompt('Passphrase for the key on this device');
+		if (pass === null) return;
+		const der = K.unwrap(record, pass);
+		if (!der) return say('That passphrase does not unlock the key on this device.', 'danger');
+		K.holdKey(K.keyFromDer(der, record.form), { fingerprint: record.fingerprint });
+		say('');
+		render();
+	}
+
+	function promptBackup() {
+		const pass = window.prompt('Passphrase for the key on this device');
+		if (pass === null) return;
+		const der = K.unwrap(record, pass);
+		if (!der) return say('That passphrase does not unlock the key on this device.', 'danger');
+		download('owner-' + record.fingerprint.slice(0, 8) + '.pem',
+			C.pemWrap(record.form === 'pkcs1' ? 'RSA PRIVATE KEY' : 'PRIVATE KEY', der));
+		say('Keep it somewhere you will still have it in three years. Lose every copy and every ' +
+			'recording sealed to this key is gone — there is no way back into them.', 'warning');
+	}
+
+	function promptForget() {
+		if (!window.confirm('Remove this key from this browser?\n\n' +
+			'Recordings sealed to it stay sealed. Without a backup of the private key, nothing ' +
+			'will ever open them again.')) return;
+		K.forgetAll();
+		K.remove().then(refresh).then(function () { say('The key is gone from this browser.', 'secondary'); });
+	}
+
+	function promptGenerate() {
+		const pass = window.prompt('Choose a passphrase for this browser’s copy of the key');
+		if (pass === null) return;
+		if (!pass) return say('A key kept without a passphrase is a key anyone using this ' +
+			'computer can read. Choose one.', 'warning');
+		say('Making a key…');
+		K.generate(pass).then(function (made) {
+			download('owner-' + made.meta.fingerprint.slice(0, 8) + '.pem', made.privatePem);
+			return K.save(made.record).then(refresh).then(function () {
+				say('Made, and the private half has downloaded. <strong>That file is the only other ' +
+					'copy</strong> — this browser’s is a convenience and goes when its storage does. ' +
+					'Now save the public key to the camera so it starts sealing recordings to it.', 'success');
+			});
+		}).catch(function (e) {
+			say(esc(e.message || 'the key could not be made'), 'danger');
+		});
+	}
+
+	function loadPem(text) {
+		const pass = window.prompt('Choose a passphrase for this browser’s copy of the key');
+		if (pass === null) return;
+		let got;
+		try {
+			got = K.importPem(text, pass);
+		} catch (e) {
+			return say(esc(e.message || 'that file is not a private key'), 'danger');
+		}
+		K.save(got.record).then(refresh).then(function () {
+			say('Loaded the key ending ' + esc(fp(got.meta.fingerprint.slice(-4))) + '.', 'success');
+		});
+	}
+
+	// Publishing is two writes and the second is not guessed at: the file goes
+	// up, and the setting is written only if the camera's own schema declares
+	// it. A camera whose firmware predates the setting still gets the file, and
+	// is told that is all that happened — writing a key into a configuration
+	// the daemon ignores and calling it done is the failure this avoids.
+	function promptPublish() {
+		if (!record) return;
+		const pem = C.pemWrap('PUBLIC KEY', record.spki);
+		say('Saving the public key to the camera…');
+		apiFetch('/upload', {
+			method: 'POST',
+			headers: { 'File-Location': PUBLIC_PATH },
+			body: pem,
+		}).then(function (r) {
+			if (!r.ok) throw new Error('the camera answered ' + r.status);
+			return apiFetch('/api/v1/config.schema.json').then(function (s) {
+				return s.ok ? s.json() : null;
+			});
+		}).then(function (schema) {
+			if (!settingExists(schema))
+				return say('The public key is on the camera at <code>' + esc(PUBLIC_PATH) + '</code>. ' +
+					'This firmware does not offer a setting to point at it, so nothing else was ' +
+					'changed — a newer build will.', 'warning');
+			return apiFetch('/api/v1/config', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ records: { publicKey: PUBLIC_PATH } }),
+			}).then(function (r) {
+				if (!r.ok) throw new Error('the camera refused the setting (' + r.status + ')');
+				say('Saved. Recordings from now on carry a copy of their key sealed to this device’s ' +
+					'key — earlier ones are unchanged.', 'success');
+			});
+		}).catch(function (e) {
+			say(esc(e.message || 'the camera could not be reached'), 'danger');
+		});
+	}
+
+	function settingExists(schema) {
+		try {
+			const p = PUBLIC_KEY_SETTING.split('.');
+			let at = schema.properties;
+			for (let i = 0; i < p.length; i++) {
+				if (!at || !at[p[i]]) return false;
+				at = i === p.length - 1 ? at[p[i]] : at[p[i]].properties;
+			}
+			return true;
+		} catch (e) {
+			// A schema that could not be read is not a schema that says no.
+			// Nothing is written on the strength of a failed fetch.
+			return false;
+		}
+	}
+
+	function download(name, text) {
+		const a = document.createElement('a');
+		a.href = URL.createObjectURL(new Blob([text], { type: 'application/x-pem-file' }));
+		a.download = name;
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		setTimeout(function () { URL.revokeObjectURL(a.href); }, 30000);
+	}
+
+	function mount() {
+		const panel = $id('rec-keys');
+		if (!panel) return;
+		refresh();
+		const go = $id('rec-lock-go');
+		document.addEventListener('click', function (ev) {
+			if (ev.target && ev.target.id === 'rec-lock-go') submitLock();
+			if (ev.target && ev.target.id === 'rec-keys-publish') promptPublish();
+		});
+		document.addEventListener('keydown', function (ev) {
+			if (ev.key === 'Enter' && ev.target && ev.target.id === 'rec-lock-pass') submitLock();
+		});
+		if (go) go.addEventListener('click', submitLock);
+	}
+
+	function submitLock() {
+		const input = $id('rec-lock-pass');
+		const why = $id('rec-lock-why');
+		if (!input || !pending) return;
+		const fn = pending;
+		if (why) why.textContent = 'Working…';
+		// Stretching a passphrase holds this thread for a moment, and a button
+		// that does nothing for half a second reads as a button that did not
+		// work. The frame between the two is what puts "Working…" on screen.
+		setTimeout(function () {
+			fn(input.value, function (reason) {
+				if (why) why.textContent = reason || 'That did not open it.';
+			});
+		}, 16);
+	}
+
+	return { mount: mount, needFor: needFor, refresh: refresh, state: state };
+})();
+
+// The recordings page talks to the panel, not to the store.
+window.MajesticRecKeys.needFor = function (box, opts) {
+	return window.MajesticRecKeys.ui.needFor(box, opts);
+};

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -39,7 +39,10 @@
 		// What the open clip's header said about protection, and what the page
 		// managed to do about it: `xform` is the pair of transforms the player
 		// and the exporter run bytes through, absent on a clip in the clear.
-		prot: null, xform: null,
+		// The open clip's keys, and they are per clip: carried into the next
+		// one they would verify it against the wrong key and report tampering
+		// — an accusation about somebody's footage, made by a bug.
+		prot: null, xform: null, material: null,
 	};
 
 
@@ -671,7 +674,9 @@
 		state.hint = null;
 		state.prot = null;
 		state.xform = null;
+		state.material = null;
 		lock('');
+		sealedControls();
 		const url = fileUrl(clipPath(clip.name));
 
 		if (player) { player.destroy(); player = null; }
@@ -775,8 +780,11 @@
 				if (!material) return;                 // the lock panel explains
 				const xform = mkTransform(prot, material, init.headerLength);
 				state.xform = xform;
+				state.material = material;
 				setStatus('');
 				lock('');
+				sealedControls();
+				renderClips();
 				startPlaying(clip, url, init, mime, xform, atSec);
 			});
 
@@ -1372,6 +1380,24 @@
 		$id('rec-sel-save').addEventListener('click', saveSelection);
 	}
 
+	// What the camera is doing to recordings right now, from the configuration
+	// the page already has. Deliberately not a per-clip answer: knowing whether
+	// a given file is sealed means reading its header, and a day of clips is a
+	// range request each — on a page whose whole index strategy is built around
+	// the cost of a request being the request. So this says what is true of new
+	// recordings and does not pretend to describe old ones, which is exactly
+	// what the configuration knows.
+	function sealedHint() {
+		const mode = mjGet(state.cfg, 'records.encryption');
+		if (!mode || mode === 'none') return '';
+		const what = mode === 'passphrase' ? 'with a passphrase'
+			: mode === 'chip' ? 'to this camera’s hardware'
+			: mode === 'pubkey' ? 'to a key this camera cannot open'
+			: 'in a way this page does not know';
+		return '<div class="x-small text-secondary mb-2">New recordings are sealed ' + what +
+			'. Older clips are however they were written at the time.</div>';
+	}
+
 	function renderClips() {
 		const el = $id('rec-clips');
 		if (!el) return;
@@ -1380,7 +1406,7 @@
 			el.innerHTML = '<div class="text-secondary small">No clips in this day.</div>';
 			return;
 		}
-		let h = '';
+		let h = sealedHint();
 		// timeline.js calls the newest clip "recording" when it ends about now,
 		// which is a statement about the clock and cannot know the card stopped
 		// accepting writes. On a card that cannot be written the last clip is
@@ -1395,10 +1421,14 @@
 					hhmm(prev.end) + ' – ' + hhmm(c.start) + '</span></div>';
 			}
 			const on = state.clip && state.clip.name === c.name;
+			// A lock on the row of the clip that is open, because that is the
+			// one whose header has actually been read. Putting one on every row
+			// would be a guess dressed as a fact.
+			const sealed = on && state.prot && state.prot.encrypted ? ' 🔒' : '';
 			h += '<button type="button" class="rec-clip' + (on ? ' active' : '') + '" data-clip="' + esc(c.name) + '">' +
 				'<span class="rec-poster"' + (c.recording && writable ? ' data-live="1"' : '') + '>' +
 				'<span class="rec-poster-t">' + hhmm(c.start) + '</span></span>' +
-				'<span class="rec-clip-m"><span class="font-monospace fw-semibold">' + hhmm(c.start) + '</span>' +
+				'<span class="rec-clip-m"><span class="font-monospace fw-semibold">' + hhmm(c.start) + sealed + '</span>' +
 				'<span class="x-small text-secondary">' +
 				(c.recording && writable ? 'recording'
 					: (c.estimated ? '≈ ' : '') + TL.duration(c.dur)) +
@@ -1780,8 +1810,12 @@
 					'Recordings written by older firmware are like this.';
 			// A clip still being written ends mid-fragment. That is the camera
 			// doing its job, and saying "the chain ends early" about it would
-			// accuse a working camera of something.
-			const whole = at + 16 > clip.size;
+			// accuse a working camera of something. But "complete" has to mean
+			// the walk finished ON the last byte: a file cut a few bytes into
+			// its next fragment leaves a tail too short to parse, and calling
+			// that intact is the one verdict this button must never give by
+			// accident.
+			const whole = at === clip.size;
 			return 'Intact through ' + n + ' fragment' + (n === 1 ? '' : 's') +
 				(whole ? '. Every fragment matches its own record, and each record covers the one before it.'
 					: ', and the rest has not been written yet — this clip is still recording.');

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -452,7 +452,7 @@
 						// so once.
 						busy = false;
 						dead = true;
-						onBadFragment(e, at);
+						onBadFragment(e, at, 'fragment');
 						return;
 					}
 					cursor = at + f.total;
@@ -500,7 +500,7 @@
 							out = through('init', head);
 						} catch (e) {
 							dead = true;
-							onBadFragment(e, 0);
+							onBadFragment(e, 0, 'init');
 							return;
 						}
 						try { sb.appendBuffer(out); } catch (e) { onFallback(); }
@@ -528,7 +528,7 @@
 					// buffers nothing has a reason, and the reason is worth
 					// more than another attempt.
 					if (!has) {
-						if (xform) onBadFragment(new Error('nothing buffered'), 0);
+						if (xform) onBadFragment(new Error('nothing buffered'), 0, 'nothing');
 						else onFallback();
 					}
 				}, 5000);
@@ -633,7 +633,7 @@
 		if ('MediaSource' in window && MediaSource.isTypeSupported(mime)) {
 			player = mkPlayer(video,
 				function () { plainFallback(clip, url); },
-				function (err) { badFragment(clip, url, err); });
+				function (err, at, phase) { badFragment(clip, url, err, phase); });
 			player.attach(url, init, clip.size, mime, xform);
 		} else if (xform) {
 			// No MediaSource and a sealed clip: the element cannot be handed
@@ -654,14 +654,26 @@
 	// which fragment and what was wrong with it. Playback of what is already
 	// buffered continues: the frames on screen decoded correctly, and taking
 	// them away proves nothing.
-	function badFragment(clip, url, err) {
+	// Three failures reach here and they are not the same sentence. A header
+	// that could not be prepared and a SourceBuffer that never took anything
+	// have decoded no frames at all, so telling somebody that everything up to
+	// that point played correctly is a claim about a picture nobody saw.
+	function badFragment(clip, url, err, phase) {
 		if (state.clip !== clip) return;
 		setStatus('');
+		const save = ' <a href="' + esc(url) + '" download>Save the clip as recorded</a>.';
+		if (phase === 'init')
+			return note('<strong>This recording’s header could not be prepared.</strong> ' +
+				esc((err && err.message) || 'the header could not be rewritten') +
+				'. Nothing was played.' + save, 'danger');
+		if (phase === 'nothing')
+			return note('<strong>Nothing in this recording could be decoded.</strong> ' +
+				'The header was accepted and no frame arrived, so either the key is not the one ' +
+				'it was sealed with or the file is damaged from the start.' + save, 'danger');
 		note('<strong>This recording stops being readable ' +
 			(err && err.at ? 'at byte ' + err.at : 'partway through') + '.</strong> ' +
 			esc((err && err.message) || 'a fragment could not be decrypted') +
-			'. Everything before that point played correctly. ' +
-			'<a href="' + esc(url) + '" download>Save the clip as recorded</a>.', 'danger');
+			'. What played before that point decoded correctly.' + save, 'danger');
 	}
 
 	// ---- opening a clip --------------------------------------------------
@@ -849,7 +861,7 @@
 		// and shows a black frame — and on some builds asks for a decryption
 		// module nobody here can answer. The reason this clip buffered nothing
 		// is worth more than another attempt at playing it.
-		if (state.xform) { badFragment(clip, url, new Error('nothing could be buffered')); return; }
+		if (state.xform) { badFragment(clip, url, new Error('nothing could be buffered'), 'nothing'); return; }
 		player.destroy();
 		player = null;
 		const video = $id('rec-video');
@@ -1768,6 +1780,7 @@
 		let at = init.firstMoof;
 		let n = 0;
 		let unknown = false;
+		let damaged = false;
 		if (btn) { btn.disabled = true; btn.textContent = 'Checking…'; }
 
 		read(0, init.headerLength - 1).then(function (head) {
@@ -1778,8 +1791,15 @@
 			if (state.clip !== clip) return;
 			note(verdict, verdict.indexOf('does not match') >= 0 ? 'danger'
 				: verdict.indexOf('cannot be checked') >= 0 ? 'warning' : 'success');
-		}).catch(function () {
+		}).catch(function (e) {
 			if (btn) { btn.disabled = false; btn.textContent = 'Check integrity'; }
+			if (state.clip !== clip) return;
+			// A read that failed, a card that went away mid-walk. Silence here
+			// reads as "checked, and fine" — the one thing that must never be
+			// inferred from a check that did not finish.
+			note('<strong>This recording could not be checked.</strong> ' +
+				esc((e && e.message) || 'the card stopped answering') +
+				'. Nothing is known about the rest of it either way.', 'warning');
 		});
 
 		function step() {
@@ -1787,8 +1807,15 @@
 			if (at + 16 > clip.size) return Promise.resolve(done());
 			return read(at, Math.min(at + 1024 * 1024, clip.size) - 1).then(function (buf) {
 				const f = IDX.parseFragment(buf);
-				if (!f || f.short || !f.total || at + f.total > clip.size)
-					return done();          // the tail of a clip still being written
+				// Two different tails, and only one of them is a camera doing
+				// its job. A fragment whose header is on the card and whose
+				// payload is not — a short read, or one that runs past the end
+				// — is a recording still being written. A run of bytes that is
+				// not a fragment at all is a file that stops making sense, and
+				// calling that "still recording" tells somebody their damaged
+				// clip is fine.
+				if (!f) { damaged = true; return done(); }
+				if (f.short || !f.total || at + f.total > clip.size) return done();
 				const whole = f.total <= buf.length
 					? Promise.resolve(buf.subarray(0, f.total))
 					: read(at, at + f.total - 1);
@@ -1816,7 +1843,12 @@
 			// that intact is the one verdict this button must never give by
 			// accident.
 			const whole = at === clip.size;
-			return 'Intact through ' + n + ' fragment' + (n === 1 ? '' : 's') +
+			const held = 'Intact through ' + n + ' fragment' + (n === 1 ? '' : 's');
+			if (damaged)
+				return held + ', and then the file stops making sense at byte ' + at +
+					'. Every record up to there covers the one before it; what follows is not a ' +
+					'fragment this page can read, so the rest cannot be checked.';
+			return held +
 				(whole ? '. Every fragment matches its own record, and each record covers the one before it.'
 					: ', and the rest has not been written yet — this clip is still recording.');
 		}

--- a/www/a/recordings.js
+++ b/www/a/recordings.js
@@ -19,6 +19,8 @@
 
 	const IDX = window.MajesticMp4Index;
 	const TL = window.MajesticTimeline;
+	const CRYPT = window.MajesticMp4Crypt;
+	const KEYS = window.MajesticRecKeys;
 	const DAY = TL.DAY;
 
 	// How much of the day the detail band shows, and the steps the zoom takes.
@@ -34,6 +36,10 @@
 		view: { from: 0, to: 3600, width: 3600 },
 		playhead: 0, sel: null,
 		clip: null, mime: null, init: null, hint: null,
+		// What the open clip's header said about protection, and what the page
+		// managed to do about it: `xform` is the pair of transforms the player
+		// and the exporter run bytes through, absent on a clip in the clear.
+		prot: null, xform: null,
 	};
 
 
@@ -350,7 +356,7 @@
 	// fills and recycles in days; a few years is generous), delete plainFallback
 	// and the watchdog below with it, and let a clip that will not append fail
 	// honestly.
-	function mkPlayer(video, onFallback) {
+	function mkPlayer(video, onFallback, onBadFragment) {
 		let ms = null, sb = null, objUrl = null;
 		let read = null, size = 0, headerLen = 0;
 		let cursor = 0, dead = false, busy = false, reset = false;
@@ -387,6 +393,16 @@
 			} catch (e) { /* nothing to drop */ }
 		}
 
+		// Applied to the init segment and to every fragment before either
+		// reaches the SourceBuffer. Absent on a clip in the clear, where this
+		// is the identity and the pump below is what it always was.
+		let xform = null;
+
+		function through(what, bytes) {
+			if (!xform || !xform[what]) return bytes;
+			return xform[what](bytes);
+		}
+
 		function fill() {
 			if (dead || !sb || sb.updating || busy) return;
 			if (reset) {
@@ -421,8 +437,23 @@
 					: read(at, at + f.total - 1);
 				return whole.then(function (bytes) {
 					if (dead || !sb) { busy = false; return; }
+					let out;
+					try {
+						out = through('fragment', bytes);
+					} catch (e) {
+						// A fragment that cannot be decrypted is not a read to
+						// retry: the same bytes will fail the same way, and
+						// timeupdate would drive this straight back here for
+						// the life of the clip — a spinner, a stream of range
+						// requests, and nothing in the console. Stop, and say
+						// so once.
+						busy = false;
+						dead = true;
+						onBadFragment(e, at);
+						return;
+					}
 					cursor = at + f.total;
-					try { sb.appendBuffer(bytes); } catch (e) { evict(); }
+					try { sb.appendBuffer(out); } catch (e) { evict(); }
 					busy = false;
 				});
 			}).catch(function () { busy = false; });
@@ -448,8 +479,9 @@
 		// here as well would issue a remove() for every quarter-second the
 		// playhead advanced.
 		return {
-			attach: function (url, initInfo, clipSize, mime) {
+			attach: function (url, initInfo, clipSize, mime, transforms) {
 				read = IDX.reader(url); size = clipSize;
+				xform = transforms || null;
 				headerLen = initInfo.headerLength; cursor = initInfo.firstMoof;
 				dead = false; busy = false; reset = false; want = null;
 				ms = new MediaSource();
@@ -460,7 +492,15 @@
 					sb.addEventListener('updateend', function () { evict(); fill(); });
 					read(0, headerLen - 1).then(function (head) {
 						if (dead || !sb) return;
-						try { sb.appendBuffer(head); } catch (e) { onFallback(); }
+						let out;
+						try {
+							out = through('init', head);
+						} catch (e) {
+							dead = true;
+							onBadFragment(e, 0);
+							return;
+						}
+						try { sb.appendBuffer(out); } catch (e) { onFallback(); }
 					});
 				}, { once: true });
 
@@ -477,7 +517,17 @@
 					if (dead) return;
 					let has = 0;
 					try { has = sb ? sb.buffered.length : 0; } catch (e) {}
-					if (!has) onFallback();
+					// The fallback hands the file to a bare element, which is
+					// the right answer for a recording written before tfdt and
+					// the wrong one for a sealed clip: the element gets bytes
+					// no decoder can read, and shows a black frame instead of
+					// the sentence explaining why. An encrypted clip that
+					// buffers nothing has a reason, and the reason is worth
+					// more than another attempt.
+					if (!has) {
+						if (xform) onBadFragment(new Error('nothing buffered'), 0);
+						else onFallback();
+					}
 				}, 5000);
 			},
 			// Whether the SourceBuffer ever accepted anything. The difference
@@ -518,6 +568,99 @@
 		};
 	}
 
+	// ---- sealed clips ----------------------------------------------------
+
+	// The lock panel: shown in the stage in place of a picture, because the
+	// transient note above the player is wiped by the next seek or card poll
+	// and a request for a passphrase has to survive both.
+	function lock(html) {
+		const el = $id('rec-lock');
+		if (!el) return;
+		el.innerHTML = html || '';
+		el.hidden = !html;
+		const stage = el.parentNode;
+		if (stage && stage.classList) stage.classList.toggle('rec-locked', !!html);
+	}
+
+	// One camera writes one key across a day, so the first clip's prompt
+	// covers every clip and seek after it. `done` is called with the clip's 48
+	// bytes, or with null when nothing on this device can open it — and null
+	// is an answer, not a failure: the lock panel has already said which.
+	function needKeys(clip, prot, done) {
+		if (!prot.keyBox) {
+			lock(lockNote('This recording is sealed and carries no key box, ' +
+				'so nothing can open it.', clip));
+			return done(null);
+		}
+		KEYS.needFor(prot.keyBox, {
+			clip: clip,
+			show: lock,
+			download: fileUrl(clipPath(clip.name)),
+			name: clip.name,
+		}).then(function (material) {
+			done(material || null);
+		});
+	}
+
+	function lockNote(sentence, clip) {
+		return '<div class="rec-lock-box"><div class="rec-lock-icon">🔒</div>' +
+			'<p>' + esc(sentence) + '</p>' +
+			'<a class="btn btn-sm btn-outline-secondary" download href="' +
+			esc(fileUrl(clipPath(clip.name))) + '">Save the clip as recorded</a></div>';
+	}
+
+	// What the player and the exporter run bytes through. The init segment is
+	// rewritten once and kept, since every fragment append reuses it.
+	function mkTransform(prot, material, headerLength) {
+		let clearHead = null;
+		return {
+			init: function (bytes) {
+				if (!clearHead) clearHead = CRYPT.clearInit(bytes, headerLength || bytes.length);
+				if (!clearHead) throw new Error('the header could not be prepared');
+				return clearHead;
+			},
+			fragment: function (bytes) {
+				return CRYPT.decryptFragment(bytes, material, prot.tracks);
+			},
+		};
+	}
+
+	function startPlaying(clip, url, init, mime, xform, atSec) {
+		const video = $id('rec-video');
+		if ('MediaSource' in window && MediaSource.isTypeSupported(mime)) {
+			player = mkPlayer(video,
+				function () { plainFallback(clip, url); },
+				function (err) { badFragment(clip, url, err); });
+			player.attach(url, init, clip.size, mime, xform);
+		} else if (xform) {
+			// No MediaSource and a sealed clip: the element cannot be handed
+			// the file, because the file is not playable media. Say so rather
+			// than showing a black frame.
+			note('<strong>This browser cannot play a sealed recording.</strong> ' +
+				'It has no Media Source support, so the clip cannot be decrypted as it plays. ' +
+				'Use Save decrypted, or open the page in another browser.', 'warning');
+		} else {
+			video.src = url;
+		}
+		positionAt(atSec || 0);
+		video.play().catch(function () { /* autoplay policy; controls remain */ });
+	}
+
+	// A fragment that would not decrypt. Not a read to retry — the same bytes
+	// fail the same way — so the player has already stopped, and this says
+	// which fragment and what was wrong with it. Playback of what is already
+	// buffered continues: the frames on screen decoded correctly, and taking
+	// them away proves nothing.
+	function badFragment(clip, url, err) {
+		if (state.clip !== clip) return;
+		setStatus('');
+		note('<strong>This recording stops being readable ' +
+			(err && err.at ? 'at byte ' + err.at : 'partway through') + '.</strong> ' +
+			esc((err && err.message) || 'a fragment could not be decrypted') +
+			'. Everything before that point played correctly. ' +
+			'<a href="' + esc(url) + '" download>Save the clip as recorded</a>.', 'danger');
+	}
+
 	// ---- opening a clip --------------------------------------------------
 
 	function openClip(clip, atSec) {
@@ -526,6 +669,9 @@
 		state.clip = clip;
 		state.init = null;
 		state.hint = null;
+		state.prot = null;
+		state.xform = null;
+		lock('');
 		const url = fileUrl(clipPath(clip.name));
 
 		if (player) { player.destroy(); player = null; }
@@ -533,14 +679,56 @@
 
 		const read = IDX.reader(url);
 		// 64 KiB is generous for ftyp + moov, so the codec probe and the init
-		// parse share one request.
+		// parse share one request. A sealed clip's header is larger — a
+		// protection scheme per track and the key box — but not by anything
+		// approaching this, and a header that does not fit says so below
+		// rather than being read as a file that is not an MP4.
 		read(0, 65535).then(function (head) {
 			if (state.clip !== clip) return;          // switched away mid-flight
 			const init = IDX.parseInit(head);
 			if (!init) throw new Error('not a fragmented MP4');
 			state.init = init;
 
-			const codec = codecFromHeader(head);
+			// What the header says about protection, before any key is asked
+			// for: the real codec, whether the samples are sealed, and whether
+			// this page understands how. All of it is in the clear, so a clip
+			// nothing here can open is still described accurately rather than
+			// refused as an unplayable codec.
+			const prot = CRYPT.inspect(head, init.headerLength);
+			state.prot = prot;
+			if (!prot.ok) {
+				setStatus('');
+				note('Could not read the header of <code>' + esc(clip.name) + '</code> — ' +
+					esc(prot.reason) + '. <a href="' + esc(url) + '" download>Save the clip</a> ' +
+					'and open it in a player that can.', 'danger');
+				return;
+			}
+			if (prot.reason) {
+				setStatus('');
+				note('<strong>' + esc(clip.name) + ' cannot be opened here.</strong> ' +
+					esc(prot.reason) + '. <a href="' + esc(url) + '" download>Save the clip</a>.',
+					'warning');
+				return;
+			}
+
+			// The rewritten header, which is what a decoder is given. Done
+			// before the key, because it needs none: the codec and its
+			// configuration sit in the clear beside the protection boxes. So a
+			// clip this browser cannot decode can still be offered as a file
+			// that plays elsewhere, even when nothing here can open it.
+			let clearHead = head;
+			if (prot.wrapped) {
+				const rebuilt = CRYPT.clearInit(head, init.headerLength);
+				if (!rebuilt) {
+					setStatus('');
+					note('<strong>' + esc(clip.name) + ' has a header this page cannot prepare.</strong> ' +
+						'<a href="' + esc(url) + '" download>Save the clip</a> and open it in VLC.', 'warning');
+					return;
+				}
+				clearHead = rebuilt;
+			}
+
+			const codec = codecFromHeader(clearHead);
 			const mime = 'video/mp4; codecs="' + (codec || 'avc1.42E01E') + '"';
 
 			// An unplayable codec does not raise `error` on a <video>: H.265
@@ -549,23 +737,48 @@
 			if (codec && !video.canPlayType(mime)) {
 				const family = /^(hvc1|hev1)/.test(codec) ? 'H.265 (HEVC)' : codec.split('.')[0];
 				setStatus('');
+				// "Save it and play it in VLC" is sound advice about a clip in
+				// the clear and false about a sealed one — the file that lands
+				// on disk opens in nothing. Where the page can decrypt, it
+				// offers the copy that does play.
 				note('<strong>' + family + ' — this browser cannot decode it.</strong> ' +
-					'Save the clip and play it in VLC, or record the main stream as H.264. ' +
+					(prot.encrypted
+						? 'The saved file is encrypted, so unlock it below and use Save decrypted. '
+						: 'Save the clip and play it in VLC, or record the main stream as H.264. ') +
 					'<a href="camera.cgi?tab=video0">Stream settings</a>', 'warning');
+				if (prot.encrypted) {
+					needKeys(clip, prot, function (material) {
+						if (state.clip !== clip || !material) return;
+						state.xform = mkTransform(prot, material, init.headerLength);
+						state.material = material;
+						lock('');
+						renderSelection();
+						sealedControls();
+					});
+				}
 				return;
 			}
 			note('');
 			state.mime = mime;
 			setStatus('');
 
-			if ('MediaSource' in window && MediaSource.isTypeSupported(mime)) {
-				player = mkPlayer(video, function () { plainFallback(clip, url); });
-				player.attach(url, init, clip.size, mime);
-			} else {
-				video.src = url;
+			if (!prot.encrypted) {
+				startPlaying(clip, url, init, mime, null, atSec);
+				return;
 			}
-			positionAt(atSec || 0);
-			video.play().catch(function () { /* autoplay policy; controls remain */ });
+
+			// Sealed: everything above happens whether or not a key turns up,
+			// and only this part waits for one.
+			setStatus('Locked — waiting for a key…');
+			needKeys(clip, prot, function (material) {
+				if (state.clip !== clip) return;
+				if (!material) return;                 // the lock panel explains
+				const xform = mkTransform(prot, material, init.headerLength);
+				state.xform = xform;
+				setStatus('');
+				lock('');
+				startPlaying(clip, url, init, mime, xform, atSec);
+			});
 
 			// Two reads to turn the clip list's estimate into a real length.
 			hintDuration(url, clip, init);
@@ -601,6 +814,22 @@
 			}).catch(function () { /* stay where we are */ });
 	}
 
+	// The body of an export is a run of whole fragments, and the span already
+	// knows where each one starts — so they are cut at those boundaries and
+	// decrypted one at a time rather than the whole buffer being handed to a
+	// parser again.
+	function decryptParts(parts, span, ranges) {
+		const head = state.xform.init(new Uint8Array(parts[0]));
+		const body = new Uint8Array(parts[1]);
+		const out = [head];
+		span.fragments.forEach(function (f) {
+			const at = f.off - ranges.body.start;
+			if (at < 0 || at + f.len > body.length) return;
+			out.push(state.xform.fragment(body.subarray(at, at + f.len)));
+		});
+		return out;
+	}
+
 	// DEPRECATED, REMOVE AFTER 2029-01 — see the note above mkPlayer.
 	//
 	// A recording with no tfdt cannot go through a SourceBuffer at all. Hand it
@@ -608,6 +837,11 @@
 	// just has to find its own way to a seek.
 	function plainFallback(clip, url) {
 		if (!player || state.clip !== clip) return;
+		// A bare element handed a sealed file gets bytes no decoder can read
+		// and shows a black frame — and on some builds asks for a decryption
+		// module nobody here can answer. The reason this clip buffered nothing
+		// is worth more than another attempt at playing it.
+		if (state.xform) { badFragment(clip, url, new Error('nothing could be buffered')); return; }
 		player.destroy();
 		player = null;
 		const video = $id('rec-video');
@@ -967,6 +1201,19 @@
 		});
 	}
 
+	// The two save buttons mean different things on a sealed clip, and saying
+	// so on the button is the only place it will be read. "As recorded" keeps
+	// the encryption and the integrity record and needs a key to open later;
+	// the selection export writes a file that plays anywhere and can no longer
+	// be checked against its own tags.
+	function sealedControls() {
+		const dl = $id('rec-dl');
+		if (dl) dl.textContent = state.prot && state.prot.encrypted
+			? 'Save whole clip (as recorded)' : 'Save whole clip';
+		const check = $id('rec-verify');
+		if (check) check.hidden = !(state.prot && state.prot.encrypted && state.xform);
+	}
+
 	function setStatus(t) {
 		const s = $id('rec-status');
 		if (s) s.textContent = t || '';
@@ -1302,6 +1549,11 @@
 				read(r.body.start, r.body.end - 1),
 			]).then(function (parts) { return { parts: parts, span: span, r: r }; });
 		}).then(function (o) {
+			// A sealed selection is saved decrypted, because the point of
+			// saving a cut is that it plays somewhere. The same transforms the
+			// player uses run over the two parts: the header once, then each
+			// fragment at the boundaries the span already recorded.
+			if (state.xform) o.parts = decryptParts(o.parts, o.span, o.r);
 			const blob = new Blob(o.parts, { type: 'video/mp4' });
 			const a = document.createElement('a');
 			a.href = URL.createObjectURL(blob);
@@ -1444,6 +1696,12 @@
 			// trouble. If data HAS buffered, the error is something else and
 			// throwing away a working player would only make it worse.
 			if (player && !player.hasData()) { plainFallback(state.clip, url); return; }
+			if (state.xform) {
+				note('Playback stopped on <code>' + esc(state.clip.name) + '</code>. ' +
+					'What played was decrypted correctly; the rest could not be. ' +
+					'<a href="' + esc(url) + '" download>Save the clip as recorded</a>.', 'danger');
+				return;
+			}
 			note('Playback stopped on <code>' + esc(state.clip.name) + '</code>. ' +
 				'<a href="' + esc(url) + '" download>Save the clip</a> instead.', 'danger');
 		});
@@ -1456,6 +1714,84 @@
 			a.download = state.clip.name;
 			document.body.appendChild(a); a.click(); a.remove();
 		});
+
+		// A whole clip is handed over as it is on the card — streamed by the
+		// browser, never assembled in this tab, which is what makes it safe
+		// for a recording of any length. On a sealed clip that means the file
+		// needs a key to open later, and the button says so rather than
+		// leaving somebody to find out.
+		const check = $id('rec-verify');
+		if (check) check.addEventListener('click', function () { verifyOpenClip(); });
+	}
+
+	// Walking the integrity chain. Forward from the start of the clip, because
+	// each fragment's tag covers the one before it — which is also why this is
+	// a deliberate action rather than something the player does as it seeks: a
+	// chain restarted in the middle proves nothing about what came before, and
+	// a page that implied otherwise would be worse than one that said nothing.
+	function verifyOpenClip() {
+		const clip = state.clip, init = state.init;
+		if (!clip || !init || !state.xform || !state.material) return;
+		const btn = $id('rec-verify');
+		const read = IDX.reader(fileUrl(clipPath(clip.name)));
+		const chain = CRYPT.chain(state.material);
+		let at = init.firstMoof;
+		let n = 0;
+		let unknown = false;
+		if (btn) { btn.disabled = true; btn.textContent = 'Checking…'; }
+
+		read(0, init.headerLength - 1).then(function (head) {
+			chain.genesis(head);
+			return step();
+		}).then(function (verdict) {
+			if (btn) { btn.disabled = false; btn.textContent = 'Check integrity'; }
+			if (state.clip !== clip) return;
+			note(verdict, verdict.indexOf('does not match') >= 0 ? 'danger'
+				: verdict.indexOf('cannot be checked') >= 0 ? 'warning' : 'success');
+		}).catch(function () {
+			if (btn) { btn.disabled = false; btn.textContent = 'Check integrity'; }
+		});
+
+		function step() {
+			if (state.clip !== clip) return Promise.resolve('');
+			if (at + 16 > clip.size) return Promise.resolve(done());
+			return read(at, Math.min(at + 1024 * 1024, clip.size) - 1).then(function (buf) {
+				const f = IDX.parseFragment(buf);
+				if (!f || f.short || !f.total || at + f.total > clip.size)
+					return done();          // the tail of a clip still being written
+				const whole = f.total <= buf.length
+					? Promise.resolve(buf.subarray(0, f.total))
+					: read(at, at + f.total - 1);
+				return whole.then(function (bytes) {
+					const r = chain.step(bytes);
+					if (r.unknown) { unknown = true; return done(); }
+					if (!r.ok) return broken(n + 1, at);
+					n++;
+					at += f.total;
+					if (btn) btn.textContent = 'Checking… ' + n;
+					return step();
+				});
+			});
+		}
+
+		function done() {
+			if (unknown)
+				return 'This recording carries no integrity record, so it cannot be checked. ' +
+					'Recordings written by older firmware are like this.';
+			// A clip still being written ends mid-fragment. That is the camera
+			// doing its job, and saying "the chain ends early" about it would
+			// accuse a working camera of something.
+			const whole = at + 16 > clip.size;
+			return 'Intact through ' + n + ' fragment' + (n === 1 ? '' : 's') +
+				(whole ? '. Every fragment matches its own record, and each record covers the one before it.'
+					: ', and the rest has not been written yet — this clip is still recording.');
+		}
+
+		function broken(index, off) {
+			return 'This recording <strong>does not match its own integrity record</strong> from ' +
+				'fragment ' + index + ' (byte ' + off + '). Everything before that point matches. ' +
+				'The file has been cut, edited, or damaged since the camera wrote it.';
+		}
 	}
 
 	function goDay(name) {
@@ -1740,6 +2076,10 @@
 	let wired = false;
 
 	function start() {
+		// The panel reads its own storage and paints itself; it does not wait
+		// for the card, and a camera with no recordings still has a key to
+		// manage.
+		if (KEYS && KEYS.ui) KEYS.ui.mount();
 		return Promise.all([loadConfig(), loadPulse()]).then(function () {
 			if (!state.prefix) {
 				return empty('<strong>Recording is not configured.</strong> No recording path is set, so there is nothing to browse. ',

--- a/www/cgi-bin/recordings.cgi
+++ b/www/cgi-bin/recordings.cgi
@@ -26,13 +26,19 @@
 		<div class="col-12 col-lg-8">
 			<div class="card"><div class="card-body">
 
+				<!-- The lock sits inside the stage, in place of the picture, and
+				     not in #rec-note above: the note is wiped by the next seek and
+				     by the card poll, and a question about a passphrase has to
+				     outlive both. -->
 				<div class="rec-stage">
 					<video id="rec-video" class="rec-video" controls playsinline preload="metadata"></video>
+					<div id="rec-lock" class="rec-lock" hidden></div>
 				</div>
 
 				<div class="d-flex flex-wrap align-items-center gap-2 mt-2">
 					<span class="small text-secondary" id="rec-status"></span>
-					<button class="btn btn-sm btn-outline-secondary ms-auto" id="rec-dl" type="button">Save whole clip</button>
+					<button class="btn btn-sm btn-outline-secondary ms-auto" id="rec-verify" type="button" hidden>Check integrity</button>
+					<button class="btn btn-sm btn-outline-secondary" id="rec-dl" type="button">Save whole clip</button>
 				</div>
 
 				<div class="rec-lbl mt-3">Whole day</div>
@@ -77,6 +83,22 @@
 		</div>
 	</div>
 
+	<!-- Collapsed by default: most cameras record in the clear and this is a
+	     card about keys they do not have. The recordings page opens it the
+	     first time a clip turns out to be sealed. -->
+	<div class="card mt-4" id="rec-keys"><div class="card-body">
+		<div class="d-flex flex-wrap align-items-center gap-2">
+			<% card_head "Encryption keys" "for recordings this camera sealed" %>
+			<span class="ms-auto" id="rec-keys-chip"></span>
+			<button class="btn btn-sm btn-outline-secondary" type="button"
+				data-bs-toggle="collapse" data-bs-target="#rec-keys-wrap">Show</button>
+		</div>
+		<div class="collapse" id="rec-keys-wrap">
+			<div class="mt-3" id="rec-keys-body"></div>
+			<div class="d-none" id="rec-keys-say"></div>
+		</div>
+	</div></div>
+
 	<div class="card mt-4" id="rec-storage-card" hidden><div class="card-body">
 		<div id="rec-storage"></div>
 	</div></div>
@@ -85,6 +107,9 @@
 
 <script src="/a/timeline.js"></script>
 <script src="/a/mp4index.js"></script>
+<script src="/a/mjcrypto.js"></script>
+<script src="/a/mp4crypt.js"></script>
+<script src="/a/reckeys.js"></script>
 <script src="/a/recordings.js" defer></script>
 
 <%in p/footer.cgi %>


### PR DESCRIPTION
Closes OpenIPC/majestic-webui#352, on top of #360's machinery.

The Recordings page could list an encrypted recording and do nothing else with it. Its sample entries name a codec no decoder implements, so the probe refused it as unplayable — and the advice on screen, *save it and open it in VLC*, was false: the file that lands on disk opens in nothing either.

## What the page does now

- **Plays it.** The header is read, rewritten into one a decoder accepts (`encv` → the codec it hides, protection boxes dropped, sizes recomputed), and every fragment is decrypted on its way to the SourceBuffer. The rewrite happens **before any key is asked for**, which is what lets a browser that cannot decode the codec still offer a file that plays elsewhere — the codec and its configuration sit in the clear beside the protection boxes.
- **Asks for the key once.** One camera writes one key across a day, so the first clip's prompt covers every clip and seek after it. The prompt lives inside the stage, over the picture, and deliberately not in the note bar above it: that bar is wiped by the next seek and by the card poll, and a question about a passphrase has to outlive both.
- **Says which kind of "no" it is.** A chip-bound clip can only be opened by the camera that recorded it — no browser, on any machine, ever — and says so with what to change so the next recording can be opened here. A clip sealed to a different key names both fingerprints. A wrong passphrase says the passphrase is wrong, not that something failed.
- **Two save buttons that mean different things, said on the buttons.** The whole clip goes as it is on the card — still sealed, still carrying its integrity record, streamed by the browser so a recording of any length is safe to take. A selected cut is decrypted on the way out, because the point of saving a cut is that it plays somewhere.
- **Checks integrity on demand.** Forward from the start of the clip, because each fragment's tag covers the one before it — a chain restarted mid-file proves nothing about what came before, which is also why this is a button and not something the player does as it seeks. A clip still being written ends mid-fragment, and that is the camera doing its job: it says so rather than reporting a truncation.
- **Manages the key.** A card on the same page: generate (where the browser will make keys — a secure context, which a plain-http camera is not), or the two `openssl` commands and a file picker where it will not; unlock once per visit; download the backup; publish the public half to the camera. The setting is written **only when the camera's own schema declares it** — writing a key into a configuration the daemon ignores and reporting success is exactly the confident-sentence-with-nothing-behind-it this repo's checklist is about.
- **Masks a secret in the settings form.** The schema marks one; the form rendered it in the clear. The reveal toggle is wired to the field itself, because the one in `main.js` runs once at page load and this form is built long afterwards.

## Three paths that used to end at a bare `<video>`

The five-second watchdog, the fallback for recordings written before `tfdt`, and the element's own error handler. Each would hand a sealed file to a decoder that cannot read it — a black frame, and on some builds a prompt for a decryption module nobody here can answer. All three are gated on whether the clip is sealed and say what happened instead.

## Tests

One new case, and it is about the **wiring** rather than the format, which has its own suite from #360. A transform applied to the fragments but not the header gives the decoder an initialisation segment naming a codec nothing implements; one applied to the header but not the fragments gives it ciphertext. Neither raises anything, both are a black frame and a page that looks like it is still loading. The stub marks every buffer, so an append that skipped a transform is visible rather than merely wrong-looking.

`mp4crypt` gained two cases from a narrowing this branch forced: a `moov` whose tracks the walk cannot take apart is not the same as a header nobody saw. The bytes are there, so the question is asked directly — no protection box anywhere inside them is a *finding*, and refusing such a clip would refuse a recording that plays today.

`npm test` green, `lint-templates` green, and the purged Bootstrap subset is unchanged (every class the panel uses was already in it).

## Not verified on a camera yet

This is the part I cannot do from here. What needs a card, over plain http, in a browser where `crypto.subtle` is undefined: a passphrase clip plays and seeks and exports; a `pubkey` clip plays with an imported key and asks again after a reload; a chip clip says why it cannot be opened; a flipped byte on the card is named by fragment; and a plain clip still behaves exactly as it does today. The decrypt timings go in a comment when they exist.
