### PR TITLE
Live: one rule for which WebRTC endings are remembered, and the live ending down the shared walk (#402)

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -103,7 +103,7 @@ function load(cfg) {
 		MajesticWebRTC: impls.webrtc,
 		MajesticTransport: {
 			available: () => true, preferred: () => cfg.transport || 'mse',
-			choose() {}, demote() {},
+			choose() {}, demote() {}, durable: (s) => s === 'fallback',
 			impl: (k) => (k === 'webrtc' ? impls.webrtc : impls.mse),
 			iceServers: () => [],
 			// The real rule lives in preview-transport.js and is tested there;

--- a/tests/mj-preview.test.js
+++ b/tests/mj-preview.test.js
@@ -178,6 +178,7 @@ function load(cfg) {
 		preferred: () => cfg.preferred || 'mse',
 		choose(k) { env.chosen = k; },
 		demote() { env.demoted = true; },
+		durable: (s) => s === 'fallback',
 		impl: (k) => impls[k] || impls.mse,
 		iceServers: () => [],
 		chosenStream: () => (cfg.chosenStream === undefined ? null : cfg.chosenStream),
@@ -293,6 +294,19 @@ function ui(rec) {
 		env.made[1].say('playing');
 		check('the trial announces once it has a picture',
 			rec.playing.join() === 'webrtc,mse', rec.playing.join());
+	}
+
+	group('a live WebRTC session that goes busy stages MSE but does not demote');
+	{
+		// 'busy' is transient: it stages MSE like 'fallback' but is never
+		// remembered as a demotion (#402, the one rule in transport.durable).
+		const env = load({ preferred: 'webrtc' });
+		env.mount();
+		env.made[0].say('playing');
+		env.made[0].say('busy', 'the camera is serving as many viewers as it can');
+		check('an MSE trial was staged', env.made.length === 2 && env.made[1].kind === 'mse',
+			env.made.map((p) => p.kind).join(','));
+		check('and no demotion was recorded', env.demoted !== true, env.demoted + '');
 	}
 
 	group('MSE giving up shows the alert, and the selected channel retries');

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -152,6 +152,7 @@ function load(pickedTransport, cfg, cfgDelay, wasmOk, srcs, srcDelay, store) {
 			available: () => true,
 			preferred: () => pickedTransport || 'mse',
 			choose(k) { env.chosen = k; }, demote() { env.demoted = true; },
+			durable: (s) => s === 'fallback',
 			impl: (k) => (impls[k] || impls.mse),
 			iceServers: () => [],
 			// The real rule lives in preview-transport.js and is tested there;
@@ -324,6 +325,23 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		env.made[1].say('busy', 'the camera is serving as many viewers as it can');
 		check('the working player is untouched', !env.made[0].destroyed);
 		check('and no demotion was recorded', env.demoted !== true);
+	}
+
+	group('a live WebRTC session that goes busy stages MSE without a demotion');
+	{
+		// The live-player mid-session path, distinct from the trial-drop above:
+		// a live WebRTC player reports 'busy'. It stages MSE like a 'fallback'
+		// does, but 'busy' is transient, so nothing is remembered (#402).
+		const env = load('webrtc');
+		await tick();
+		env.made[0].say('playing');
+		env.made[0].say('busy', 'the camera is serving as many viewers as it can');
+		check('a replacement was staged', env.made.length === 2, env.made.length + '');
+		check('and it is MSE', env.made[1].kind === 'mse', env.made[1].kind);
+		check('but no demotion was recorded', env.demoted !== true);
+		check('the MSE radio is lit meanwhile',
+			env.el('mj-transport-m').checked === true &&
+			env.el('mj-transport-w').checked === false);
 	}
 
 	group('when the live player dies and its replacement fails too');

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -271,4 +271,17 @@ check('and the legacy key is kept for the next attempt',
 	stuck.store['mj-preview-stream'] === '0',
 	JSON.stringify(stuck.store));
 
+group('which WebRTC endings are worth remembering as a demotion');
+{
+	const T = load(true);
+	// 'fallback' — the camera or this browser cannot serve WebRTC at all — is
+	// durable; 'busy' — merely full right now — is not. Everything else a
+	// player might report is not a WebRTC demotion either.
+	check("'fallback' is durable", T.durable('fallback') === true);
+	check("'busy' is not", T.durable('busy') === false);
+	check("'mjpeg' is not", T.durable('mjpeg') === false);
+	check('an empty string is not', T.durable('') === false);
+	check('undefined is not', T.durable(undefined) === false);
+}
+
 done();

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -454,10 +454,14 @@ window.MajesticPreview = (function () {
 				// a first attach reports the same news once it is true.
 				if (proven) announcePlaying(kind);
 			},
-			onFailed: (kind, why, permanent) => {
+			onFailed: (kind, why, state) => {
 				// 'fallback' is durable and worth remembering; 'busy' says the
-				// camera is full, which it will not be for long.
-				if (kind === 'webrtc' && permanent) window.MajesticTransport.demote();
+				// camera is full, which it will not be for long. The rule lives
+				// in one place now, asked here and by the live-player branch
+				// below (MajesticTransport.durable, #402).
+				if (kind === 'webrtc' && window.MajesticTransport.durable(state)) {
+					window.MajesticTransport.demote();
+				}
 			},
 			// Nothing on screen left to protect. Past MSE this stage has no
 			// preview at all, so what it owes the viewer is the reason — an
@@ -487,11 +491,17 @@ window.MajesticPreview = (function () {
 					return;
 				}
 				if (st === 'fallback' || st === 'busy') {
-					if (st === 'fallback') window.MajesticTransport.demote();
+					// The same demote rule as the trial-drop path above (#402).
+					if (window.MajesticTransport.durable(st)) {
+						window.MajesticTransport.demote();
+					}
 					// Its picture is frozen from here; the replacement is staged
-					// over it rather than blanking the stage.
+					// over it rather than blanking the stage. Down the shared
+					// walk, not a second copy of webrtc -> mse: chain.next runs
+					// swap.start('mse'), since decide('webrtc', …) is always
+					// {start:'mse'}.
 					swap.retire();
-					swap.start('mse');
+					chain.next('webrtc', d);
 				}
 			},
 		});

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -980,7 +980,7 @@
 		},
 		// A trial was dropped and the screen is untouched. All that changes is
 		// the toggle, which has to come back up carrying the reason.
-		onFailed: (kind, why, permanent) => {
+		onFailed: (kind, why, state) => {
 			// The trial is gone and the live player is whatever it was. The
 			// toggle has to describe that, not the transport that just failed
 			// — including when the failure was MSE and WebRTC is still playing,
@@ -1006,8 +1006,10 @@
 				}
 				// 'busy' says the camera is full, which will not be true for
 				// long. Only a real refusal is worth remembering, and even
-				// that expires.
-				if (permanent) rememberDemotion();
+				// that expires. The rule for which endings are durable lives in
+				// one place now (MajesticTransport.durable), asked here and by
+				// the live-player branch below (#402).
+				if (MajesticTransport.durable(state)) rememberDemotion();
 			} else if (swap.playing() === 'webrtc') {
 				reflectTransport('webrtc');
 				rememberTransport('webrtc');
@@ -1057,9 +1059,15 @@
 						transportLbl.title = 'WebRTC: ' + (d || 'unavailable') +
 							'\n\n' + TRANSPORT_TITLE;
 					}
-					if (s === 'fallback') rememberDemotion();
+					// The same demote rule as the trial-drop path above (#402).
+					if (MajesticTransport.durable(s)) rememberDemotion();
+					// Retire so the frozen frame holds, then down the shared
+					// walk: webrtc -> mse lives in the chain now, not a second
+					// copy here. decide('webrtc', …) is always {start:'mse'}
+					// (only codec-changed diverts, which a webrtc fallback is
+					// not), so this runs the same attachPlayer('mse') as before.
 					swap.retire();
-					attachPlayer('mse');
+					chain.next('webrtc', d);
 				} else {
 					showFallback(d);
 				}

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -37,8 +37,12 @@ window.MajesticSwap = function (opts) {
 	// opts.open       (kind, el, id, onState) -> player
 	// opts.onLive     (state, detail, kind) — from the player on screen
 	// opts.onPromoted (kind) — a trial has taken over
-	// opts.onFailed   (kind, detail, permanent) — trial dropped, screen intact
-	// opts.onExhausted(kind, detail, permanent) — trial dropped, nothing left
+	// opts.onFailed   (kind, detail, state) — trial dropped, screen intact;
+	//                 `state` is the player state it dropped on ('fallback' /
+	//                 'busy' / 'mjpeg'), a fact for the caller to judge (is it
+	//                 durable? — preview-transport.js:durable), not a judgment
+	//                 this state machine makes.
+	// opts.onExhausted(kind, detail) — trial dropped, nothing left
 	const els = opts.elements;
 	let live = null;     // { id, p, slot, kind, dead }
 	let staging = null;  // { id, p, slot, kind }
@@ -99,14 +103,14 @@ window.MajesticSwap = function (opts) {
 	// The trial failed. Leave the screen exactly as it was — unless what is on
 	// screen is already dead, in which case there is nothing left to protect
 	// and the caller has to decide where to go instead.
-	function drop(detail, permanent) {
+	function drop(detail, state) {
 		const s = staging;
 		staging = null;
 		kill(s);
-		if (opts.onFailed) opts.onFailed(s.kind, detail, permanent);
+		if (opts.onFailed) opts.onFailed(s.kind, detail, state);
 		if (live && !live.dead) return;
 		if (live) { kill(live); live = null; }
-		if (opts.onExhausted) opts.onExhausted(s.kind, detail, permanent);
+		if (opts.onExhausted) opts.onExhausted(s.kind, detail);
 	}
 
 	// Try `kind`. If something is playing it keeps playing until this works.
@@ -140,7 +144,7 @@ window.MajesticSwap = function (opts) {
 				if (state === 'playing') promote(true);
 				else if (state === 'fallback' || state === 'busy' ||
 					state === 'mjpeg') {
-					drop(detail, state === 'fallback');
+					drop(detail, state);
 				}
 				return;
 			}

--- a/www/a/preview-transport.js
+++ b/www/a/preview-transport.js
@@ -125,6 +125,20 @@ window.MajesticTransport = (function () {
 	// it is reached by the chain, never remembered, never picked. So a caller
 	// asking for 'wasm' has decided already, and an unknown string still lands
 	// on the player that plays anything the browser can decode.
+	// Whether a WebRTC session's ENDING is worth remembering as a demotion.
+	// 'fallback' is the camera or this browser saying it cannot serve WebRTC at
+	// all — a durable fact that still expires, since demote() timestamps it —
+	// while 'busy' says only that the camera is full right now, which it will
+	// not be for long and so is never remembered. One rule, asked wherever a
+	// WebRTC session ends: a dropped trial (a page's onFailed) and a live player
+	// giving up mid-session (its onLive), on both the Live page and the settings
+	// preview, so the two cannot drift (#402). It takes the machine STATE, not
+	// the reason detail — the detail is a human string ('RTCPeerConnection
+	// failed', 'the camera refused the offer'), the state is 'fallback'/'busy'.
+	function durable(state) {
+		return state === 'fallback';
+	}
+
 	// Whether the software-decode rung is worth trying for a given failure.
 	// Here rather than in the walk (preview-chain.js) because it is a RULE,
 	// which is what this module is for: the walk asks whether the attempt is
@@ -306,6 +320,7 @@ window.MajesticTransport = (function () {
 		choose: choose,
 		demote: demote,
 		impl: impl,
+		durable: durable,
 		softwareRungFor: softwareRungFor,
 		softwareRungForCodec: softwareRungForCodec,
 		multipartRungFor: multipartRungFor,

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -21,7 +21,8 @@
 //
 // 'busy' is the same instruction with a shorter shelf life — the camera is out
 // of session slots rather than unable to serve this browser — so a caller that
-// remembers 'fallback' should not remember this one.
+// remembers 'fallback' should not remember this one. Which of these two a
+// caller demotes on is one rule now, preview-transport.js:durable() (#402).
 window.MajesticWebRTC = (function () {
 	// How long to wait for media before saying so. Longer than MSE's 4 s: ICE
 	// and DTLS happen first, and on a camera gathering a reflexive address


### PR DESCRIPTION
Fixes #402. Last of the three follow-ups split out of #400 (with #401 already merged).

## The duplication

#400 moved the fallback walk into `preview-chain.js` and deliberately left one path out of it: what happens when the **live** WebRTC player gives up mid-session. Both `preview-page.js` and `mj-preview.js` still wrote that out — demote on `'fallback'` but not on `'busy'`, `swap.retire()` the live player, go to MSE — so "is this WebRTC failure worth remembering" was answered in **three** places: the swap's `permanent` flag for a dropped trial, and one `onLive` branch per page for the live player. #269 was exactly that class of fault: a demotion written from the wrong branch, found on one page only.

## What changed

- **`preview-transport.js`** gains `durable(state)`. `'fallback'` is the camera or this browser saying it cannot serve WebRTC at all — a durable fact that still expires, since `demote()` timestamps it; `'busy'` says only that the camera is full right now, so it is never remembered.
- **`preview-swap.js`** hands `onFailed` the raw ending **state** instead of a `permanent` boolean, and drops the third argument to `onExhausted`, which nothing read. Whether an ending is durable is transport semantics; the swap is a state machine and says so in its own header, so it now reports the fact and leaves the judgment to the caller.
- **Both pages** ask that one rule — in `onFailed` and in the live `onLive` branch alike — and the live ending reaches MSE through `chain.next('webrtc', d)` rather than a second hardcoded hop. `decide('webrtc', …)` is always `{start:'mse'}` (only `codec-changed` diverts, which a WebRTC fallback never is), so the same attach runs and the hop lives only in the chain. What stays per page is what each *shows*: the Live page's radio and tooltip, the settings preview's nothing.

### The detail that decided the design

The player reports the state and the reason separately — `onState('fallback', 'RTCPeerConnection failed')`, `onState('busy', 'the camera is serving as many viewers as it can')`. So `durable()` takes the **state**, never the detail: a predicate keyed on the detail would have compiled, read plausibly, and silently stopped demoting.

## Behaviour

Unchanged — the same demotions happen on the same endings. #269's invariant is intact: the demotion still writes only from the WebRTC-failure origin, and the `swap.playing() === 'webrtc'` guard that stops a post-retirement MSE failure writing a preference is untouched.

## Tests

- `transport.test.js` pins the rule (`fallback` true; `busy`/`mjpeg`/`''`/`undefined` false).
- `staging.test.js` and `mj-preview.test.js` each gain a **live**-WebRTC-`'busy'` group beside the `'fallback'` ones they already had — it stages MSE and records no demotion. The #269 invariant group passes untouched.
- Full suite green (40 files). Mutation-checked both ways: forcing the rule to "always durable" fails three groups (a `busy` wrongly demoting), forcing "never durable" fails three more including the #269 group.

## Verification

Deployed to a lab hi3516ev300 and smoke-tested in real Chrome: the Live page plays over WebRTC (242 frames) and MSE (271 frames), the settings preview plays (214 frames, H.265), one `/ws/video` session each, no console errors. A genuine mid-session WebRTC fallback cannot be forced on demand, so the routing and the demote rule rest on the unit tests above.