### PR TITLE
Live: retry play() on a user gesture when autoplay is refused

### DIFF
--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -90,8 +90,13 @@ function makeEnv(o) {
 		RTCPeerConnection: RTCPeerConnection,
 		isSecureContext: o.secure !== false,
 	};
+	env.docHandlers = {};
+	const document = {
+		addEventListener(t, fn) { (env.docHandlers[t] = env.docHandlers[t] || []).push(fn); },
+		removeEventListener(t, fn) { env.docHandlers[t] = (env.docHandlers[t] || []).filter((f) => f !== fn); },
+	};
 	const ctx = {
-		window: win, navigator: navigator, WebSocket: WebSocket,
+		window: win, navigator: navigator, WebSocket: WebSocket, document: document,
 		RTCPeerConnection: RTCPeerConnection,
 		location: { protocol: 'https:', host: 'cam' },
 		setTimeout, clearTimeout, setInterval, clearInterval, console,
@@ -263,9 +268,36 @@ async function cameraTakesMicButSendsNothing() {
 	p.destroy();
 }
 
+async function playRetriesOnGesture() {
+	group('a muted video refused autoplay retries on the first user gesture (#317)');
+	// Opera for Android refuses autoplay of the muted WebRTC picture on a fresh
+	// load; the picture is ready but paused. The player must retry play() on the
+	// first user gesture rather than leave it paused for ever.
+	const env = makeEnv();
+	let plays = 0, reject = true;
+	const video = {
+		muted: true, volume: 1, srcObject: null,
+		play() { plays++; return reject ? Promise.reject({ name: 'NotAllowedError' }) : Promise.resolve(); },
+	};
+	env.MajesticWebRTC.attach(video, {});
+	await tick();
+	check('a peer connection was made', env.pcs.length >= 1, env.pcs.length + '');
+	// The camera's video track arrives; play() is attempted and refused.
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick();
+	check('play() was attempted and refused', plays === 1, plays + ' plays');
+	check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
+		JSON.stringify(Object.keys(env.docHandlers)));
+	// The viewer taps: play() is retried, and this time it is allowed.
+	reject = false;
+	env.docHandlers.pointerdown[0]();
+	check('play() was retried on the gesture', plays === 2, plays + ' plays');
+	check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
+}
+
 (async () => {
 	for (const t of [reentrancy, cameraTakesMicButSendsNothing, destroyedDuringPrompt, cameraDeclines,
-		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused]) {
+		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused, playRetriesOnGesture]) {
 		await t();
 	}
 	done();

--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -288,10 +288,18 @@ async function playRetriesOnGesture() {
 	check('play() was attempted and refused', plays === 1, plays + ' plays');
 	check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
 		JSON.stringify(Object.keys(env.docHandlers)));
+	// A second attempt (as a reconnect would make) is also refused: it must
+	// re-arm afresh, not be blocked by the first arming nor stack a second
+	// listener.
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick();
+	check('play() attempted again', plays === 2, plays + ' plays');
+	check('still exactly one retry (re-armed, not stacked or blocked)',
+		(env.docHandlers.pointerdown || []).length === 1);
 	// The viewer taps: play() is retried, and this time it is allowed.
 	reject = false;
 	env.docHandlers.pointerdown[0]();
-	check('play() was retried on the gesture', plays === 2, plays + ' plays');
+	check('play() was retried on the gesture', plays === 3, plays + ' plays');
 	check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
 }
 

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -67,18 +67,28 @@ window.MajesticWebRTC = (function () {
 		// happens to carry an activation. Retry play() on the first user gesture
 		// instead. One-shot, capture phase so a tap the controls also handle still
 		// counts, and guarded for the vm tests, which have no document.
-		let gestureArmed = false;
+		let gestureRetry = null;
+		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
+		function disarmGesture() {
+			if (gestureRetry && typeof document !== 'undefined')
+				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
+			gestureRetry = null;
+		}
 		function playOnGesture(v, alive) {
-			if (gestureArmed || typeof document === 'undefined') return;
-			gestureArmed = true;
-			const evs = ['pointerdown', 'touchstart', 'keydown'];
+			if (typeof document === 'undefined') return;
+			// Replace any arming left by a previous attempt rather than refuse to
+			// arm: a reconnect after arming but before a gesture must be able to
+			// arm its own retry (bound to the CURRENT attempt), or the stale
+			// callback fires, finds its attempt no longer current, and removes
+			// the listeners without ever playing -- leaving the picture paused.
+			disarmGesture();
 			const retry = function () {
-				gestureArmed = false;
-				evs.forEach(function (t) { try { document.removeEventListener(t, retry, true); } catch (e) {} });
+				disarmGesture();
 				if (alive && !alive()) return;
 				try { const p = v.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
 			};
-			evs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
+			gestureRetry = retry;
+			gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
 		}
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let failCount = 0, gotMedia = false;
@@ -708,6 +718,9 @@ window.MajesticWebRTC = (function () {
 		}
 
 		function reconnect() {
+			// A new attempt begins here; drop any gesture retry bound to the old
+			// one so this attempt can arm its own if it too is refused autoplay.
+			disarmGesture();
 			// Retire the attempt before dismantling it. Closing a peer
 			// connection rejects whatever it had in flight, and a rejection
 			// that arrives while its own attempt still looks current would be
@@ -800,6 +813,7 @@ window.MajesticWebRTC = (function () {
 			// only control able to stop it is the worst of the failures this
 			// file guards against.
 			releaseMic();
+			disarmGesture();
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			stop();
 		}

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -61,6 +61,25 @@ window.MajesticWebRTC = (function () {
 		let stream = opts.stream | 0;
 
 		let pc = null, ws = null, statsTimer = null, signalTimer = null;
+		// Autoplay refused on a fresh document load with no user activation (Opera
+		// for Android, majestic-webui#317): the muted picture is ready but paused,
+		// and play() is never retried, so nothing shows until an in-app navigation
+		// happens to carry an activation. Retry play() on the first user gesture
+		// instead. One-shot, capture phase so a tap the controls also handle still
+		// counts, and guarded for the vm tests, which have no document.
+		let gestureArmed = false;
+		function playOnGesture(v, alive) {
+			if (gestureArmed || typeof document === 'undefined') return;
+			gestureArmed = true;
+			const evs = ['pointerdown', 'touchstart', 'keydown'];
+			const retry = function () {
+				gestureArmed = false;
+				evs.forEach(function (t) { try { document.removeEventListener(t, retry, true); } catch (e) {} });
+				if (alive && !alive()) return;
+				try { const p = v.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
+			};
+			evs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
+		}
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let failCount = 0, gotMedia = false;
 		// From the caller, not fixed at false: a player staged as a replacement
@@ -512,7 +531,14 @@ window.MajesticWebRTC = (function () {
 					// aborts the video track's play() with AbortError: treating
 					// that as an autoplay refusal reports "no audio" over a
 					// working Opus stream, which is exactly what it did.
-					if (!current(my) || video.muted) return;
+					if (!current(my)) return;
+					// A muted element has no sound to blame: autoplay was refused on a
+					// fresh load with no user activation (#317). Retry on the first gesture.
+					if (video.muted) {
+						if (err && err.name === 'NotAllowedError')
+							playOnGesture(video, function () { return current(my); });
+						return;
+					}
 					if (!err || err.name !== 'NotAllowedError') return;
 					onAudio(null);
 					// Renegotiate rather than just muting. The audio


### PR DESCRIPTION
## What

On Opera for Android the Live picture is missing on a **fresh document load** (refresh, new tab, first navigation) but plays after navigating in from another camera page.

## Evidence

A diagnostic build drew the media/stage state as an overlay. On the broken load and the working load the state is identical **except the paused flag**:

| | fresh load (broken) | in-app nav (works) |
|---|---|---|
| videoWidth × ready | `1600x1200`, `ready=4` | `1600x1200`, `ready=4` |
| srcObject | set (WebRTC) | set (WebRTC) |
| rect / visibility | `384x288`, visible | `384x288`, visible |
| **paused** | **true** (stays) | **false** after 1s |

So the WebRTC stream connects, decodes and is laid out — it is simply never **played**. `play()` is refused on a fresh load (no user activation), and the muted branch of `ontrack`'s error handler returned without retrying. The in-app navigation works only because the click that triggered it supplies the activation. (The reporter confirmed: tapping the black area showed the controls but did not start it — nothing called `play()` on that tap.)

## The change

When a muted element's `play()` is refused with `NotAllowedError`, arm a one-shot, capture-phase `pointerdown`/`touchstart`/`keydown` listener that retries `play()` and removes itself. So the picture starts on the viewer's first tap instead of staying paused — and that first tap now recovers it. Guarded for the vm tests, which have no `document`.

## Tests

`tests/talkback.test.js`: a muted video refused with `NotAllowedError` arms exactly one gesture retry, the gesture re-calls `play()`, and the listener removes itself.