### PR TITLE
Notices: the severity mark joins the cluster it was left out of (#347)

### DIFF
--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -107,9 +107,10 @@ check('and the close button is out of the flow to sit in it',
 
 // The mark, the actions and the close are one cluster: whatever alignment a
 // notice's shape calls for, all three take it. The mark was left behind exactly
-// once — it stayed on the first line when the other two were centred, and the
-// reporter of #347 is who noticed, not us. So it is centred by default and both
-// exceptions that put the others back on the first line have to name it too.
+// once, staying on the first line when the other two were centred (#347), and
+// nothing said so — a mark hanging above the controls it belongs with renders
+// perfectly. So it is centred by default and both exceptions that put the
+// others back on the first line have to name it too.
 check('the mark is centred with the controls opposite it',
 	/\.mj-notice-ico\s*\{[^}]*align-self:\s*center/.test(css),
 	'the mark hangs at the top while the actions and the close are centred');
@@ -316,9 +317,8 @@ groups.forEach((g) => {
 				? where + '\n    acts on the camera without the class that asks first'
 				: where + '\n    navigation wearing the class main.js hangs confirm() off');
 
-		// An arrow said what the button shape already says. Dropped at the
-		// reporter's request, and pinned so it cannot creep back one banner at
-		// a time.
+		// An arrow said what the button shape already says, so it went (#347).
+		// Pinned so it cannot creep back one banner at a time.
 		check('"' + text + '" carries no arrow', !/(&rarr;|→)$/.test(text), where);
 	}
 });

--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -105,6 +105,18 @@ check('and the close button is out of the flow to sit in it',
 	/\.mj-notice > \.btn-close \{[^}]*position: absolute/.test(css),
 	'a close button back in the flow pushes the actions left again');
 
+// The mark, the actions and the close are one cluster: whatever alignment a
+// notice's shape calls for, all three take it. The mark was left behind exactly
+// once — it stayed on the first line when the other two were centred, and the
+// reporter of #347 is who noticed, not us. So it is centred by default and both
+// exceptions that put the others back on the first line have to name it too.
+check('the mark is centred with the controls opposite it',
+	/\.mj-notice-ico\s*\{[^}]*align-self:\s*center/.test(css),
+	'the mark hangs at the top while the actions and the close are centred');
+check('and follows them back to the first line in both exceptions',
+	(css.match(/\.mj-notice-ico\s*\{[^}]*align-self:\s*flex-start/g) || []).length === 2,
+	'a body row and a narrow screen each move all three, or none of them');
+
 const full = mjNotice('warn', 'sentence', {
 	body: 'body', acts: '<a href="#">Go</a>', dismiss: true,
 });

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3391,18 +3391,31 @@ mark {
 	box-shadow: var(--bs-box-shadow-sm);
 }
 
-/* Sized against the close button opposite it, not by eye. A glyph paints a
-   good deal smaller than its em box, so at the inherited 1rem the warning mark
-   was 13x12px of ink while .btn-close paints 16x16 — the severity indicator
-   was the smallest thing in the row and the way out was the biggest, which is
-   exactly backwards (#273). An SVG paints the box it is given, so this is
-   18x18 and stays 18x18; the nudge is optical alignment against a 21px first
-   line. */
+/* Sized against the close button opposite it, not by eye. A glyph paints a good
+   deal smaller than its em box, so at the inherited 1rem the warning mark was
+   13x12px of ink while .btn-close paints 16x16 — the severity indicator was the
+   smallest thing in the row and the way out was the biggest, which is exactly
+   backwards (#273). An SVG paints the box it is given, so this is a stated size
+   and stays it.
+
+   28px rather than the 18px that first fixed #273, at the reporter's ask
+   (#347). It is the one thing in the row that says what KIND of notice this is
+   before a word is read, and 18px left it the quietest mark on a card. 28 is
+   the largest that changes nothing else: a one-line notice is 31px of content
+   tall, set by the button beside it, so the mark grows into room that was
+   already there — at 36px every banner in the page gets taller to carry it.
+   The stroke is 1.8 of a 24 viewBox and so thickens with the box, which is why
+   this reads as a bolder mark and not just a bigger one.
+
+   Centred, like the two controls opposite it, so all three things that are not
+   the sentence sit on one line through the notice. It was aligned to the first
+   line when everything else was, and stayed there when the actions and the
+   close were centred, which left it the only thing still hanging at the top. */
 .mj-notice-ico {
 	flex: 0 0 auto;
-	width: 18px;
-	height: 18px;
-	margin-top: 0.1rem;
+	width: 28px;
+	height: 28px;
+	align-self: center;
 	color: var(--bs-secondary-color);
 }
 
@@ -3493,8 +3506,17 @@ mark {
    whether the list is open or shut, which is the point. A browser without
    :has() centres them, which is the request as asked and no worse than any
    other notice gets. */
-.mj-notice:has(.mj-notice-body) > .mj-notice-acts {
+.mj-notice:has(.mj-notice-body) > .mj-notice-acts,
+.mj-notice:has(.mj-notice-body) > .mj-notice-ico {
 	align-self: flex-start;
+}
+
+/* The mark is taller than the line it is marking — 28px against 21px — so
+   top-aligning it drops its middle 3.5px below the middle of the first line.
+   Pulling it back up is what makes it read as pointing at that line rather
+   than as sitting slightly low; there is 9.6px of padding above it to spend. */
+.mj-notice:has(.mj-notice-body) > .mj-notice-ico {
+	margin-top: -0.2rem;
 }
 
 .mj-notice:has(.mj-notice-body) > .btn-close {
@@ -3538,14 +3560,21 @@ mark {
 		justify-content: flex-end;
 	}
 
-	/* Back to the corner. Centring the x against the notice is right while it
-	   stands beside the button on one row; here the actions have taken a row of
-	   their own below the sentence, so the middle of the box is a third of the
-	   way down the text — the x landed over the sentence it was meant to sit
-	   clear of. */
+	/* Back to the corner, and the mark back to the first line with it. Centring
+	   either against the notice is right while they stand on one row with the
+	   sentence; here the actions have taken a row of their own below it, so the
+	   middle of the box is a third of the way down the text — the x landed over
+	   the sentence it was meant to sit clear of, and a centred mark would point
+	   at the middle of a paragraph instead of at its first line. The reporter of
+	   #347 asked for the centring on desktop only for exactly this reason. */
 	.mj-notice > .btn-close {
 		top: calc(0.6rem + 0.15rem);
 		transform: none;
+	}
+
+	.mj-notice-ico {
+		align-self: flex-start;
+		margin-top: -0.2rem;
 	}
 }
 

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3398,9 +3398,9 @@ mark {
    backwards (#273). An SVG paints the box it is given, so this is a stated size
    and stays it.
 
-   28px rather than the 18px that first fixed #273, at the reporter's ask
-   (#347). It is the one thing in the row that says what KIND of notice this is
-   before a word is read, and 18px left it the quietest mark on a card. 28 is
+   28px rather than the 18px that first fixed #273 (#347). It is the one thing
+   in the row that says what KIND of notice this is before a word is read, and
+   18px left it the quietest mark on a card. 28 is
    the largest that changes nothing else: a one-line notice is 31px of content
    tall, set by the button beside it, so the mark grows into room that was
    already there — at 36px every banner in the page gets taller to carry it.
@@ -3470,10 +3470,11 @@ mark {
 	display: flex;
 	align-items: center;
 	/* Centred against the whole notice, which on one or two lines is what the
-	   eye expects of a control beside a sentence (#347). The BOX stays
-	   flex-start, so the severity mark keeps its place against the first line
-	   whatever the sentence does — they are different items and only one of
-	   them is annotating the first word. */
+	   eye expects of a control beside a sentence (#347). Per item rather than
+	   on the box, because the sentence must not be centred with it: the text
+	   column is the thing that grows, and centring it would leave a short
+	   notice's body row floating away from the sentence it belongs under. The
+	   mark opposite is centred by its own rule for the same reason. */
 	align-self: center;
 	gap: 0.5rem;
 	margin-left: auto;
@@ -3565,8 +3566,8 @@ mark {
 	   sentence; here the actions have taken a row of their own below it, so the
 	   middle of the box is a third of the way down the text — the x landed over
 	   the sentence it was meant to sit clear of, and a centred mark would point
-	   at the middle of a paragraph instead of at its first line. The reporter of
-	   #347 asked for the centring on desktop only for exactly this reason. */
+	   at the middle of a paragraph instead of at its first line. Which is why
+	   the centring is a desktop rule and not a rule (#347). */
 	.mj-notice > .btn-close {
 		top: calc(0.6rem + 0.15rem);
 		transform: none;

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -326,9 +326,8 @@ log_create() {
 # EVERY action is a button, and the colour says what pressing it costs (#347).
 # A notice is read the way a system dialog is -- a sentence, a way out in the
 # corner, and the thing to press -- so the thing to press is shaped like one.
-# The reporter of #347 put it plainly after seeing the alternative: a bare link
-# among banners of buttons is the odd one out, and an arrow after it says only
-# what the underline already said.
+# A bare link among banners of buttons is the odd one out, and an arrow after it
+# says only what the underline already said (#347).
 #
 #   btn-primary    go to the page that fixes this
 #   btn-secondary  a second, diagnostic destination beside a primary
@@ -856,10 +855,9 @@ update_caminfo() {
 	# different wire), or "motor" (a motor profile in ptz_profile or the
 	# legacy ptz value). An explicit method is trusted but still needs its
 	# binary — a pad whose every press fails is worse than no pad. Unset
-	# means no PTZ, exactly like "none": the reporter of #227 ruled that a
-	# camera without ptz_control shows no pad, so the old auto-detection
-	# from gpio_motors/ptz alone is gone and a field camera configured that
-	# way must set ptz_control once.
+	# means no PTZ, exactly like "none" (#227): a camera without ptz_control
+	# shows no pad, so the old auto-detection from gpio_motors/ptz alone is
+	# gone and a field camera configured that way must set ptz_control once.
 	# The backend decides which pad p/motor.cgi draws — gpio and motor are
 	# stepped eight-way pan/tilt, the Pelco variants are four directions in
 	# timed pulses plus zoom and focus.


### PR DESCRIPTION
Fixes #347 — the fourth and (I hope) last round, after #350, #357 and #362.

@usa- pointed out that centring the actions and the close left the severity mark as the only thing in the notice still hanging at the top, and asked for it to be centred on desktop only, and made 1.5–2× larger.

## One cluster, one alignment

The mark, the button and the × are the three things in a notice that are not the sentence. Whatever alignment the notice's shape calls for, all three should take it — the mark was simply left out when the other two were centred, and the reporter noticed rather than us.

So it is centred, and it follows the other two back to the first line in both places they go there:

- **A notice with a body row**, where the text column is content that can grow, and the mark should point at the sentence rather than at the middle of a paragraph.
- **Below sm**, where the actions take a row of their own and the middle of the box is a third of the way down the text. This is exactly why the request was "on desktop only".

## 18px → 28px

1.56×, inside the 1.5–2× asked for, and the largest that changes nothing else. A one-line notice is 31px of content tall, set by the button beside it, so the mark grows into room that was already there:

```
mark   one-line banner height
18px          52px
27px          52px
28px          52px      ← this branch
32px          53px
36px          57px
```

Five pixels on every banner on every page, and these stack — that is the only reason I did not go to the top of the range. **Say so and it goes to 36px; it is one number.**

The 18px it replaces was sized against `.btn-close` in #273, on the argument that a severity indicator smaller than the way out is backwards. This is more of that argument, not less: the mark is the one thing in the row that says what *kind* of notice this is before a word is read. The stroke is 1.8 of a 24 viewBox and thickens with the box, so it reads as a bolder mark and not only a bigger one.

The optical nudge flips from `+0.1rem` to `-0.2rem` and is doing the opposite job — at 18px the mark was shorter than the 21px first line and was pushed down onto it; at 28px it is taller and has to be pulled up. Measured against the middle of the first line, the old pairing sat **4.7px high**; this one lands within **0.3px**.

## Test

`tests/notice.test.js` pins the *cluster*, not the numbers: the mark is centred by default, and both exceptions that move the other two name it as well. Losing an arm is precisely the defect this PR fixes, and it renders perfectly when it happens. Verified by deleting the narrow-width arm — the check fails and names the invariant that went.

## Verification

Full suite green (28 files), template lint clean, `bootstrap.min.css` reproduces unchanged. Rendered at 1300px in both themes and at 390px, at 18/27/28/32/36, against the built tree served over loopback rather than on the shared lab board.
