### PR TITLE
Day / Night: one threshold is a half-finished setup, not a camera that cannot see (#370)

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -435,6 +435,68 @@ function runRest() {
 			ic.diagnose({ irCutPin1: 11, lightMonitor: true },
 				{ night: 0, ircut: 0, light: 0, src: null }, null)
 				.some(x => x.id === 'monitor-blind'));
+
+		// One threshold is a half-finished configuration, and the camera
+		// answers it by setting up no monitor at all rather than falling
+		// through to automatic mode. It then reports source 0 — the SAME
+		// number a camera whose SoC has no exposure to offer reports, which
+		// is what made this branch accuse the SoC and tell the owner to go
+		// and wire a daylight sensor, on a camera whose exposure gauges were
+		// working perfectly (#370). Settled from the configuration, which
+		// knows which of the two it is, before the gauge is consulted.
+		const halfHi = ic.diagnose(
+			{ irCutPin1: 11, lightMonitor: true, maxThreshold: 14000 },
+			{ night: 0, ircut: 0, light: 0, src: 0 }, null);
+		check('one threshold alone is called out as half-finished',
+			halfHi.some(x => x.id === 'threshold-half' && x.level === 'warning'));
+		check('...and the SoC is not blamed for it',
+			!halfHi.some(x => x.id === 'auto-retired'));
+		check('...nor is the owner sent to wire a sensor',
+			!/daylight sensor to a GPIO pad/.test(
+				halfHi.filter(x => x.id === 'threshold-half')[0].detail));
+		check('it names the one to fill in and the one to clear',
+			/Fill in "Minimum sensor threshold for day"/.test(
+				halfHi.filter(x => x.id === 'threshold-half')[0].detail) &&
+			/clear "Maximum sensor threshold for night"/.test(
+				halfHi.filter(x => x.id === 'threshold-half')[0].detail));
+		// And the other way round, since either half can be the one that is set.
+		const halfLo = ic.diagnose(
+			{ irCutPin1: 11, lightMonitor: true, minThreshold: 5000 },
+			{ night: 0, ircut: 0, light: 0, src: 0 }, null);
+		check('the mirror case names the mirror controls',
+			/Fill in "Maximum sensor threshold for night"/.test(
+				halfLo.filter(x => x.id === 'threshold-half')[0].detail));
+		// The SoC case is real and must survive: no thresholds at all, and the
+		// camera says nothing is deciding.
+		check('a genuinely blind SoC is still called out as one',
+			ic.diagnose({ irCutPin1: 11, lightMonitor: true },
+				{ night: 0, ircut: 0, light: 0, src: 0 }, null)
+				.some(x => x.id === 'auto-retired'));
+		check('and a half-set pair is not reported where a sensor decides',
+			!ic.diagnose({ irCutPin1: 11, lightMonitor: true,
+				lightSensorPin: 15, maxThreshold: 14000 },
+			{ night: 0, ircut: 0, light: 0, src: 1 }, null)
+				.some(x => x.id === 'threshold-half'));
+	}
+
+	group('monitorView: source 0 has two causes and says which');
+	{
+		// The same collision the finding above disentangles, in the panel's own
+		// sentence. A half-set threshold pair gets no monitor at all, on purpose;
+		// describing it as a camera with no exposure to watch and no threshold
+		// set is wrong twice over on a camera where one plainly is (#370).
+		const half = ic.monitorView({ lightMonitor: true, maxThreshold: 14000 },
+			{ night_mode_source: 0, night_enabled: 0 });
+		check('a half-set pair is named as the reason',
+			/one of the two sensor thresholds is filled in/.test(half.line), half.line);
+		check('...and the camera is not said to be reporting no exposure',
+			!/reports no exposure to watch/.test(half.line), half.line);
+		const none = ic.monitorView({ lightMonitor: true },
+			{ night_mode_source: 0, night_enabled: 0 });
+		check('with neither set the original sentence stands',
+			/reports no exposure to watch/.test(none.line), none.line);
+		check('and both are the idle mode either way',
+			half.mode === 'idle' && none.mode === 'idle');
 	}
 
 	group('monitorView: what the panel charts');

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -286,7 +286,39 @@
 			(has(nm.minThreshold) && has(nm.maxThreshold));
 		if (monitor && !senses) {
 			const src = sample && sample.src != null ? sample.src : null;
-			if (src === 4) {
+			// Exactly one threshold filled in is a configuration half-finished,
+			// and the camera answers it by installing NO light monitor at all —
+			// deliberately, rather than falling through to automatic mode and
+			// starting to switch a camera whose owner was in the middle of
+			// setting something else up. It then reports source 0, which is the
+			// same number a camera whose SoC has no exposure to offer reports,
+			// and that collision is the bug this branch used to have: it read
+			// the 0, blamed the SoC, and told the owner to go and wire a
+			// daylight sensor — the opposite of what they needed, on a camera
+			// whose exposure gauges were working perfectly (#370).
+			//
+			// So this is settled from the configuration, which says which of
+			// the two it is, before the gauge is consulted at all.
+			if (has(nm.minThreshold) !== has(nm.maxThreshold)) {
+				out.push({
+					id: 'threshold-half', level: 'warning',
+					title: 'Day/night is set up half-way',
+					detail: 'Only one of the two sensor thresholds is filled ' +
+						'in, and the camera wants both or neither: with one it ' +
+						'sets up no light monitor at all, so nothing switches ' +
+						'day or night however dark it gets. Fill in ' +
+						(has(nm.maxThreshold)
+							? '"Minimum sensor threshold for day"'
+							: '"Maximum sensor threshold for night"') +
+						' as well to decide by gain, or clear ' +
+						(has(nm.maxThreshold)
+							? '"Maximum sensor threshold for night"'
+							: '"Minimum sensor threshold for day"') +
+						' to hand day/night to automatic mode, which needs no ' +
+						'numbers at all.',
+					fix: 'nightMode',
+				});
+			} else if (src === 4) {
 				out.push({
 					id: 'auto-active', level: 'info',
 					title: 'Automatic day/night is watching the exposure',
@@ -951,11 +983,21 @@
 				'is nothing to plot here.' + lampNote);
 		}
 		// The monitor is on and the daemon says nothing is driving it. The
-		// finding above names the two ways out; this only says the state.
+		// finding above names the way out; this only says the state — and it
+		// has to say the right one, because source 0 has two causes and the
+		// configuration is what tells them apart. A half-set threshold pair
+		// gets no monitor at all, deliberately, and describing that as a
+		// camera with no exposure to watch and no threshold set is wrong twice
+		// over on a camera where one plainly is (#370).
 		if (src === 0) {
-			return say('idle', modeWord + 'Nothing is deciding: this camera ' +
-				'reports no exposure to watch, and no daylight sensor or ' +
-				'threshold is set.' + lampNote);
+			return say('idle', modeWord + (
+				has(nm.minThreshold) !== has(nm.maxThreshold)
+					? 'Nothing is deciding: one of the two sensor thresholds ' +
+						'is filled in and the camera wants both or neither, so ' +
+						'it has set up no light monitor at all.'
+					: 'Nothing is deciding: this camera reports no exposure to ' +
+						'watch, and no daylight sensor or threshold is set.'
+			) + lampNote);
 		}
 		return say('unknown', modeWord + 'This firmware does not report what ' +
 			'the monitor is watching.' + lampNote);


### PR DESCRIPTION
Found while working #370. It is **not** that reporter's headline problem — that one is already answered on a current build, see below — but it sits squarely on the path out of it, and it is the kind of fault this UI exists to stop making: a confident sentence with the wrong cause and the opposite advice attached.

## Two causes, one number

With **Automatic day/night** on and exactly one of the two sensor thresholds filled in, the camera sets up **no light monitor at all**. That is deliberate: falling through to automatic mode there would start physically switching a camera whose owner was half-way through configuring something else. It reports `night_mode_source 0` for that state.

`night_mode_source 0` is also what a camera whose SoC has no exposure state to offer reports.

The page read the `0` and picked the wrong one of the two:

> **This camera cannot watch the light by itself** — Automatic day/night is on, but this SoC reports no exposure state to decide from, so it has stood down. Wire a daylight sensor to a GPIO pad and assign it on the map for it to have something to watch.

On the reporter's camera the exposure gauges were working perfectly — `isp_again` reaching 22924 in darkness — so every clause of that is wrong, and the advice is the opposite of what they need.

The monitor panel's own line had the same fault and one more on top:

> Nothing is deciding: this camera reports **no exposure to watch**, and **no daylight sensor or threshold is set**.

…on a camera where one plainly is.

## The configuration knows which it is

So it is settled there, before the gauge is consulted at all. Both sentences now say the true thing:

> **Day/night is set up half-way** — Only one of the two sensor thresholds is filled in, and the camera wants both or neither: with one it sets up no light monitor at all, so nothing switches day or night however dark it gets. Fill in "Minimum sensor threshold for day" as well to decide by gain, or clear "Maximum sensor threshold for night" to hand day/night to automatic mode, which needs no numbers at all.

> Nothing is deciding: one of the two sensor thresholds is filled in and the camera wants both or neither, so it has set up no light monitor at all.

The two ways out are named in the words the page puts on screen, and which one is offered as "fill in" flips with whichever half is already set.

## What #370's reporter actually hit

Different mechanism, and worth stating so this PR is not mistaken for the whole answer. They have a photocell wired **and** thresholds set. A wired daylight sensor takes the decision before thresholds are looked at, so theirs were inert — which is exactly why "different values of borders for day\night mode were tested, none of them lead to correct transition."

A current build already says so: the panel reads *"The daylight sensor decides. It reports light or dark and nothing in between"*, every ignored control is annotated *"Not in use — the daylight sensor is deciding."*, and there is a finding naming the fix. Their firmware is 2026-09-03, which predates all of that.

Clearing the sensor pin is the first step out — and it lands them precisely in the state this PR is about.

## Verified

On an hi3516ev200 put into that state — light monitor on, one threshold set, `night_mode_source 0` confirmed from `/metrics/night` — the page names the half-finished pair in both sentences and no longer blames the SoC. Tests cover both halves of the pair, that the genuine no-exposure case still reports as before, and that this never fires where a sensor is deciding.
