### PR TITLE
Live: retry a refused muted WebRTC start on a gesture, whatever the error is named

### DIFF
--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -274,10 +274,12 @@ async function playRetriesOnGesture() {
 	// load; the picture is ready but paused. The player must retry play() on the
 	// first user gesture rather than leave it paused for ever.
 	const env = makeEnv();
-	let plays = 0, reject = true;
+	let plays = 0, reject = true, rejectName = 'AbortError';
 	const video = {
 		muted: true, volume: 1, srcObject: null,
-		play() { plays++; return reject ? Promise.reject({ name: 'NotAllowedError' }) : Promise.resolve(); },
+		// Not NotAllowedError: browsers name a refused muted autoplay
+		// differently, and the retry must arm regardless (#317).
+		play() { plays++; return reject ? Promise.reject({ name: rejectName }) : Promise.resolve(); },
 	};
 	env.MajesticWebRTC.attach(video, {});
 	await tick();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -542,11 +542,18 @@ window.MajesticWebRTC = (function () {
 					// that as an autoplay refusal reports "no audio" over a
 					// working Opus stream, which is exactly what it did.
 					if (!current(my)) return;
-					// A muted element has no sound to blame: autoplay was refused on a
-					// fresh load with no user activation (#317). Retry on the first gesture.
+					// A muted element has no sound to blame: it was left paused,
+					// which on a fresh load with no user activation is autoplay
+					// being refused (Opera for Android refuses even a muted
+					// MediaStream, #317). Retry on the first gesture, whatever the
+					// rejection was named -- browsers disagree on that (Chrome
+					// NotAllowedError, others AbortError or an unnamed reject), and
+					// the actionable fact is only that a muted picture is paused
+					// and a gesture will start it. No audio track is requested
+					// while muted, so ontrack fires once and this is not the
+					// audio-track AbortError the unmuted branch below guards.
 					if (video.muted) {
-						if (err && err.name === 'NotAllowedError')
-							playOnGesture(video, function () { return current(my); });
+						playOnGesture(video, function () { return current(my); });
 						return;
 					}
 					if (!err || err.name !== 'NotAllowedError') return;


### PR DESCRIPTION
## What

Follow-up to #391. On Opera for Android the Live picture is missing on a fresh WebRTC load; the reporter confirmed the video is decoding and laid out but `paused=true`. #391 retried `play()` on the first user gesture — but only when the refusal was a `NotAllowedError`. After `updatewebui` the reporter said nothing changed, so the rejection Opera raises for a **muted** MediaStream refusal is not named `NotAllowedError`, and the retry never armed.

Chrome always allows muted autoplay, so this refusal **cannot be reproduced there** (verified: even `--autoplay-policy=user-gesture-required` still plays the muted stream). The `NotAllowedError` gate was a guess, and too narrow.

## The change

In the muted branch, drop the error-name check: a muted element left paused after a `play()` attempt is, on a fresh load, autoplay being refused, and the only actionable fact is that a gesture will start it. No audio track is requested while muted (`ontrack` fires once), so this is not the audio-track `AbortError` the unmuted branch guards. Transparent where autoplay is allowed — the `catch` never runs (lab WebRTC unchanged, 185 frames / 0 dropped).

## Tests

`tests/talkback.test.js` now rejects the muted `play()` with `AbortError` to prove the retry arms regardless of the error name (and still re-arms per attempt, does not stack).

Addresses the WebRTC half of #317. Pending the reporter's confirmation on Opera before merge, since it can't be verified against Chrome.