### PR TITLE
Day / Night: a dimmable lamp is a lamp that is connected

### DIFF
--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -138,15 +138,19 @@
 			if (FOREIGN[a.role]) owned[a.pin] = FOREIGN[a.role];
 			// A DIMMABLE lamp is configured as a PWM channel, and the pad that
 			// channel takes over is the SoC's, named in no field on this page.
-			// So the camera reports a pad here that the role's own assignment
-			// does not have — and that pad is exactly as unpickable as the PTZ
-			// driver's, for the same reason: nothing on this page can move it,
-			// and a coil assigned to it would fight the lamp for the mux.
+			// It is exactly as unpickable as the PTZ driver's pad: nothing here
+			// can move it, and a coil assigned to it would fight the lamp for
+			// the mux.
 			//
-			// Judged against the assignment rather than by role name, because
-			// the same role covers a lamp on a plain pad, where the field IS
-			// the editable truth and the pad must stay pickable.
-			if (a.role === 'backlightPin' && assign.backlightPin !== a.pin) {
+			// Told by the caller, not worked out from the assignment. The first
+			// try owned the pad only where it DIFFERED from backlightPin — an
+			// equality standing in for "the field is authoritative", which it
+			// is not: with a channel selected the camera ignores that field
+			// whatever it holds, so a stale pin that happened to equal the PWM
+			// pad handed the lamp's own pad back to the picker. The lamp being
+			// on a channel is a fact about the configuration, and the page that
+			// reads the configuration is the one that should say so.
+			if (a.role === 'backlightPin' && opts.pwmLamp) {
 				owned[a.pin] = 'used by the night illuminator';
 			}
 		});

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -136,6 +136,19 @@
 		const owned = {};
 		(info.assigned || []).forEach((a) => {
 			if (FOREIGN[a.role]) owned[a.pin] = FOREIGN[a.role];
+			// A DIMMABLE lamp is configured as a PWM channel, and the pad that
+			// channel takes over is the SoC's, named in no field on this page.
+			// So the camera reports a pad here that the role's own assignment
+			// does not have — and that pad is exactly as unpickable as the PTZ
+			// driver's, for the same reason: nothing on this page can move it,
+			// and a coil assigned to it would fight the lamp for the mux.
+			//
+			// Judged against the assignment rather than by role name, because
+			// the same role covers a lamp on a plain pad, where the field IS
+			// the editable truth and the pad must stay pickable.
+			if (a.role === 'backlightPin' && assign.backlightPin !== a.pin) {
+				owned[a.pin] = 'used by the night illuminator';
+			}
 		});
 		(info.held || []).forEach((h) => {
 			if (h.owner && h.owner !== 'sysfs') owned[h.pin] = 'held by ' + h.owner;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -6381,6 +6381,11 @@
 		const map = window.MajesticIrcutMap.mount(host, {
 			info: info,
 			assign: currentAssign(),
+			// Whether a channel is driving the lamp, which decides that its pad
+			// is nobody's to pick. The map cannot work this out — it holds no
+			// configuration — and the fact lives in one key, so it is passed
+			// rather than inferred from the pad assignment.
+			pwmLamp: !!pwmLamp(),
 			soc: (window.mjSoc || '') + (info.banks ? ' · ' + info.banks.length + ' banks' : ''),
 			onChange: (a) => { pushAssign(a); paintRoles(); },
 		});
@@ -6395,18 +6400,36 @@
 		// camera still drives could sit under the word "not set".
 		state.ircutRoles = paintRoles;
 
-		// Which pad the camera says the dimmable lamp took over, or undefined.
-		// The enumeration is the only place that number exists: the lamp is
-		// configured as a CHANNEL, and which GPIO a channel occupies is the
-		// processor's business, not the configuration's. Read only where the
-		// field is empty — with a lamp on a plain pad the field is the truth
-		// and this must not second-guess it.
+		// The dimmable lamp, if one is configured, and the pad it took over
+		// where the camera can name it.
+		//
+		// The CHANNEL alone decides. A lamp pin may be configured as well —
+		// the camera ignores it while a channel is selected, and says so in
+		// that field's own hint — so its presence proves nothing about how the
+		// lamp is driven, and the first version of this used exactly that to
+		// decide, which hid an active channel behind a pin nothing reads.
+		//
+		// The pad only where the camera reports exactly one for this role.
+		// With a lamp pin also left configured the camera reports two, and
+		// which of them the channel took is not something this page can tell
+		// without guessing. The channel is the honest answer then, and it is
+		// still an answer — unlike "not set", which was the bug.
 		function pwmLamp() {
 			const ch = getDotted(state.config, 'nightMode.backlightPwmChannel');
 			if (!ch || ch === 'none') return null;
-			const from = (state.ircutInfo && state.ircutInfo.assigned) || [];
-			const row = from.filter((x) => x.role === 'backlightPin')[0];
-			return { channel: String(ch), pin: row ? row.pin : undefined };
+			const pads = [];
+			((state.ircutInfo && state.ircutInfo.assigned) || []).forEach((x) => {
+				// Deduplicated, because a lamp pin left set to the pad the
+				// channel took is reported twice and is still one pad. Two
+				// entries naming the same number are not an ambiguity.
+				if (x.role === 'backlightPin' && pads.indexOf(x.pin) < 0) {
+					pads.push(x.pin);
+				}
+			});
+			return {
+				channel: String(ch),
+				pin: pads.length === 1 ? pads[0] : undefined,
+			};
 		}
 
 		function paintRoles() {
@@ -6420,8 +6443,12 @@
 				// because the field this row draws from holds a pad and the
 				// lamp is on a channel. Nothing was wrong with the camera; the
 				// row was reading the one place the answer could not be.
-				const lamp = r.key === 'backlightPin' && a[r.key] === undefined
-					? pwmLamp() : null;
+				//
+				// Not gated on the field being empty: a lamp pin left over
+				// beside a selected channel is ignored by the camera, so
+				// letting it suppress this would show a dimmable lamp as an
+				// ordinary switched one and name a pad nothing drives.
+				const lamp = r.key === 'backlightPin' ? pwmLamp() : null;
 				const set = a[r.key] !== undefined || !!lamp;
 				if (!set) row.classList.add('mj-ircut-role-unset');
 				const dot = el('span', 'mj-ircut-rdot');
@@ -6502,12 +6529,14 @@
 				// Clicking a role selects its pad, so the two halves of the
 				// panel always point at the same thing.
 				row.addEventListener('click', () => {
-					if (onChip) map.select(a[r.key]);
-					// The lamp's pad is not this row's to edit, but it is
-					// worth pointing at: selecting it is how the map says
-					// which pad the channel took.
-					else if (lamp && lamp.pin !== undefined && map.has(lamp.pin)) {
+					// The lamp's own pad first, and it is not this row's to
+					// edit — selecting it is only how the map says which pad
+					// the channel took. It wins over a[r.key] because with a
+					// channel selected that pin is the one the camera ignores.
+					if (lamp && lamp.pin !== undefined && map.has(lamp.pin)) {
 						map.select(lamp.pin);
+					} else if (onChip) {
+						map.select(a[r.key]);
 					}
 				});
 				list.appendChild(row);

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -6395,6 +6395,20 @@
 		// camera still drives could sit under the word "not set".
 		state.ircutRoles = paintRoles;
 
+		// Which pad the camera says the dimmable lamp took over, or undefined.
+		// The enumeration is the only place that number exists: the lamp is
+		// configured as a CHANNEL, and which GPIO a channel occupies is the
+		// processor's business, not the configuration's. Read only where the
+		// field is empty — with a lamp on a plain pad the field is the truth
+		// and this must not second-guess it.
+		function pwmLamp() {
+			const ch = getDotted(state.config, 'nightMode.backlightPwmChannel');
+			if (!ch || ch === 'none') return null;
+			const from = (state.ircutInfo && state.ircutInfo.assigned) || [];
+			const row = from.filter((x) => x.role === 'backlightPin')[0];
+			return { channel: String(ch), pin: row ? row.pin : undefined };
+		}
+
 		function paintRoles() {
 			syncTestBtn();
 			const a = map.get();
@@ -6402,7 +6416,13 @@
 			map.roles.forEach((r) => {
 				const row = el('button', 'mj-ircut-role');
 				row.type = 'button';
-				const set = a[r.key] !== undefined;
+				// A dimmable lamp is connected, and was reported as "not set"
+				// because the field this row draws from holds a pad and the
+				// lamp is on a channel. Nothing was wrong with the camera; the
+				// row was reading the one place the answer could not be.
+				const lamp = r.key === 'backlightPin' && a[r.key] === undefined
+					? pwmLamp() : null;
+				const set = a[r.key] !== undefined || !!lamp;
 				if (!set) row.classList.add('mj-ircut-role-unset');
 				const dot = el('span', 'mj-ircut-rdot');
 				dot.style.background = set ? r.color : '';
@@ -6412,7 +6432,9 @@
 				l.textContent = r.label;
 				t.appendChild(l);
 				const h = el('em');
-				h.textContent = r.hint;
+				h.textContent = lamp
+					? 'dimmable, on ' + lamp.channel
+					: r.hint;
 				t.appendChild(h);
 				row.appendChild(t);
 				// The polarity chip: what this pad does in its active state, in
@@ -6449,13 +6471,27 @@
 				// nothing else: without it the press would return silently
 				// while the words went on naming a signal level, which is a
 				// control that lies rather than one that is missing.
+				// `set` now covers a lamp on a channel, which is what keeps the
+				// active-low chip reachable for one: the invert is applied to
+				// the duty just as it is to a switched pad, so a dimmable lamp
+				// wired the other way round needs the same control.
 				if (pol && polF && (set || stored) && (applies || stored)) {
 					row.appendChild(polarityChip(pol, !applies));
 				}
 				const pin = el('span', 'mj-ircut-rpin');
-				pin.textContent = set ? String(a[r.key]) : 'not set';
+				// The pad, where the camera could say which one the channel
+				// took over; the channel alone otherwise. Never "not set",
+				// which is the one thing that is certainly untrue here.
+				pin.textContent = lamp
+					? (lamp.pin === undefined ? lamp.channel : String(lamp.pin))
+					: (set ? String(a[r.key]) : 'not set');
 				row.appendChild(pin);
-				if (set && !onChip) {
+				// `!lamp`, because a dimmable lamp reaches here with no pad of
+				// its own in the assignment and would otherwise be accused of
+				// naming a pin this processor does not have. Its pad, where the
+				// camera reports one, is the camera's own answer and is drawn
+				// like any other.
+				if (set && !onChip && !lamp) {
 					// Configured, but this kernel reports no such pad — a config
 					// from another SoC, or a hand-edited yaml. Saying so beats a
 					// row that points at a pad which is not drawn.
@@ -6467,6 +6503,12 @@
 				// panel always point at the same thing.
 				row.addEventListener('click', () => {
 					if (onChip) map.select(a[r.key]);
+					// The lamp's pad is not this row's to edit, but it is
+					// worth pointing at: selecting it is how the map says
+					// which pad the channel took.
+					else if (lamp && lamp.pin !== undefined && map.has(lamp.pin)) {
+						map.select(lamp.pin);
+					}
 				});
 				list.appendChild(row);
 			});


### PR DESCRIPTION
The **Night illuminator** row read *"not set"* on a camera with a lamp wired and working.

The row draws from `nightMode.backlightPin`, which holds a **pad**. A dimmable lamp is configured as a PWM **channel**, and which GPIO that channel takes over is the processor's business — named in no field on this page. So the row was reading the one place the answer could not be, and reporting the absence as an absence of lamp.

### What it says now

The pad where the camera can name one, the channel otherwise, and `dimmable, on pwm1` where the hint goes. Never "not set", which is the single thing that is certainly wrong here.

Three things had to follow:

- **The active-low chip is reachable again.** A dimmable lamp honours `backlightInvert` exactly as a switched one does — the invert is applied to the duty — so a lamp wired the other way round needs the same control. The chip only ever appeared for a row that counted as set.
- **The row points at its pad when clicked**, since that is the only way the map says which pad the channel took.
- **The "not a pin on this processor" branch is guarded**, or a lamp with no pad in the assignment would be accused of naming a pin the camera does not have.

### The map marks that pad too

…and refuses to let a coil be assigned onto it. Judged by whether the role's own assignment holds the pad the camera reports, **not** by the role's name: the same role covers a lamp on a plain pad, where the field *is* the editable truth and the pad must stay pickable. Only where the two disagree is the pad somebody else's — and then it is exactly as unpickable as the PTZ driver's, because nothing on this page can move it and a coil assigned to it would fight the lamp for the mux.

### Verified against a live camera

Rendered against an hi3516ev200 with the lamp on `pwm1`, using the whole tree served locally with the API proxied to the camera — so the page ran one consistent tree against real data without installing anything:

- Row: **`4`**, `dimmable, on pwm1`, with its `lamp on = HIGH` polarity chip.
- Map: `<button class="mj-pin mj-pin-owned" data-pin="4" title="Pin 4 — used by the night illuminator" disabled>`
- Zero console errors on the page.

`npm test` and `tools/lint-templates.sh` green.

### Note on the pad number

The pad comes from the camera's own enumeration, which is the only place it exists. A camera that does not report one still gets the honest answer — the channel name instead of the pad — rather than "not set".
