### PR TITLE
Day / Night: the Dashboard never had the gauge it was judging by

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -308,7 +308,7 @@ function runRest() {
 		check('an empty nightMode reports no-pins', f[0].id === 'no-pins', f[0] && f[0].id);
 		check('and reports it as a fault', f[0].level === 'danger');
 		check('with nothing to add about a monitor that is off',
-			f.filter(x => x.id === 'monitor-blind').length === 0);
+			f.filter(x => /^(auto-active|auto-retired)$/.test(x.id)).length === 0);
 	}
 
 	group('diagnose: GPIO 0 is a pin, not an absence');
@@ -402,39 +402,47 @@ function runRest() {
 
 	group('diagnose: the light monitor');
 	{
-		const blind = ic.diagnose({ irCutPin1: 11, lightMonitor: true }, null, null);
-		check('a monitor with no sensor and no thresholds is flagged',
-			blind.some(x => x.id === 'monitor-blind'));
-		check('a monitor with a sensor pin is not',
-			!ic.diagnose({ irCutPin1: 11, lightMonitor: true, lightSensorPin: 66 }, null, null)
-				.some(x => x.id === 'monitor-blind'));
-		check('a monitor with a threshold pair is not',
-			!ic.diagnose({ irCutPin1: 11, lightMonitor: true, minThreshold: 1500, maxThreshold: 4000 },
-				null, null).some(x => x.id === 'monitor-blind'));
-		// A string "true" reaches here from a hand-edited majestic.yaml.
-		check('lightMonitor as a string still counts as on',
-			ic.diagnose({ irCutPin1: 11, lightMonitor: 'true' }, null, null)
-				.some(x => x.id === 'monitor-blind'));
+		// The daemon says who decides via night_mode_source (sample.src).
+		// Source 4 is automatic mode running and is an observation; source 0
+		// is the SoC declining to answer, which is a fault with a way out.
+		// Anything else — including no sample at all — is not knowing, and
+		// carries no finding: the Dashboard passes null while the heartbeat
+		// is down and passed a sample with no src at all until #325, so the
+		// old third arm accused every working automatic camera of having
+		// nothing to watch.
+		check('a monitor nothing has reported on yet says nothing',
+			!ic.diagnose({ irCutPin1: 11, lightMonitor: true }, null, null)
+				.some(x => /^(auto-active|auto-retired)$/.test(x.id)));
+		check('...and no finding claims the firmware is too old for it',
+			!ic.diagnose({ irCutPin1: 11, lightMonitor: true },
+				{ night: 0, ircut: 0, light: 0, src: null }, null)
+				.some(x => /firmware/.test(x.detail || '')));
 		check('pins wired but no monitor is only an observation',
 			ic.diagnose({ irCutPin1: 11 }, null, null)
 				.some(x => x.id === 'manual-only' && x.level === 'info'));
-		// The daemon says who decides via night_mode_source (sample.src).
-		// Source 4 turns "blind" into the automatic-mode observation; source
-		// 0 means the SoC could not answer and the monitor stood down; no
-		// source at all keeps the old warning for older firmware.
 		const auto = ic.diagnose({ irCutPin1: 11, lightMonitor: true },
 			{ night: 0, ircut: 0, light: 0, src: 4 }, null);
 		check('an automatic monitor is an observation, not a fault',
 			auto.some(x => x.id === 'auto-active' && x.level === 'info') &&
-			!auto.some(x => x.id === 'monitor-blind'));
+			!auto.some(x => /^(auto-retired|threshold-half)$/.test(x.id)));
+		// A string "true" reaches here from a hand-edited majestic.yaml.
+		check('lightMonitor as a string still counts as on',
+			ic.diagnose({ irCutPin1: 11, lightMonitor: 'true' },
+				{ night: 0, ircut: 0, light: 0, src: 4 }, null)
+				.some(x => x.id === 'auto-active'));
 		check('a monitor the SoC could not feed is flagged as retired',
 			ic.diagnose({ irCutPin1: 11, lightMonitor: true },
 				{ night: 0, ircut: 0, light: 0, src: 0 }, null)
 				.some(x => x.id === 'auto-retired' && x.level === 'warning'));
-		check('no source gauge keeps the older-firmware warning',
-			ic.diagnose({ irCutPin1: 11, lightMonitor: true },
-				{ night: 0, ircut: 0, light: 0, src: null }, null)
-				.some(x => x.id === 'monitor-blind'));
+		check('a sensor pin is neither of those',
+			!ic.diagnose({ irCutPin1: 11, lightMonitor: true, lightSensorPin: 66 },
+				{ night: 0, ircut: 0, light: 0, src: 1 }, null)
+				.some(x => /^(auto-active|auto-retired)$/.test(x.id)));
+		check('nor is a threshold pair',
+			!ic.diagnose({ irCutPin1: 11, lightMonitor: true,
+				minThreshold: 1500, maxThreshold: 4000 },
+			{ night: 0, ircut: 0, light: 0, src: 2 }, null)
+				.some(x => /^(auto-active|auto-retired)$/.test(x.id)));
 
 		// One threshold is a half-finished configuration, and the camera
 		// answers it by setting up no monitor at all rather than falling

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -259,15 +259,14 @@
 			});
 		}
 
-		// With nothing wired and nothing calibrated, what happens next depends
-		// on the daemon. A current one takes the automatic exposure-based mode
-		// — an observation, not a fault — and says so in night_mode_source
-		// (carried here as sample.src, null when the gauge is absent). One
-		// whose SoC reports no exposure state retires the monitor and says
-		// source 0. An older daemon says nothing and is genuinely blind: it
-		// owns the three runtime switches (wireRuntime hides them while the
-		// monitor is on) and then never decides anything, so day/night is
-		// frozen AND unreachable.
+		// With nothing wired and nothing calibrated, the camera takes the
+		// automatic exposure-based mode — an observation, not a fault — and
+		// says so in night_mode_source, carried here as sample.src. A SoC that
+		// reports no exposure state retires the monitor and says source 0
+		// instead, which is a fault and has something to do about it.
+		//
+		// src is null where no sample has arrived yet, or where the heartbeat
+		// is down: that is not knowing, and nothing below speaks from it.
 		const senses = has(nm.lightSensorPin) ||
 			(has(nm.minThreshold) && has(nm.maxThreshold));
 		if (monitor && !senses) {
@@ -326,19 +325,17 @@
 						'it on the map for it to have something to watch.',
 					fix: 'nightMode',
 				});
-			} else {
-				out.push({
-					id: 'monitor-blind', level: 'warning',
-					title: 'Automatic day/night has nothing to watch',
-					detail: 'Automatic day/night is on, but nothing tells it how ' +
-						'dark it is: no daylight sensor is connected, and no day ' +
-						'or night threshold is set. Current firmware decides ' +
-						'from the sensor’s own exposure in this situation — ' +
-						'this camera has not reported that mode, so a firmware ' +
-						'update would give it that.',
-					fix: 'nightMode',
-				});
 			}
+			// No third arm. The one that stood here answered a src of neither 0
+			// nor 4 by telling the operator their firmware was too old to
+			// decide from the exposure — prose for a state the project does
+			// not have, since the page and the daemon ship in one image and
+			// move together (#377 removed its twin). It was also what an
+			// ABSENT src produced, and src is absent whenever no sample has
+			// arrived: on the Dashboard that is every camera with automatic
+			// mode running, which is how the reporter of #325 got told their
+			// working monitor had nothing to watch. An unrecognised source is
+			// not knowing, and not knowing has no finding.
 		}
 
 		// Three mechanisms decide the same thing and the camera picks one; the
@@ -1019,13 +1016,32 @@
 			const marks = [];
 			if (lo !== null) marks.push({ v: lo, color: '#2fb673', label: 'day' });
 			if (hi !== null) marks.push({ v: hi, color: '#e0a020', label: 'night' });
+			// Why there is no countdown here, said where the countdown would
+			// have been. The two mechanisms look interchangeable on the page —
+			// a pair of numbers and a delay either way — so the reporter of
+			// #325 read the missing countdown as a fault in the legacy half.
+			// It is a difference in what the camera does: a threshold monitor
+			// switches on the first check that lands past a threshold, with no
+			// dwell to serve out, while automatic mode holds a condition for
+			// its two delays before acting. Saying nothing left the operator
+			// to conclude the timer was broken.
+			//
+			// The period is the same "seconds between light checks" both
+			// mechanisms are armed from, and majestic floors an unset or zero
+			// one at 5 s — so the number here is the one the camera is using,
+			// not the one the config happens to hold.
+			const period = pin(nm.monitorDelay);
+			const everyS = period > 0 ? period : 5;
 			return {
 				mode: 'thresholds', chart: true,
 				value: ('isp_again' in v) ? v.isp_again : null,
 				marks: marks,
 				line: modeWord +
 					'Comparing raw sensor gain against the thresholds ' +
-					'(vendor-specific units).' + lampNote,
+					'(vendor-specific units). It switches on the first check ' +
+					'past one — every ' + everyS + ' s — so there is no wait ' +
+					'to count down; the two delays belong to automatic mode.' +
+					lampNote,
 				unit: '',
 			};
 		}

--- a/www/a/main.js
+++ b/www/a/main.js
@@ -504,6 +504,17 @@ function heartbeat() {
 				night: ('night_enabled' in v) ? (v.night_enabled | 0) : null,
 				ircut: ('ircut_enabled' in v) ? (v.ircut_enabled | 0) : null,
 				light: ('light_enabled' in v) ? (v.light_enabled | 0) : null,
+				// Which door the camera says it is actually watching, and the
+				// wait it is currently applying. Both belong here rather than in
+				// one page's own copy: ircut-check's diagnose() reads them off
+				// the sample it is handed, and the Dashboard handed it one that
+				// carried neither — so every automatic camera answered the
+				// question "which mechanism is deciding?" with silence, and the
+				// finding for a camera with nothing to watch was the one that
+				// drew (#325). Same null-not-zero rule as the three above.
+				src: ('night_mode_source' in v) ? v.night_mode_source : null,
+				dwell: ('night_auto_dwell_seconds' in v)
+					? v.night_auto_dwell_seconds : null,
 				rx: m.rx, tx: m.tx, m,
 				// Consumers do their own counter deltas (net, venc bytes, md rects)
 				// against this snapshot; CPU% is computed here because its state

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -5690,20 +5690,14 @@
 		if (!IRCUT || typeof mjMetricsSubscribe !== 'function') return;
 		mjMetricsSubscribe((s) => {
 			if (!s.ok) return;
-			const v = (s.m && s.m.v) || {};
-			ircutSample = {
-				night: s.night, ircut: s.ircut, light: s.light,
-				// Which door the daemon says is being watched — diagnose()
-				// tells an automatic monitor from a blind one by it, and null
-				// (gauge absent) keeps the older-firmware reading.
-				src: ('night_mode_source' in v) ? v.night_mode_source : null,
-				// The wait the camera says it is currently applying. The
-				// hunting finding used to ASSERT that automatic mode backs off
-				// after a flip; this is the gauge that would show it, so the
-				// finding reads it instead of claiming it.
-				dwell: ('night_auto_dwell_seconds' in v)
-					? v.night_auto_dwell_seconds : null,
-			};
+			// The heartbeat's own sample, not a second one assembled here.
+			// Which door is being watched (src) and the wait the camera is
+			// currently applying (dwell) used to be read out of the raw metrics
+			// on this page alone, so the Dashboard's copy of the same call had
+			// neither and every finding that turns on them was decided from an
+			// absence (#325). One place builds the sample now, and both pages
+			// ask the same question of the same object.
+			ircutSample = s;
 			ircutStats = ircutTrack.push(ircutSample, performance.now() / 1000);
 			paintNightInert(ircutSample.src);
 			paintFindings();
@@ -6033,7 +6027,13 @@
 	// threshold holds a value, because that is what the camera decides on; a
 	// flag beside it would be a second copy of a fact the daemon already keeps,
 	// and a second copy needs an invalidation rule (#367).
-	const LEGACY_KEYS = ['minThreshold', 'maxThreshold', 'monitorDelay'];
+	//
+	// The thresholds, and only the thresholds. "Seconds between light checks"
+	// is the tick period of ALL three monitors — majestic arms the automatic
+	// one from it too — so hiding it with the switch took automatic mode's only
+	// polling knob off the page, and left the operator reading the legacy
+	// position as the one with a delay in it (#325).
+	const LEGACY_KEYS = ['minThreshold', 'maxThreshold'];
 	const AUTO_KEYS = ['autoNightGain', 'autoDayGain', 'autoNightDelay', 'autoDayDelay'];
 
 	function legacyOn() {
@@ -6099,6 +6099,16 @@
 			paint();
 			stageLegacy(box.checked);
 			showLegacy(box.checked);
+			// setValue() writes a control without firing its events, so the
+			// x-requires notes under the automatic rows — the ones saying a
+			// threshold outranks them — would still be claiming a threshold
+			// that this press has just emptied. They were painted while the
+			// rows were hidden and turned up stale the moment the switch
+			// revealed them (#325). runVisibility() is the repaint every other
+			// programmatic write on this page already pairs with updateDirty();
+			// nothing in nightMode carries a visibleWhen, so it cannot fight
+			// the display writes showLegacy() has just made.
+			runVisibility();
 			updateDirty();
 		});
 		box.checked = legacyOn();
@@ -6205,6 +6215,10 @@
 			const f = pinField(k);
 			if (f) f.setValue(a[k] === undefined ? '' : String(a[k]));
 		});
+		// A daylight sensor pin outranks both switching sets, so assigning or
+		// clearing one on the map decides whether six other rows are inert —
+		// and setValue() fires nothing that would repaint the notes saying so.
+		runVisibility();
 		updateDirty();
 	}
 


### PR DESCRIPTION
Three reports from #325 ([comment](https://github.com/OpenIPC/majestic-webui/issues/325#issuecomment-5579679302)), and each one turned out to be a different fault.

### "Automatic day/night has nothing to watch", on a camera that was watching it

`diagnose()` asks the sample it is handed which door the camera says is being watched, and two pages build that sample: the settings page assembled its own out of the raw metrics and carried `src`, while the Dashboard passed the heartbeat's sample straight through — and the heartbeat carried day/night, IR-cut and lamp but not the source. So on the Dashboard the source was absent for **every** camera, always, and the one arm of the switch that fires on an absence was the only arm that could ever draw. The reporter's camera publishes `night_mode_source 4`, which is the case that arm exists to rule out.

The gauge lives in the heartbeat sample now, beside the other three and under the same rule that an absent reading is `null` and not a zero; the settings page reads the shared object rather than keeping a second copy of it.

That arm is gone with it. It told the operator that a firmware update would give them exposure-based switching — prose for a state this project does not have, since the page and the daemon ship in one image (#377 removed its twin) — and because an absent source reached it, it was also what the Dashboard said whenever the heartbeat was down.

### The orange notes that survived the switch that cleared them

Turning **Legacy settings** off empties both thresholds through `setValue()`, which fires no event, so the notes under the four automatic rows went on naming a threshold that the press had just removed — painted while those rows were hidden, and stale by the time the switch revealed them. The repaint every other programmatic write on this page already pairs with `updateDirty()` is now on the Legacy row and on the pin map, which writes the daylight sensor pin and so decides the same question for six rows.

### No countdown under the thresholds, and why

It is a difference in what the camera does rather than a gap in the page: the threshold monitor switches on the first check that lands past a threshold, with no dwell to serve out, while automatic mode holds a condition for its two delays. The panel says that now, in the sentence where the countdown would have been, and names the interval it is checking at.

And "seconds between light checks" is not a legacy setting — majestic arms the automatic timer from it too — so hiding it with the switch took automatic mode's only polling knob off the page and left the legacy position looking like the one with a delay in it. It shows in both.

### Verified

On an hi3516ev300 running a 2026-09-07 nightly, by driving the rendered pages rather than by reading the diff:

- the Dashboard is silent with automatic mode running, and still raises the legacy notice for a browser that never dismissed it, and the outranked-settings finding where a daylight sensor pin is wired;
- no note is left standing on an automatic row the switch has just revealed;
- the poll interval is on screen in both positions;
- the threshold panel reads *"…It switches on the first check past one — every 5 s — so there is no wait to count down; the two delays belong to automatic mode."*

`npm test` passes (32 files).

Refs #325
