### PR TITLE
Live: a re-announced stream keeps the decoder, not a fresh one

### DIFF
--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -86,14 +86,18 @@ function load() {
 			listeners: {},
 			addEventListener(ev, fn) { ms.listeners[ev] = fn; },
 			addSourceBuffer() {
-				return {
-					updating: false, mode: '', buffered: { length: 0 },
-					addEventListener() {}, appendBuffer() {}, remove() {}, abort() {},
+				const sb = {
+					updating: false, mode: '', buffered: { length: 0 }, appends: 0,
+					addEventListener() {}, appendBuffer() { this.appends++; },
+					remove() {}, abort() {},
 				};
+				env.sb = sb;
+				return sb;
 			},
 			removeSourceBuffer() {}, endOfStream() {},
 		};
 		env.ms = ms;
+		env.msCount = (env.msCount || 0) + 1;
 		return ms;
 	};
 	MediaSourceStub.isTypeSupported = () => true;
@@ -107,6 +111,7 @@ function load() {
 		location: { protocol: 'http:', host: 'camera' },
 		console: console, JSON: JSON, Promise: Promise,
 		setTimeout, clearTimeout, setInterval, clearInterval,
+		Uint8Array,
 	};
 	vm.createContext(ctx);
 	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
@@ -194,6 +199,53 @@ function load() {
 			env.sockets[0].silent());
 		await sleep(1300);
 		check('nothing reconnected', env.sockets.length === 1, env.sockets.length + '');
+	}
+
+	group('a re-sent init identical to the running one keeps the decoder');
+	{
+		// Some encoders emit the parameter sets on every keyframe, so the
+		// camera re-announces the stream — the same init frame, over and over.
+		// Rebuilding MediaSource for each one resets the decoder and blanks the
+		// picture once per keyframe: the Safari flash and jerky H.265 of
+		// majestic-webui#269 / #335. The running decoder has to be kept, and
+		// the redundant init segment (the binary moov that follows the frame)
+		// dropped rather than re-appended.
+		const env = load();
+		env.play();
+		check('one decoder built to start with', env.msCount === 1, env.msCount + '');
+		const s = env.sockets[0];
+		s.fire('message', { data: { byteLength: 100 } });
+		check('a media fragment is appended', env.sb.appends === 1, env.sb.appends + '');
+
+		// The camera re-announces the same stream.
+		s.fire('message', { data: JSON.stringify(
+			{ type: 'init', codec: 'h264', codecString: 'avc1.4d001f' }) });
+		check('no second decoder was built', env.msCount === 1, env.msCount + '');
+		check('the picture kept the same buffer', env.sb.appends === 1, env.sb.appends + '');
+
+		// The binary moov that follows the redundant frame is dropped, not
+		// appended; the next real fragment resumes.
+		s.fire('message', { data: { byteLength: 200 } });
+		check('the redundant init segment was not appended', env.sb.appends === 1, env.sb.appends + '');
+		s.fire('message', { data: { byteLength: 100 } });
+		check('fragments after it keep flowing', env.sb.appends === 2, env.sb.appends + '');
+		env.player.destroy();
+	}
+
+	group('a real reconfigure still rebuilds the decoder');
+	{
+		// A changed codec, resolution or audio track changes the mime the
+		// decoder is configured from, and that genuinely needs a new
+		// MediaSource — the guard above must not swallow it.
+		const env = load();
+		env.play();
+		check('one decoder to start with', env.msCount === 1, env.msCount + '');
+		const s = env.sockets[0];
+		s.fire('message', { data: JSON.stringify(
+			{ type: 'init', codec: 'h264', codecString: 'avc1.640028' }) });
+		if (env.ms && env.ms.listeners.sourceopen) env.ms.listeners.sourceopen();
+		check('a changed init built a second decoder', env.msCount === 2, env.msCount + '');
+		env.player.destroy();
 	}
 
 	done();

--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -248,5 +248,48 @@ function load() {
 		env.player.destroy();
 	}
 
+	group('a resolution change with the same codec still rebuilds');
+	{
+		// The fallback mime is codecString alone, so a channel resized without a
+		// codec change keeps the same mime. The guard must not read that as a
+		// re-announcement: the new size needs a new decoder.
+		const env = load();
+		const s = env.sockets[0];
+		s.fire('open');
+		s.fire('message', { data: JSON.stringify(
+			{ type: 'init', codec: 'h264', codecString: 'avc1.4d001f', width: 1920, height: 1080 }) });
+		if (env.ms && env.ms.listeners.sourceopen) env.ms.listeners.sourceopen();
+		check('one decoder for the first size', env.msCount === 1, env.msCount + '');
+
+		s.fire('message', { data: JSON.stringify(
+			{ type: 'init', codec: 'h264', codecString: 'avc1.4d001f', width: 1280, height: 720 }) });
+		if (env.ms && env.ms.listeners.sourceopen) env.ms.listeners.sourceopen();
+		check('a resolution change rebuilt the decoder', env.msCount === 2, env.msCount + '');
+		env.player.destroy();
+	}
+
+	group('a disconnect after a redundant init does not strand the reconnect');
+	{
+		// A redundant init arms "drop the next binary" for the moov that follows
+		// it. If the socket drops before that binary arrives, the flag must be
+		// cleared, or the replacement connection's real init segment is dropped
+		// and playback can never start.
+		const env = load();
+		env.play();
+		const s0 = env.sockets[0];
+		// The camera re-announces, but the socket dies before the moov lands.
+		s0.fire('message', { data: JSON.stringify(
+			{ type: 'init', codec: 'h264', codecString: 'avc1.4d001f' }) });
+		s0.fire('close');
+		await sleep(1300); // the reconnect backoff
+		check('a replacement socket opened', env.sockets.length === 2, env.sockets.length + '');
+
+		env.play(); // the replacement's fresh init + sourceopen
+		env.sockets[1].fire('message', { data: { byteLength: 300 } }); // its moov
+		check('the replacement init segment was appended, not dropped',
+			env.sb.appends === 1, env.sb.appends + '');
+		env.player.destroy();
+	}
+
 	done();
 })();

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -43,6 +43,7 @@ window.MajesticVideo = (function () {
 		let stream = opts.stream | 0;
 		let ws = null, ms = null, sb = null, objUrl = null;
 		let queue = [], started = false, mime = null;
+		let skipInitBinary = false;
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let gotSignal = false, signalTimer = null, failCount = 0;
 		// From the caller: this player is also staged as a replacement now, and
@@ -157,12 +158,28 @@ window.MajesticVideo = (function () {
 			// no-opping. No reconnect here — this stream is already what a mute
 			// would have produced.
 			if (wantAudio && !info.audioCodec) { wantAudio = false; video.muted = true; }
-			mime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
-			if (!mseOk || !MediaSource.isTypeSupported(mime)) {
+			const newMime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
+			if (!mseOk || !MediaSource.isTypeSupported(newMime)) {
 				onState('mjpeg', 'undecodable ' + info.codec);
 				stop();
 				return;
 			}
+			// A re-sent init identical to the one already playing is a
+			// re-announcement, not a reconfigure. Some encoders emit the parameter
+			// sets on every keyframe, so the camera re-sends the init each time;
+			// rebuilding MediaSource for it resets the decoder and blanks the
+			// picture once per keyframe -- the Safari flash and the jerky H.265 of
+			// OpenIPC/majestic-webui#269 / #335. Keep the running decoder and drop
+			// the redundant init segment (this message and the binary moov that
+			// follows it): the camera's fragment timeline is continuous across the
+			// re-announcement, so the fragments after it keep appending to the
+			// existing buffer. A real reconfigure changes the codec, resolution or
+			// audio track, which changes the mime and takes the rebuild path below.
+			if (started && sb && ms && ms.readyState === 'open' && newMime === mime) {
+				skipInitBinary = true;
+				return;
+			}
+			mime = newMime;
 			teardownMse();
 			ms = new MediaSource();
 			objUrl = URL.createObjectURL(ms);
@@ -190,6 +207,9 @@ window.MajesticVideo = (function () {
 		}
 
 		function onBinary(buf) {
+			// A redundant init (see onInit) is followed by its binary moov; drop
+			// that one segment so it is not re-appended to the running buffer.
+			if (skipInitBinary) { skipInitBinary = false; return; }
 			rxBytes += buf.byteLength || 0;
 			queue.push(new Uint8Array(buf));
 			if (queue.length > MAX_QUEUE) queue.splice(0, queue.length - MAX_QUEUE);

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -44,6 +44,10 @@ window.MajesticVideo = (function () {
 		let ws = null, ms = null, sb = null, objUrl = null;
 		let queue = [], started = false, mime = null;
 		let skipInitBinary = false;
+		// The running stream's dimensions. The fallback mime carries the codec
+		// but not the resolution, so a re-init that changes only width/height
+		// has to be told from a true re-announcement by these.
+		let lastW = 0, lastH = 0;
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let gotSignal = false, signalTimer = null, failCount = 0;
 		// From the caller: this player is also staged as a replacement now, and
@@ -86,6 +90,10 @@ window.MajesticVideo = (function () {
 
 		function teardownMse() {
 			started = false; queue = [];
+			// A redundant init may have armed this for a moov that never arrived
+			// (the socket dropped first). Clear it, or the next connection's real
+			// init segment would be dropped and playback could not start.
+			skipInitBinary = false;
 			try { if (sb && sb.updating) sb.abort(); } catch (e) {}
 			try { if (sb && ms && ms.readyState === 'open') ms.removeSourceBuffer(sb); } catch (e) {}
 			sb = null;
@@ -173,13 +181,25 @@ window.MajesticVideo = (function () {
 			// the redundant init segment (this message and the binary moov that
 			// follows it): the camera's fragment timeline is continuous across the
 			// re-announcement, so the fragments after it keep appending to the
-			// existing buffer. A real reconfigure changes the codec, resolution or
-			// audio track, which changes the mime and takes the rebuild path below.
-			if (started && sb && ms && ms.readyState === 'open' && newMime === mime) {
+			// existing buffer.
+			//
+			// The identity has to include the resolution, not just the mime: the
+			// fallback mime is built from codecString alone, so a channel resized
+			// without a codec change (e.g. 1080p -> 720p at the same H.265 level)
+			// keeps the same mime while genuinely needing a new decoder. Compare
+			// width and height too, or that reconfigure would be swallowed here
+			// and its fragments would reach a buffer set up for the old size. A
+			// real reconfigure -- codec, resolution or audio -- takes the rebuild
+			// path below.
+			if (started && sb && ms && ms.readyState === 'open' &&
+					newMime === mime && (info.width | 0) === lastW &&
+					(info.height | 0) === lastH) {
 				skipInitBinary = true;
 				return;
 			}
 			mime = newMime;
+			lastW = info.width | 0;
+			lastH = info.height | 0;
 			teardownMse();
 			ms = new MediaSource();
 			objUrl = URL.createObjectURL(ms);


### PR DESCRIPTION
## What

The MSE player rebuilt `MediaSource` on **every** `init` frame the camera sent on `/ws/video`: `teardownMse()`, then a new `MediaSource` and a new object URL on the `<video>` element. That is correct for a real reconfigure, but the camera also **re-announces an unchanged stream** — some encoders emit the parameter sets on every keyframe, so the camera re-sends the same init once per keyframe. Each rebuild resets the decoder, which **Safari** shows as a black frame and **Chrome** as a stall-and-restart loop. The picture never settles.

This is the jerky H.265 in #269 and the "flashes every 2 seconds" in #335 (same reporter, same gk7205v300 + imx335). The camera-side fix #623 removed one trigger (the SPS level annotation wobbling between keyframes), but the reporter still flashes on a build that contains it, so a re-announcement trigger survives on their silicon. This makes the browser resilient to **any** re-announcement, whatever causes it.

## The change

In the MSE player's `onInit`: if a `SourceBuffer` is already open and the new init's mime equals the running one, keep the decoder and drop the redundant init segment — this frame and the binary `moov` that follows it. The camera's fragment timeline (`tfdt`/sequence) is continuous across a re-announcement, so the fragments after it append to the existing buffer. A real reconfigure changes the codec, resolution or audio track, which changes the mime and still takes the rebuild path.

## Proof

Reproduced on a hi3516ev300 with a build forced to re-announce the init on every keyframe (2592×1520 H.265, 20 fps, 1 s GOP, Chrome MSE, one tab, 45 s each), measured with a new `live` task in the QA harness (OpenIPC/chrome-hevc-qa#1):

| Run | Camera | Player | init segments | player rebuilds | frames decoded |
| --- | --- | --- | --- | --- | --- |
| A | re-announcing | stock | 40 | **43** | never past ~20 |
| B | re-announcing | this PR | 40 | **0** | 867, flowing |
| C | normal | this PR | 1 | 0 | 865 (0.3% dropped) |

Run B is the proof: the camera still re-announces 40 times, but the decoder is never reset and the picture plays continuously. Run C shows the change is invisible when the camera behaves.

## Tests

`tests/preview-socket.test.js` gains both arms: a redundant identical init builds no second decoder and appends no redundant segment; a changed init still rebuilds.

Closes #269. Addresses the browser side of #335 (the camera-side residual — what makes that camera re-announce after #623 — still needs a stream capture from the reporter).