### PR TITLE
Live: size the full-bleed page to the large viewport, not the dynamic one (#335)

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2883,8 +2883,18 @@ button.mj-osd-chip,
    flex item's default min-height is auto, so without it the stage refuses to
    shrink below its content and the page scrolls after all. */
 #page-live {
+	/* The LARGE viewport height, deliberately not the dynamic one. On iOS Safari
+	   the URL bar collapses about a second after load; with 100dvh the page grows
+	   then, the stage grows with it, and preview-zoom re-fits the picture -- a 4:3
+	   stream is height-driven under Fill on a portrait phone, so the picture
+	   visibly jumps size, which reads as a flicker (majestic-webui#335). Sizing
+	   to the large, bar-collapsed height holds the picture the size it will be
+	   from the first frame (the #294 rule); the cost is that the bottom of the
+	   stage sits under the URL bar until it collapses, where the control bar is
+	   overlaid and revealed on demand regardless. On every desktop browser lvh,
+	   dvh and vh are the same value, so nothing there changes. */
 	height: 100vh;
-	height: 100dvh;
+	height: 100lvh;
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2887,12 +2887,12 @@ button.mj-osd-chip,
 	   the URL bar collapses about a second after load; with 100dvh the page grows
 	   then, the stage grows with it, and preview-zoom re-fits the picture -- a 4:3
 	   stream is height-driven under Fill on a portrait phone, so the picture
-	   visibly jumps size, which reads as a flicker (majestic-webui#335). Sizing
-	   to the large, bar-collapsed height holds the picture the size it will be
-	   from the first frame (the #294 rule); the cost is that the bottom of the
-	   stage sits under the URL bar until it collapses, where the control bar is
-	   overlaid and revealed on demand regardless. On every desktop browser lvh,
-	   dvh and vh are the same value, so nothing there changes. */
+	   visibly jumps size a second after it appeared. Sizing to the large,
+	   bar-collapsed height holds the picture the size it will be from the first
+	   frame; the cost is that the bottom of the stage sits under the URL bar until
+	   it collapses, where the control bar is overlaid and revealed on demand
+	   regardless. On every desktop browser lvh, dvh and vh are the same value, so
+	   nothing there changes. */
 	height: 100vh;
 	height: 100lvh;
 	display: flex;


### PR DESCRIPTION
The residual flicker on the Live page after #411 turned out **not to be a decode fault at all** — it's an **iOS layout reflow**, and it's aspect-specific.

## Root cause (proven on real Safari)

`#page-live` was `height: 100dvh` — the **dynamic** viewport height. On iOS Safari the URL bar collapses ~1 s after load, so `100dvh` grows, the full-bleed flex chain grows the stage, and `preview-zoom`'s `ResizeObserver` re-fits the picture. For a **4:3** stream (height-driven under Fill on a portrait phone) the picture **visibly jumps size** — the reporter's "flicker," with **no black frame** and no fall to software. A **16:9/wider** stream is width-driven and doesn't move, and the embedded Live-adjustments preview isn't full-window — which is exactly why only 4:3 on the Live page shows it (matching the reporter's asymmetry).

Reproduced in [`OpenIPC/safari-hevc-qa`](https://github.com/OpenIPC/safari-hevc-qa) driving the **actual Live page** through its startup on real Safari 26.6.1, portrait stage, with a URL-bar-like height grow at ~1.25 s:

| stream | aspect | Safari result |
|---|---|---|
| 4:3 (1440×1080) | 1.333 | picture reflows 885×664 → 1000×750, **3/4** loads, `black=0` |
| wide (2592×1520) | 1.705 | **0/4** reflow |

A stable-height stage (the no-resize baseline) is clean 4/4 — i.e. the fix's behaviour.

## The fix

`height: 100lvh` — the **large** (bar-collapsed) viewport height — holds the picture the size it will be from the first frame, which is the #294 rule ("the picture is the size it will be, from the first frame"). The `100vh` line stays as the fallback. The trade-off (chosen deliberately) is that the bottom of the stage sits under the URL bar until it collapses, where the control bar is overlaid and revealed on demand anyway. On every desktop browser `lvh`/`dvh`/`vh` are the same value, so nothing there changes; `clean-css` preserves the `vh`+`lvh` pair.

Separate from the #411 decode fix; this is the remaining iOS/portrait/4:3 reflow. (Two other `100dvh` uses — the embedded preview's width calc and a modal's max-height — are left as-is; the preview isn't reported as flickering, a possible follow-up.)