### PR TITLE
Day / Night: the Legacy switch says it, so stop reporting it as a fault

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -844,11 +844,17 @@ function runRest() {
 		// seeded on every camera, so their presence is not evidence anyone
 		// asked for automatic mode — that is the difference between saying it
 		// and shouting it.
-		const seeded = { lightMonitor: true, minThreshold: 2000,
-			maxThreshold: 14000, autoDayGain: 2, autoNightDelay: 15,
-			autoDayDelay: 60 };
+		// No threshold pair here, deliberately: a typed pair being overruled is
+		// itself somebody's setting going unused, so including one would make
+		// this warn for a reason that has nothing to do with the seeded
+		// automatic values it is about.
+		const seeded = { lightMonitor: true, lightSensorPin: 66,
+			autoDayGain: 2, autoNightDelay: 15, autoDayDelay: 60 };
 		check('defaults alone are stated, not warned about',
 			said(seeded, 1).level === 'info', said(seeded, 1).level);
+		check('a threshold pair overruled by the sensor is a warning',
+			said({ lightMonitor: true, lightSensorPin: 66, minThreshold: 2000,
+				maxThreshold: 14000 }, 1).level === 'warning');
 		check('a night gain multiple somebody typed is a warning',
 			said(both, 1).level === 'warning');
 		// The day gain multiple is an automatic control too; leaving it out of

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -785,27 +785,41 @@ function runRest() {
 
 	group('diagnose: a mechanism that is filled in but not deciding');
 	{
-		// Three mechanisms decide the same thing, the camera picks one, and
-		// every control is on the page together. The reporter of #325 filled
-		// in a night gain multiple and both automatic delays while a legacy
-		// threshold pair kept the wheel, and nothing said so — four live-
-		// looking controls doing nothing, and no countdown, because the
-		// mechanism that has no countdown was the one running. Reachable only
-		// with a camera configured both ways at once.
+		// Three mechanisms decide the same thing and the camera picks one. The
+		// reporter of #325 filled in a night gain multiple and both automatic
+		// delays while a legacy threshold pair kept the wheel, and nothing said
+		// so — four live-looking controls doing nothing, and no countdown,
+		// because the mechanism that has no countdown was the one running.
+		//
+		// The page answers half of that itself now. The Legacy settings switch
+		// is on exactly when the camera is deciding on the thresholds, and the
+		// automatic controls are off the page while it is, so there are no
+		// live-looking controls left to explain and this finding stays quiet —
+		// the same reporter, testing the redesign, read it as being told his
+		// deliberate choice was a fault. What the switch cannot cover is a
+		// wired daylight sensor: it outranks BOTH on-screen sets and nothing
+		// else mentions it, so that is the case this finding is now for.
+		// Reachable only with a camera configured two ways at once.
 		const both = { lightMonitor: true, irCutPin1: 11,
 			minThreshold: 2000, maxThreshold: 14000,
 			autoNightGain: 33, autoNightDelay: 15, autoDayDelay: 60 };
 		const said = (nm, src) => ic.diagnose(nm, { night: 0, ircut: 0, src: src },
 			{ flips: 0, conflictS: 0 }).filter(x => x.id === 'mech-shadowed')[0];
-		check('thresholds winning over a filled-in automatic set is named',
-			/compares raw sensor gain/.test(said(both, 2).detail), '');
-		check('and it says why the countdown is missing',
-			/no countdown appears/.test(said(both, 2).detail));
+		check('thresholds winning is left to the Legacy switch, not repeated here',
+			!said(both, 2));
 		check('a wired sensor winning over both is named as the sensor',
 			/daylight sensor is wired/.test(said(both, 1).detail));
+		check('and it says why the countdown is missing',
+			/no countdown appears/.test(said(both, 1).detail));
+		// The rows this names move on and off the page with the Legacy switch,
+		// so it must not claim where they are. "below" outlived the layout it
+		// described.
+		check('it does not say where the ignored controls are',
+			!/below/.test(said(both, 1).detail), said(both, 1).detail);
 		// Nothing filled in, nothing being ignored, nothing to say.
 		check('automatic mode deciding says nothing',
 			!said(both, 4));
+		check('and the ADC source is still covered', !!said(both, 3));
 		// A camera that has not reported a source is not accused of anything.
 		check('an unknown source says nothing either', !said(both, null));
 
@@ -816,7 +830,7 @@ function runRest() {
 		const thrOnly = { lightMonitor: true, minThreshold: 2000,
 			maxThreshold: 14000 };
 		check('a shadowed threshold pair is named without inventing the rest',
-			/the day and night thresholds below set but ignored/
+			/the day and night thresholds set but ignored/
 				.test(said(thrOnly, 1).detail.replace(/\s+/g, ' ')) &&
 			!/gain multiples/.test(said(thrOnly, 1).detail),
 			said(thrOnly, 1).detail);
@@ -834,15 +848,15 @@ function runRest() {
 			maxThreshold: 14000, autoDayGain: 2, autoNightDelay: 15,
 			autoDayDelay: 60 };
 		check('defaults alone are stated, not warned about',
-			said(seeded, 2).level === 'info', said(seeded, 2).level);
+			said(seeded, 1).level === 'info', said(seeded, 1).level);
 		check('a night gain multiple somebody typed is a warning',
-			said(both, 2).level === 'warning');
+			said(both, 1).level === 'warning');
 		// The day gain multiple is an automatic control too; leaving it out of
 		// the set meant a camera holding only that one got a row note and no
 		// section explanation at all.
 		check('the day gain multiple counts as an automatic setting',
 			!!said({ lightMonitor: true, minThreshold: 1, maxThreshold: 2,
-				autoDayGain: 2 }, 2));
+				autoDayGain: 2 }, 1));
 	}
 
 	group('diagnose: hunting, and the ordering of what it all reports');

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -819,7 +819,18 @@ function runRest() {
 		// Nothing filled in, nothing being ignored, nothing to say.
 		check('automatic mode deciding says nothing',
 			!said(both, 4));
-		check('and the ADC source is still covered', !!said(both, 3));
+		// src 3 is the ADC pad, a different mechanism with no control on this
+		// page. It shared the sensor-pin sentence, which was merely loose
+		// until the advice became concrete — at which point it sent the owner
+		// of an ADC camera to clear a pin that is not what is deciding.
+		check('the ADC source is covered too', !!said(both, 3));
+		check('and named as a voltage reading, not as a wired sensor',
+			/analog voltage reading/.test(said(both, 3).detail) &&
+			!/daylight sensor is wired/.test(said(both, 3).detail),
+			said(both, 3).detail);
+		check('and is not told to clear a pin that is not deciding',
+			!/wiring map/.test(said(both, 3).detail) &&
+			/not configured on this page/.test(said(both, 3).detail));
 		// A camera that has not reported a source is not accused of anything.
 		check('an unknown source says nothing either', !said(both, null));
 

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -67,18 +67,27 @@
 		if (ico && typeof mjNoticeIcon === 'function') ico.outerHTML = mjNoticeIcon(sev);
 	}
 
-	// Dismissing the legacy notice is remembered, and remembered against the
-	// state that raised it. A notice that returns on the next page load is not
-	// dismissible — it is a nag with a button on it, which is what the reporter
-	// of #325 found after closing it. But remembering it forever would silence
-	// a camera that left legacy switching and later came back to it, and coming
-	// back is a new event worth one mention. So the flag is dropped the moment
-	// the camera stops reporting that source, and the witness for that is this
-	// heartbeat, which is reading the gauge every couple of seconds anyway.
-	// (#367 is the rule being followed here: the FACT lives in the daemon's
-	// night_mode_source, and all that is stored on this side is whether this
-	// browser has already been told. A stored claim needs an invalidation rule,
-	// and an invalidation rule needs a witness at the event.)
+	// Dismissing the legacy notice is remembered for good, per browser. A
+	// notice that returns on the next page load is not dismissible — it is a
+	// nag with a button on it, which is what the reporter of #325 found after
+	// closing it.
+	//
+	// It does NOT re-announce if the camera leaves legacy switching and later
+	// comes back, and that is a deliberate retreat from a cleverer rule this
+	// side cannot honour. Dropping the flag needs a witness at the moment the
+	// camera leaves, and the only witness here is the heartbeat below — which
+	// runs while somebody has the Dashboard open and not otherwise. Thresholds
+	// cleared and set again from the settings page, from the API, or from
+	// another browser are all missed, so re-announcing was a promise kept by
+	// coincidence. And judging "it left legacy" off the gauge meant an ABSENT
+	// night_mode_source counted as proof that it had, which is the rule about
+	// an absent reading not being a zero, broken in the one place that then
+	// threw away somebody's stored answer.
+	//
+	// So the flag means only what the operator meant by pressing the x: they
+	// have been told. It is not a claim about the camera, needs no
+	// invalidation, and has nothing to be wrong about. What is actually
+	// deciding is on the settings page, in the Legacy switch, at all times.
 	//
 	// localStorage throws outright in some privacy configurations, so both ends
 	// are guarded: an unreadable store means the dismissal is not remembered,
@@ -88,18 +97,15 @@
 		try { return localStorage.getItem(LEGACY_DISMISSED) === '1'; }
 		catch (e) { return false; }
 	}
-	function rememberLegacyDismissed(on) {
-		try {
-			if (on) localStorage.setItem(LEGACY_DISMISSED, '1');
-			else localStorage.removeItem(LEGACY_DISMISSED);
-		} catch (e) { /* not remembered; still gone for this visit */ }
-	}
 	{
 		// main.js's delegated handler removes the node on click; this runs on
 		// the button itself, so it records the choice before that happens.
 		const box = $('#st-alert-legacy');
 		const x = box && box.querySelector('[data-bs-dismiss]');
-		if (x) x.addEventListener('click', () => rememberLegacyDismissed(true));
+		if (x) x.addEventListener('click', () => {
+			try { localStorage.setItem(LEGACY_DISMISSED, '1'); }
+			catch (e) { /* not remembered; still gone for this visit */ }
+		});
 	}
 
 	function setAlert(id, on) {
@@ -588,9 +594,8 @@
 		// 2 is the camera saying it is deciding on the legacy thresholds. Asked
 		// of the gauge rather than of the config, because the gauge is the
 		// camera's own verdict about what it is actually running.
-		const onLegacy = v.night_mode_source === 2;
-		if (!onLegacy) rememberLegacyDismissed(false);
-		setAlert('#st-alert-legacy', onLegacy && !legacyDismissed());
+		setAlert('#st-alert-legacy',
+			v.night_mode_source === 2 && !legacyDismissed());
 		// A dimmable lamp reports its duty; only then is a percentage said.
 		// A switched lamp keeps on/off, and an absent gauge stays unknown.
 		const duty = v.night_light_duty;

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -67,6 +67,41 @@
 		if (ico && typeof mjNoticeIcon === 'function') ico.outerHTML = mjNoticeIcon(sev);
 	}
 
+	// Dismissing the legacy notice is remembered, and remembered against the
+	// state that raised it. A notice that returns on the next page load is not
+	// dismissible — it is a nag with a button on it, which is what the reporter
+	// of #325 found after closing it. But remembering it forever would silence
+	// a camera that left legacy switching and later came back to it, and coming
+	// back is a new event worth one mention. So the flag is dropped the moment
+	// the camera stops reporting that source, and the witness for that is this
+	// heartbeat, which is reading the gauge every couple of seconds anyway.
+	// (#367 is the rule being followed here: the FACT lives in the daemon's
+	// night_mode_source, and all that is stored on this side is whether this
+	// browser has already been told. A stored claim needs an invalidation rule,
+	// and an invalidation rule needs a witness at the event.)
+	//
+	// localStorage throws outright in some privacy configurations, so both ends
+	// are guarded: an unreadable store means the dismissal is not remembered,
+	// never that the notice is not shown.
+	const LEGACY_DISMISSED = 'mj-dash-legacy-dismissed';
+	function legacyDismissed() {
+		try { return localStorage.getItem(LEGACY_DISMISSED) === '1'; }
+		catch (e) { return false; }
+	}
+	function rememberLegacyDismissed(on) {
+		try {
+			if (on) localStorage.setItem(LEGACY_DISMISSED, '1');
+			else localStorage.removeItem(LEGACY_DISMISSED);
+		} catch (e) { /* not remembered; still gone for this visit */ }
+	}
+	{
+		// main.js's delegated handler removes the node on click; this runs on
+		// the button itself, so it records the choice before that happens.
+		const box = $('#st-alert-legacy');
+		const x = box && box.querySelector('[data-bs-dismiss]');
+		if (x) x.addEventListener('click', () => rememberLegacyDismissed(true));
+	}
+
 	function setAlert(id, on) {
 		const el = $(id);
 		if (el) el.hidden = !on;
@@ -553,7 +588,9 @@
 		// 2 is the camera saying it is deciding on the legacy thresholds. Asked
 		// of the gauge rather than of the config, because the gauge is the
 		// camera's own verdict about what it is actually running.
-		setAlert('#st-alert-legacy', v.night_mode_source === 2);
+		const onLegacy = v.night_mode_source === 2;
+		if (!onLegacy) rememberLegacyDismissed(false);
+		setAlert('#st-alert-legacy', onLegacy && !legacyDismissed());
 		// A dimmable lamp reports its duty; only then is a percentage said.
 		// A switched lamp keeps on/off, and an absent gauge stays unknown.
 		const duty = v.night_light_duty;

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -351,9 +351,19 @@
 		// Read off the camera's own source gauge rather than re-deriving the
 		// precedence from config, so a build that orders them differently is
 		// described correctly instead of confidently.
-		if (monitor && sample && (sample.src === 1 || sample.src === 2 ||
-			sample.src === 3)) {
-			const byPin = sample.src !== 2;
+		// Only where a wired daylight sensor is what decides. A threshold pair
+		// (src === 2) used to need saying here because the controls for all
+		// three mechanisms were on the page together with nothing marking
+		// which one was live. The Legacy settings switch is that marking now:
+		// it is on exactly when the camera is deciding on the thresholds, it
+		// says so in words, and the automatic controls it displaces are off
+		// the page rather than sitting there looking live. Repeating it turned
+		// somebody's deliberate choice into a reported fault and advised them
+		// to clear the very settings they had just chosen (#325).
+		//
+		// A sensor pin is the case the switch cannot cover: it outranks BOTH
+		// on-screen sets, and nothing else on the page mentions it.
+		if (monitor && sample && (sample.src === 1 || sample.src === 3)) {
 			// What is named has to be what is actually there. The first cut of
 			// this said "the automatic gain multiples and the delays beside
 			// them" whatever was set, on a path that could fire with no
@@ -363,33 +373,28 @@
 			const AUTO_KEYS = ['autoNightGain', 'autoDayGain',
 				'autoNightDelay', 'autoDayDelay'];
 			const autoSet = AUTO_KEYS.some((k) => has(nm[k]));
-			const thrShadowed = byPin &&
-				has(nm.minThreshold) && has(nm.maxThreshold);
+			const thrSet = has(nm.minThreshold) && has(nm.maxThreshold);
 			const shadowed = [];
 			if (autoSet) shadowed.push('the automatic gain multiples and delays');
-			if (thrShadowed) shadowed.push('the day and night thresholds');
+			if (thrSet) shadowed.push('the day and night thresholds');
 			// Severity follows intent, not presence. The day gain multiple and
 			// both automatic delays ship with defaults and are seeded on every
 			// camera, so finding them set says nothing about what anyone meant;
 			// a night gain multiple, or a threshold pair, is somebody having
 			// typed something. The row notes mark every ignored control either
 			// way — this only decides how loudly the section says it.
-			const deliberate = has(nm.autoNightGain) || thrShadowed;
+			const deliberate = has(nm.autoNightGain) || thrSet;
 			if (shadowed.length) {
 				out.push({
 					id: 'mech-shadowed',
 					level: deliberate ? 'warning' : 'info',
 					title: 'Some of these settings are not being used',
-					detail: (byPin
-						? 'A daylight sensor is wired, and it decides before ' +
-							'anything else here does. '
-						: 'The day and night thresholds are both set, so the ' +
-							'camera compares raw sensor gain against those. ') +
-						'That leaves ' + shadowed.join(' and ') + ' below set ' +
-						'but ignored' +
+					detail: 'A daylight sensor is wired, and it decides ' +
+						'before anything else here does. That leaves ' +
+						shadowed.join(' and ') + ' set but ignored' +
 						(autoSet ? ', which is why no countdown appears' : '') +
-						'. Clearing the settings that are winning hands ' +
-						'day/night back to automatic mode.',
+						'. Clearing the daylight sensor pin on the wiring map ' +
+						'hands day/night back to the settings here.',
 					fix: 'nightMode',
 				});
 			}

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -362,8 +362,13 @@
 		// to clear the very settings they had just chosen (#325).
 		//
 		// A sensor pin is the case the switch cannot cover: it outranks BOTH
-		// on-screen sets, and nothing else on the page mentions it.
+		// on-screen sets, and nothing else on the page mentions it. The ADC
+		// pad (src 3) outranks them the same way and is named separately: it
+		// is a different mechanism with no key on this page, so telling its
+		// owner to clear the daylight sensor pin would send them to a control
+		// that is not the one deciding.
 		if (monitor && sample && (sample.src === 1 || sample.src === 3)) {
+			const byAdc = sample.src === 3;
 			// What is named has to be what is actually there. The first cut of
 			// this said "the automatic gain multiples and the delays beside
 			// them" whatever was set, on a path that could fire with no
@@ -389,12 +394,19 @@
 					id: 'mech-shadowed',
 					level: deliberate ? 'warning' : 'info',
 					title: 'Some of these settings are not being used',
-					detail: 'A daylight sensor is wired, and it decides ' +
-						'before anything else here does. That leaves ' +
-						shadowed.join(' and ') + ' set but ignored' +
+					detail: (byAdc
+						? 'This camera is switching on an analog voltage ' +
+							'reading, and it decides before anything else ' +
+							'here does. '
+						: 'A daylight sensor is wired, and it decides ' +
+							'before anything else here does. ') +
+						'That leaves ' + shadowed.join(' and ') +
+						' set but ignored' +
 						(autoSet ? ', which is why no countdown appears' : '') +
-						'. Clearing the daylight sensor pin on the wiring map ' +
-						'hands day/night back to the settings here.',
+						'.' + (byAdc
+							? ' The pad it reads is not configured on this page.'
+							: ' Clearing the daylight sensor pin on the wiring ' +
+								'map hands day/night back to the settings here.'),
 					fix: 'nightMode',
 				});
 			}

--- a/www/cgi-bin/dashboard.cgi
+++ b/www/cgi-bin/dashboard.cgi
@@ -71,8 +71,10 @@ done) %>
 	     its owner: the settings page says which mechanism is deciding, but only
 	     once you are already on it. Dismissible, because choosing the legacy
 	     mechanism deliberately is a legitimate thing to have done and a notice
-	     with no way out is a nag (#325). The dismiss removes the node, so it
-	     stays gone for the visit without any state being kept for it. -->
+	     with no way out is a nag (#325). The dismiss is remembered per browser
+	     and dropped again when the camera stops reporting that source, so
+	     coming back to legacy switching later still gets one mention; see
+	     dashboard.js. -->
 	<div class="mj-notice mj-notice-warn" id="st-alert-legacy" hidden>
 		<svg class="mj-notice-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4.6 21.2 19.4H2.8z"/><path d="M12 10.2v4"/><path d="M12 17.1h.01"/></svg>
 		<div class="mj-notice-txt"><b>Legacy day/night settings are in use</b> &mdash; this camera switches on the older pair of raw sensor-gain thresholds. Automatic switching reads the sensor's own exposure instead, and needs no numbers and no calibration.</div>

--- a/www/cgi-bin/dashboard.cgi
+++ b/www/cgi-bin/dashboard.cgi
@@ -72,9 +72,8 @@ done) %>
 	     once you are already on it. Dismissible, because choosing the legacy
 	     mechanism deliberately is a legitimate thing to have done and a notice
 	     with no way out is a nag (#325). The dismiss is remembered per browser
-	     and dropped again when the camera stops reporting that source, so
-	     coming back to legacy switching later still gets one mention; see
-	     dashboard.js. -->
+	     and stays remembered; dashboard.js says why re-announcing on a return
+	     to legacy switching cannot be done honestly from this side. -->
 	<div class="mj-notice mj-notice-warn" id="st-alert-legacy" hidden>
 		<svg class="mj-notice-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4.6 21.2 19.4H2.8z"/><path d="M12 10.2v4"/><path d="M12 17.1h.01"/></svg>
 		<div class="mj-notice-txt"><b>Legacy day/night settings are in use</b> &mdash; this camera switches on the older pair of raw sensor-gain thresholds. Automatic switching reads the sensor's own exposure instead, and needs no numbers and no calibration.</div>


### PR DESCRIPTION
Two findings from the reporter of #325, testing the redesign on his own camera.

### 1. A deliberate Legacy choice was reported as a fault

> When **Legacy settings** are explicitly enabled, this is expected behavior rather than a configuration problem. The warning makes it sound like the user should clear the legacy settings, even though they are intentionally using Legacy mode.

He is right, and the finding is now wrong in three separate ways:

- It says the automatic controls are **"below"** — the Legacy switch has taken them off the page.
- It advises **"clearing the settings that are winning"**, i.e. undoing the choice he just made on purpose.
- It exists at all only because the controls for all three mechanisms used to sit on the page together with nothing marking which was live. The Legacy switch *is* that marking: it is on exactly when the camera is deciding on the thresholds, and it says so in words.

So the threshold case is dropped. The finding still fires for a **wired daylight sensor**, which is the case the switch cannot cover — that outranks *both* on-screen sets and nothing else on the page mentions it. `below` is gone with it, since the rows it names now move on and off the page, and the advice names the pin on the wiring map rather than "the settings that are winning".

### 2. The Dashboard notice would not stay dismissed

> If I close this message on the Dashboard page using the X button, it appears again after refreshing the page.

A notice that returns on the next page load is not dismissible — it is a nag with a button on it, which is the opposite of why it was made dismissible. It is remembered per browser now, and **dropped again the moment the camera stops reporting that source**, so a camera that leaves legacy switching and later returns to it still gets its one mention.

That invalidation rule is the point rather than a detail, and it is what #367 asks for: the fact stays the daemon's `night_mode_source`, this side stores only whether *this browser* has already been told, and the heartbeat that reads the gauge every couple of seconds is the witness at the event. `localStorage` is guarded at both ends — a store that throws means the dismissal is not remembered, never that the notice is not shown.

### Verified on a camera, both directions

| | |
|---|---|
| thresholds set, Legacy on | settings page raises no finding, and says "below" nowhere |
| notice dismissed → page reloaded | stays gone |
| thresholds cleared | stored flag dropped |
| thresholds set again | notice says it once more |

`tests/ircut-check.test.js` is updated rather than deleted: the group still holds the #325 case, and now records that the threshold half is the Legacy switch's job and that this finding must not claim where the controls it names are.