### PR TITLE
Day / Night: drop a compatibility branch for a state that cannot happen

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -687,24 +687,9 @@ function runRest() {
 		const noPins = (nm) =>
 			ic.diagnose(nm, null, null).filter(x => x.id === 'no-pins')[0].detail;
 		check('and that finding names the switch that answers it',
-			/turn off "Drive the IR-cut filter"/.test(noPins({ irCutEnabled: true })));
-
-		// But only where the camera has it. The switch is recent and the
-		// settings page is drawn from the daemon's own schema, so on a build
-		// without the key there is no such control to go and find — sending
-		// someone to look for one would be the page inventing an answer.
-		// Absence is a reliable signal: config.json reports the EFFECTIVE
-		// configuration, so a key sitting at its default is still in it
-		// (measured on an hi3516ev200 after resetting the key: gone from
-		// majestic.yaml, still present in config.json), and only a daemon that
-		// has never heard of the key leaves it out.
-		check('an older daemon is told the truth instead',
-			/arrives with a newer firmware/.test(noPins({})));
-		check('...and is never sent to a switch it does not have',
-			!/turn off "Drive the IR-cut filter"/.test(noPins({})));
-		check('the fault itself is stated either way',
-			/Nothing is connected to the filter/.test(noPins({})) &&
-			/Nothing is connected to the filter/.test(noPins({ irCutEnabled: true })));
+			/turn off "Drive the IR-cut filter"/.test(noPins({})));
+		check('alongside the fault itself',
+			/Nothing is connected to the filter/.test(noPins({})));
 		check('a parked lamp with wiring says so',
 			ic.diagnose({ backlightEnabled: false, backlightPin: 52 },
 				null, null)

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -189,25 +189,11 @@
 					// setting that makes this finding stop (the branch above).
 					// It used to be a × on the Dashboard writing a private file,
 					// which said the same thing where only that banner could
-					// read it (#367).
-					//
-					// Only where the camera HAS that switch. It is recent, and
-					// the settings page is drawn from the daemon's own schema,
-					// so on a build without it there is no such control to go
-					// and find — naming one would be this page inventing an
-					// answer. An absent key is a reliable signal here and a
-					// default is not mistaken for one: /api/v1/config.json
-					// reports the effective configuration, so a key sitting at
-					// its default is still present in it, and only a daemon
-					// that has never heard of it leaves it out.
-					(nm.irCutEnabled === undefined
-						? ' If this camera has no IR-cut filter fitted, there ' +
-							'is nothing here to say so with: the switch that ' +
-							'settles it, "Drive the IR-cut filter", arrives ' +
-							'with a newer firmware than this one.'
-						: ' If this camera has no IR-cut filter fitted, turn ' +
-							'off "Drive the IR-cut filter" and nothing here ' +
-							'will ask again.'),
+					// read it (#367). Said unconditionally: the WebUI and the
+					// daemon ship in one firmware image, so a camera running
+					// this page has the switch this sentence names.
+					' If this camera has no IR-cut filter fitted, turn off ' +
+					'"Drive the IR-cut filter" and nothing here will ask again.',
 				fix: 'nightMode',
 			});
 		} else if (pictureOpen) {

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -1054,8 +1054,10 @@
 
 		// Parked (nightMode.*Enabled: false) outranks wired: the daemon
 		// refuses the toggle, so a live-looking switch would move and snap
-		// back. Explicit === false — an absent key on an older daemon means
-		// the switch does not exist there, not that it is off.
+		// back. Explicit === false, because absent is not off: a key the page
+		// was never given is one it knows nothing about, and reading that as
+		// "switched off" would grey out the control on a camera whose filter
+		// is working perfectly.
 		const ircutParked =
 			getDotted(state.config, 'nightMode.irCutEnabled') === false;
 		const lightParked =


### PR DESCRIPTION
The no-pins finding names the setting that answers it — turn off **Drive the IR-cut filter** on a camera that has none fitted — and it did so only where the daemon published that key, saying *"arrives with a newer firmware than this one"* otherwise.

There is no such camera. The WebUI and majestic are built into one firmware image and move together, so a camera running this page has the switch this sentence names. The other arm was unreachable prose describing a configuration the project does not support, and writing it made that mismatch look like a state worth planning for.

Said unconditionally now; the two checks asserting the unreachable wording go with it. **−37 / +8**, no behaviour change on any supported camera.
