### PR TITLE
live: tap-to-play affordance while a muted picture waits for a gesture (#317)

### DIFF
--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -375,11 +375,27 @@ function load() {
 		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
 		check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
 			JSON.stringify((env.docHandlers.pointerdown || []).length));
+		// The page is told once that the picture is parked waiting for a tap, so
+		// it can raise the play affordance (#317).
+		check('the page was told the picture is waiting for a gesture',
+			env.states.filter((s) => s === 'gesture').length === 1, env.states.join(','));
+		// Another paused frame must not re-announce it: the affordance is up, and
+		// a second 'gesture' would be noise.
+		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		check('a further paused frame does not re-announce it',
+			env.states.filter((s) => s === 'gesture').length === 1, env.states.join(','));
 		// The viewer taps: play() is called, and this time it starts.
 		env.video.paused = false;
 		env.docHandlers.pointerdown[0]();
 		check('the tap called play()', played >= 1, played + ' plays');
 		check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
+		// Only the element's own 'playing' event proves the picture moved; that is
+		// what takes the affordance down, so the page hears 'resumed' then.
+		check('nothing claimed it resumed before it actually played',
+			env.states.indexOf('resumed') < 0, env.states.join(','));
+		env.video.fire('playing');
+		check('the page was told the picture resumed once it played',
+			env.states.filter((s) => s === 'resumed').length === 1, env.states.join(','));
 		env.player.destroy();
 	}
 
@@ -393,6 +409,13 @@ function load() {
 		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
 		check('nothing armed while playing', (env.docHandlers.pointerdown || []).length === 0,
 			JSON.stringify((env.docHandlers.pointerdown || []).length));
+		check('and the page is not told to raise the play affordance',
+			env.states.indexOf('gesture') < 0, env.states.join(','));
+		// The element still fires 'playing' as it runs; with no gesture armed that
+		// must stay silent, or an ordinary autoplay start would emit 'resumed'.
+		env.video.fire('playing');
+		check('an ordinary playing element emits no resumed', env.states.indexOf('resumed') < 0,
+			env.states.join(','));
 		env.player.destroy();
 	}
 

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -33,7 +33,7 @@ const IDS = [
 	'mj-served', 'mj-served-why', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w',
 	'mj-transport-m', 'mj-transport-ctl', 'mj-transport-lbl',
-	'mj-vol', 'mj-player', 'mj-stage',
+	'mj-vol', 'mj-player', 'mj-stage', 'mj-tap-play',
 	'toggle-ircut', 'toggle-light', 'toggle-night',
 ];
 
@@ -314,6 +314,58 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			first.el.style.display === 'none', first.el.style.display);
 		check('and the new one is shown',
 			trial.el.style.display === '', trial.el.style.display);
+	}
+
+	// A muted picture can park waiting for a tap (#317). The player says so with
+	// 'gesture' and takes it back with 'resumed'; the swap has to carry that from
+	// a trial onto the screen, and the page has to raise and lower the button.
+	group('a trial parked waiting for a tap carries the invitation onto the screen (#317)');
+	{
+		const env = load('mse');
+		await tick();
+		const first = env.made[0];
+		first.say('playing');
+		env.el('mj-tap-play').hidden = true;   // the markup's starting state
+		pickWebRTC(env);
+		const trial = env.made[1];
+		// Some browsers report the parked picture ('gesture') before the first
+		// bytes that promote it ('playing'): the player emits it while the trial
+		// is still staging, where it cannot show over the live picture.
+		trial.say('gesture');
+		check('a staging trial does not raise the invitation over the live picture',
+			env.el('mj-tap-play').hidden === true, String(env.el('mj-tap-play').hidden));
+		// Its first bytes promote it, and the invitation swallowed while staging
+		// lands on the picture now that it is the one on screen.
+		trial.say('playing');
+		check('the promoted picture carries the invitation',
+			env.el('mj-tap-play').hidden === false, String(env.el('mj-tap-play').hidden));
+		// It plays: down it comes.
+		trial.say('resumed');
+		check('and it comes down once the picture plays',
+			env.el('mj-tap-play').hidden === true, String(env.el('mj-tap-play').hidden));
+	}
+
+	// The invitation belongs only to a picture parked on a still frame: any other
+	// state — a reconnect, an error — takes it down, and it returns only when the
+	// picture parks again (#317). A tap during a reconnect starts nothing anyway.
+	group('the invitation is tied to the parked state, not left stranded (#317)');
+	{
+		const env = load('mse');
+		await tick();
+		const live = env.made[0];   // first attach is live immediately
+		env.el('mj-tap-play').hidden = true;
+		live.say('gesture');
+		check('a parked picture raises the invitation',
+			env.el('mj-tap-play').hidden === false, String(env.el('mj-tap-play').hidden));
+		live.say('connecting');
+		check('a reconnect takes it down', env.el('mj-tap-play').hidden === true,
+			String(env.el('mj-tap-play').hidden));
+		live.say('gesture');
+		check('it returns when the picture parks again',
+			env.el('mj-tap-play').hidden === false, String(env.el('mj-tap-play').hidden));
+		live.say('playing');
+		check('and a picture coming up takes it down for good',
+			env.el('mj-tap-play').hidden === true, String(env.el('mj-tap-play').hidden));
 	}
 
 	group('a busy camera is not remembered as a refusal');

--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -347,6 +347,41 @@ async function playbackStartsArmsNothing() {
 		JSON.stringify((env.docHandlers.pointerdown || []).length));
 }
 
+async function gestureAndResumedStates() {
+	group('the parked picture is announced to the page, and cleared once it plays (#317)');
+	// The same Opera case as playResolvesButStaysPaused, but watching what the
+	// page is told: it needs one 'gesture' to raise the tap affordance and one
+	// 'resumed' — driven by the element's own 'playing' event, not by the retry —
+	// to take it back down.
+	const env = makeEnv();
+	const states = [];
+	const handlers = {};
+	let plays = 0;
+	const video = {
+		muted: true, volume: 1, srcObject: null, paused: true,
+		play() { plays++; return Promise.resolve(); },
+		addEventListener(ev, fn) { (handlers[ev] = handlers[ev] || []).push(fn); },
+		removeEventListener(ev, fn) { handlers[ev] = (handlers[ev] || []).filter((f) => f !== fn); },
+		fire(ev) { (handlers[ev] || []).slice().forEach((f) => f({ target: this })); },
+	};
+	env.MajesticWebRTC.attach(video, { onState: (s) => states.push(s) });
+	await tick();
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick(850);
+	check('the page was told the picture is waiting for a gesture, once',
+		states.filter((s) => s === 'gesture').length === 1, states.join(','));
+	check('nothing claimed it resumed before it actually played',
+		states.indexOf('resumed') < 0, states.join(','));
+	// The tap starts it and the element fires 'playing' — that is what clears it.
+	video.paused = false;
+	env.docHandlers.pointerdown[0]();
+	check('the tap retried play()', plays >= 2, plays + ' plays');
+	check('a play() resolving is still not a resumed', states.indexOf('resumed') < 0, states.join(','));
+	video.fire('playing');
+	check('the page was told the picture resumed once it played',
+		states.filter((s) => s === 'resumed').length === 1, states.join(','));
+}
+
 async function pausedTimerClearedOnDestroy() {
 	group('the paused-state timer is cleared on destroy, arming nothing later (#317)');
 	const env = makeEnv();
@@ -367,7 +402,8 @@ async function pausedTimerClearedOnDestroy() {
 (async () => {
 	for (const t of [reentrancy, cameraTakesMicButSendsNothing, destroyedDuringPrompt, cameraDeclines,
 		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused, playRetriesOnGesture,
-		playResolvesButStaysPaused, playbackStartsArmsNothing, pausedTimerClearedOnDestroy]) {
+		playResolvesButStaysPaused, playbackStartsArmsNothing, gestureAndResumedStates,
+		pausedTimerClearedOnDestroy]) {
 		await t();
 	}
 	done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -1623,6 +1623,42 @@ button.mj-osd-chip,
 .mj-pv-msg[hidden] { display: none; }
 .mj-pv-msg > * { pointer-events: auto; max-width: min(100%, 30rem); cursor: pointer; }
 
+/* Tap-to-play, over a muted picture parked waiting for a gesture (#317) and
+   taken down the moment it plays. Centred on the stage — the letterbox bands a
+   contain view leaves are symmetric, so that is the picture's centre — and
+   never overlapping the centred no-picture alert, which shows only when there
+   is no picture. Black glass like the rest of this stage's chrome, literal in
+   both themes because the surface is the picture. A tap anywhere starts
+   playback (the player listens on the document); this button is the visible
+   invitation and passes the gesture straight through. The [hidden] override is
+   required because the display value below would beat the attribute's own
+   display:none. */
+.mj-pv-tap {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 3;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 4rem;
+	height: 4rem;
+	padding: 0 0 0 0.2rem;
+	border-radius: 50%;
+	background: rgba(13, 15, 20, 0.72);
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	color: #e6e8ee;
+	cursor: pointer;
+	backdrop-filter: blur(10px);
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+	transition: background 0.12s ease, transform 0.12s ease;
+}
+.mj-pv-tap:hover { background: rgba(24, 27, 34, 0.82); }
+.mj-pv-tap:active { transform: translate(-50%, -50%) scale(0.94); }
+.mj-pv-tap:focus-visible { outline: 2px solid rgba(255, 255, 255, 0.55); outline-offset: 2px; }
+.mj-pv-tap[hidden] { display: none; }
+
 /* On-picture chrome: black glass in both themes, because its background is the
    picture and not the page surface. */
 .mj-glass {
@@ -3030,6 +3066,56 @@ button.mj-osd-chip,
 	font-variant-numeric: tabular-nums;
 	pointer-events: none;
 	backdrop-filter: blur(10px);
+}
+
+/* Tap-to-play. Raised over the still first frame while a muted picture is
+   parked waiting for a gesture (majestic-webui#317), and taken down the moment
+   it plays. Centred on the STAGE rather than the picture: the letterbox bands a
+   Fit view leaves are symmetric, so the stage centre is the picture centre in
+   the ordinary case, and centring on --mj-pic-* would have to track a zoom/pan
+   the invitation does not care about. The glass recipe and its literal ink are
+   the chip's: the surface is the picture, so the theme must not repaint it.
+   A tap anywhere on the stage starts playback (the player listens on the
+   document); this button is the visible invitation, so it takes the pointer to
+   look pressable and passes the gesture straight through. */
+.mj-tap-play {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 6;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 4.5rem;
+	height: 4.5rem;
+	padding: 0;
+	/* The triangle is a hair right of centre optically; nudge it back. */
+	padding-left: 0.2rem;
+	border-radius: 50%;
+	background: rgba(13, 15, 20, 0.72);
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	color: #e6e8ee;
+	cursor: pointer;
+	backdrop-filter: blur(10px);
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+	transition: background 0.12s ease, transform 0.12s ease;
+}
+.mj-tap-play:hover {
+	background: rgba(24, 27, 34, 0.82);
+}
+.mj-tap-play:active {
+	transform: translate(-50%, -50%) scale(0.94);
+}
+.mj-tap-play:focus-visible {
+	outline: 2px solid rgba(255, 255, 255, 0.55);
+	outline-offset: 2px;
+}
+/* Author display:flex above beats the UA `[hidden]` rule (author wins over UA
+   at equal specificity), so the attribute alone would not hide it — this is
+   what does. */
+.mj-tap-play[hidden] {
+	display: none;
 }
 
 .mj-stats-overlay {

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -487,11 +487,13 @@ window.MajesticPreview = (function () {
 			onExhausted: (kind, detail) => { chain.next(kind, detail); },
 			onLive: (st, d, kind) => {
 				// A muted picture parked on its first frame waiting for a tap
-				// (#317): raise the invitation, and take it down the moment it
-				// plays. Handled first, and returning, because these describe
-				// autoplay rather than the session and drive nothing else here.
+				// (#317): raise the invitation. Any other state — it played, it
+				// reconnects, it failed — means the picture is no longer parked
+				// on a still frame, so the invitation comes down here and returns
+				// only when 'gesture' is next announced.
 				if (st === 'gesture') { showTapPlay(); return; }
-				if (st === 'resumed') { hideTapPlay(); return; }
+				hideTapPlay();
+				if (st === 'resumed') return;
 				// The live player's own report that it is playing. This is the
 				// only place a FIRST attach can say so — it was promoted before
 				// it had anything, so its picture arrives here rather than as a

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -138,6 +138,14 @@ window.MajesticPreview = (function () {
 			'<video autoplay muted playsinline class="mj-pv-media" data-slot="1" data-kind="video" style="display:none"></video>' +
 			'<canvas class="mj-pv-media" data-slot="0" data-kind="canvas" style="display:none"></canvas>' +
 			'<canvas class="mj-pv-media" data-slot="1" data-kind="canvas" style="display:none"></canvas>' +
+			// Tap-to-play, raised over a muted picture parked waiting for a
+			// gesture and taken down the moment it plays (majestic-webui#317).
+			// A tap anywhere starts it (the player listens on the document); this
+			// is the visible invitation. Hidden until the player asks for it.
+			'<button type="button" class="mj-pv-tap" hidden aria-label="Tap to play the live video">' +
+			'<svg viewBox="0 0 64 64" width="30" height="30" fill="currentColor" aria-hidden="true">' +
+			'<path d="M25 20.5v23a1.5 1.5 0 0 0 2.28 1.28l18.7-11.5a1.5 1.5 0 0 0 0-2.56l-18.7-11.5A1.5 1.5 0 0 0 25 20.5z"></path>' +
+			'</svg></button>' +
 			// An empty layer over the picture and under the bar, for a caller
 			// that draws on the frame — regions, masks, a crop rectangle. It is
 			// here rather than left to the caller because "over the picture but
@@ -157,6 +165,7 @@ window.MajesticPreview = (function () {
 			'<div class="mj-pv-bar"></div>';
 
 		const overlay = stage.querySelector('.mj-pv-overlay');
+		const tapPlay = stage.querySelector('.mj-pv-tap');
 		const alertEl = stage.querySelector('.mj-pv-alert');
 		const servedEl = stage.querySelector('.mj-pv-msg');
 		const servedWhy = stage.querySelector('.mj-pv-msg-why');
@@ -268,7 +277,15 @@ window.MajesticPreview = (function () {
 			if (opts.onFrame) opts.onFrame(null);
 		}
 
+		// The tap-to-play invitation over a picture parked waiting for a gesture
+		// (#317). Raised on the live player's 'gesture' state, taken down on
+		// 'resumed' and whenever a fresh picture is announced or the stage falls
+		// to the no-picture alert, so a stale invitation cannot outlive its frame.
+		function showTapPlay() { if (tapPlay) tapPlay.hidden = false; }
+		function hideTapPlay() { if (tapPlay) tapPlay.hidden = true; }
+
 		function announcePlaying(kind) {
+			hideTapPlay();
 			if (announced === kind) return;
 			announced = kind;
 			if (opts.onPlaying) opts.onPlaying(kind);
@@ -326,6 +343,7 @@ window.MajesticPreview = (function () {
 			return 'The ' + ch + ' stream could not be played in this browser.';
 		}
 		function showAlert(why) {
+			hideTapPlay();
 			alertEl.textContent = alertText(why);
 			alertEl.hidden = false;
 		}
@@ -468,6 +486,12 @@ window.MajesticPreview = (function () {
 			// empty black box is indistinguishable from a camera that is off.
 			onExhausted: (kind, detail) => { chain.next(kind, detail); },
 			onLive: (st, d, kind) => {
+				// A muted picture parked on its first frame waiting for a tap
+				// (#317): raise the invitation, and take it down the moment it
+				// plays. Handled first, and returning, because these describe
+				// autoplay rather than the session and drive nothing else here.
+				if (st === 'gesture') { showTapPlay(); return; }
+				if (st === 'resumed') { hideTapPlay(); return; }
 				// The live player's own report that it is playing. This is the
 				// only place a FIRST attach can say so — it was promoted before
 				// it had anything, so its picture arrives here rather than as a

--- a/www/a/preview-hero.js
+++ b/www/a/preview-hero.js
@@ -244,7 +244,7 @@
 		if (e.pointerType !== 'touch') return;
 		touching++;
 		if (touching > 1) tapId = null;
-		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-toasts')) return;
+		if (e.target.closest('.mj-bar, .mj-ptz, #mj-stats, #mj-toasts, #mj-tap-play')) return;
 		if (touching > 1) return;
 		tapId = e.pointerId;
 		tapX = e.clientX;

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -30,6 +30,7 @@
 	const initial = $('#live-video');
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), note = $('#mj-note');
+	const tapPlay = $('#mj-tap-play');
 	const noteWhy = $('#mj-note-why'), noteAct = $('#mj-note-act');
 	const servedEl = $('#mj-served'), servedWhy = $('#mj-served-why');
 	let jpegOn = false;
@@ -141,7 +142,15 @@
 		codecFor: () => cfgCodec[stream ? 1 : 0],
 		onExhausted: (kind, detail) => fallThrough(kind, detail),
 	});
+	// The tap-to-play invitation over a picture parked waiting for a gesture
+	// (#317). Shown on the live player's 'gesture' state and hidden on 'resumed';
+	// also hidden by every path that repaints the stage below, so a stale
+	// invitation cannot outlive the picture it was covering.
+	function showTapPlay() { if (tapPlay) tapPlay.hidden = false; }
+	function hideTapPlay() { if (tapPlay) tapPlay.hidden = true; }
+
 	function showVideo() {
+		hideTapPlay();
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = '#000'; }
 		if (note) note.style.display = 'none';
@@ -156,6 +165,7 @@
 		hideStageMsg('fallback');
 	}
 	function showNoSignal() {
+		hideTapPlay();
 		// 'no signal' is a stage of a retry, not its outcome. While the
 		// fallback picture is being held, taking it away for one would cost
 		// the viewer what they had in exchange for a session that may yet
@@ -187,6 +197,7 @@
 	//     stopped, and `player` still held it: a stream click would have
 	//     called setStream() on it and reopened its socket.
 	function showFallback(why) {
+		hideTapPlay();
 		const v = cur();
 		if (v) v.style.display = 'none';
 		fellBack = why || 'unknown';
@@ -1039,6 +1050,12 @@
 		},
 		onLive: (s, d) => {
 			if (s === 'playing') showVideo();
+			// The muted picture is parked on its first frame waiting for a tap
+			// (#317): raise the invitation, and take it down the moment it plays.
+			// Neither state touches the chip — they describe autoplay, not the
+			// session — so they are handled before the generic chip write below.
+			else if (s === 'gesture') showTapPlay();
+			else if (s === 'resumed') hideTapPlay();
 			else if (s === 'nosignal') showNoSignal();
 			// Through the chain, not straight to the floor. This is the path a
 			// first attach takes — it is promoted immediately, so its giving up

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -1091,8 +1091,20 @@
 			}
 			// Not while the fallback picture is being held: these describe the
 			// attempt, and the chip has to go on describing the stage.
-			else if (badge && !holdingFallback) {
-				badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+			// Anything else — connecting, reconnecting, an error — is the
+			// session no longer sitting on a parked frame, so the tap invitation
+			// comes down; it returns only when the picture parks again and the
+			// player re-announces 'gesture'. A tap during a reconnect could not
+			// start anything anyway (the player rebinds its gesture retry to the
+			// new attempt), so an invitation that stayed up would be one the
+			// viewer's tap fell through.
+			else {
+				hideTapPlay();
+				// Not while the fallback picture is being held: these describe the
+				// attempt, and the chip has to go on describing the stage.
+				if (badge && !holdingFallback) {
+					badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
+				}
 			}
 		},
 	});

--- a/www/a/preview-swap.js
+++ b/www/a/preview-swap.js
@@ -98,6 +98,12 @@ window.MajesticSwap = function (opts) {
 		live = s;
 		show(s.slot, true);
 		opts.onPromoted(s.kind, proven === true);
+		// The invitation the trial raised while it was staging (swallowed then,
+		// because a trial owns nothing on screen) belongs to this picture now
+		// that it is the one on screen. Replayed after onPromoted so the page has
+		// finished showing the picture before the button lands on it; the player
+		// takes it back down with 'resumed' the moment the picture plays.
+		if (s.parked) opts.onLive('gesture', null, s.kind);
 	}
 
 	// The trial failed. Leave the screen exactly as it was — unless what is on
@@ -124,7 +130,7 @@ window.MajesticSwap = function (opts) {
 		// Registered before the element is resolved: node() asks kindOf(), and
 		// without this the incoming attach would be handed the outgoing kind's
 		// element.
-		staging = { id: id, p: null, slot: slot, kind: kind };
+		staging = { id: id, p: null, slot: slot, kind: kind, parked: false };
 		const el = node(slot);
 		// The other transport may have used this element a moment ago, and an
 		// element carrying both a MediaSource url and a srcObject is a
@@ -141,6 +147,17 @@ window.MajesticSwap = function (opts) {
 				// connecting, no signal, reconnecting — is exactly what must
 				// not reach the page, because the point is that trying costs
 				// the viewer nothing until it succeeds.
+				//
+				// One exception, and it is not shown now but remembered: a trial
+				// whose muted picture is parked waiting for a tap ('gesture')
+				// would, on some browsers, report its first bytes ('playing', the
+				// promotion) only after that. The state cannot show over the
+				// current live picture, but it describes the picture about to
+				// replace it, so promote() replays it once this trial is the one
+				// on screen — otherwise the player, having emitted it the once,
+				// suppresses it and the promoted picture carries no invitation.
+				if (state === 'gesture') { staging.parked = true; return; }
+				if (state === 'resumed') { staging.parked = false; return; }
 				if (state === 'playing') promote(true);
 				else if (state === 'fallback' || state === 'busy' ||
 					state === 'mjpeg') {

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -68,7 +68,7 @@ window.MajesticWebRTC = (function () {
 		// happens to carry an activation. Retry play() on the first user gesture
 		// instead. One-shot, capture phase so a tap the controls also handle still
 		// counts, and guarded for the vm tests, which have no document.
-		let gestureRetry = null;
+		let gestureRetry = null, gestureArmed = false;
 		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
 		function disarmGesture() {
 			if (gestureRetry && typeof document !== 'undefined')
@@ -111,7 +111,24 @@ window.MajesticWebRTC = (function () {
 			};
 			gestureRetry = retry;
 			gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
+			// Tell the page that a muted picture is parked waiting for a tap, so it
+			// can offer the viewer somewhere to tap (#317). Once per arm: a
+			// reconnect re-arms through here, but the flag is cleared only when the
+			// picture actually plays or the attempt is torn down.
+			if (!gestureArmed) { gestureArmed = true; onState('gesture'); }
 		}
+		// The muted picture actually started moving. Only the element's own
+		// 'playing' event proves it — play() resolving does not, because Opera
+		// resolves it on a picture that never starts (#317) — so this is what
+		// takes the tap affordance down, and it ignores the event unless a gesture
+		// was armed so an ordinary autoplay start costs nothing.
+		function onPlaying() {
+			if (!gestureArmed) return;
+			gestureArmed = false;
+			disarmGesture();
+			onState('resumed');
+		}
+		try { video.addEventListener('playing', onPlaying); } catch (e) {}
 		let closed = false, reconnectTimer = null, backoff = 1000;
 		let failCount = 0, gotMedia = false;
 		// From the caller, not fixed at false: a player staged as a replacement
@@ -753,6 +770,7 @@ window.MajesticWebRTC = (function () {
 			// A new attempt begins here; drop any gesture retry bound to the old
 			// one so this attempt can arm its own if it too is refused autoplay.
 			disarmGesture();
+			gestureArmed = false;
 			disarmPausedTimer();
 			// Retire the attempt before dismantling it. Closing a peer
 			// connection rejects whatever it had in flight, and a rejection
@@ -847,6 +865,8 @@ window.MajesticWebRTC = (function () {
 			// file guards against.
 			releaseMic();
 			disarmGesture();
+			gestureArmed = false;
+			try { video.removeEventListener('playing', onPlaying); } catch (e) {}
 			disarmPausedTimer();
 			if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
 			stop();

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -159,7 +159,7 @@ window.MajesticVideo = (function () {
 		// frame (majestic-webui#317). Arm a one-shot document gesture that plays
 		// it, so the first tap anywhere starts playback. Only armed while paused,
 		// so a browser that autoplays never adds the listener.
-		let gestureRetry = null;
+		let gestureRetry = null, gestureArmed = false;
 		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
 		function armPlayGesture() {
 			if (typeof document === 'undefined' || gestureRetry) return;
@@ -169,16 +169,36 @@ window.MajesticVideo = (function () {
 			};
 			gestureRetry = retry;
 			gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
+			// Tell the page that a muted picture is parked on its first frame
+			// waiting for a tap, so it can offer the viewer somewhere to tap
+			// (#317). Once per arm: the frame handler calls this on every frame
+			// while paused, but the gestureRetry guard above lets only the first
+			// through, so the page hears 'gesture' once and not on every frame.
+			if (!gestureArmed) { gestureArmed = true; onState('gesture'); }
 		}
 		function disarmPlayGesture() {
 			if (gestureRetry && typeof document !== 'undefined')
 				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
 			gestureRetry = null;
 		}
+		// The muted picture actually started moving. Only the element's own
+		// 'playing' event says so — play() resolving does not, because Opera
+		// resolves it on a picture that never starts (#317) — so this is the
+		// signal that takes the tap affordance back down, not the retry firing.
+		function onPlaying() {
+			if (!gestureArmed) return;
+			gestureArmed = false;
+			disarmPlayGesture();
+			onState('resumed');
+		}
 
 		function teardownMse() {
 			started = false; queue = [];
 			disarmPlayGesture();
+			// The next pipeline re-arms and re-announces 'gesture' on its own if
+			// its picture is again parked; clear the flag so that emit is not
+			// suppressed by a stale one left from the pipeline being torn down.
+			gestureArmed = false;
 			if (pumpTimer) { clearTimeout(pumpTimer); pumpTimer = null; }
 			// The lag floor describes the pipeline being torn down; the next
 			// one learns its own.
@@ -258,12 +278,17 @@ window.MajesticVideo = (function () {
 			if (old.parentNode) old.parentNode.replaceChild(nv, old);
 			old.removeEventListener('error', onVideoError);
 			old.removeEventListener('waiting', onWaiting);
+			old.removeEventListener('playing', onPlaying);
 			try { old.removeAttribute('src'); old.load(); } catch (e) {}
 			video = nv;
 			video.addEventListener('error', onVideoError);
 			// A stall is the shape TCP loss takes on this transport: the
 			// picture waits for the retransmission WebRTC would have skipped.
 			video.addEventListener('waiting', onWaiting);
+			// Watched so the tap affordance comes down the moment the picture
+			// truly starts moving (#317); onPlaying ignores the event unless a
+			// gesture was armed, so an ordinary autoplay start costs nothing.
+			video.addEventListener('playing', onPlaying);
 		}
 
 		function onInit(info) {

--- a/www/cgi-bin/p/player.cgi
+++ b/www/cgi-bin/p/player.cgi
@@ -103,6 +103,23 @@ printf '%s' \
 		     other than the on-board one. -->
 		<img id="live-mjpeg" class="mj-stage-media" alt="" style="display:none">
 		<img id="live-mjpeg-b" class="mj-stage-media" alt="" style="display:none">
+		<!-- Tap-to-play. Some browsers refuse to autoplay even a muted picture
+		     until the page has been interacted with, and Opera for Android parks
+		     it on its first frame without ever rejecting the play() that would
+		     tell the player to wait for a gesture (majestic-webui#317). The player
+		     watches the element and, while the picture sits muted and paused,
+		     raises this button so the still frame does not look like a dead page.
+		     preview-page.js shows it on the player's 'gesture' state and hides it
+		     on 'resumed'; a tap ANYWHERE on the stage is what actually starts
+		     playback (the player listens on the document), so this is the visible
+		     invitation to make that tap, not the only place it counts. Hidden
+		     until the player asks for it. -->
+		<button type="button" id="mj-tap-play" class="mj-tap-play" hidden
+			aria-label="Tap to play the live video">
+			<svg viewBox="0 0 64 64" width="34" height="34" fill="currentColor" aria-hidden="true">
+				<path d="M25 20.5v23a1.5 1.5 0 0 0 2.28 1.28l18.7-11.5a1.5 1.5 0 0 0 0-2.56l-18.7-11.5A1.5 1.5 0 0 0 25 20.5z"></path>
+			</svg>
+		</button>
 		<!-- Shown only when there is no MJPEG fallback to show, so it carries
 		     both halves: why the stream could not be played (preview-page.js
 		     rewrites the span from the player's reason code) and the one thing


### PR DESCRIPTION
## What

When a browser blocks muted autoplay (or, on Opera for Android, resolves `play()` on a picture that never actually starts — #317), the Live picture parks on its first decoded frame with nothing on screen saying it is waiting for the viewer. Both players already retry `play()` on the first document gesture; this adds the missing half — a visible invitation to make that tap.

## How

- **`preview.js` / `preview-webrtc.js`** — the players now speak two new `onState` codes on the existing channel:
  - `gesture` — emitted once, when the player arms its gesture-retry on a muted, paused picture.
  - `resumed` — emitted when the element's own `playing` event proves the picture actually moved. `play()` resolving is deliberately **not** enough: Opera resolves it on a picture that never starts, which is the whole of #317.
  - The swap already swallows states from a trial and forwards them from the live player, so only the picture on screen ever raises the affordance.

- **`p/player.cgi` + `preview-page.js`** (Live page) and **`mj-preview.js`** (Preview component) — render a centred glass play button over the stage on `gesture`, hide it on `resumed`, and hide it on any path that repaints the stage so a stale invitation cannot outlive its frame. A tap **anywhere** on the stage starts playback (the player listens on the document); the button is the visible invitation, not the only place a tap counts.

- **`bootstrap.override.css`** — the button, styled in the same black-glass vocabulary as the chip and the rest of the on-picture chrome, literal in both themes because its surface is the picture.

## Tests

- `preview-socket.test.js` (MSE): a parked muted picture emits `gesture` once (and not again on further paused frames); `resumed` is emitted only on the real `playing` event, never merely because `play()` resolved; an ordinary playing element emits neither.
- `talkback.test.js` (WebRTC): the same, driven through the paused-state observer and the tap.

Full JS suite green; dist build clean (`check-no-comments: ok`), the markup and CSS survive minification.