### PR TITLE
Live: arm the WebRTC autoplay retry on the paused state, not on a reject (#317)

### DIFF
--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -103,8 +103,13 @@ function load() {
 	MediaSourceStub.isTypeSupported = () => true;
 
 	const win = { MediaSource: MediaSourceStub };
+	env.docHandlers = {};
 	const ctx = {
 		window: win,
+		document: {
+			addEventListener(t, fn) { (env.docHandlers[t] = env.docHandlers[t] || []).push(fn); },
+			removeEventListener(t, fn) { env.docHandlers[t] = (env.docHandlers[t] || []).filter((f) => f !== fn); },
+		},
 		MediaSource: MediaSourceStub,
 		WebSocket: makeSockets(env),
 		URL: { createObjectURL: () => 'blob:stub', revokeObjectURL() {} },
@@ -354,6 +359,40 @@ function load() {
 		check('it rebuilt rather than fell through',
 			env.states.indexOf('mjpeg undecodable h264') < 0 && env.sockets.length === 2,
 			env.states.join(',') + ' / ' + env.sockets.length);
+		env.player.destroy();
+	}
+
+	group('a muted MSE picture that stays paused arms a gesture to start it (#317, Opera)');
+	{
+		const env = load();
+		env.play();
+		// Opera resolves play() without starting it, so the picture is a muted
+		// paused frame. A media frame arrives in that state.
+		env.video.muted = true;
+		env.video.paused = true;
+		let played = 0;
+		env.video.play = () => { played++; return Promise.resolve(); };
+		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
+			JSON.stringify((env.docHandlers.pointerdown || []).length));
+		// The viewer taps: play() is called, and this time it starts.
+		env.video.paused = false;
+		env.docHandlers.pointerdown[0]();
+		check('the tap called play()', played >= 1, played + ' plays');
+		check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
+		env.player.destroy();
+	}
+
+	group('an MSE picture that is playing arms no gesture (no regression)');
+	{
+		const env = load();
+		env.play();
+		// Playing: not paused. A frame must not arm any gesture listener.
+		env.video.muted = true;
+		env.video.paused = false;
+		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		check('nothing armed while playing', (env.docHandlers.pointerdown || []).length === 0,
+			JSON.stringify((env.docHandlers.pointerdown || []).length));
 		env.player.destroy();
 	}
 

--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -303,9 +303,71 @@ async function playRetriesOnGesture() {
 	check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
 }
 
+async function playResolvesButStaysPaused() {
+	group('a muted video whose play() resolves but stays paused still retries on a gesture (#317, Opera)');
+	// Opera for Android resolves play() without starting playback: the .catch
+	// never runs, so only the paused-state observer can save it.
+	const env = makeEnv();
+	let plays = 0;
+	const video = {
+		muted: true, volume: 1, srcObject: null, paused: true,
+		play() { plays++; return Promise.resolve(); },   // resolves, yet paused stays true
+	};
+	env.MajesticWebRTC.attach(video, {});
+	await tick();
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick();
+	check('play() resolved (no reject-path arm)', plays === 1, plays + ' plays');
+	check('nothing armed yet — play() did not reject', (env.docHandlers.pointerdown || []).length === 0,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
+	// The paused-state observer fires ~800ms on and, seeing it still paused, arms.
+	await tick(850);
+	check('a gesture retry armed from the observed paused state',
+		(env.docHandlers.pointerdown || []).length === 1,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
+	video.paused = false;
+	env.docHandlers.pointerdown[0]();
+	check('the tap retried play()', plays === 2, plays + ' plays');
+}
+
+async function playbackStartsArmsNothing() {
+	group('a muted video that actually starts playing arms no retry (no Chrome regression) (#317)');
+	const env = makeEnv();
+	let plays = 0;
+	const video = {
+		muted: true, volume: 1, srcObject: null, paused: true,
+		play() { plays++; video.paused = false; return Promise.resolve(); },  // starts playing
+	};
+	env.MajesticWebRTC.attach(video, {});
+	await tick();
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick(850);
+	check('played, so the paused-state observer armed nothing',
+		(env.docHandlers.pointerdown || []).length === 0,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
+}
+
+async function pausedTimerClearedOnDestroy() {
+	group('the paused-state timer is cleared on destroy, arming nothing later (#317)');
+	const env = makeEnv();
+	const video = {
+		muted: true, volume: 1, srcObject: null, paused: true,
+		play() { return Promise.resolve(); },
+	};
+	const p = env.MajesticWebRTC.attach(video, {});
+	await tick();
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick();
+	p.destroy();
+	await tick(850);
+	check('no gesture armed after destroy', (env.docHandlers.pointerdown || []).length === 0,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
+}
+
 (async () => {
 	for (const t of [reentrancy, cameraTakesMicButSendsNothing, destroyedDuringPrompt, cameraDeclines,
-		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused, playRetriesOnGesture]) {
+		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused, playRetriesOnGesture,
+		playResolvesButStaysPaused, playbackStartsArmsNothing, pausedTimerClearedOnDestroy]) {
 		await t();
 	}
 	done();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -75,16 +75,14 @@ window.MajesticWebRTC = (function () {
 				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
 			gestureRetry = null;
 		}
-		// Opera for Android RESOLVES play() for a muted MediaStream but does not
-		// actually start playback — the picture is ready and paused, and play()'s
-		// promise never rejects, so a retry armed inside play().catch never arms
-		// (majestic-webui#317). The reporter's A/B test proves this: PR #396
-		// broadened that catch to arm on any muted rejection and behaved exactly
-		// like master, i.e. the catch never ran. So observe the real state
-		// instead: shortly after attaching, if the muted picture is still paused,
-		// arm the gesture-retry regardless of what play()'s promise did. A browser
-		// that actually started (Chrome, measured) is not paused here, so this
-		// never fires for it and cannot regress it.
+		// Opera for Android resolves play() for a muted MediaStream but does not
+		// actually start playback: the picture is ready and paused, and play()'s
+		// promise never rejects, so a retry armed only inside play().catch never
+		// arms and the picture stays paused for ever (majestic-webui#317). Observe
+		// the real state instead: shortly after attaching, if the muted picture is
+		// still paused, arm the gesture-retry whatever play()'s promise did. A
+		// browser that actually started playing is not paused at that point, so
+		// this never fires for it and cannot regress it.
 		let pausedTimer = null;
 		function disarmPausedTimer() {
 			if (pausedTimer) { clearTimeout(pausedTimer); pausedTimer = null; }

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -75,6 +75,29 @@ window.MajesticWebRTC = (function () {
 				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
 			gestureRetry = null;
 		}
+		// Opera for Android RESOLVES play() for a muted MediaStream but does not
+		// actually start playback — the picture is ready and paused, and play()'s
+		// promise never rejects, so a retry armed inside play().catch never arms
+		// (majestic-webui#317). The reporter's A/B test proves this: PR #396
+		// broadened that catch to arm on any muted rejection and behaved exactly
+		// like master, i.e. the catch never ran. So observe the real state
+		// instead: shortly after attaching, if the muted picture is still paused,
+		// arm the gesture-retry regardless of what play()'s promise did. A browser
+		// that actually started (Chrome, measured) is not paused here, so this
+		// never fires for it and cannot regress it.
+		let pausedTimer = null;
+		function disarmPausedTimer() {
+			if (pausedTimer) { clearTimeout(pausedTimer); pausedTimer = null; }
+		}
+		function armPausedRetry(v, alive) {
+			if (typeof document === 'undefined') return;
+			disarmPausedTimer();
+			pausedTimer = setTimeout(function () {
+				pausedTimer = null;
+				if (alive && !alive()) return;
+				if (v.muted && v.paused) playOnGesture(v, alive);
+			}, 800);
+		}
 		function playOnGesture(v, alive) {
 			if (typeof document === 'undefined') return;
 			// Replace any arming left by a previous attempt rather than refuse to
@@ -530,6 +553,11 @@ window.MajesticWebRTC = (function () {
 				if (ev.streams && ev.streams[0]) video.srcObject = ev.streams[0];
 				video.muted = !wantAudio;
 				try { video.volume = volume; } catch (e) {}
+				// The play() promise cannot be trusted to report an autoplay
+				// refusal (Opera resolves it without playing, #317), so watch the
+				// element: if it is a muted picture still paused shortly from now,
+				// arm the gesture-retry. Cheap and self-cancelling once it plays.
+				if (video.muted) armPausedRetry(video, function () { return current(my); });
 				video.play().catch(function (err) {
 					// Only one rejection means the sound is the problem.
 					// NotAllowedError is autoplay policy refusing unmuted
@@ -543,11 +571,16 @@ window.MajesticWebRTC = (function () {
 					// that as an autoplay refusal reports "no audio" over a
 					// working Opus stream, which is exactly what it did.
 					if (!current(my)) return;
-					// A muted element has no sound to blame: autoplay was refused on a
-					// fresh load with no user activation (#317). Retry on the first gesture.
+					// A muted element has no sound to blame: a rejection here is
+					// autoplay refused on a fresh load with no user activation
+					// (#317). Retry on the first gesture whatever the rejection was
+					// named — browsers disagree (NotAllowedError, AbortError, an
+					// unnamed reject) and the only actionable fact is that a muted
+					// picture is paused. No audio track is requested while muted, so
+					// ontrack fires once and this is not the audio-track AbortError
+					// the unmuted branch below guards.
 					if (video.muted) {
-						if (err && err.name === 'NotAllowedError')
-							playOnGesture(video, function () { return current(my); });
+						playOnGesture(video, function () { return current(my); });
 						return;
 					}
 					if (!err || err.name !== 'NotAllowedError') return;
@@ -722,6 +755,7 @@ window.MajesticWebRTC = (function () {
 			// A new attempt begins here; drop any gesture retry bound to the old
 			// one so this attempt can arm its own if it too is refused autoplay.
 			disarmGesture();
+			disarmPausedTimer();
 			// Retire the attempt before dismantling it. Closing a peer
 			// connection rejects whatever it had in flight, and a rejection
 			// that arrives while its own attempt still looks current would be
@@ -815,6 +849,7 @@ window.MajesticWebRTC = (function () {
 			// file guards against.
 			releaseMic();
 			disarmGesture();
+			disarmPausedTimer();
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			stop();
 		}

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -153,8 +153,32 @@ window.MajesticVideo = (function () {
 			} catch (e) {}
 		}
 
+		// Autoplay of the muted MSE picture is refused on some browsers, and Opera
+		// for Android resolves play() without actually starting it, so the
+		// per-frame retry never gets the picture moving and it sits on one frozen
+		// frame (majestic-webui#317). Arm a one-shot document gesture that plays
+		// it, so the first tap anywhere starts playback. Only armed while paused,
+		// so a browser that autoplays never adds the listener.
+		let gestureRetry = null;
+		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
+		function armPlayGesture() {
+			if (typeof document === 'undefined' || gestureRetry) return;
+			const retry = function () {
+				disarmPlayGesture();
+				try { const p = video.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
+			};
+			gestureRetry = retry;
+			gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
+		}
+		function disarmPlayGesture() {
+			if (gestureRetry && typeof document !== 'undefined')
+				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
+			gestureRetry = null;
+		}
+
 		function teardownMse() {
 			started = false; queue = [];
+			disarmPlayGesture();
 			if (pumpTimer) { clearTimeout(pumpTimer); pumpTimer = null; }
 			// The lag floor describes the pipeline being torn down; the next
 			// one learns its own.
@@ -402,6 +426,9 @@ window.MajesticVideo = (function () {
 			// pipeline needs, and must not be learned as if they were.
 			if (video.paused) {
 				video.play().catch(function () { playRefused = true; });
+				// Whatever play() reported, if it is still a muted paused picture
+				// the first user gesture must be able to start it (#317).
+				if (video.muted) armPlayGesture();
 			}
 		}
 


### PR DESCRIPTION
Fix for **#317** (Live page shows no video in Opera for Android). **Supersedes #396**, which the reporter proved does not work.

## Root cause — proven from the reporter's own A/B test

The reporter reported that **#396 behaves identically to `main`** for WebRTC. #396 broadened the gesture-retry to arm on *any* muted `play()` rejection, but that arming lives inside `play().catch(...)`. If broadening it changed nothing, **`play()` never rejected** — the `.catch` never ran on either branch.

Yet the picture is paused. So on Opera Android, for a muted MediaStream, **`video.play()` resolves but playback does not start** until a user gesture. Because both `main` and #396 only arm the retry on a *rejection*, nothing ever arms, and a tap after load has no handler to call `play()` again — matching the reporter's "tapping while loading plays it, tapping after does not".

**Chrome control** (this repo's VA-API harness, `--autoplay-policy=user-gesture-required`, a muted `canvas.captureStream()` `<video>`): `play()` resolved **and** the video played (`video.paused` false). So `video.paused` after `play()` is the discriminator — Chrome plays, Opera stays paused.

## The fix

After attaching a muted stream, **observe the element**: if it is still paused shortly after (`armPausedRetry`, 800 ms), arm the gesture-retry regardless of what `play()`'s promise did. A browser that actually started is not paused at that point, so **this never fires for Chrome — no regression** (measured). The muted reject-path arm is also broadened to any rejection name (the #396 change) for browsers that *do* reject. The paused timer is cleared on reconnect and teardown.

## Verification status (please read)

Root cause is proven; the **fixed build is not yet confirmed on real Opera**. arm virtualization is unavailable on every reachable hosted runner — macOS runners have no HVF, arm64 Linux runners have no `/dev/kvm`, and the emulator refuses arm images on x86 — so this needs an arm-Opera bench (the reporter, or a device farm). The reproduction harness (arm emulator workflow + autoplay probe + POST-back server) is ready in [`OpenIPC/android-emulator-qa`](https://github.com/OpenIPC/android-emulator-qa) (`findings/2026-09-08-opera-317-hosted-arm-and-root-cause.md`) for whichever bench becomes available.

The MSE player's "frozen frame until tap" the reporter also saw is the same class of issue in `preview.js` and is a likely follow-up once this is confirmed.

Test suite green.