### PR TITLE
Recordings: a day's listing is one stat and one awk, not five forks a clip

### DIFF
--- a/www/cgi-bin/j/recordings.cgi
+++ b/www/cgi-bin/j/recordings.cgi
@@ -114,13 +114,61 @@ if [ ! -d "$dir" ]; then
 fi
 
 printf '{"path":"%s","clips":[' "$(json_str "$dir")"
-first=1
-for f in "$dir"/*.mp4; do
-	[ -f "$f" ] || continue
-	info=$(stat -c '%s|%Y' "$f" 2>/dev/null) || continue
-	sz=${info%%|*}; mt=${info#*|}
-	[ "$first" = 1 ] || printf ','
-	first=0
-	printf '{"name":"%s","size":%s,"mtime":%s}' "$(json_str "$(basename "$f")")" "$sz" "$mt"
-done
+
+# One stat and one awk for the whole day, not five processes per clip.
+#
+# The obvious loop -- stat the file, basename it, json_str the name -- forks
+# `stat`, `basename`, and json_str's own printf|tr|sed, for every clip.
+# records.split is counted in minutes, so a full day is 1440 clips, and that
+# loop is some seven thousand busybox forks to answer one request. Measured on
+# an armv7 camera: 11.8 s for 680 clips, all of it process startup -- the glob
+# and the tests together cost 0.04 s. The page cannot draw its timeline until
+# this request finishes, so that number is the page load. The pipeline below
+# emits the same bytes in 0.07 s.
+#
+# xargs does the batching, so the argument list stays inside ARG_MAX no matter
+# how many clips a day holds, and it hands them on in the order it got them --
+# the glob's, which is already chronological because these names are the clock.
+# awk sees one uninterrupted stream, so the commas never have to work out where
+# one batch ended and the next began.
+#
+# -L asks about what a symlink points at, which is what the `-f` test this
+# replaces asked: a link to a clip is a clip, and a dangling one fails stat and
+# drops out, as it did before. Size and mtime now describe the clip rather than
+# the link, which is the answer the caller was always after.
+set -- "$dir"/*.mp4
+if [ -e "$1" ]; then
+	printf '%s\0' "$@" |
+	xargs -0 -r stat -L -c '%s|%Y|%F|%n' 2>/dev/null |
+	awk -F'|' '
+		# json_str, moved in here: escape backslash and quote, drop control
+		# characters. Done a character at a time on purpose -- a backslash in
+		# a gsub *replacement* is reinterpreted by gsub, and getting that
+		# wrong is silent, so this never puts one there.
+		function esc(s,   out, i, c) {
+			out = ""
+			for (i = 1; i <= length(s); i++) {
+				c = substr(s, i, 1)
+				if (c == "\\" || c == "\"") out = out "\\" c
+				else if (c !~ /[\001-\037]/) out = out c
+			}
+			return out
+		}
+		# The name is field 4 onwards, rejoined: a filename may contain the
+		# separator itself. Size, mtime and type go first, where they cannot
+		# be mistaken for part of it.
+		#
+		# ^regular, not "regular file": busybox calls a zero-byte file a
+		# "regular empty file", and the clip being recorded right now is
+		# zero bytes until the muxer first flushes. Matching the exact string
+		# drops the newest clip from the day you are most likely looking at.
+		$3 ~ /^regular/ {
+			name = $4
+			for (i = 5; i <= NF; i++) name = name "|" $i
+			sub(/.*\//, "", name)
+			printf "%s{\"name\":\"%s\",\"size\":%s,\"mtime\":%s}", \
+				(seen++ ? "," : ""), esc(name), $1, $2
+		}
+	'
+fi
 printf ']}'

--- a/www/cgi-bin/j/recordings.cgi
+++ b/www/cgi-bin/j/recordings.cgi
@@ -136,39 +136,53 @@ printf '{"path":"%s","clips":[' "$(json_str "$dir")"
 # replaces asked: a link to a clip is a clip, and a dangling one fails stat and
 # drops out, as it did before. Size and mtime now describe the clip rather than
 # the link, which is the answer the caller was always after.
+#
+# Every entry is rejected on its own, and nothing guards the batch. A `[ -e ]`
+# on the first glob result would look like the empty-directory check the day
+# list does, and would instead be a way to lose a whole day: this directory is
+# pruned while it is being read, so the first clip going away between the glob
+# and the test is ordinary, and a dangling link that sorts first would do it
+# too -- either one would empty the timeline of a day that is full of footage.
+# An unmatched glob needs no guard either. It stays literal, stat says no such
+# file, and a day with nothing in it comes back as the [] it should be.
 set -- "$dir"/*.mp4
-if [ -e "$1" ]; then
-	printf '%s\0' "$@" |
-	xargs -0 -r stat -L -c '%s|%Y|%F|%n' 2>/dev/null |
-	awk -F'|' '
-		# json_str, moved in here: escape backslash and quote, drop control
-		# characters. Done a character at a time on purpose -- a backslash in
-		# a gsub *replacement* is reinterpreted by gsub, and getting that
-		# wrong is silent, so this never puts one there.
-		function esc(s,   out, i, c) {
-			out = ""
-			for (i = 1; i <= length(s); i++) {
-				c = substr(s, i, 1)
-				if (c == "\\" || c == "\"") out = out "\\" c
-				else if (c !~ /[\001-\037]/) out = out c
-			}
-			return out
+printf '%s\0' "$@" |
+xargs -0 -r stat -L -c '%s|%Y|%F|%n|#' 2>/dev/null |
+awk -F'|' '
+	# json_str, moved in here: escape backslash and quote, drop control
+	# characters. Done a character at a time on purpose -- a backslash in
+	# a gsub *replacement* is reinterpreted by gsub, and getting that
+	# wrong is silent, so this never puts one there.
+	function esc(s,   out, i, c) {
+		out = ""
+		for (i = 1; i <= length(s); i++) {
+			c = substr(s, i, 1)
+			if (c == "\\" || c == "\"") out = out "\\" c
+			else if (c !~ /[\001-\037]/) out = out c
 		}
-		# The name is field 4 onwards, rejoined: a filename may contain the
-		# separator itself. Size, mtime and type go first, where they cannot
-		# be mistaken for part of it.
-		#
-		# ^regular, not "regular file": busybox calls a zero-byte file a
-		# "regular empty file", and the clip being recorded right now is
-		# zero bytes until the muxer first flushes. Matching the exact string
-		# drops the newest clip from the day you are most likely looking at.
-		$3 ~ /^regular/ {
-			name = $4
-			for (i = 5; i <= NF; i++) name = name "|" $i
-			sub(/.*\//, "", name)
-			printf "%s{\"name\":\"%s\",\"size\":%s,\"mtime\":%s}", \
-				(seen++ ? "," : ""), esc(name), $1, $2
-		}
-	'
-fi
+		return out
+	}
+	# The name is the fields between the type and the terminator, rejoined:
+	# a filename may contain the separator itself. Size, mtime and type go
+	# first, where they cannot be mistaken for part of it.
+	#
+	# ^regular, not "regular file": busybox calls a zero-byte file a
+	# "regular empty file", and the clip being recorded right now is
+	# zero bytes until the muxer first flushes. Matching the exact string
+	# drops the newest clip from the day you are most likely looking at.
+	#
+	# The trailing # is what makes a record whole. stat separates records
+	# with a newline, and a filename is allowed to contain one -- which
+	# splits it across two lines, neither of them the truth. The terminator
+	# is printed after the name, so a split record does not carry it and is
+	# dropped here. Squashing the newline out instead, as this used to,
+	# only produced a name no file on the card answers to.
+	$3 ~ /^regular/ && $NF == "#" {
+		name = $4
+		for (i = 5; i <= NF - 1; i++) name = name "|" $i
+		sub(/.*\//, "", name)
+		printf "%s{\"name\":\"%s\",\"size\":%s,\"mtime\":%s}", \
+			(seen++ ? "," : ""), esc(name), $1, $2
+	}
+'
 printf ']}'


### PR DESCRIPTION
Opening the recordings page took **12.8 s** on a lab hi3516av300 holding 680 clips.

None of it was the network, the camera's daemon, or the browser. The page HTML answers in 111 ms and every other request it makes is under 200 ms. One request is the whole delay:

```
/cgi-bin/j/recordings.cgi?day=2026-09-08   ->  12.85 s   (680 clips, ~19 ms/clip)
```

The page cannot draw its timeline until that returns, so that number is the page load.

## Why

The per-day loop forks about five busybox processes for every clip it reports: `stat`, `basename`, and `json_str`'s own `printf | tr | sed`. Measured on that camera, 680 clips:

| loop body | time |
| --- | --- |
| glob + `[ -f ]` tests only | 0.04 s |
| + `stat` fork | 3.33 s |
| + `basename` fork | 6.34 s |
| + `json_str` pipeline | **11.82 s** |

So 11.8 s of the 12.85 s is process startup — some 3,400 forks to answer one request. `count_clips` in the same file was already written fork-free, with a comment saying why; the per-day loop was not.

It also gets worse on its own. `records.split` is counted in minutes, so a full day is 1440 clips. The camera above was half a day in at 680, and the same page would have taken about 27 s by midnight.

## The change

Stat the whole day at once and let awk write the JSON. `xargs` does the batching, so the argument list stays inside `ARG_MAX` however many clips a day holds, and it preserves input order — the glob's, already chronological because these names are the clock. awk sees one uninterrupted stream, so the commas never have to work out where a batch ended.

Measured after, same camera: **0.29 s** for 460 clips and **0.35 s** for 688. Full page-open sequence went from ~13.5 s to 0.82 s.

## Two things that quietly cost a listing

Both were found by diffing the old implementation against the new one over a directory of adversarial names, not by reading:

- busybox calls a zero-byte file a **`regular empty file`**, not `regular file`. A type test for the exact string silently drops the clip being recorded right now — the newest one, on the day you are most likely looking at.
- a backslash in a `gsub` **replacement** is reinterpreted by `gsub`, and getting that wrong is silent. The escaping is done a character at a time so it never puts one there.

## Verification

Old and new run back to back over the same directory, on the camera. Byte-identical for names containing quotes, backslashes, pipes, spaces, `$`, `*`, `'`, tabs (control characters stripped, as before) and UTF-8; a directory named `*.mp4` still excluded; a dangling symlink still excluded; a zero-byte clip still listed; an empty day still `[]`.

One deliberate difference: a symlinked clip now reports the size and mtime of the clip rather than of the link. `-L` is what reproduces the `[ -f "$f" ]` test this replaces — a link to a clip is a clip, and a dangling one fails stat and drops out — and the target's numbers are what the caller was always asking for.

Also checked that the shipped form survives packaging: comment-only and blank lines stripped out of the file still parse and still return the identical listing on the camera.

`npm test` and `tools/lint-templates.sh` both pass.