### PR TITLE
Day / Night: automatic mode says what night is waiting for

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -519,6 +519,37 @@ function runRest() {
 				isp_exposureismax: 1, isp_avelum: 200 }).line;
 		check('an explicit night gain keeps the old sentence',
 			!/run out/.test(byGain), byGain);
+
+		// In night the camera waits for the OTHER door. Saying "night comes
+		// when the exposure runs out" under the word "Night." reads as a
+		// switch that has not happened on a camera where it has, and the
+		// appendix made it an outright contradiction.
+		const atNight = (extra) => ic.monitorView({ lightMonitor: true },
+			Object.assign({ night_mode_source: 4, night_enabled: 1,
+				night_auto_gain_milli: 1400 }, extra)).line;
+
+		const settled = atNight({ isp_exposureismax: 0, isp_avelum: 40 });
+		check('night is not told how night arrives',
+			/^Night\./.test(settled) && !/night comes when/.test(settled), settled);
+		check('...it is told how day does',
+			/day comes when the gain settles back down/.test(settled), settled);
+		check('...and nothing is said about a ceiling it is off',
+			!/still at its ceiling/.test(settled), settled);
+
+		// The half the plot cannot show: gain under the day mark, and day
+		// still will not come, because the exposure is pinned.
+		const pinned = atNight({ isp_exposureismax: 1, isp_avelum: 40 });
+		check('a pinned exposure is named as what day is waiting on',
+			/still at its ceiling, so day waits/.test(pinned), pinned);
+
+		// Direction unknown: the sentence stops at the mechanism rather than
+		// claiming a door. Naming the wrong one is the bug above.
+		const unknown = ic.monitorView({ lightMonitor: true },
+			{ night_mode_source: 4, night_auto_gain_milli: 1400,
+				isp_exposureismax: 0, isp_avelum: 40 }).line;
+		check('with no reported side, neither appendix is spoken',
+			!/has not run out yet/.test(unknown) &&
+				!/day comes when/.test(unknown), unknown);
 	}
 
 	group('monitorView: source 0 has two causes and says which');

--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -479,6 +479,48 @@ function runRest() {
 				.some(x => x.id === 'threshold-half'));
 	}
 
+	group('monitorView: automatic mode says what night is waiting for');
+	{
+		// Uncalibrated, night is not decided by gain at all — it waits for the
+		// exposure to run out and for the picture to be dark with it. The panel
+		// said so and then plotted the gain, which answers neither, so a camera
+		// sitting in day at 22x gain had nothing further on the page to read
+		// (#370).
+		const auto = (extra) => ic.monitorView({ lightMonitor: true },
+			Object.assign({ night_mode_source: 4, night_enabled: 0,
+				night_auto_gain_milli: 22386, isp_again: 22924 }, extra)).line;
+
+		const waiting = auto({ isp_exposureismax: 0, isp_avelum: 40 });
+		check('not run out yet is said out loud',
+			/exposure has not run out yet/.test(waiting), waiting);
+
+		const dark = auto({ isp_exposureismax: 1, isp_avelum: 40 });
+		check('run out, and dark with it',
+			/run out and the picture is dark with it/.test(dark), dark);
+
+		// The half of the rule nothing on the page could show: the exposure is
+		// finished but the veto still holds day, which is indistinguishable
+		// from "nothing is happening" without saying it.
+		const bright = auto({ isp_exposureismax: 1, isp_avelum: 200 });
+		check('run out but vetoed by a bright picture, with the reading',
+			/still too bright to call it night \(200 of 255\)/.test(bright), bright);
+
+		// A missing reading is not a "no". Saying the exposure has not run out
+		// about a camera that never said would be exactly the confident wrong
+		// answer this panel exists to avoid.
+		const quiet = auto({});
+		check('a camera that does not publish it is not accused either way',
+			!/run out/.test(quiet.replace('runs out', '')), quiet);
+
+		// With an explicit night threshold the gain IS the rule, and the
+		// sentence must not start describing a mechanism that is not running.
+		const byGain = ic.monitorView({ lightMonitor: true, autoNightGain: 8 },
+			{ night_mode_source: 4, night_enabled: 0, night_auto_gain_milli: 3000,
+				isp_exposureismax: 1, isp_avelum: 200 }).line;
+		check('an explicit night gain keeps the old sentence',
+			!/run out/.test(byGain), byGain);
+	}
+
 	group('monitorView: source 0 has two causes and says which');
 	{
 		// The same collision the finding above disentangles, in the panel's own

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -877,6 +877,23 @@
 				'to call it night (' + v.isp_avelum + ' of 255).';
 	}
 
+	// In night the camera is waiting for the OTHER door, and the gain half of
+	// it is already the plot. The half that is not is the exposure: while it
+	// is still pinned at its ceiling, day cannot come however far the gain
+	// falls — so a lamp that has brought the gain down under the day mark can
+	// sit there looking like a switch that is refusing to happen.
+	//
+	// Spoken only while it is the thing in the way. "The exposure is off its
+	// ceiling" on every tick of every night is noise, and the chart is already
+	// showing what is then actually being waited for.
+	function stillPinned(v) {
+		if (!v || !('isp_exposureismax' in v)) return '';
+		return v.isp_exposureismax > 0
+			? ' The exposure is still at its ceiling, so day waits whatever ' +
+				'the gain does.'
+			: '';
+	}
+
 	function monitorView(nm, v, ageS) {
 		nm = nm || {};
 		if (!v) return null;
@@ -884,9 +901,10 @@
 
 		// An absent night_enabled is a camera whose state is unknown, and an
 		// unknown is not a day — the sentence then simply skips the word.
-		const modeWord = v.night_enabled === 1 || v.night_enabled === true
-			? 'Night. '
-			: v.night_enabled === 0 || v.night_enabled === false ? 'Day. ' : '';
+		const inNight = v.night_enabled === 1 || v.night_enabled === true ? true
+			: v.night_enabled === 0 || v.night_enabled === false ? false : null;
+		const modeWord = inNight === true ? 'Night. '
+			: inNight === false ? 'Day. ' : '';
 
 		// Only a camera with a dimmable lamp publishes a duty; a switched
 		// lamp gets no invented percentage, and 0 on a dimmer is a real
@@ -959,11 +977,23 @@
 				? 'Dark enough for night' + inLeft
 				: pend === 2
 					? 'Bright enough for day' + inLeft
-					: modeWord + 'Watching the sensor gain' +
-						(nightG === null
-							? '; night comes when the exposure runs out.' +
-								runOut(v)
-							: '.');
+					: modeWord + 'Watching the sensor gain' + (
+						nightG !== null ? '.'
+							// Which door is being waited for is decided by
+							// which side the camera is on, and saying the wrong
+							// one is worse than saying less: "Night." followed
+							// by "night comes when the exposure runs out" reads
+							// as a switch that has not happened, on a camera
+							// where it has. Where night_enabled is absent the
+							// direction is unknown, so the sentence stops at
+							// the mechanism and claims neither.
+							: inNight === true
+								? '; day comes when the gain settles back ' +
+									'down.' + stillPinned(v)
+								: inNight === false
+									? '; night comes when the exposure runs ' +
+										'out.' + runOut(v)
+									: '; night comes when the exposure runs out.');
 			return {
 				mode: 'auto', chart: true,
 				value: gm != null && gm >= 0 ? gm / 1000 : null,

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -849,6 +849,34 @@
 	// two cadences happen to beat out. Ageing the streak locally makes it fall
 	// a second at a time and resync on every sample: the number is still the
 	// camera's, read forward by a clock rather than invented.
+	// The camera holds day until the exposure has genuinely run out AND the
+	// picture is dark with it; below this the veto stands aside. It is the
+	// daemon's number, mirrored here only to word the sentence — nothing is
+	// decided on this side.
+	const LUMA_NIGHT = 128;
+
+	// Whether the two things night waits for are true YET.
+	//
+	// Uncalibrated, the camera does not decide by gain at all: it waits for
+	// the automatic exposure to run out of shutter and gain, and for the
+	// picture to be dark with it. This panel named both and then plotted the
+	// gain, which can answer neither — so a camera sitting in day with its
+	// gain at 22x looked like one ignoring an obvious night, and there was
+	// nothing further on the page to read (#370).
+	//
+	// Silent where the camera does not publish the reading. A missing answer
+	// is not a "no", and "it has not run out" about a camera that never said
+	// would be the confident wrong answer this panel exists to avoid.
+	function runOut(v) {
+		if (!v || !('isp_exposureismax' in v)) return '';
+		if (!(v.isp_exposureismax > 0)) return ' The exposure has not run out yet.';
+		if (!('isp_avelum' in v)) return ' The exposure has run out.';
+		return v.isp_avelum < LUMA_NIGHT
+			? ' The exposure has run out and the picture is dark with it.'
+			: ' The exposure has run out, but the picture is still too bright ' +
+				'to call it night (' + v.isp_avelum + ' of 255).';
+	}
+
 	function monitorView(nm, v, ageS) {
 		nm = nm || {};
 		if (!v) return null;
@@ -933,7 +961,8 @@
 					? 'Bright enough for day' + inLeft
 					: modeWord + 'Watching the sensor gain' +
 						(nightG === null
-							? '; night comes when the exposure runs out.'
+							? '; night comes when the exposure runs out.' +
+								runOut(v)
 							: '.');
 			return {
 				mode: 'auto', chart: true,


### PR DESCRIPTION
Uncalibrated, the camera does not decide by gain at all. It waits for the automatic exposure to run out of shutter and gain, **and** for the picture to be dark with it.

The panel said the first half in words — *"night comes when the exposure runs out"* — and then plotted the gain, which answers neither.

So a camera sitting in day with its gain at 22x looks like one ignoring an obvious night, and the page has nothing further to offer. The plot it does draw is structurally blind to the direction being waited on, and the two readings that actually decide sit on the Dashboard's luminance panel rather than beside the sentence that names them. That is [#370](https://github.com/OpenIPC/majestic-webui/issues/370), where the reporter posted a full ISP dump asking why night never comes and the answer was not in it.

### The sentence finishes itself now

| state | what it says |
|---|---|
| not there yet | `The exposure has not run out yet.` |
| both terms true | `The exposure has run out and the picture is dark with it.` |
| run out, vetoed | `The exposure has run out, but the picture is still too bright to call it night (200 of 255).` |

The third carries the luminance deliberately: it is the state nothing on the page could distinguish from "nothing is happening", and the number is what tells its owner whether the scene or the reading is the odd one.

### What it does not do

- **Silent where the camera does not publish the reading.** A missing answer is not a "no", and *"the exposure has not run out"* about a camera that never said would be the confident wrong answer this panel exists to avoid.
- **An explicit night gain keeps the old sentence.** Gain is then genuinely the rule, and describing a mechanism that is not running would be worse than saying less.
- **Decides nothing.** The `128` is the daemon's own veto threshold, mirrored here to word a sentence.

### Tests

Five cases in `tests/ircut-check.test.js` — each of the three states, the unpublished-reading case, and the explicit-night-gain case that must keep the old wording. Full suite and `tools/lint-templates.sh` green.

`monitorView` is a pure function and its `line` goes straight to `#mj-ircut-mon-line`, an element already rendering on hardware, so this adds no DOM and no new dependency.
