### PR TITLE
Network: the form shows the file it edits, and says a restart is owed while the kernel disagrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,11 +99,11 @@ This is the most important file to read before editing anything. It defines:
 - `/etc/majestic.yaml` — Majestic config. Written by majestic and nothing else; the WebUI reads `/api/v1/get` and writes `/api/v1/config`, and never opens the file.
 - `/etc/webui/webui.conf` — UI theme.
 - `/etc/webui/{telegram,ntfy,proxy,openwall,vtun,wireguard,backup}.conf` — one per extension, sourced as shell.
-- `/etc/network/interfaces.d/{eth0,wlan0}` — written by `sbin/setnetwork` (not by the CGI directly).
+- `/etc/network/interfaces.d/{eth0,wlan0}` — written by `sbin/setnetwork` (not by the CGI directly), and applied by nothing but the boot script's `ifup`: a saved address exists nowhere else until the camera restarts. So `network.cgi` draws its **form** from the file (what it edits) and its **Current connection** card from the kernel (what is running), and while the two disagree it raises the restart banner by setting `restart_pending` before including the header — judged on every draw, so it clears itself on a restart or on a save that puts things back. Drawing the form from the kernel too, as it used to, showed a static address that had just been saved as still absent, visible only in the file dumped under Diagnostics (OpenIPC/majestic#311).
 - `/etc/crontabs/root` — extensions add/remove their own lines with `sed -i /name/d` then append.
 - `/etc/webui/ircut-scan.json` — the pin scan's journal: the pair about to be driven, written and `sync`ed **before** any register is touched. It is in `/etc` rather than `/tmp` because its whole purpose is to survive the pad that stops the camera answering (see `j/gpio.cgi` below).
 - `/tmp/webui/` — scratch (sysinfo, schema cache, flash log, signature, `ircut-pulse.lock`).
-- `/tmp/system-reboot` — sentinel file; presence triggers the "restart required" banner in `header.cgi`.
+- `/tmp/system-reboot` — sentinel file; presence triggers the "restart required" banner in `header.cgi`. A page that can *see* its pending state on every draw sets `restart_pending` before the include instead, since a flag nothing clears goes on announcing a change that has since been undone.
 - U-Boot env via `fw_printenv -n` / `fw_setenv` for `ethaddr`, `wlanssid`, `wlanpass`, `upgrade`, `sensor`, `soc`, and the PTZ family `ptz_control`/`ptz_gpio`/`ptz_port`/`ptz_speed`/`ptz_profile`/`ptz_caps` (legacy aliases `gpio_motors`, `ptz`).
 
 ### Talking to Majestic

--- a/www/cgi-bin/network.cgi
+++ b/www/cgi-bin/network.cgi
@@ -5,12 +5,89 @@
 params="address dhcp gateway hostname nameserver netmask interface wlan_ssid wlan_password"
 
 network_list="$(ls /sys/class/net | grep -e eth0 -e wlan0)"
-network_nameserver="$(cat /etc/resolv.conf | grep nameserver | cut -d' ' -f2)"
-network_netmask="$(ifconfig ${network_interface} | grep Mask | cut -d: -f4)"
-network_dhcp="$(cat /etc/network/interfaces.d/${network_interface} | grep -q dhcp && echo true)"
-
 network_wlan_ssid="$(fw_printenv -n wlanssid)"
 network_wlan_password="$(fw_printenv -n wlanpass)"
+
+# The interface the camera is on: the one carrying the default route, as
+# sysinfo found it. The form edits this one's file and the card reports this
+# one's state. The select can point a save at the other interface, and what
+# that does at boot is the boot script's decision, not this page's -- it
+# brings wlan0 up from its file only when U-Boot names a wireless driver, and
+# eth0 from its file only when it does not -- so nothing here promises when
+# such a save takes effect.
+now_iface="${network_interface:-eth0}"
+
+# Two readings, kept apart, because they are only the same thing between a
+# restart and the next save. sbin/setnetwork writes
+# /etc/network/interfaces.d/<iface> and applies nothing but the hostname; the
+# boot script's ifup is what reads the file, so a saved address exists nowhere
+# but in that file until the camera restarts. The FORM shows the file, since
+# that is what it edits. The CARD shows the kernel, since that is what
+# "current connection" means. The form used to be drawn from the kernel too,
+# so a static address that had just been saved came back as the DHCP lease
+# still in use, and the only place the save was visible was the file dumped
+# under Diagnostics (OpenIPC/majestic#311).
+net_read() {
+	local f="/etc/network/interfaces.d/$1"
+	cfg_mode=$(awk '$1 == "iface" { print $4; exit }' "$f" 2>/dev/null)
+	cfg_address=$(awk '$1 == "address" { print $2; exit }' "$f" 2>/dev/null)
+	cfg_netmask=$(awk '$1 == "netmask" { print $2; exit }' "$f" 2>/dev/null)
+	cfg_gateway=$(awk '$1 == "gateway" { print $2; exit }' "$f" 2>/dev/null)
+	# The resolver is a pre-up line that writes /tmp/resolv.conf. That
+	# spelling is setnetwork's, and this is its only reader.
+	cfg_nameserver=$(awk '$1 == "pre-up" && $2 == "echo" && $3 == "nameserver" { print $4; exit }' "$f" 2>/dev/null)
+
+	local inet=$(ifconfig "$1" 2>/dev/null | sed -n 's/.*inet addr:\([^ ]*\).*Mask:\([^ ]*\).*/\1 \2/p')
+	now_address=${inet% *}
+	now_netmask=${inet#* }
+	now_gateway=$(ip -4 route 2>/dev/null | awk -v i="$1" '
+		$1 == "default" {
+			gw = ""; dev = ""
+			for (n = 2; n <= NF; n++) {
+				if ($n == "via") gw = $(n + 1)
+				if ($n == "dev") dev = $(n + 1)
+			}
+			if (dev == i && gw != "") { print gw; exit }
+		}')
+	now_nameserver=$(awk '$1 == "nameserver" { print $2; exit }' /etc/resolv.conf 2>/dev/null)
+	# A live udhcpc for the interface is what being on DHCP means; ifup
+	# leaves its pid where ifdown will look for it.
+	local pid=$(cat "/var/run/udhcpc.$1.pid" 2>/dev/null)
+	if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+		now_mode=dhcp
+	else
+		now_mode=static
+	fi
+	# The wireless network in use is the one wpa_supplicant was started
+	# with: the pre-up wrote it from the U-Boot variables of that moment,
+	# and a later save changes the variables and nothing else.
+	now_ssid=$(sed -n 's/^[[:space:]]*ssid="\(.*\)"$/\1/p' /tmp/wpa_supplicant.conf 2>/dev/null | head -n1)
+	now_psk=$(sed -n 's/^[[:space:]]*psk=\([0-9a-f]*\)$/\1/p' /tmp/wpa_supplicant.conf 2>/dev/null | head -n1)
+}
+
+# True while the file says something the kernel is not doing. Judged from the
+# two readings every time rather than flagged at save time, so it clears
+# itself on a restart, on a save that puts things back, and for a file edited
+# by hand -- a flag left in /tmp would say "waiting for a restart" about a
+# change that had since been undone.
+net_pending() {
+	[ -n "$cfg_mode" ] || return 1
+	[ "$cfg_mode" = "$now_mode" ] || return 0
+	if [ "$cfg_mode" = "static" ]; then
+		[ "$cfg_address" = "$now_address" ] || return 0
+		[ "$cfg_netmask" = "$now_netmask" ] || return 0
+		[ "$cfg_gateway" = "$now_gateway" ] || return 0
+		[ "$cfg_nameserver" = "$now_nameserver" ] || return 0
+	fi
+	if [ "$now_iface" = "wlan0" ] && [ -n "$now_ssid" ] && command -v wpa_passphrase >/dev/null; then
+		[ "$network_wlan_ssid" = "$now_ssid" ] || return 0
+		local psk=$(wpa_passphrase "$network_wlan_ssid" "$network_wlan_password" 2>/dev/null | sed -n 's/^[[:space:]]*psk=//p')
+		[ "$psk" = "$now_psk" ] || return 0
+	fi
+	return 1
+}
+
+net_read "$now_iface"
 
 if [ "$REQUEST_METHOD" = "POST" ]; then
 	case "$POST_action" in
@@ -32,7 +109,10 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 		reset)
 			rm -f /etc/network/interfaces.d/*
 			cp -f /rom/etc/network/interfaces.d/* /etc/network/interfaces.d
-			redirect_back
+			net_read "$now_iface"
+			msg="Network configuration reset to the firmware's."
+			net_pending && msg="$msg It takes effect when the camera restarts."
+			redirect_back "success" "$msg"
 			;;
 
 		update)
@@ -73,16 +153,50 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 				fi
 
 				echo "$command" >> /tmp/webui.log
-				eval "$command" > /dev/null 2>&1
+				# setnetwork refuses on its own checks and says why on stdout;
+				# its status used to be dropped, so a refused save was
+				# reported as a save.
+				if ! out=$(eval "$command" 2>&1); then
+					redirect_back "danger" "Network settings were not saved: $(esc "$out")"
+				fi
 
 				update_caminfo
-				redirect_back "success" "Network settings updated."
+				msg="Network settings saved."
+				if [ "$network_interface" = "$now_iface" ]; then
+					net_read "$now_iface"
+					net_pending && msg="$msg They take effect when the camera restarts."
+				fi
+				redirect_back "success" "$msg"
 			fi
 			;;
 	esac
 fi
+
+# The header reads network_gateway for its no-default-route banner, and that
+# is a statement about the kernel; so the banner it does draw for the pending
+# save is asked for by name, and the form's variables are filled in below it.
+net_pending && restart_pending=1
 %>
 <%in p/header.cgi %>
+
+<%
+# The fields carry the file. On DHCP the static fields are hidden, and what
+# they hold is the starting point for turning the switch off: the lease in
+# use, which is what most people mean to pin.
+network_interface=$now_iface
+network_dhcp=$([ "$cfg_mode" = "dhcp" ] && echo true)
+if [ "$cfg_mode" = "static" ]; then
+	network_address=$cfg_address
+	network_netmask=$cfg_netmask
+	network_gateway=$cfg_gateway
+	network_nameserver=$cfg_nameserver
+else
+	network_address=$now_address
+	network_netmask=$now_netmask
+	network_gateway=$now_gateway
+	network_nameserver=$now_nameserver
+fi
+%>
 
 <div class="row g-4">
 	<div class="col-12 col-lg-7">
@@ -120,14 +234,20 @@ fi
 	<div class="col-12 col-lg-5">
 		<div class="card"><div class="card-body">
 			<% card_head "Current connection" %>
+			<% if net_pending; then %>
+			<p class="small text-secondary">Still the setup from before the save. The saved settings take effect when the camera restarts.</p>
+			<% fi %>
 			<dl class="small list mb-0">
 				<dt>Hostname</dt><dd><% esc "$network_hostname" %></dd>
-				<dt>Interface</dt><dd><% esc "$network_interface" %></dd>
-				<dt>Mode</dt><dd><%= $([ "$network_dhcp" = "true" ] && echo DHCP || echo Static) %></dd>
-				<dt>IP</dt><dd><% esc "$network_address" %></dd>
-				<dt>Netmask</dt><dd><% esc "${network_netmask:-—}" %></dd>
-				<dt>Gateway</dt><dd><% esc "${network_gateway:-—}" %></dd>
-				<dt>DNS</dt><dd><% esc "${network_nameserver:-—}" %></dd>
+				<dt>Interface</dt><dd><% esc "$now_iface" %></dd>
+				<dt>Mode</dt><dd><%= $([ "$now_mode" = "dhcp" ] && echo DHCP || echo Static) %></dd>
+				<% if [ "$now_iface" = "wlan0" ] && [ -n "$now_ssid" ]; then %>
+				<dt>Wi-Fi</dt><dd><% esc "$now_ssid" %></dd>
+				<% fi %>
+				<dt>IP</dt><dd><% esc "${now_address:-—}" %></dd>
+				<dt>Netmask</dt><dd><% esc "${now_netmask:-—}" %></dd>
+				<dt>Gateway</dt><dd><% esc "${now_gateway:-—}" %></dd>
+				<dt>DNS</dt><dd><% esc "${now_nameserver:-—}" %></dd>
 				<dt>MAC</dt><dd class="text-break"><% esc "$network_macaddr" %></dd>
 			</dl>
 		</div></div>

--- a/www/cgi-bin/network.cgi
+++ b/www/cgi-bin/network.cgi
@@ -8,14 +8,28 @@ network_list="$(ls /sys/class/net | grep -e eth0 -e wlan0)"
 network_wlan_ssid="$(fw_printenv -n wlanssid)"
 network_wlan_password="$(fw_printenv -n wlanpass)"
 
-# The interface the camera is on: the one carrying the default route, as
-# sysinfo found it. The form edits this one's file and the card reports this
-# one's state. The select can point a save at the other interface, and what
-# that does at boot is the boot script's decision, not this page's -- it
-# brings wlan0 up from its file only when U-Boot names a wireless driver, and
-# eth0 from its file only when it does not -- so nothing here promises when
+# The interface the camera is on. The default route names it when there is
+# one and it is one of the two edited here; a route through a tunnel or a
+# modem must not point the form at a file it cannot show. Without one -- a
+# static setup with no gateway, which is what a save on this page can
+# produce -- it is the interface the firmware's boot script brought up from
+# its file, which is also the only file a restart will read: wlan0 when
+# U-Boot names a wireless driver, eth0 when it does not. The form edits this
+# one's file and the card reports this one's state. The select can point a
+# save at the other interface, and what that does at boot is the boot
+# script's decision rather than this page's, so nothing here promises when
 # such a save takes effect.
-now_iface="${network_interface:-eth0}"
+now_iface=""
+for i in $network_list; do
+	[ "$i" = "$network_interface" ] && now_iface=$i
+done
+if [ -z "$now_iface" ]; then
+	if [ -n "$(fw_printenv -n wlandev 2>/dev/null)" ] && echo "$network_list" | grep -qx wlan0; then
+		now_iface=wlan0
+	else
+		now_iface=eth0
+	fi
+fi
 
 # Two readings, kept apart, because they are only the same thing between a
 # restart and the next save. sbin/setnetwork writes
@@ -37,6 +51,9 @@ net_read() {
 	# spelling is setnetwork's, and this is its only reader.
 	cfg_nameserver=$(awk '$1 == "pre-up" && $2 == "echo" && $3 == "nameserver" { print $4; exit }' "$f" 2>/dev/null)
 
+	# Empty here is an absence, not a failed reading: the tools are busybox's
+	# own, and an interface with no address, no route or no resolver is a
+	# fact about it that the file may well disagree with.
 	local inet=$(ifconfig "$1" 2>/dev/null | sed -n 's/.*inet addr:\([^ ]*\).*Mask:\([^ ]*\).*/\1 \2/p')
 	now_address=${inet% *}
 	now_netmask=${inet#* }
@@ -51,12 +68,16 @@ net_read() {
 		}')
 	now_nameserver=$(awk '$1 == "nameserver" { print $2; exit }' /etc/resolv.conf 2>/dev/null)
 	# A live udhcpc for the interface is what being on DHCP means; ifup
-	# leaves its pid where ifdown will look for it.
+	# leaves its pid where ifdown will look for it. An address with no
+	# udhcpc behind it is static. No address at all is neither, and the card
+	# says so rather than picking one.
 	local pid=$(cat "/var/run/udhcpc.$1.pid" 2>/dev/null)
 	if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
 		now_mode=dhcp
-	else
+	elif [ -n "$now_address" ]; then
 		now_mode=static
+	else
+		now_mode=""
 	fi
 	# The wireless network in use is the one wpa_supplicant was started
 	# with: the pre-up wrote it from the U-Boot variables of that moment,
@@ -107,8 +128,21 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 			;;
 
 		reset)
-			rm -f /etc/network/interfaces.d/*
-			cp -f /rom/etc/network/interfaces.d/* /etc/network/interfaces.d
+			# The firmware's set is staged beside the directory and swapped in
+			# only once every copy succeeded, so a copy that fails -- the
+			# overlay full, say -- leaves what was there rather than a camera
+			# with no interface file to boot from. Staged rather than copied
+			# onto the merged path, because a file the overlay has never
+			# copied up is the firmware's own inode showing through, and cp
+			# refuses to copy a file onto itself.
+			d=/etc/network/interfaces.d
+			rm -rf "$d.new"
+			if ! out=$({ mkdir "$d.new" && cp -f "/rom$d"/* "$d.new/"; } 2>&1); then
+				rm -rf "$d.new"
+				redirect_back "danger" "Network configuration was not reset: $(esc "$out")"
+			fi
+			rm -f "$d"/*
+			mv "$d.new"/* "$d/" && rmdir "$d.new"
 			net_read "$now_iface"
 			msg="Network configuration reset to the firmware's."
 			net_pending && msg="$msg It takes effect when the camera restarts."
@@ -182,19 +216,24 @@ net_pending && restart_pending=1
 <%
 # The fields carry the file. On DHCP the static fields are hidden, and what
 # they hold is the starting point for turning the switch off: the lease in
-# use, which is what most people mean to pin.
-network_interface=$now_iface
-network_dhcp=$([ "$cfg_mode" = "dhcp" ] && echo true)
-if [ "$cfg_mode" = "static" ]; then
-	network_address=$cfg_address
-	network_netmask=$cfg_netmask
-	network_gateway=$cfg_gateway
-	network_nameserver=$cfg_nameserver
-else
-	network_address=$now_address
-	network_netmask=$now_netmask
-	network_gateway=$now_gateway
-	network_nameserver=$now_nameserver
+# use, which is what most people mean to pin. A save the checks above
+# refused falls through to here with the posted values still in the
+# variables, and they stay: the page is showing the person their own
+# attempt beside what was wrong with it.
+if [ -z "$error" ]; then
+	network_interface=$now_iface
+	network_dhcp=$([ "$cfg_mode" = "dhcp" ] && echo true)
+	if [ "$cfg_mode" = "static" ]; then
+		network_address=$cfg_address
+		network_netmask=$cfg_netmask
+		network_gateway=$cfg_gateway
+		network_nameserver=$cfg_nameserver
+	else
+		network_address=$now_address
+		network_netmask=$now_netmask
+		network_gateway=$now_gateway
+		network_nameserver=$now_nameserver
+	fi
 fi
 %>
 
@@ -235,12 +274,12 @@ fi
 		<div class="card"><div class="card-body">
 			<% card_head "Current connection" %>
 			<% if net_pending; then %>
-			<p class="small text-secondary">Still the setup from before the save. The saved settings take effect when the camera restarts.</p>
+			<p class="small text-secondary">What the camera is on now. The saved settings take effect when it restarts.</p>
 			<% fi %>
 			<dl class="small list mb-0">
 				<dt>Hostname</dt><dd><% esc "$network_hostname" %></dd>
 				<dt>Interface</dt><dd><% esc "$now_iface" %></dd>
-				<dt>Mode</dt><dd><%= $([ "$now_mode" = "dhcp" ] && echo DHCP || echo Static) %></dd>
+				<dt>Mode</dt><dd><%= $(case "$now_mode" in dhcp) echo DHCP ;; static) echo Static ;; *) echo "—" ;; esac) %></dd>
 				<% if [ "$now_iface" = "wlan0" ] && [ -n "$now_ssid" ]; then %>
 				<dt>Wi-Fi</dt><dd><% esc "$now_ssid" %></dd>
 				<% fi %>

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -229,7 +229,14 @@ Pragma: no-cache
      data-mj-version="<% attr_escape "$mj_version" %>"
      data-soc-vendor="<% attr_escape "$soc_vendor" %>"></div>
 
-<% if [ -e /tmp/system-reboot ]; then %>
+<%# The flag file is how a page says so from a POST it has already left.
+    restart_pending is how a page that can SEE the pending state on every
+    draw says so without leaving a flag nothing can clear: network.cgi
+    compares the saved interface file with what the kernel is doing, so its
+    banner clears itself on a restart and on a save that puts things back,
+    where a flag would go on saying "waiting for a restart" about a change
+    that had since been undone. %>
+<% if [ -e /tmp/system-reboot ] || [ -n "$restart_pending" ]; then %>
 <% notice warn '<b>Settings are waiting for a restart</b> &mdash; video and recording stop for about half a minute while the camera comes back.' '<a class="btn btn-sm btn-danger" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>' %>
 <% fi %>
 


### PR DESCRIPTION
Reported in OpenIPC/majestic#311 (a side note in the memory-leak thread): on System / Network, changing the IP address, netmask, gateway or DNS and pressing Save left the fields holding the old values, while the file shown under Diagnostics proved the save had happened.

## Cause

`sbin/setnetwork` writes `/etc/network/interfaces.d/<iface>` and applies nothing but the hostname. The only reader of that file is the boot script's `ifup`, so a saved address exists nowhere else until the camera restarts. The form was drawn from the **running** state instead — routing table, `ifconfig`, `resolv.conf` — with only the DHCP switch read from the file. Those two agree between a restart and the next save, and disagree from then on, and nothing on the page said a restart was owed.

## Change

- **The form shows the file, the card shows the kernel.** `net_read` parses the interfaces.d file into the form and asks the kernel for the *Current connection* card. On DHCP the hidden static fields are pre-filled with the lease in use, so turning the switch off starts from the address most people mean to pin. On wlan0 the card also names the network wpa_supplicant was started with.
- **A restart is announced while the two disagree.** `net_pending` compares them on every draw; the page sets `restart_pending` before including the header, whose banner now honours that variable beside `/tmp/system-reboot`. Deliberately not the flag file: this page cannot clear it (the MAC change and `time.cgi` set it too), so it would keep saying "waiting for a restart" about a save that had since been undone. The live comparison clears itself on a restart and on a save that puts things back.
- The card says *Still the setup from before the save. The saved settings take effect when the camera restarts.* while pending, and the flash says the same. The reset action gets a flash as well.
- `setnetwork`'s exit status is checked; a refused save used to be reported as a save.
- The comparison is only made for the interface the camera is on. The boot script brings wlan0 up from its file only when U-Boot names a wireless driver, and eth0 from its file only when it does not, so the page cannot promise when a save to the other interface applies.
- CLAUDE.md documents the split and `restart_pending`.

## Checked

On an hi3516ev300, through the page: a static save equal to the lease shows the form static and the card on DHCP with the banner up; a different address shows in the form while the card keeps the lease (the reported case); a later plain GET keeps the banner with no flag file present; saving DHCP back clears it and leaves the file identical to the firmware's. Nothing is applied live, so the camera never moved.

Applying the change without a restart would be a feature on top of this and is not part of it.
