### PR TITLE
Live adjustments: a held button is not text to select

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1264,6 +1264,17 @@ mark {
 	user-select: none;
 }
 
+/* Hold to compare is held, not tapped, and Safari reads a long press on text
+   as a request to select the word under it and offer the Dictionary (#316).
+   The label is a caption, not text to select — the prefixed form is the one
+   Safari honours, and the callout is iOS's version of the same reflex. */
+.mj-live-compare,
+.mj-live-compare span {
+	-webkit-user-select: none;
+	user-select: none;
+	-webkit-touch-callout: none;
+}
+
 /* Hold to compare at stock: nothing to compare, and the title says so */
 .mj-hud-btn:disabled {
 	opacity: 0.45;


### PR DESCRIPTION
From the reporter's last comment on #316: in Safari, holding **Hold to compare** sometimes selects a word of its label and offers the Dictionary. They also found the fix — `-webkit-user-select: none` on the span, since the unprefixed form is not honoured there.

Applied to the button and its span, with `-webkit-touch-callout: none` for the iOS version of the same reflex. Verified on an hi3516ev200 that the computed style is `none` on both. Stylesheet only.