### PR TITLE
Day / Night: say why the sweep is refused, on the page

### DIFF
--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -6394,10 +6394,21 @@
 			if (info.ownersUnknown) cant.push('which pads the kernel already holds');
 			if (info.ptzUnknown) cant.push('which pads the PTZ driver is on');
 			find.disabled = true;
+			// What is refused is the SWEEP, and only the sweep: it is the one
+			// thing here that drives pads nobody has vouched for. Testing a
+			// filter the camera already knows about still works, and still
+			// moves it. "Nothing may be driven" said otherwise, and then the
+			// same sentence sent the reader to a control that drives.
+			//
+			// It ends at Save because the pin map only STAGES: the map writes
+			// into the hidden fields, while the test reads the configuration
+			// the camera is running on. Skip the save and the verdict is about
+			// the old wiring — which is the one answer this panel must never
+			// give. The scan's own success path has always said it this way.
 			const why = 'This camera cannot say ' + cant.join(' or ') +
-				', so nothing may be driven. Set the coils by hand on the pin ' +
-				'map — that writes a number into a field and moves nothing, and ' +
-				'Test the filter will check them.';
+				', so the sweep may not drive pads it has not been told about. ' +
+				'Set the coils by hand on the pin map, Save, then Test the ' +
+				'filter checks them.';
 			find.title = why;
 			// The reason goes on the page and not only in the title, for the
 			// reason syncTestBtn() says two controls down: a tooltip is not an

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -6205,6 +6205,7 @@
 			'<button type="button" class="btn btn-primary btn-sm" id="mj-ircut-find">Find them for me</button>' +
 			'<button type="button" class="btn btn-outline-secondary btn-sm" id="mj-ircut-run">Test the filter</button>' +
 			'</div>' +
+			'<div class="small text-secondary mt-2" id="mj-ircut-find-why" hidden></div>' +
 			'<div class="small text-secondary mt-2" id="mj-ircut-why" hidden></div>' +
 			'<div class="small text-secondary mt-2" id="mj-ircut-status"></div>' +
 			'<div id="mj-ircut-result" class="small" hidden></div>' +
@@ -6393,9 +6394,21 @@
 			if (info.ownersUnknown) cant.push('which pads the kernel already holds');
 			if (info.ptzUnknown) cant.push('which pads the PTZ driver is on');
 			find.disabled = true;
-			find.title = 'This camera cannot say ' + cant.join(' or ') +
-				', so nothing may be driven. Set the pins by hand, or check that '
-				+ 'debugfs is mounted and the boot environment is readable.';
+			const why = 'This camera cannot say ' + cant.join(' or ') +
+				', so nothing may be driven. Set the coils by hand on the pin ' +
+				'map — that writes a number into a field and moves nothing, and ' +
+				'Test the filter will check them.';
+			find.title = why;
+			// The reason goes on the page and not only in the title, for the
+			// reason syncTestBtn() says two controls down: a tooltip is not an
+			// explanation on a touchscreen, where there is no hover at all.
+			// This button was the one place in the panel that broke that rule,
+			// and the greyed-out control it left had to be asked about.
+			const note = box.querySelector('#mj-ircut-find-why');
+			if (note) {
+				note.textContent = why;
+				note.hidden = false;
+			}
 		}
 
 		// A camera that came back from the dead mid-scan says so before anything


### PR DESCRIPTION
**Find them for me** disables itself when the camera cannot say which pads are already spoken for, and put the reason in the button's `title` attribute alone.

Fifty lines below, `syncTestBtn()` writes the *test* button's reason into `#mj-ircut-why`, with the comment that says why:

> The reason goes on the page, not only in the title. A tooltip is not an explanation on a touchscreen, where there is no hover at all, and a control that refuses without saying why is the thing this whole panel exists to stop happening.

This button was the one place in the panel that broke that rule. The result is a greyed-out control with no visible reason and no next step — which is exactly how it was reported: *"How am I supposed to use `Find them for me`? It's not active."*

### What changed

The reason now renders in `#mj-ircut-find-why`, its own element rather than the test button's. The two have different lifetimes: this one is a property of the camera, decided once from the enumeration, while `syncTestBtn()` rewrites `#mj-ircut-why` on every map edit and would wipe it. Same `small text-secondary` styling, no new Bootstrap classes, so `bootstrap.min.css` is unaffected.

The sentence also now says what to do instead — set the coils by hand on the pin map, which writes a number into a field and moves nothing, and let **Test the filter** check them. That is the answer the reporter actually needed, and the panel already supports it: nothing about setting a pin by hand is blocked when a sweep is.

The advice it replaces told the reader to check that debugfs is mounted. That is no longer the gate — the camera establishes pad ownership without it now — and on a camera that still cannot answer there is nothing the reader can do from this page anyway, so naming a filesystem was pointing at a lever that isn't there.

### Verification

`npm test` and `tools/lint-templates.sh` green.

Exercised on an hi3516ev200 whose `/api/v1/gpio` reports `ownersUnknown: true`: the button disables and the note renders in its place, with the tooltip kept for pointer users. The disabled state itself was confirmed by pixel rather than by eye — on the dark theme a disabled `.btn-primary` is still recognisably blue, sampling `(18, 82, 178)`, which is Bootstrap's 65% opacity blend and not the full `#0d6efd`.

Not yet exercised as part of a full `build-dist` install on a camera; happy to do that before merge if wanted.
