### PR TITLE
Day / Night: the precedence comes from the camera, not from a table here

### DIFF
--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -294,5 +294,86 @@ group('a requirement satisfied by any one of several alternatives');
 		req.met({ when: 'true', message: 'x' }, { self: () => true }) === true);
 }
 
+group('a precedence: inert while any of several fields is set (majestic#314)');
+{
+	// The shapes majestic emits for the day/night keys, verbatim. No top-level
+	// field, when or message: each condition carries its own, the first unmet
+	// one is shown, and a build that predates `all` reads the whole thing as
+	// satisfied.
+	const PIN_MSG_T = 'Not in use while a daylight sensor pin is set: the pin decides day and night. Clear the pin for the thresholds to take over.';
+	const PIN_MSG_A = 'Not in use while a daylight sensor pin is set: the pin decides day and night. Clear the pin for automatic mode.';
+	const PAIR_MSG = 'Not in use while a sensor threshold is set. Clear both thresholds for automatic mode.';
+	const THRESHOLD = { whenSet: true, all: [
+		{ field: 'nightMode.lightSensorPin', unset: true, message: PIN_MSG_T },
+	] };
+	const AUTO = { whenSet: true, all: [
+		{ field: 'nightMode.lightSensorPin', unset: true, message: PIN_MSG_A },
+		{ field: 'nightMode.minThreshold', unset: true, message: PAIR_MSG },
+		{ field: 'nightMode.maxThreshold', unset: true, message: PAIR_MSG },
+	] };
+	const night = (self, nm) => page(self, { nightMode: nm });
+
+	// "Unset" is a fact about presence, not a value: an absent key, a removed
+	// leaf and an emptied control all say it, and 0 -- pad 0 -- does not.
+	check('unset: an absent key', req.matches({ unset: true }, undefined));
+	check('unset: a removed leaf', req.matches({ unset: true }, null));
+	check('unset: an emptied control', req.matches({ unset: true }, ''));
+	check('unset: pad 0 is a value', !req.matches({ unset: true }, 0));
+	check('unset: so is the text "0"', !req.matches({ unset: true }, '0'));
+	check('unset: so is false', !req.matches({ unset: true }, false));
+	check('unset false asks for a value',
+		req.matches({ unset: false }, 5) && !req.matches({ unset: false }, ''));
+
+	// The table from the issue: which set of controls is live.
+	const pair = { minThreshold: 2000, maxThreshold: 14000 };
+	check('nothing set: automatic mode is live', req.met(AUTO, night(33, { lightMonitor: true })));
+	check('thresholds set: the night gain is not', !req.met(AUTO, night(33, pair)));
+	check('and the note names the pair', req.notice(AUTO, night(33, pair)) === PAIR_MSG);
+	check('one threshold is enough to outrank it',
+		req.notice(AUTO, night(33, { maxThreshold: 14000 })) === PAIR_MSG);
+	check('thresholds with no pin are live', req.met(THRESHOLD, night(2000, pair)));
+	check('a pin outranks the thresholds',
+		req.notice(THRESHOLD, night(2000, { lightSensorPin: 61 })) === PIN_MSG_T);
+	check('and the automatic set',
+		req.notice(AUTO, night(33, { lightSensorPin: 61, minThreshold: 2000 })) === PIN_MSG_A);
+	check('the first unmet condition wins, in list order',
+		req.unmet(AUTO, night(33, { lightSensorPin: 61, minThreshold: 2000 })).field
+			=== 'nightMode.lightSensorPin');
+	check('pad 0 counts as a pin', !req.met(THRESHOLD, night(2000, { lightSensorPin: 0 })));
+
+	// whenSet: an empty control that is being ignored misleads nobody, while
+	// a defaulted one holds a value and is told.
+	check('an empty night gain says nothing', req.met(AUTO, night('', pair)));
+	check('nor an absent one', req.met(AUTO, night(undefined, { minThreshold: 2000 })));
+	check('a defaulted delay is set, and is told',
+		req.notice(AUTO, night(60, { lightSensorPin: 61 })) === PIN_MSG_A);
+
+	// The controlling fields share the page with these, so an unsaved edit
+	// to the pin moves the note before the save, exactly as for visibleWhen.
+	check('a pin emptied on the page lifts the note', req.met(THRESHOLD, {
+		self: () => 2000,
+		mounted: (dot) => (dot === 'nightMode.lightSensorPin' ? '' : undefined),
+		saved: (dot) => (dot === 'nightMode.lightSensorPin' ? 61 : undefined),
+	}));
+	check('a pin typed on the page paints it', !req.met(THRESHOLD, {
+		self: () => 2000,
+		mounted: (dot) => (dot === 'nightMode.lightSensorPin' ? '61' : undefined),
+		saved: () => undefined,
+	}));
+
+	// Fail-open, per condition and for the whole, and the older shapes keep
+	// their meaning.
+	check('an unresolvable field holds', req.met(AUTO, { self: () => 33 }));
+	check('an empty list is satisfied', req.met({ whenSet: true, all: [] }, { self: () => 33 }));
+	check('a missing self lookup is satisfied', req.met(AUTO, { saved: () => 61 }));
+	check('a condition with no message falls back to the requirement\'s',
+		req.notice({ whenSet: true, message: 'fallback', all: [{ field: 'a.b', unset: true }] },
+			{ self: () => 1, saved: () => 1 }) === 'fallback');
+	check('the substream shape is unchanged',
+		req.notice(SUBSTREAM, saved({ video1: { enabled: false }, outgoing: { substream: true } }))
+			=== SUBSTREAM.message);
+	check('an old build\'s reading -- no field, no any -- would be silence',
+		!AUTO.field && !Array.isArray(AUTO.any));
+}
 
 done();

--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -296,13 +296,13 @@ group('a requirement satisfied by any one of several alternatives');
 
 group('a precedence: inert while any of several fields is set (majestic#314)');
 {
-	// The shapes majestic emits for the day/night keys, verbatim. No top-level
-	// field, when or message: each condition carries its own, the first unmet
-	// one is shown, and a build that predates `all` reads the whole thing as
-	// satisfied.
-	const PIN_MSG_T = 'Not in use while a daylight sensor pin is set: the pin decides day and night. Clear the pin for the thresholds to take over.';
-	const PIN_MSG_A = 'Not in use while a daylight sensor pin is set: the pin decides day and night. Clear the pin for automatic mode.';
-	const PAIR_MSG = 'Not in use while a sensor threshold is set. Clear both thresholds for automatic mode.';
+	// The shapes the camera serves for the day/night keys at
+	// /api/v1/config.schema.json, as they arrive. No top-level field, when or
+	// message: each condition carries its own, the first unmet one is shown,
+	// and a build that predates `all` reads the whole thing as satisfied.
+	const PIN_MSG_T = 'Not in use while a daylight sensor pin is set: the pin outranks the thresholds. Clear the pin for the thresholds to take over.';
+	const PIN_MSG_A = 'Not in use while a daylight sensor pin is set: the pin outranks automatic mode. Clear the pin for automatic mode.';
+	const PAIR_MSG = 'Not in use while a sensor threshold is set: the thresholds outrank automatic mode. Clear both thresholds for automatic mode.';
 	const THRESHOLD = { whenSet: true, all: [
 		{ field: 'nightMode.lightSensorPin', unset: true, message: PIN_MSG_T },
 	] };

--- a/www/a/mj-requires.js
+++ b/www/a/mj-requires.js
@@ -26,6 +26,28 @@
 //                   stream is published instead."
 //     }
 //
+// A second shape carries a precedence rather than a substitution -- the
+// day/night keys, where a sensor pin outranks the raw threshold pair, which
+// outranks the automatic policy, and a camera with thresholds left over from
+// earlier experimentation silently ignored a night gain multiple and both
+// automatic delays (OpenIPC/majestic#314, from #325 here):
+//
+//     "x-requires": {
+//       "whenSet": true,
+//       "all": [
+//         { "field": "nightMode.lightSensorPin", "unset": true,
+//           "message": "Not in use while a daylight sensor pin is set: ..." },
+//         { "field": "nightMode.minThreshold", "unset": true, "message": "..." },
+//         { "field": "nightMode.maxThreshold", "unset": true, "message": "..." }
+//       ]
+//     }
+//
+// Every condition must hold and the first unmet one supplies the message, so
+// the list is in precedence order; `whenSet` scopes the rule to the annotated
+// field holding a value, as `when` scopes a boolean. There is no top-level
+// `field`, so a build that predates `all` reads it as satisfied and says
+// nothing -- the same degradation `any` chose.
+//
 // This module is the decision, kept away from the DOM so it can be tested:
 // getting it wrong is silent in the worst way, because a warning that never
 // draws looks exactly like a camera doing what it was told.
@@ -48,8 +70,20 @@
 	// screen that nothing on the page can clear, nor hide a row it does not
 	// understand how to reveal, so a newer schema degrades to silence rather
 	// than to noise.
+	// Has a field no value? Three spellings of one fact, from three sources: a
+	// key absent from the config resolves to undefined, a leaf the camera has
+	// removed comes back as null, and an emptied number control reads ''. The
+	// number 0 is none of them -- pad 0 is a real GPIO, and #273 was filed from
+	// exactly a clear that had become 0.
+	function isUnset(v) {
+		return v === undefined || v === null || v === '';
+	}
+
 	function matches(cond, v) {
 		if (!cond) return true;
+		// Before the stringify below: String(undefined) is 'undefined', a value,
+		// and an absent field would count as set.
+		if ('unset' in cond) return isUnset(v) === Boolean(cond.unset);
 		v = String(v);
 		if ('equals' in cond) return v === String(cond.equals);
 		if ('notEquals' in cond) return v !== String(cond.notEquals);
@@ -95,12 +129,24 @@
 	//   An unresolvable controlling field. If no lookup can answer, a warning
 	//   would be a definite claim made from no data, and nothing on the page
 	//   could clear it. Same reasoning as an unknown operator holding.
-	function met(req, lookup) {
-		if (!req || (!req.field && !Array.isArray(req.any))) return true;
+	// The condition that fails, or null when the requirement is satisfied.
+	// A condition rather than a boolean because `all` carries a message per
+	// condition, and notice() has to know which one to show.
+	function unmet(req, lookup) {
+		if (!req || (!req.field && !Array.isArray(req.any) && !Array.isArray(req.all))) return null;
 		lookup = lookup || {};
+		const self = () => (typeof lookup.self === 'function' ? lookup.self() : undefined);
 		if (req.when !== undefined) {
-			const self = typeof lookup.self === 'function' ? lookup.self() : undefined;
-			if (self === undefined || String(self) !== String(req.when)) return true;
+			const s = self();
+			if (s === undefined || String(s) !== String(req.when)) return null;
+		}
+		// `whenSet` is `when` for a field with no fixed value: the rule applies
+		// while the annotated field holds one. An empty control that is being
+		// ignored misleads nobody, and a missing self lookup is satisfied for
+		// the same reason `when` treats it so.
+		if (req.whenSet) {
+			const s = self();
+			if (s === undefined || isUnset(s)) return null;
 		}
 
 		// A list of alternatives, satisfied when any one of them holds.
@@ -117,30 +163,56 @@
 		// requirement outright, because a warning drawn from no data is one
 		// nothing on the page can clear.
 		if (Array.isArray(req.any)) {
-			if (!req.any.length) return true;
-			return req.any.some(function (alt) {
+			if (!req.any.length) return null;
+			const ok = req.any.some(function (alt) {
 				if (!alt || !alt.field) return true;
 				const av = resolve(alt.field, lookup);
 				if (av === undefined) return true;
 				return matches(alt, av);
 			});
+			return ok ? null : req;
+		}
+
+		// A list every condition of which must hold: a precedence, where the
+		// annotated setting is outranked by any one of several others. The
+		// first that fails is the answer, so the list's order is the order of
+		// precedence and the note names what actually won. Same fail-open rule
+		// per condition: one whose field nothing can answer for holds.
+		if (Array.isArray(req.all)) {
+			for (const cond of req.all) {
+				if (!cond || !cond.field) continue;
+				const cv = resolve(cond.field, lookup);
+				if (cv === undefined) continue;
+				if (!matches(cond, cv)) return cond;
+			}
+			return null;
 		}
 
 		const v = resolve(req.field, lookup);
-		if (v === undefined) return true;
-		return matches(req, v);
+		if (v === undefined) return null;
+		return matches(req, v) ? null : req;
+	}
+
+	// Is the requirement satisfied? See unmet() for the rules.
+	function met(req, lookup) {
+		return unmet(req, lookup) === null;
 	}
 
 	// What to tell the operator, or '' when there is nothing to say. A
 	// condition that is unmet but carries no message stays silent: an empty
 	// warning box is worse than no warning box, and the message is the whole
-	// content -- this module has no idea what the field means.
+	// content -- this module has no idea what the field means. A condition
+	// inside `all` carries its own; the requirement's is the fallback.
 	function notice(req, lookup) {
-		if (met(req, lookup)) return '';
-		return (req && req.message) || '';
+		const failed = unmet(req, lookup);
+		if (!failed) return '';
+		return failed.message || (req && req.message) || '';
 	}
 
-	const api = { matches: matches, resolve: resolve, met: met, notice: notice };
+	const api = {
+		matches: matches, resolve: resolve, met: met, unmet: unmet,
+		notice: notice, isUnset: isUnset,
+	};
 	if (typeof module === 'object' && module.exports) module.exports = api;
 	if (typeof window === 'object') window.MajesticRequires = api;
 })();

--- a/www/a/mj-requires.js
+++ b/www/a/mj-requires.js
@@ -82,7 +82,11 @@
 	function matches(cond, v) {
 		if (!cond) return true;
 		// Before the stringify below: String(undefined) is 'undefined', a value,
-		// and an absent field would count as set.
+		// and an absent field would count as set. Only `unset: true` is ever
+		// served; `unset: false` is accepted for symmetry, but note that met()
+		// never gets here for a field no lookup could answer for -- that is
+		// the fail-open rule, and it means a rule asking for PRESENCE cannot
+		// tell an absent key from an unanswerable one and stays silent.
 		if ('unset' in cond) return isUnset(v) === Boolean(cond.unset);
 		v = String(v);
 		if ('equals' in cond) return v === String(cond.equals);

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -4789,6 +4789,21 @@
 			control = p.querySelector('input');
 			const show = p.querySelector('.show-value');
 			control.addEventListener('input', () => { show.textContent = control.value; });
+			// A range input cannot be empty: given value="" the browser parks
+			// the thumb at the midpoint and .value reads that number, so an
+			// unset field reported itself as set — the night gain multiple,
+			// unset on every camera by default, read as 33 — and a note that
+			// applies only while the field holds a value drew under a control
+			// nobody had touched. The display beside the thumb is the page's
+			// own record of "nothing chosen": empty until an input or a real
+			// value arrives, so it is what getValue() asks, and a pushed-in
+			// empty value keeps it empty rather than copying the midpoint in.
+			control._get = () => (show.textContent === '' ? '' : String(control.value));
+			control._set = (v) => {
+				const s = v !== undefined && v !== null ? String(v) : '';
+				control.value = s;
+				show.textContent = s === '' ? '' : String(control.value);
+			};
 		} else if (type === 'integer') {
 			p = el('p', 'number mj-row');
 			const minA = isNum(sub.minimum) ? ' min="' + sub.minimum + '"' : '';

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -3741,6 +3741,12 @@
 	// gets, for the same reason, and deliberately NOT by hiding or disabling
 	// them — the value is real, it is what is causing the surprise, and it has
 	// to stay findable and clearable. Hiding it would only move the surprise.
+	//
+	// A daemon that declares the precedence itself (OpenIPC/majestic#314) puts
+	// the note on these fields through the ordinary x-requires path, from its
+	// own schema; this table then stands down for them, since two notes under
+	// one control is the clutter #325 objected to. It stays for an older
+	// daemon, whose schema says nothing about it.
 	const NIGHT_MECH = {
 		'nightMode.minThreshold': 'thresholds',
 		'nightMode.maxThreshold': 'thresholds',
@@ -3769,6 +3775,10 @@
 			const mech = NIGHT_MECH[f.dot];
 			if (!mech || !f.p) return;
 			let note = f.p.querySelector('.mj-night-inert');
+			if (f.schema && f.schema['x-requires']) {
+				if (note) note.remove();
+				return;
+			}
 			// An empty control misleads nobody; only a filled-in one that is
 			// being ignored needs saying.
 			const v = f.getValue();
@@ -4391,11 +4401,13 @@
 		// Where it does happen to share the page, an unsaved edit to it has to
 		// repaint the warning, exactly as it moves a visibleWhen row.
 		for (const u of state.reqUpdaters || []) {
-			// Every field the condition consults, since `any` names more than
-			// one. Missing the second of them would leave the warning correct
-			// on mount and stale under exactly the edit that clears it.
-			const fields = Array.isArray(u.req.any)
-				? u.req.any.map(a => a && a.field).filter(Boolean)
+			// Every field the condition consults, since `any` and `all` name
+			// more than one. Missing the second of them would leave the warning
+			// correct on mount and stale under exactly the edit that clears it.
+			const list = Array.isArray(u.req.any) ? u.req.any
+				: Array.isArray(u.req.all) ? u.req.all : null;
+			const fields = list
+				? list.map(a => a && a.field).filter(Boolean)
 				: [u.req.field];
 			for (const dot of fields) {
 				const ctrl = byDot[dot];
@@ -5063,12 +5075,14 @@
 		// disabling it: the setting is a legitimate thing to want, it is
 		// remembered, and it starts working the moment its requirement is met.
 		// Hiding it would only move the surprise.
-		// `.field` or `.any`: a requirement carries one controlling field, or a
-		// list of alternatives for a rule that only bites when two settings
-		// coincide. Both shapes are decided by mj-requires.js; this only has to
-		// recognise that there is a requirement to paint.
+		// `.field`, `.any` or `.all`: a requirement carries one controlling
+		// field, a list of alternatives for a rule that only bites when two
+		// settings coincide, or a list that must all hold for a setting that
+		// several others outrank. Every shape is decided by mj-requires.js;
+		// this only has to recognise that there is a requirement to paint.
 		if (!live && sub['x-requires']
-			&& (sub['x-requires'].field || Array.isArray(sub['x-requires'].any))) {
+			&& (sub['x-requires'].field || Array.isArray(sub['x-requires'].any)
+				|| Array.isArray(sub['x-requires'].all))) {
 			const req = sub['x-requires'];
 			const warn = el('div', 'hint mj-requires');
 			const paint = () => {


### PR DESCRIPTION
The WebUI half of OpenIPC/majestic#314, from the thread on #325.

#343 taught this page to say which Day / Night controls a losing mechanism leaves inert — from a table of its own (`NIGHT_MECH`) and the `night_mode_source` gauge. The right note, derived in the wrong place: every other client would have to derive it again. The daemon now declares the rule in its schema, as `x-requires` in a shape the evaluator here did not know:

```json
"x-requires": { "whenSet": true, "all": [
  { "field": "nightMode.lightSensorPin", "unset": true, "message": "Not in use while a daylight sensor pin is set: the pin outranks automatic mode. …" },
  { "field": "nightMode.minThreshold",   "unset": true, "message": "Not in use while a sensor threshold is set: the thresholds outrank automatic mode. …" },
  { "field": "nightMode.maxThreshold",   "unset": true, "message": "…" } ] }
```

## What changes

- **`mj-requires.js`** learns `all` (every condition must hold; the first unmet one supplies the message), `unset` (presence, not a value: an absent key, a removed leaf and an emptied control all say it, and `0` does not — pad 0 is a real GPIO, #273 — so it is tested before the stringify), and `whenSet` (`when` for a field with no fixed value). The decision is now `unmet()`, returning the failing condition rather than a boolean, because with `all` the message belongs to the condition.
- **`mj-settings.js`**: the painter accepts `all` beside `field` and `any`; `applyVisibility()` wires listeners to every field an `all` names, so an unsaved edit to the pin moves the note before the save; and the #343 table stands down for a field whose schema carries `x-requires`, so a daemon that declares the precedence yields one note per control, not two. It stays for an older daemon whose schema says nothing. The section banner keeps reading `night_mode_source` — the camera's verdict is still the truth about the outcome; the schema is now the truth about the rule.
- **`tests/requires.test.js`**: the issue's table (nothing / thresholds / pin), `unset` on all its spellings, `whenSet` on an empty and a defaulted control, mounted-beats-saved for the pin, and fail-open in both directions: an older WebUI reading the new shape sees no `field` and no `any` and says nothing; this WebUI reading an older schema keeps every old shape's meaning.

Also in this PR, found by checking the page on a camera: a range slider rendered with no value reports the browser's midpoint (33 for the night gain multiple) as its value, so an untouched slider counted as set and drew the note. `getValue()` now reads the display beside the thumb, which is empty until something is chosen.

Either landing order with the daemon PR is safe. `npm test` passes in full (node via docker); verified on a camera running the daemon side: six notes under the pin, four under the thresholds naming the pair, none with the monitor alone, and none under an untouched slider.

**A finding for the overhaul (v5 mockup):** `monitorDelay` is the tick period of all three monitors, the automatic one included, not a legacy setting — it must not disappear behind the Legacy switch.

