### PR TITLE
Day / Night: say the threshold rule in one clause, not three

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -658,6 +658,23 @@ function runRest() {
 				{ lightMonitor: true, lightSensorPin: 66,
 					minThreshold: 1500, maxThreshold: 4000 },
 				{ isp_again: 2000, night_enabled: 0 }).mode === 'sensor');
+		// Why there is no countdown, on the one mechanism that has none. It
+		// has to name the interval it is actually checking at, which is the
+		// camera's floor of five where nothing is configured, not the 0 the
+		// config holds (#325).
+		check('the threshold line says there is no countdown',
+			/no countdown/.test(thr.line) && !/switching in/.test(thr.line),
+			thr.line);
+		check('...at the camera\'s floor when nothing is set',
+			/every 5 s/.test(thr.line), thr.line);
+		check('...and at the configured interval when there is one',
+			/every 30 s/.test(ic.monitorView(
+				Object.assign({ monitorDelay: 30 }, nmThr),
+				{ night_mode_source: 2, isp_again: 6000 }).line));
+		check('...and a zero is the floor, not a zero',
+			/every 5 s/.test(ic.monitorView(
+				Object.assign({ monitorDelay: 0 }, nmThr),
+				{ night_mode_source: 2, isp_again: 6000 }).line));
 		check('the night rule sits at maxThreshold',
 			thr.marks[1].v === 4000 && thr.marks[1].label === 'night');
 		check('and the day rule at minThreshold',

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -1017,14 +1017,17 @@
 			if (lo !== null) marks.push({ v: lo, color: '#2fb673', label: 'day' });
 			if (hi !== null) marks.push({ v: hi, color: '#e0a020', label: 'night' });
 			// Why there is no countdown here, said where the countdown would
-			// have been. The two mechanisms look interchangeable on the page —
-			// a pair of numbers and a delay either way — so the reporter of
-			// #325 read the missing countdown as a fault in the legacy half.
-			// It is a difference in what the camera does: a threshold monitor
-			// switches on the first check that lands past a threshold, with no
-			// dwell to serve out, while automatic mode holds a condition for
-			// its two delays before acting. Saying nothing left the operator
-			// to conclude the timer was broken.
+			// have been: a threshold monitor switches on the first check that
+			// lands past a threshold, with no dwell to serve out, while
+			// automatic mode holds a condition for its two delays first. The
+			// reporter of #325 read the missing countdown as a fault in the
+			// legacy half, because saying nothing left nothing else to think.
+			//
+			// Said in one clause rather than three. The first cut of this
+			// closed by naming which mechanism the delays belong to, which was
+			// explaining the page in the page: the Legacy switch is two rows
+			// up and the check interval now says what it is on its own row, so
+			// the sentence can state the behaviour and stop (#325).
 			//
 			// The period is the same "seconds between light checks" both
 			// mechanisms are armed from, and majestic floors an unset or zero
@@ -1037,10 +1040,9 @@
 				value: ('isp_again' in v) ? v.isp_again : null,
 				marks: marks,
 				line: modeWord +
-					'Comparing raw sensor gain against the thresholds ' +
-					'(vendor-specific units). It switches on the first check ' +
-					'past one — every ' + everyS + ' s — so there is no wait ' +
-					'to count down; the two delays belong to automatic mode.' +
+					'Comparing raw sensor gain (vendor units) against the ' +
+					'thresholds. It switches on the first check past one, ' +
+					'every ' + everyS + ' s — so there is no countdown.' +
 					lampNote,
 				unit: '',
 			};


### PR DESCRIPTION
The reporter of #325 quoted the sentence back ([comment](https://github.com/OpenIPC/majestic-webui/issues/325#issuecomment-5581699000)): *"Isn't this too long? I think the UI would be much clearer with shorter, more direct wording."* They are right, and it is the third time in that thread they have asked for less text.

**Before**

> Day. Comparing raw sensor gain against the thresholds (vendor-specific units). It switches on the first check past one — every 60 s — so there is no wait to count down; the two delays belong to automatic mode.

**After**

> Day. Comparing raw sensor gain (vendor units) against the thresholds. It switches on the first check past one, every 60 s — so there is no countdown.

The closing clause was explaining the page inside the page. It was written when the caption above the interval still said "Delay before switching day/night mode" and a reader had every reason to expect a countdown; with the Legacy switch two rows up and that row naming itself, the sentence can state the behaviour and stop.

### Tests

Four, holding what the sentence is *for* — nothing pinned it before: that it says there is no countdown, that it names the interval the camera is actually checking at, and that a stored `0` prints as the daemon's floor of five rather than as zero.

`npm test` passes (32 files).

### Also in that comment, and deliberately not changed here

The reporter asked whether the orange "Not in use…" notes could be removed entirely, since the Legacy switch shows one mechanism at a time. Checked on a camera across four configurations rather than reasoned about: they now appear in exactly one state — a **wired daylight sensor pin**, which outranks both on-screen sets and is assigned on the pin map, so the switch cannot cover it. In every other state, and in both positions of the switch, there are none. Their underlying point about the wording's length stands and is answered on the daemon side, where the message lives.

Refs #325
