### PR TITLE
Time: an empty NTP box is not a reason to delete the file

### DIFF
--- a/www/cgi-bin/j/time.cgi
+++ b/www/cgi-bin/j/time.cgi
@@ -16,7 +16,12 @@ case "$QUERY_STRING" in
 		fi
 		;;
 	*)
-		if ntpd -n -q -N; then
+		if [ ! -f /etc/ntp.conf ]; then
+			# busybox ntpd has no built-in peers -- with the file gone it prints
+			# its usage and exits, and "Synchronization failed!" was all the page
+			# ever said about a camera that could not sync and never would.
+			payload='{"result":"danger","message":"No NTP servers are configured: /etc/ntp.conf is missing. Fill the servers in above and save."}'
+		elif ntpd -n -q -N; then
 			payload='{"result":"success","message":"Camera time synchronized with NTP server."}'
 		else
 			payload='{"result":"danger","message":"Synchronization failed!"}'

--- a/www/cgi-bin/time.cgi
+++ b/www/cgi-bin/time.cgi
@@ -72,7 +72,16 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 					# reports servers the running daemon goes on ignoring until
 					# the next reboot -- and on a camera being repaired from the
 					# whiteout above there is no daemon running to ignore them.
-					[ -x /etc/init.d/S49ntpd ] && /etc/init.d/S49ntpd restart > /dev/null 2>&1
+					#
+					# Reported rather than assumed: an image can ship without
+					# the init script at all (rubyfpv's tweaksys removes it),
+					# and "saved" and "in effect" are not the same claim to
+					# make. The list is on the camera either way, so this is a
+					# warning about when it starts counting, not a failure.
+					if ! { [ -x /etc/init.d/S49ntpd ] && /etc/init.d/S49ntpd restart > /dev/null 2>&1; }; then
+						saved_class="warning"
+						saved_text="Saved. ntpd could not be restarted, so the new servers take effect at the next boot."
+					fi
 				else
 					rm -f /etc/ntp.conf.new
 					saved_class="danger"
@@ -111,11 +120,26 @@ for host in $(ntp_read "$ntp_src"); do
 	eval "server_${i}=\$host"
 	i=$((i + 1))
 done
+
+# Two different situations wear the same missing file, and promising a repair
+# that cannot happen is worse than admitting there is none. Keyed on whether a
+# box actually got filled rather than on $ntp_rom existing, because that is the
+# thing the reader is about to look at: a /rom copy that is present but carries
+# no server line leaves the form just as empty, and Save just as refused.
+ntp_warn=""
+if [ -n "$ntp_missing" ]; then
+	ntp_warn='<b>This camera has no NTP configuration.</b> <code>/etc/ntp.conf</code> is missing, so <code>ntpd</code> exits at every boot and nothing ever corrects the clock &mdash; recordings and log rows carry whatever time the camera drifted to. '
+	if [ -n "$server_0" ]; then
+		ntp_warn="${ntp_warn}The servers below are the firmware defaults, filled in but not in effect; saving the form writes the file back."
+	else
+		ntp_warn="${ntp_warn}This image has no copy to restore from either, so nothing could be filled in below: type a server &mdash; <code>0.pool.ntp.org</code> will do &mdash; and save."
+	fi
+fi
 %>
 
 <%in p/header.cgi %>
 
-<% [ -n "$ntp_missing" ] && notice warn '<b>This camera has no NTP configuration.</b> <code>/etc/ntp.conf</code> is missing, so <code>ntpd</code> exits at every boot and nothing ever corrects the clock &mdash; recordings and log rows carry whatever time the camera drifted to. The servers below are the firmware defaults, filled in but not in effect; saving the form writes the file back.' %>
+<% [ -n "$ntp_warn" ] && notice warn "$ntp_warn" %>
 
 <div class="row g-4">
 	<div class="col-12">

--- a/www/cgi-bin/time.cgi
+++ b/www/cgi-bin/time.cgi
@@ -45,9 +45,9 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 			# masked for good -- through reboots, and through sysupgrade, which
 			# does not touch the overlay. busybox ntpd has no built-in peers and
 			# takes them from that file alone, so it exits 1 the moment S49ntpd
-			# starts it and the clock is never disciplined again. Found on a lab
-			# ssc30kq that had drifted 863 minutes with nothing on this page
-			# saying why; the boxes then read back from the file the save had
+			# starts it and the clock is never disciplined again. Found on an
+			# ssc30kq + imx335 that had drifted 863 minutes with nothing on this
+			# page saying why; the boxes then read back from the file the save had
 			# just destroyed, came up empty, and armed the same trap for the
 			# next save.
 			ntp_new=""

--- a/www/cgi-bin/time.cgi
+++ b/www/cgi-bin/time.cgi
@@ -4,6 +4,21 @@
 tz_data=$(cat /etc/TZ)
 tz_name=$(cat /etc/timezone)
 
+# The firmware's own copy of the stock list. The rootfs is a read-only squashfs
+# pivoted to /rom with a jffs2 overlay on top, so this is what /etc/ntp.conf
+# reads through to until something writes over it -- and what is still sitting
+# there, untouched, on a camera where something has deleted it.
+ntp_rom=/rom/etc/ntp.conf
+
+# The hostname of every "server" line, in file order. `awk` on the keyword
+# rather than `sed -n <N>p` by line number: a comment or a blank line at the top
+# shifted every box down one, so the form offered a comment's second word as a
+# hostname and saving the form put it back as one.
+ntp_read() {
+	[ -f "$1" ] || return 0
+	awk '$1 == "server" && $2 != "" { print $2 }' "$1"
+}
+
 if [ "$REQUEST_METHOD" = "POST" ]; then
 	case "$POST_action" in
 		update)
@@ -18,24 +33,89 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 				touch /tmp/system-reboot
 			fi
 
-			rm -f /etc/ntp.conf
+			# Build the list first, and only then go near the file. What this
+			# replaced removed /etc/ntp.conf up front and appended the boxes to
+			# the live file a line at a time, which failed two ways -- and the
+			# second is not repairable from this page.
+			#
+			# A save with the boxes empty left no file at all. On an overlayfs
+			# root, deleting a file that lives in the lower layer does not free
+			# anything: it writes a WHITEOUT into the overlay, so the firmware's
+			# own /rom/etc/ntp.conf is still there, still perfectly good, and
+			# masked for good -- through reboots, and through sysupgrade, which
+			# does not touch the overlay. busybox ntpd has no built-in peers and
+			# takes them from that file alone, so it exits 1 the moment S49ntpd
+			# starts it and the clock is never disciplined again. Found on a lab
+			# ssc30kq that had drifted 863 minutes with nothing on this page
+			# saying why; the boxes then read back from the file the save had
+			# just destroyed, came up empty, and armed the same trap for the
+			# next save.
+			ntp_new=""
 			for i in $(seq 0 3); do
 				eval ntp="\$POST_server_${i}"
-				[ -n "$ntp" ] && echo "server $ntp iburst" >> /etc/ntp.conf
+				[ -n "$ntp" ] && ntp_new="${ntp_new}server ${ntp} iburst
+"
 			done
+
+			saved_class="success"
+			saved_text="Configuration updated."
+			if [ -n "$ntp_new" ]; then
+				# Written beside the target rather than in /tmp, so `mv` is a
+				# rename instead of the truncate-and-copy it falls back to
+				# across a filesystem: a reader gets the whole old list or the
+				# whole new one, and there is never a moment with no file. The
+				# mode goes on before the rename for the same reason -- the
+				# CGI's umask is 077 and the firmware ships this file 644.
+				if printf '%s' "$ntp_new" > /etc/ntp.conf.new && chmod 644 /etc/ntp.conf.new &&
+					mv /etc/ntp.conf.new /etc/ntp.conf; then
+					# ntpd reads the file once, at start. Without this the page
+					# reports servers the running daemon goes on ignoring until
+					# the next reboot -- and on a camera being repaired from the
+					# whiteout above there is no daemon running to ignore them.
+					[ -x /etc/init.d/S49ntpd ] && /etc/init.d/S49ntpd restart > /dev/null 2>&1
+				else
+					rm -f /etc/ntp.conf.new
+					saved_class="danger"
+					saved_text="Time zone saved, but the NTP server list could not be written."
+				fi
+			else
+				saved_class="warning"
+				saved_text="Time zone saved. The NTP servers were left as they were: ntpd has no peers of its own, so an empty list is not a setting, it is a clock that never syncs again."
+			fi
 			update_caminfo
-			redirect_back "success" "Configuration updated."
+			redirect_back "$saved_class" "$saved_text"
 			;;
 	esac
 fi
 
-for i in $(seq 0 3); do
-	eval server_${i}=$(sed -n $((i + 1))p /etc/ntp.conf | awk '{print $2}')
+# The summary is what is IN EFFECT, so it reads /etc/ntp.conf and nothing else:
+# on a camera with the file deleted it says "—", which is the truth.
+ntp_summary=$(ntp_read /etc/ntp.conf | awk '{ printf "%s%s", sep, $0; sep = ", " }')
+
+# The boxes are what there is to EDIT, so where the file is gone they offer the
+# firmware's own list instead of nothing -- Save is then the way back out of the
+# whiteout, and the banner below is what keeps the two apart on screen.
+ntp_missing=""
+ntp_src=/etc/ntp.conf
+if [ ! -f /etc/ntp.conf ]; then
+	ntp_missing=1
+	[ -f "$ntp_rom" ] && ntp_src="$ntp_rom"
+fi
+
+i=0
+for host in $(ntp_read "$ntp_src"); do
+	[ "$i" -gt 3 ] && break
+	# `\$host`, so eval is handed an assignment rather than the contents of the
+	# file: the line this replaced was `eval server_$i=$(...)`, which gave
+	# whatever was on that line to the shell to parse as a command.
+	eval "server_${i}=\$host"
+	i=$((i + 1))
 done
-ntp_summary=$(echo $server_0 $server_1 $server_2 $server_3 | sed 's/ /, /g')
 %>
 
 <%in p/header.cgi %>
+
+<% [ -n "$ntp_missing" ] && notice warn '<b>This camera has no NTP configuration.</b> <code>/etc/ntp.conf</code> is missing, so <code>ntpd</code> exits at every boot and nothing ever corrects the clock &mdash; recordings and log rows carry whatever time the camera drifted to. The servers below are the firmware defaults, filled in but not in effect; saving the form writes the file back.' %>
 
 <div class="row g-4">
 	<div class="col-12">


### PR DESCRIPTION
An ssc30kq + imx335 had been showing `⚠ camera -863m` on the dashboard. Its clock was 863 minutes — 14 h 23 m — behind, and had been for a fortnight. The rate was sound: it advanced 61 s over 60 s of real time. A pure offset that nothing was correcting, and the badge was the only thing anywhere in the WebUI that said so.

## Why

`ntpd` was not running, and starting it by hand reported success and then exited within seconds: it could not open `/etc/ntp.conf`.

busybox ntpd carries no built-in peers. `S49ntpd` runs it as `-n -S /usr/sbin/ntpd-script`, with no `-p`, so that file is its only source of servers — and with the file gone every sync path on the camera is dead at once: the daemon, the `ntpd -q -N -n` step the firmware runs from `udhcpc/default.script`, and `sysupgrade`'s own `ntpd -Nnq`. These boards have no battery-backed RTC, so `fake-hwclock` then restores the already-wrong checkpoint at the next boot and the error compounds instead of healing.

`/rom/etc/ntp.conf` was intact throughout. The overlay's upper layer held, in place of the file, a character device with major/minor 0,0 — an overlayfs whiteout, dated the afternoon the camera was last configured. Root here is a read-only squashfs pivoted to `/rom` with jffs2 over it, so deleting a file that lives in the lower layer frees nothing: it masks it, permanently, through reboots and through `sysupgrade`, which does not touch the overlay. `firstboot` is the only thing that clears one.

This page wrote it, at `time.cgi:21`:

```sh
rm -f /etc/ntp.conf
for i in $(seq 0 3); do
	eval ntp="\$POST_server_${i}"
	[ -n "$ntp" ] && echo "server $ntp iburst" >> /etc/ntp.conf
done
```

The delete is unconditional; the rewrite is not. A save with the Server boxes empty destroys the file.

And it is a **one-way trap**, because line 33 prefilled those same boxes by reading the file back:

```sh
eval server_${i}=$(sed -n $((i + 1))p /etc/ntp.conf | awk '{print $2}')
```

Once the file is gone the boxes render empty, so the next save deletes it again. The page showed `NTP servers —`, offered four blank boxes, and had no way back to a working configuration. `Sync now` reported `Synchronization failed!` — true, and useless.

## The change

- **Build the list before going near the file.** Write it only when there is something to write, into `/etc/ntp.conf.new` beside the target so `mv` is a rename rather than the truncate-and-copy it falls back to across a filesystem. `chmod 644` before the rename, since the CGI's umask is 077 and the firmware ships that file 644. There is no longer any moment with no file, and nothing deletes one.
- **An empty form is refused, and says why.** ntpd has no peers of its own, so an empty list is not a setting — it is a clock that never syncs again. The old list stays and the flash message explains. Clearing *one* box still drops that server; only clearing all four is refused.
- **A camera already carrying the whiteout can get out.** Where `/etc/ntp.conf` is missing the boxes are filled from `/rom`'s copy behind a banner saying they are the firmware defaults, filled in but not in effect. Save writes the file, which replaces the whiteout with a real file. The Current card still reads `—`, because that is what is actually in effect.
- **The banner says which of the two situations this camera is in.** On an image with a writable rootfs there is no `/rom` to fall back on, so nothing gets prefilled and Save would be refused; the second sentence is chosen on whether a box actually received a value rather than on the `/rom` path existing, which also covers a `/rom` copy that is present but carries no `server` line.
- **ntpd is restarted after a write, and the restart is reported rather than assumed.** It reads its peers once, at start; without this the page reports servers the running daemon ignores until the next reboot, and on a camera being repaired there is no daemon running at all. An image can ship without the init script (rubyfpv's `tweaksys` removes it), so a save that could not restart it says when the new servers will take effect. It stays a warning, not a failure — the list is on the camera either way.
- **`Sync now` names the fault** instead of reporting a bare failure.
- The read-back matches the `server` keyword instead of counting lines — a comment or blank line at the top shifted every box down one — and no longer hands the file's contents to `eval`.

## Tested on

**ssc30kq + imx335**, `ssc30kq_lite`, current master firmware, in the failed state described above — the board that had the fault, driven through its own web server rather than through a fixture. `tools/lint-templates.sh` and `npm test` both pass.

Behaviour before the change, with the file missing: the Current card read `—`, all four server boxes rendered empty, and `Sync now` answered with a bare failure.

After, on the same still-broken camera: the Current card still reads `—` (nothing *is* in effect, and the page must not pretend otherwise), the four boxes come up carrying the firmware defaults, the missing-configuration banner is raised, and `Sync now` reports that `/etc/ntp.conf` is missing and points at the form.

Then, each behaviour exercised end to end:

| what was posted | result |
| --- | --- |
| every box empty — the exact save that caused this | refused with a warning; no file written, and the existing whiteout untouched, its timestamp unchanged |
| the form as the page offers it, on a camera with the whiteout | whiteout replaced by a regular 644 file holding the four defaults; ntpd restarted and running |
| — 45 s later, clock wound back 863 min beforehand | camera and host agreed to the second; dashboard drift 0.0 min, badge gone |
| every box empty, with a good file present | file survives intact with all four servers; warning explains why nothing changed |
| one server, three boxes cleared | written 644, ntpd restarted, Current card reflects it, `Sync now` succeeds |
| a save with the init script made unavailable | list written, and the flash says the servers take effect at the next boot instead of claiming success |
| the missing-configuration banner with no `/rom` copy to draw on | boxes stay empty and the banner says to type a server, rather than claiming defaults were loaded |

The whole repair path runs through the browser; no shell access is needed at any point.

## Not in this PR

The firmware side deserves the same treatment, so that no bug of this shape can cost a camera its clock and so the cameras already carrying a whiteout repair themselves. That is OpenIPC/firmware#2383, opened alongside this.
