### PR TITLE
Live: a decoder that keeps failing falls through, instead of flashing forever

### DIFF
--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -291,5 +291,49 @@ function load() {
 		env.player.destroy();
 	}
 
+	group('a decoder that cannot take the stream falls through instead of looping');
+	{
+		// Safari can reject a conformant HEVC with MEDIA_ERR_DECODE about a
+		// second in; rebuilding the same MSE decoder reproduces it forever (the
+		// ~2s flash of majestic-webui#335). After two strikes the player must
+		// stop and hand the page an `undecodable` verdict so the chain can try
+		// the software decoder or MJPEG.
+		const env = load();
+		env.play();
+		check('one session to start with', env.sockets.length === 1, env.sockets.length + '');
+
+		// First decode error: still worth one rebuild (it might be a one-off).
+		env.video.error = { code: 3 };
+		env.video.fire('error');
+		await sleep(1300); // the reconnect backoff
+		check('rebuilt once after the first decode error', env.sockets.length === 2, env.sockets.length + '');
+		env.play();
+
+		// Second strike in quick succession: give up on this decoder.
+		env.video.error = { code: 3 };
+		env.video.fire('error');
+		check('fell through with an undecodable verdict',
+			env.states.indexOf('mjpeg undecodable h264') >= 0, env.states.join(','));
+		await sleep(1300);
+		check('and did not open a third session', env.sockets.length === 2, env.sockets.length + '');
+		check('no session is left live', env.live().length === 0, env.live().length + ' live');
+		env.player.destroy();
+	}
+
+	group('a lone decode error is not treated as an inability');
+	{
+		// One decode glitch, then clean playback, must not fall through — the
+		// count only fires on failures close together in time.
+		const env = load();
+		env.play();
+		env.video.error = { code: 3 };
+		env.video.fire('error');
+		await sleep(1300);
+		check('it rebuilt rather than fell through',
+			env.states.indexOf('mjpeg undecodable h264') < 0 && env.sockets.length === 2,
+			env.states.join(',') + ' / ' + env.sockets.length);
+		env.player.destroy();
+	}
+
 	done();
 })();

--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -320,6 +320,28 @@ function load() {
 		env.player.destroy();
 	}
 
+	group('a stream switch does not inherit the previous stream\'s decode strike');
+	{
+		// One decode error on Main, then the viewer switches to Sub within the
+		// window: a single error on the new stream must not fall through, because
+		// the switch is a fresh decode context.
+		const env = load();
+		env.play();
+		env.video.error = { code: 3 };
+		env.video.fire('error');   // strike 1 on the first stream
+		await sleep(1300);
+		env.player.setStream(1);   // deliberate switch -> resets the count
+		await sleep(400);
+		env.play();
+		env.video.error = { code: 3 };
+		env.video.fire('error');   // strike 1 on the new stream, not 2
+		check('the switched stream was not routed away',
+			env.states.indexOf('mjpeg undecodable h264') < 0, env.states.join(','));
+		await sleep(1300);
+		check('it rebuilt for the new stream instead', env.live().length === 1, env.live().length + ' live');
+		env.player.destroy();
+	}
+
 	group('a lone decode error is not treated as an inability');
 	{
 		// One decode glitch, then clean playback, must not fall through — the

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -1,6 +1,13 @@
 // Low-latency H.264/H.265 MSE player over the majestic /ws/video WebSocket.
 window.MajesticVideo = (function () {
 	const MAX_QUEUE = 240;
+	// Consecutive decode failures on one player before we stop rebuilding it
+	// and fall through the chain. A browser whose decoder cannot take this
+	// stream (a Safari that rejects a conformant HEVC, majestic-webui#335) fails
+	// again on every rebuild, so retrying forever is the ~2s flash; two strikes
+	// is enough to tell a permanent inability from a one-off glitch.
+	const DECODE_MAX = 2;
+	const DECODE_RESET_MS = 30000;
 	const LIVE_EDGE = 1.0;
 
 	// Audio is opt-in per connection: the camera only encodes it while someone
@@ -50,6 +57,9 @@ window.MajesticVideo = (function () {
 		let lastW = 0, lastH = 0;
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let gotSignal = false, signalTimer = null, failCount = 0;
+		// Decode failures (MediaError code 3), and the codec to name when we give
+		// up on the browser's own decoder and ask the page for the next rung.
+		let decodeErrs = 0, lastDecodeAt = 0, lastCodec = '';
 		// From the caller: this player is also staged as a replacement now, and
 		// a session that proved itself must not be reopened just to turn on the
 		// audio the outgoing one already had. See preview-swap.js.
@@ -130,7 +140,28 @@ window.MajesticVideo = (function () {
 		}
 
 		function onVideoError(e) {
-			if (!closed && e.target === video) reconnect();
+			if (closed || e.target !== video) return;
+			// A decode error (MEDIA_ERR_DECODE) that keeps coming back is the
+			// browser telling us its decoder cannot play this stream -- a Safari
+			// that rejects a conformant HEVC (#335). Rebuilding the same decoder
+			// only reproduces it (the ~2s flash), so after DECODE_MAX strikes stop
+			// and hand the page an `undecodable` verdict, the same one onInit gives
+			// for a mime MSE will not take: the chain then tries the software
+			// decoder (which can play what the hardware one refused) or MJPEG.
+			// Strikes far apart in time are a one-off, not an inability, so a gap
+			// longer than DECODE_RESET_MS starts the count over.
+			var code = video.error && video.error.code;
+			if (code === 3) {
+				var now = Date.now();
+				if (now - lastDecodeAt > DECODE_RESET_MS) decodeErrs = 0;
+				lastDecodeAt = now;
+				if (++decodeErrs >= DECODE_MAX) {
+					onState('mjpeg', 'undecodable ' + (lastCodec || 'h265'));
+					stop();
+					return;
+				}
+			}
+			reconnect();
 		}
 		// The element is replaced on every (re)connect, so mute and volume have
 		// to be re-applied — cloneNode does not carry them, and defaulting to
@@ -155,6 +186,7 @@ window.MajesticVideo = (function () {
 		function onInit(info) {
 			markSignal();
 			failCount = 0;
+			lastCodec = info.codec;
 			onCodec(info.codec, info.codecString, info.width, info.height);
 			// Null when we asked for audio and the camera has none to give —
 			// a mic that is off or not producing. Report it either way so the

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -331,6 +331,12 @@ window.MajesticVideo = (function () {
 		function reopen() {
 			backoff = 1000;
 			failCount = 0;
+			// A deliberate switch (Main/Sub, audio) is a fresh decode context:
+			// the new stream must not inherit the old one's decode strikes, or a
+			// single error on it within DECODE_RESET_MS of an earlier one would
+			// route it straight to software/MJPEG (only reconnect(), the error
+			// path, keeps the count).
+			decodeErrs = 0; lastDecodeAt = 0;
 			stop();
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			reconnectTimer = setTimeout(function () { reconnectTimer = null; open(); }, 300);


### PR DESCRIPTION
## What

When the browser's decoder cannot play a stream, the MSE player looped forever. A Safari that rejects a conformant HEVC raises `MEDIA_ERR_DECODE` about a second in; the error handler rebuilt the decoder unconditionally, the rebuild hit the same error, and the picture flashed every ~2 seconds. That is the residual in #335.

## Evidence

The reporter's console from a diagnostic build showed, every ~2s:

```
VIDEO ERROR code=3 msg="Media failed to decode"  readyState=3  ct=0.9x  msSinceLiveSeek=never
reconnect (teardown + reopen)
socket #N opening ...
```

- `code=3` is `MEDIA_ERR_DECODE` — the decoder failed, not the socket (there is no socket close in the trace) and not a live-edge seek (`msSinceLiveSeek=never`).
- His captured stream decodes **cleanly** under `ffmpeg -err_detect +explode`, and its SPS is structurally identical to a lab camera's H.265 that played in an earlier Safari. So it is a decoder-side failure (a Safari 26.6 HEVC/MSE regression) the page has to degrade around — not something to retry, and unrelated to #380 (every rebuild is a fresh session).

## The change

Count `MediaError` code-3 failures; after two in quick succession, stop rebuilding and emit the same `undecodable <codec>` verdict `onInit` already gives for a mime MSE won't take. The page's chain then falls to the **software H.265 decoder** — which can play what the hardware decoder refused — or MJPEG, with a message. Failures more than 30 s apart reset the count, so a one-off glitch still gets its single rebuild.

So instead of flashing forever, a browser that can't hardware-decode the stream lands on a working software-decoded picture (or MJPEG).

## Tests

`tests/preview-socket.test.js`: two decode errors fall through with the verdict and open no third session; a lone decode error still rebuilds.