### PR TITLE
Recordings: take the protection boxes out with the protection

### DIFF
--- a/tests/mp4crypt.test.js
+++ b/tests/mp4crypt.test.js
@@ -547,29 +547,82 @@ group('decrypting a fragment');
 (function roundTrip() {
 	const p = CRYPT.inspect(u8(init), init.length);
 	const f = fragment();
-	const got = CRYPT.decryptFragment(u8(f.bytes), MATERIAL, p.tracks);
-	check('a fragment decrypts to exactly what was recorded',
-		hex(got) === hex(f.plainBytes));
+	const got = Buffer.from(CRYPT.decryptFragment(u8(f.bytes), MATERIAL, p.tracks));
 
-	// The trap. A multi-NAL sample's protected runs are one keystream; the
-	// clear five bytes between them do not advance it, and the runs are not
-	// multiples of the block size. Decrypting each run from its own counter
-	// gets the first one right — a picture, with the rest of the frame wrong.
-	const first = f.video ? 0 : 0;
-	check('including every NAL of a multi-NAL frame, not just the first',
-		hex(Buffer.from(got).subarray(f.payloadAt, f.payloadAt + 600)) ===
+	// The output is not the input with its samples swapped: the boxes that
+	// described the protection come out with it, because a browser reads them,
+	// finds them on a track that is no longer protected, and refuses the whole
+	// fragment. So the payload moves, and three numbers move with it.
+	check('the boxes describing the protection are gone',
+		got.indexOf(Buffer.from('senc', 'ascii')) < 0 &&
+		got.indexOf(Buffer.from('saiz', 'ascii')) < 0 &&
+		got.indexOf(Buffer.from('saio', 'ascii')) < 0);
+	check('and the integrity tag is not — it describes the recording, not the protection',
+		got.indexOf(INTEGRITY_UUID) > 0);
+
+	const moofLen = got.readUInt32BE(0);
+	check('the moof says how long it now is',
+		got.toString('ascii', 4, 8) === 'moof' && moofLen < f.moofLen);
+	check('and the mdat behind it is untouched in length',
+		got.toString('ascii', moofLen + 4, moofLen + 8) === 'mdat' &&
+		got.readUInt32BE(moofLen) === f.bytes.readUInt32BE(f.moofLen));
+
+	// Every container's size still equals what it holds, walked by a checker
+	// that shares no code with the rewriter.
+	const bad = [];
+	walkFragmentSizes(got, bad);
+	check('every box in the rebuilt moof is as long as its contents', bad.length === 0, bad.join(', '));
+
+	// The one that decides whether a picture decodes: the payload starts
+	// exactly where the trun says it does, and holds what was recorded.
+	const trunAt = got.indexOf(Buffer.from('trun', 'ascii'));
+	const dataOffset = got.readUInt32BE(trunAt + 12);
+	check('the sample offset moved with the moof, exactly',
+		dataOffset === f.payloadAt - (f.moofLen - moofLen),
+		'data_offset ' + dataOffset + ', moof shrank by ' + (f.moofLen - moofLen));
+	check('and the bytes at that offset are what the camera recorded',
+		hex(got.subarray(dataOffset, dataOffset + 600)) ===
 		hex(f.plainBytes.subarray(f.payloadAt, f.payloadAt + 600)));
 
 	// Audio has no subsample list: the whole sample is protected. Applying the
 	// video rule to it would corrupt every audio sample and produce noise at
 	// full volume rather than silence.
-	const audioAt = f.bytes.length - 320;
-	check('and the audio samples, which are protected whole',
-		hex(Buffer.from(got).subarray(audioAt)) === hex(f.plainBytes.subarray(audioAt)));
+	const tail = 320;
+	check('including the audio samples, which are protected whole',
+		hex(got.subarray(got.length - tail)) === hex(f.plainBytes.subarray(f.plainBytes.length - tail)));
 
-	check('twice over is the original again — CTR is its own inverse',
-		hex(CRYPT.decryptFragment(got, MATERIAL, p.tracks)) === hex(f.bytes));
+	// And the whole payload, not just its ends.
+	const payloadLen = f.plainBytes.length - f.payloadAt;
+	check('and every byte of the payload in between',
+		hex(got.subarray(dataOffset, dataOffset + payloadLen)) ===
+		hex(f.plainBytes.subarray(f.payloadAt)));
 })();
+
+// The size of every container in a fragment, checked independently.
+function walkFragmentSizes(b, bad) {
+	const moofLen = b.readUInt32BE(0);
+	let sum = 8;
+	let at = 8;
+	while (at + 8 <= moofLen) {
+		const size = b.readUInt32BE(at);
+		const type = b.toString('ascii', at + 4, at + 8);
+		if (size < 8 || at + size > moofLen) { bad.push(type + ' size ' + size); return; }
+		if (type === 'traf') {
+			let inner = 8;
+			let k = at + 8;
+			while (k + 8 <= at + size) {
+				const ks = b.readUInt32BE(k);
+				if (ks < 8) { bad.push('traf child size ' + ks); return; }
+				inner += ks;
+				k += ks;
+			}
+			if (inner !== size) bad.push('traf says ' + size + ', holds ' + inner);
+		}
+		sum += size;
+		at += size;
+	}
+	if (sum !== moofLen) bad.push('moof says ' + moofLen + ', holds ' + sum);
+}
 
 (function refusals() {
 	const p = CRYPT.inspect(u8(init), init.length);

--- a/tests/mp4crypt.test.js
+++ b/tests/mp4crypt.test.js
@@ -598,6 +598,79 @@ group('decrypting a fragment');
 		hex(f.plainBytes.subarray(f.payloadAt)));
 })();
 
+// A protected track and a clear one in the same fragment. They share the mdat,
+// so anything removed from either traf moves BOTH tracks' samples — and a
+// clear traf loses nothing, which is exactly why its offset is the one that
+// gets forgotten. Its samples then read from wherever the protected track's
+// used to start, and decode as pictures made of somebody else's bytes.
+(function clearTrackBeside() {
+	const p = CRYPT.inspect(u8(init), init.length);
+	const tracks = { 1: p.tracks[1], 9: { id: 9, kind: 'avc1', format: 'avc1', protected: false } };
+
+	const video = [{ plain: videoSample([300, 60], 0x20).bytes, subs: videoSample([300, 60], 0x20).subs, iv: ivFor(1) }];
+	const clear = Buffer.alloc(200, 0x33);
+
+	function build(protBase, clearBase) {
+		return box('moof',
+			box('mfhd', u32(0, 7)),
+			traf(1, [{ bytes: video[0].plain, subs: video[0].subs, iv: video[0].iv }], true, protBase),
+			// A traf with no senc at all: the track is not protected.
+			box('traf', box('tfhd', u32(0x020030, 9, clear.length, 0)),
+				box('trun', u32(0x000201, 1, clearBase), u32(clear.length))));
+	}
+	const probe = build(0, 0);
+	const payloadAt = probe.length + 8;
+	const moof = build(payloadAt, payloadAt + video[0].plain.length);
+	const enc = encryptSample(video[0].plain, video[0].subs, video[0].iv);
+	const frag = Buffer.concat([moof, box('mdat', Buffer.concat([enc, clear]))]);
+
+	const got = Buffer.from(CRYPT.decryptFragment(u8(frag), MATERIAL, tracks));
+	const moofLen = got.readUInt32BE(0);
+	const shrank = moof.length - moofLen;
+	check('the fragment shrank when the protected track lost its boxes', shrank > 0);
+
+	// Both offsets, read back out of the rebuilt trafs.
+	const offsets = [];
+	let at = 8;
+	while (at + 8 <= moofLen) {
+		const size = got.readUInt32BE(at);
+		if (got.toString('ascii', at + 4, at + 8) === 'traf') {
+			const t = got.indexOf(Buffer.from('trun', 'ascii'), at);
+			offsets.push(got.readUInt32BE(t + 12));
+		}
+		at += size;
+	}
+	check('both tracks moved by exactly what came out of the fragment',
+		offsets.length === 2 &&
+		offsets[0] === payloadAt - shrank &&
+		offsets[1] === payloadAt + video[0].plain.length - shrank,
+		offsets.join(',') + ' vs ' + (payloadAt - shrank) + ',' +
+		(payloadAt + video[0].plain.length - shrank));
+
+	check('the protected track decrypted where it now says it is',
+		hex(got.subarray(offsets[0], offsets[0] + video[0].plain.length)) === hex(video[0].plain));
+	check('and the clear track is still its own bytes, untouched',
+		hex(got.subarray(offsets[1], offsets[1] + clear.length)) === hex(clear));
+})();
+
+// Decryption happens before the boxes come out, so a moof this cannot rebuild
+// has already had its samples decrypted. Handing that back — decrypted samples
+// still wearing their protection boxes — is the exact state a browser refuses
+// without saying why, so it is refused here instead.
+(function malformedAfterDecrypt() {
+	const p = CRYPT.inspect(u8(init), init.length);
+	const whole = fragment();
+	const bent = Buffer.from(whole.bytes);
+	// A child box after the ones decryption needs, with a length that runs
+	// past its parent.
+	const saioAt = bent.indexOf(Buffer.from('saio', 'ascii'));
+	bent.writeUInt32BE(0x0fffffff, saioAt - 4);
+	let code = null;
+	try { CRYPT.decryptFragment(u8(bent), MATERIAL, p.tracks); } catch (e) { code = e.code; }
+	check('a moof that cannot be rebuilt is refused, not handed back half-done',
+		code === 'bad-traf' || code === 'bad-moof', 'got ' + code);
+})();
+
 // The size of every container in a fragment, checked independently.
 function walkFragmentSizes(b, bad) {
 	const moofLen = b.readUInt32BE(0);

--- a/www/a/mp4crypt.js
+++ b/www/a/mp4crypt.js
@@ -552,12 +552,24 @@ window.MajesticMp4Crypt = (function () {
 	}
 
 	// A copy of `bytes` — one moof and its mdat — with every protected sample
-	// decrypted. `tracks` is what inspect() returned.
+	// decrypted, and with the boxes that described the protection removed.
 	//
 	// The keystream runs continuously across one sample's protected runs, so a
 	// sample's runs are decrypted as one stream and never restarted per run: a
 	// per-run counter still decodes the first NAL of a frame, which means a
 	// picture appears and only the detail is wrong.
+	//
+	// WHY THE AUXILIARY BOXES GO. `senc`, `saiz` and `saio` describe how the
+	// samples were protected, and they were left in place at first on the
+	// reasoning that a track whose sample entry is no longer protected has no
+	// use for them. A browser disagrees: Chromium's parser reads them, finds
+	// them on a track with no protection scheme, and refuses the whole
+	// fragment — appendBuffer raises an error event and nothing plays, while
+	// ffmpeg reads the same bytes without complaint. So they are removed, and
+	// removing them means moving the payload: `trun.data_offset` counts from
+	// the start of the moof, so it shrinks with the moof, and the traf and
+	// moof sizes shrink with what came out of them. Three numbers, and being
+	// wrong about any of them puts the decoder four bytes into a picture.
 	function decryptFragment(bytes, material, tracks) {
 		const src = C.bytes(bytes);
 		if (src.length < 16) throw fail('short-fragment');
@@ -579,6 +591,75 @@ window.MajesticMp4Crypt = (function () {
 				decryptTraf(src, out, at, at + size, moofSize, mdatSize, key, tracks);
 			at += size;
 		}
+		return stripAux(out, moofSize, mdatSize);
+	}
+
+	// The boxes that said how the samples were protected, taken out of a
+	// fragment whose samples no longer are.
+	const AUX = { senc: 1, saiz: 1, saio: 1 };
+
+	function stripAux(frag, moofSize, mdatSize) {
+		// How much comes out, per traf and in total, before anything moves.
+		let removed = 0;
+		const trafs = [];
+		let at = 8;
+		while (at + 8 <= moofSize) {
+			const size = be32(frag, at);
+			if (size < 8 || at + size > moofSize) return frag;   // already refused above
+			if (fourcc(frag, at + 4) === 'traf') {
+				let drop = 0;
+				let k = at + 8;
+				while (k + 8 <= at + size) {
+					const ksize = be32(frag, k);
+					if (ksize < 8 || k + ksize > at + size) return frag;
+					if (AUX[fourcc(frag, k + 4)]) drop += ksize;
+					k += ksize;
+				}
+				trafs.push({ at: at, size: size, drop: drop });
+				removed += drop;
+			}
+			at += size;
+		}
+		if (!removed) return frag;
+
+		const out = new Uint8Array(frag.length - removed);
+		let w = 0;
+		// moof header, then each box, with trafs rebuilt as they are copied.
+		out.set(frag.subarray(0, 8), w); w += 8;
+		at = 8;
+		while (at + 8 <= moofSize) {
+			const size = be32(frag, at);
+			const type = fourcc(frag, at + 4);
+			const traf = trafs.find(function (t) { return t.at === at; });
+			if (type !== 'traf' || !traf || !traf.drop) {
+				out.set(frag.subarray(at, at + size), w);
+				w += size;
+				at += size;
+				continue;
+			}
+			const trafStart = w;
+			out.set(frag.subarray(at, at + 8), w); w += 8;
+			let k = at + 8;
+			while (k + 8 <= at + size) {
+				const ksize = be32(frag, k);
+				const ktype = fourcc(frag, k + 4);
+				if (AUX[ktype]) { k += ksize; continue; }
+				const kAt = w;
+				out.set(frag.subarray(k, k + ksize), w);
+				w += ksize;
+				// The payload starts `removed` bytes earlier than it did, and
+				// this offset counts from the front of the moof.
+				if (ktype === 'trun') {
+					const flags = be32(out, kAt + 8) & 0xffffff;
+					if (flags & 0x000001) put32(out, kAt + 16, (be32(out, kAt + 16) - removed) >>> 0);
+				}
+				k += ksize;
+			}
+			put32(out, trafStart, w - trafStart);
+			at += size;
+		}
+		put32(out, 0, w);                                   // the moof's own size
+		out.set(frag.subarray(moofSize, moofSize + mdatSize), w);
 		return out;
 	}
 

--- a/www/a/mp4crypt.js
+++ b/www/a/mp4crypt.js
@@ -599,39 +599,43 @@ window.MajesticMp4Crypt = (function () {
 	const AUX = { senc: 1, saiz: 1, saio: 1 };
 
 	function stripAux(frag, moofSize, mdatSize) {
-		// How much comes out, per traf and in total, before anything moves.
+		// How much comes out, before anything moves. A malformed child here is
+		// a refusal and not a reason to hand back what arrived: the samples
+		// have already been decrypted by this point, so returning the original
+		// buffer would produce exactly the thing this function exists to
+		// prevent — decrypted samples still wearing their protection boxes,
+		// which is the state a browser refuses without saying why.
 		let removed = 0;
-		const trafs = [];
 		let at = 8;
 		while (at + 8 <= moofSize) {
 			const size = be32(frag, at);
-			if (size < 8 || at + size > moofSize) return frag;   // already refused above
+			if (size < 8 || at + size > moofSize) throw fail('bad-moof');
 			if (fourcc(frag, at + 4) === 'traf') {
-				let drop = 0;
 				let k = at + 8;
 				while (k + 8 <= at + size) {
 					const ksize = be32(frag, k);
-					if (ksize < 8 || k + ksize > at + size) return frag;
-					if (AUX[fourcc(frag, k + 4)]) drop += ksize;
+					if (ksize < 8 || k + ksize > at + size) throw fail('bad-traf');
+					if (AUX[fourcc(frag, k + 4)]) removed += ksize;
 					k += ksize;
 				}
-				trafs.push({ at: at, size: size, drop: drop });
-				removed += drop;
 			}
 			at += size;
 		}
 		if (!removed) return frag;
 
+		// EVERY traf is rewritten, not only the ones that lost something. The
+		// mdat is shared: it moves earlier by the total removed from the whole
+		// moof, so a clear track sitting beside a protected one — which this
+		// module explicitly allows — would keep an offset pointing past its own
+		// samples and decode somebody else's bytes as pictures.
 		const out = new Uint8Array(frag.length - removed);
 		let w = 0;
-		// moof header, then each box, with trafs rebuilt as they are copied.
 		out.set(frag.subarray(0, 8), w); w += 8;
 		at = 8;
 		while (at + 8 <= moofSize) {
 			const size = be32(frag, at);
 			const type = fourcc(frag, at + 4);
-			const traf = trafs.find(function (t) { return t.at === at; });
-			if (type !== 'traf' || !traf || !traf.drop) {
+			if (type !== 'traf') {
 				out.set(frag.subarray(at, at + size), w);
 				w += size;
 				at += size;


### PR DESCRIPTION
Found by running the merged code against a camera, which is the only place it could have been found.

## What happened

A fragment came back with its samples decrypted and its `senc`, `saiz` and `saio` still in it. The reasoning was that a track whose sample entry no longer names a protection scheme has no use for boxes describing one — and ffmpeg agrees, reading those files without a word.

Chromium does not. Its parser finds sample-auxiliary information on a track with no scheme and refuses the fragment: `appendBuffer` raises an error event, the SourceBuffer takes nothing, and the page shows the spinner it shows for a camera that has gone quiet.

This is the shape of failure the whole feature is written against, and nothing in the suite could have caught it: the bytes were correct, every test passed, ffmpeg decoded them, and the only parser that disagreed is the one that matters here.

## The fix, and the three numbers

The boxes come out, which moves the payload:

- `trun.data_offset` counts from the front of the moof, so it shrinks by exactly what was removed — **in every traf**, because the mdat is shared and a clear track beside a protected one loses nothing yet still moves;
- each `traf` shrinks by what came out of it;
- the `moof` shrinks by the total.

Four bytes wrong about any of those lands the decoder inside a picture instead of at the start of one, so the tests pin all three: what came out, what stayed, that every container is as long as what it holds, that both tracks' offsets moved by exactly the bytes removed, and that the payload at each new offset is byte-for-byte what the camera recorded.

A moof that cannot be rebuilt is refused rather than returned. Decryption happens first, so handing back what arrived would mean decrypted samples still wearing their protection boxes — the state this change exists to prevent, reached silently.

The integrity `uuid` stays. It describes the recording rather than the protection, a parser has no opinion about a `uuid` box it does not know, and a decrypted export that still carries the camera's own tags is worth more than one that does not — the tags no longer match the bytes beside them, which the page already says on the button.

## Verified against hardware

On an hi3516av300 with an SD card, over plain http, with clips the camera recorded in each mode — a 4K H.265 main stream and a 1080p H.264 substream, both sealed with a passphrase, one sealed to a public key, one bound to the camera's own hardware and one in the clear.

The shipped page modules, loaded the way the browser loads them, opened every clip the camera's own tooling can open and refused the ones it should: the chip-bound clip is recognised as openable by that camera alone, with both a passphrase and a recovery key declined by name. Each sealed clip's integrity chain matched across every one of its fragments, a clip with a single byte altered was reported at the fragment where it stops matching with everything before it still intact, and the decrypted output decodes without a complaint from ffmpeg while the sealed file produces over a thousand decoder errors.

In a real browser — headless Chromium, driving the shipped modules against a sealed H.264 recording — the SourceBuffer accepts the rewritten header, takes six decrypted fragments and decodes 1920x1080 video with three seconds buffered. **Before this commit that run reached the header and failed on the first fragment.** The same browser reports no support for `hvc1`, so a 4K H.265 recording takes the page's "this browser cannot decode it" path and is offered as a decrypted file to save instead — which is why the header rewrite happens before any key is asked for.

## What it costs

Measured on the same hardware class, on a 15.6 Mbit/s recording: unlocking a clip costs about half a second of PBKDF2, paid once per passphrase rather than per clip; rewriting the header is under a millisecond; decryption runs at roughly 60 MB/s and the integrity walk at 90 MB/s, so playback spends around 3% of one core and a full-clip integrity check is bounded by how fast the card can be read rather than by the cryptography.
