### PR TITLE
A page writes nothing to stderr

### DIFF
--- a/www/cgi-bin/editor.cgi
+++ b/www/cgi-bin/editor.cgi
@@ -36,12 +36,16 @@ else
 	if [ ! -f "$editor_file" ]; then
 		log_create "danger" "File not found!"
 	elif [ -n "$editor_file" ]; then
-		if [ "b" = "$( (cat -v "$editor_file" | grep -q "\^@") && echo "b" )" ]; then
+		# 2>/dev/null: the path is whatever GET_f said, and a regular file can
+		# pass -f and still fail to read (/proc/self/mem). The probe's answer
+		# is "not a text file" either way, so the read error has nothing to add
+		# except a line on a stderr the service sends nowhere.
+		if [ "b" = "$( (cat -v "$editor_file" 2>/dev/null | grep -q "\^@") && echo "b" )" ]; then
 			log_create "danger" "Not a text file!"
-		elif [ "$(stat -c%s $editor_file)" -gt "102400" ]; then
+		elif [ "$(stat -c%s "$editor_file" 2>/dev/null)" -gt "102400" ]; then
 			log_create "danger" "Uploaded file is too large!"
 		else
-			editor_text="$(cat $editor_file)"
+			editor_text="$(cat "$editor_file" 2>/dev/null)"
 		fi
 	fi
 fi

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -115,9 +115,10 @@ ex() {
 	echo "<div class=\"${2:-ex}\"><h6># ${1}</h6><pre class=\"small\">"
 	# 2>&1 because this block exists to SHOW what a command said, and what a
 	# failing one says is on stderr. Without it the operator gets an empty box
-	# and the reason goes to majestic's stderr, which under the service goes
-	# nowhere: `ip link show wg0` on a camera with no tunnel printed "can't find
-	# device" there and nothing here, on a panel whose whole job is to report.
+	# while the reason goes to a stderr the service sends nowhere -- on a panel
+	# whose whole job is to report. wireguard.cgi's `ip link show wg0` is the
+	# case that shows it: on a camera with no tunnel the command fails, and the
+	# page had nothing to say about why.
 	eval "$1" 2>&1 | sed "s/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g;s/\"/\&quot;/g"
 	echo "</pre></div>"
 }
@@ -285,12 +286,23 @@ field_text() {
 field_textedit() {
 	local n="$1"
 	local l="$2"
-	# The file need not exist. editor.cgi passes "$editor_file", which is empty
-	# until a file is chosen, so opening the editor from the menu ran `cat ""`
-	# and put "can't open ''" on majestic's stderr on every visit. An unreadable
-	# path is an empty box, which is what the page shows anyway.
+	# The path need not name a readable regular file, and both halves of that
+	# matter. editor.cgi passes "$editor_file" straight from GET_f: it is empty
+	# until a file is chosen, and it is whatever the query string said
+	# otherwise -- a directory included, which editor.cgi logs as not found
+	# without stopping the render. `cat` on either writes to a stderr the
+	# service sends nowhere, and shows the operator the same empty textarea it
+	# shows for a file that is simply absent. So test for a regular file, not
+	# merely a readable one: -r alone is true of a directory.
+	#
+	# And redirect anyway. The test says what this accepts; the redirect covers
+	# what it cannot predict -- a regular file that passes -r and still fails to
+	# read, /proc/self/mem being the reachable example, since the path is
+	# whatever the query string said. Nothing is hidden by it: the operator's
+	# answer is the empty textarea either way, and editor.cgi writes the banner
+	# that explains why.
 	local v=""
-	[ -r "$3" ] && v=$(cat "$3")
+	[ -f "$3" ] && [ -r "$3" ] && v=$(cat "$3" 2>/dev/null)
 	echo "<p class=\"textarea\" id=\"${n}_wrap\">" \
 		"<label for=\"${n}\" class=\"form-label\">${l}</label>" \
 		"<textarea id=\"${n}\" name=\"${n}\" class=\"form-control\">${v}</textarea>"

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -113,7 +113,12 @@ check_password() {
 
 ex() {
 	echo "<div class=\"${2:-ex}\"><h6># ${1}</h6><pre class=\"small\">"
-	eval "$1" | sed "s/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g;s/\"/\&quot;/g"
+	# 2>&1 because this block exists to SHOW what a command said, and what a
+	# failing one says is on stderr. Without it the operator gets an empty box
+	# and the reason goes to majestic's stderr, which under the service goes
+	# nowhere: `ip link show wg0` on a camera with no tunnel printed "can't find
+	# device" there and nothing here, on a panel whose whole job is to report.
+	eval "$1" 2>&1 | sed "s/&/\&amp;/g;s/</\&lt;/g;s/>/\&gt;/g;s/\"/\&quot;/g"
 	echo "</pre></div>"
 }
 
@@ -280,7 +285,12 @@ field_text() {
 field_textedit() {
 	local n="$1"
 	local l="$2"
-	local v=$(cat "$3")
+	# The file need not exist. editor.cgi passes "$editor_file", which is empty
+	# until a file is chosen, so opening the editor from the menu ran `cat ""`
+	# and put "can't open ''" on majestic's stderr on every visit. An unreadable
+	# path is an empty box, which is what the page shows anyway.
+	local v=""
+	[ -r "$3" ] && v=$(cat "$3")
 	echo "<p class=\"textarea\" id=\"${n}_wrap\">" \
 		"<label for=\"${n}\" class=\"form-label\">${l}</label>" \
 		"<textarea id=\"${n}\" name=\"${n}\" class=\"form-control\">${v}</textarea>"

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -1,6 +1,26 @@
 #!/usr/bin/haserl
 <%in p/pages.cgi %>
 <%
+# A partial, not a page. majestic execs this file for anyone who asks for
+# /cgi-bin/p/header.cgi, and haserl then runs it with none of p/common.cgi's
+# helpers defined: eleven "not found" lines on majestic's stderr and a fragment
+# with an empty <title>, from a URL nothing links to and nobody can use.
+#
+# Every real page includes common.cgi before this one, so the helpers ARE the
+# test. Inside this block rather than one of its own: what follows the closing
+# tag is the response's own headers, and a block above them would put a newline
+# in front of the status line.
+#
+# An `HTTP/1.1` line sets the code, the way j/fw-latest.cgi does it; a CGI
+# `Status:` header does not -- measured, it arrives as a response header of
+# that name and the reply is a 500. Plain \n for the same reason: a \r survives
+# into the header value.
+command -v esc >/dev/null 2>&1 || {
+	printf 'HTTP/1.1 404 Not Found\nContent-type: text/plain; charset=UTF-8\n\n'
+	printf 'Not a page.\n'
+	exit 0
+}
+
 # The page's name, from the one place it is written. This runs here rather
 # than in p/common.cgi because a page's own block sits between the two
 # includes -- so a page that needs a name this file cannot know (one built

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -3,8 +3,9 @@
 <%
 # A partial, not a page. majestic execs this file for anyone who asks for
 # /cgi-bin/p/header.cgi, and haserl then runs it with none of p/common.cgi's
-# helpers defined: eleven "not found" lines on majestic's stderr and a fragment
-# with an empty <title>, from a URL nothing links to and nobody can use.
+# helpers defined -- so the shell fails to find every one it calls, a line each
+# on a stderr the service sends nowhere, and serves a fragment with an empty
+# <title> from a URL nothing links to and nobody can use.
 #
 # Every real page includes common.cgi before this one, so the helpers ARE the
 # test. Inside this block rather than one of its own: what follows the closing


### PR DESCRIPTION
Asked whether the `/bin/sh: not found` lines were really gone, I measured
instead of assuming, and they were not — just not on the Live page any more.

Rendering all 47 pages on a camera left **434 bytes on majestic's stderr**, from
three places. None of it is visible under the service, because that stderr goes
nowhere: all of it is only findable by running the daemon in the foreground,
which is exactly how the six lines that started this were found.

This takes that to **zero**.

## Three sources

**`field_textedit` ran `cat "$3"` on a path that need not exist.** `editor.cgi`
passes `"$editor_file"`, which is empty until a file is chosen, so opening the
editor from the menu printed `cat: can't open ''` on every visit. The textarea
was empty either way — which is why nothing ever looked wrong. The served bytes
are identical; only the noise is gone.

**`ex` escaped stdout and left stderr to the daemon.** Its whole job is to show
what a command said, on a panel called *"Advanced — raw configuration"*. On a
camera with no tunnel, `ip link show wg0` therefore gave the operator an **empty
box** while the reason went somewhere nobody reads. It shows the reason now,
which is both the fix and the better page.

**`p/header.cgi` is a partial, and majestic execs it for anyone who asks for
`/cgi-bin/p/header.cgi`.** haserl then runs it with none of `p/common.cgi`'s
helpers defined: eleven `/bin/sh: <fn>: not found` lines and a fragment with an
empty `<title>`, from a URL nothing links to and nobody can use. Every real page
includes `common.cgi` first, so the helpers are the test — no `esc`, no page. It
answers 404 now instead of 200-with-a-broken-fragment, which also makes it
consistent with `p/motor.cgi` and `p/pages.cgi`, whose direct requests already
failed.

## Two things about that guard are measured, not assumed

The status line has to be an `HTTP/1.1` one, the way `j/fw-latest.cgi` writes
it. A CGI `Status:` header arrives as a **response header of that name** and the
reply is a 500 — that was my first attempt, and the camera said so.

And the guard lives inside the existing code block rather than one of its own,
because what follows that block's closing tag is the response's own headers, and
haserl emits the newline that follows a closing tag. A block above them puts a
blank line in front of the status line.

## Verified on an ssc30kq + imx335

- 47 pages, **434 bytes of stderr before, 0 after**, no `not found` anywhere.
- Output unchanged except where it should be: `p/header.cgi` 9,352 → 78 bytes,
  `wireguard.cgi` +56 for the error text it now shows, **`editor.cgi`
  byte-identical**, and `network.cgi`'s two bytes of live `ifconfig` counters.
- Over HTTP through majestic: every real page still 200, the partial a clean
  404 with `Not a page.`
- `tools/lint-templates.sh`, the dist build and its comment gate (133 assets)
  and the full suite all green.

## What I got wrong before

Earlier verification runs recorded `stderr A/B = 434 / 434` and I treated
*equality* as the result. That was sound for what it was doing — proving a
refactor changed nothing — but I then spoke as though stderr were clean. Equal
is not empty, and I never opened those 434 bytes until asked.
