### PR TITLE
Settings: a slider with nothing in it says so, and can be emptied again (#416)

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -136,6 +136,39 @@
 	background-color: var(--bs-primary);
 }
 
+/* A slider that holds nothing. A range input has no empty state: given value=""
+   the browser parks the thumb at the middle of the track and reads that number
+   back, so a field nobody has set draws its handle exactly where a chosen one
+   would be — the night gain multiple (1–64) at 33, the reference enhancement
+   layers (0–3) at 2 of 3. The readout beside the track says the word (see
+   UNSET_WORD in mj-settings.js) and the handle steps off the track, because a
+   handle parked at a number nobody picked is the whole of #416. Hover, focus
+   and the drag itself bring it back: it is still a slider, it just has no
+   position to state until it has a value.
+
+   The two engines' thumb pseudo-elements are written as separate rules on
+   purpose — an unrecognised pseudo-element invalidates the entire selector
+   list, so grouping them would leave both browsers with no rule at all. */
+.range.mj-unset .form-range::-webkit-slider-thumb {
+	opacity: 0;
+}
+
+.range.mj-unset .form-range::-moz-range-thumb {
+	opacity: 0;
+}
+
+.range.mj-unset .form-range:hover::-webkit-slider-thumb,
+.range.mj-unset .form-range:focus::-webkit-slider-thumb,
+.range.mj-unset .form-range:active::-webkit-slider-thumb {
+	opacity: 1;
+}
+
+.range.mj-unset .form-range:hover::-moz-range-thumb,
+.range.mj-unset .form-range:focus::-moz-range-thumb,
+.range.mj-unset .form-range:active::-moz-range-thumb {
+	opacity: 1;
+}
+
 /* small integers (ports, timeouts, sizes…) don't need the full card width */
 .number .input-group {
 	max-width: 10rem;

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -149,6 +149,11 @@
 		[640, 360, 'nHD'], [352, 288, 'CIF'],
 	];
 	const RES_CUSTOM = '__custom__';
+	// What a slider prints instead of a number when nothing is chosen. The same
+	// plain word the resolution picker's "Auto · unset" entry ends on, because
+	// it is the same state: the key is absent from the camera's config and the
+	// camera is doing whatever it does without one.
+	const UNSET_WORD = 'Unset';
 	// Sizes an unset field falls back to, per the firmware's own defaulting, so
 	// "no value" reads as a deliberate choice instead of an empty Custom box.
 	const RES_AUTO_LABEL = {
@@ -7673,26 +7678,47 @@
 				'<label for="' + id + '" class="form-label">' + labelHtml + '</label>' +
 				'<span class="input-group">' +
 				'<input type="range" id="' + id + '" class="form-control form-range" min="' + min + '" max="' + max + '" step="1" value="' + esc(v) + '">' +
-				'<span class="input-group-text show-value">' + esc(v) + '</span>' +
+				'<span class="input-group-text show-value"></span>' +
 				'</span>';
 			control = p.querySelector('input');
 			const show = p.querySelector('.show-value');
-			control.addEventListener('input', () => { show.textContent = control.value; });
-			// A range input cannot be empty: given value="" the browser parks
-			// the thumb at the midpoint and .value reads that number, so an
-			// unset field reported itself as set — the night gain multiple,
-			// unset on every camera by default, read as 33 — and a note that
-			// applies only while the field holds a value drew under a control
-			// nobody had touched. The display beside the thumb is the page's
-			// own record of "nothing chosen": empty until an input or a real
-			// value arrives, so it is what getValue() asks, and a pushed-in
-			// empty value keeps it empty rather than copying the midpoint in.
-			control._get = () => (show.textContent === '' ? '' : String(control.value));
-			control._set = (v) => {
-				const s = v !== undefined && v !== null ? String(v) : '';
-				control.value = s;
-				show.textContent = s === '' ? '' : String(control.value);
+			// A range input cannot be empty. Given value="" the browser runs its
+			// value-sanitisation algorithm and parks the thumb at the midpoint of
+			// the track — min + (max − min) / 2, snapped up to a whole step — and
+			// .value then reads that number back as if somebody had chosen it.
+			// So a field with no value in the config draws a thumb halfway along
+			// a track, which is what a chosen value looks like: the night gain
+			// multiple (1–64, no default) sits at 33, and the reference
+			// enhancement layers (0–3) sit at 2 of 3, two thirds of the way
+			// across (#416).
+			//
+			// `chosen` is the page's own record of whether anything is set, kept
+			// beside the control rather than read back out of the display, and it
+			// is what getValue() answers with — so an untouched field stays clean
+			// through dirty tracking, Save and the x-requires notes.
+			//
+			// The row then has to SAY so, because the thumb cannot. The readout
+			// beside the track prints the word instead of standing empty, and
+			// .mj-unset takes the thumb off the track until the pointer or the
+			// keyboard reaches for it: a blank readout is an absence, and an
+			// absence is what the reporter of #416 read as the number 33.
+			let chosen = v !== '';
+			const paint = () => {
+				show.textContent = chosen ? String(control.value) : UNSET_WORD;
+				p.classList.toggle('mj-unset', !chosen);
 			};
+			// Any input is a choice — a drag, a click on the track, an arrow key.
+			// Registered before renderField's own updateDirty listener below, so
+			// the value it reads is already a chosen one.
+			control.addEventListener('input', () => { chosen = true; paint(); });
+			control._get = () => (chosen ? String(control.value) : '');
+			control._set = (val) => {
+				const s = val !== undefined && val !== null ? String(val) : '';
+				chosen = s !== '';
+				control.value = s;
+				paint();
+			};
+			paint();
 		} else if (type === 'integer') {
 			p = el('p', 'number mj-row');
 			const minA = isNum(sub.minimum) ? ' min="' + sub.minimum + '"' : '';
@@ -7952,14 +7978,27 @@
 			// The Live deck's glyph, not U+21BA: a text arrow is a different shape
 			// in every font stack, and these two controls do the same thing.
 			reset.innerHTML = ICON.reset;
-			reset.setAttribute('aria-label', 'Reset ' + desc + ' to default');
-			if (!hasDefault) {
-				reset.disabled = true;
-				reset.title = 'Server has no recorded default for this key.';
-			} else {
-				reset.title = 'Reset to default: ' + String(sub.default);
-				reset.addEventListener('click', () => onReset(dot, reset));
-			}
+			// One button, two answers, because the camera's reset has two. A key
+			// the schema declares a default for goes back to that value; a key it
+			// declares none for is REMOVED, which is the unset state — and on a
+			// slider that is the only way back to it, since a range input cannot
+			// be emptied by hand.
+			//
+			// This used to be switched off wherever the schema had no default, on
+			// the assumption that the camera would refuse. It does not: reset
+			// answers 200 and removes the key, and 404 now means the camera has no
+			// such setting at all. So the one control that could put the night
+			// gain multiple back to "when the exposure runs out" — a different
+			// day/night trigger, not a missing number — was the one control
+			// disabled, and every value typed into it was permanent (#416). The
+			// 404 is still handled, in onReset, where the camera's answer arrives.
+			const clears = !hasDefault;
+			reset.setAttribute('aria-label',
+				clears ? 'Clear ' + desc : 'Reset ' + desc + ' to default');
+			reset.title = clears
+				? 'Clear this setting and leave it to the camera.'
+				: 'Reset to default: ' + String(sub.default);
+			reset.addEventListener('click', () => onReset(dot, reset, desc, clears));
 			// Put the glyph on the control's own line instead of below it. The
 			// live rows are left alone: .mj-live-row.range > .input-group is a
 			// direct-child selector that this wrapper would break.
@@ -8452,18 +8491,32 @@
 		if (btn) { btn.disabled = false; btn.textContent = 'Retry'; }
 	}
 
-	async function onReset(dot, btn) {
-		if (!confirm('Reset "' + dot + '" to its declared default?')) return;
+	// `desc` and `clears` are the field's on-screen name and which of the two
+	// things this press does, both settled by renderField. The question names
+	// the setting the way the row above it does rather than by its dotted key:
+	// a key is a second vocabulary, readable only by someone who already knows
+	// the answer, and this sentence is asked of someone deciding.
+	async function onReset(dot, btn, desc, clears) {
+		const name = desc || dot;
+		if (!confirm(clears
+			? 'Clear "' + name + '" and leave it to the camera?'
+			: 'Reset "' + name + '" to its default?')) return;
 		btn.disabled = true;
 		const orig = btn.textContent;
 		btn.textContent = '…';
 		clearError();
+		// A 404 is the camera saying it has no such setting — the button stays
+		// down afterwards, and nothing else may lift it. Tracked as a flag
+		// rather than re-read off the title, which the finally clause used to
+		// match by its opening words: the sentence and the state then had to be
+		// kept in step by hand, and rewording one silently re-enabled the button.
+		let gone = false;
 		try {
 			const res = await apiFetch('/api/v1/reset?key=' + encodeURIComponent(dot), { credentials: 'same-origin' });
 			if (!res.ok) {
 				if (res.status === 404) {
-					btn.title = 'Server has no recorded default for this key.';
-					btn.disabled = true;
+					btn.title = 'This camera has no such setting.';
+					gone = true;
 				} else {
 					const txt = await safeText(res);
 					showError('Reset failed (HTTP ' + res.status + '). ' + txt);
@@ -8475,7 +8528,7 @@
 			showError('Reset failed: ' + e.message);
 		} finally {
 			btn.textContent = orig;
-			if (!btn.title.startsWith('Server has no')) btn.disabled = false;
+			btn.disabled = gone;
 		}
 	}
 

--- a/www/a/mj-settings.js
+++ b/www/a/mj-settings.js
@@ -8502,8 +8502,15 @@
 			? 'Clear "' + name + '" and leave it to the camera?'
 			: 'Reset "' + name + '" to its default?')) return;
 		btn.disabled = true;
-		const orig = btn.textContent;
-		btn.textContent = '…';
+		// innerHTML, not textContent: the glyph is an inline SVG, so the button's
+		// text is the empty string — saving that and putting it back at the end
+		// left an empty 13px target where the arrow had been, on success and on
+		// failure alike, for the rest of the leaf's life. It was invisible while
+		// only defaulted keys could be pressed and one press is usually the last
+		// thing anybody does to a row; a page where every no-default key can be
+		// cleared is a page where the second press has to find the button.
+		const orig = btn.innerHTML;
+		btn.innerHTML = '…';
 		clearError();
 		// A 404 is the camera saying it has no such setting — the button stays
 		// down afterwards, and nothing else may lift it. Tracked as a flag
@@ -8527,7 +8534,7 @@
 		} catch (e) {
 			showError('Reset failed: ' + e.message);
 		} finally {
-			btn.textContent = orig;
+			btn.innerHTML = orig;
 			btn.disabled = gone;
 		}
 	}


### PR DESCRIPTION
Fixes #416.

## What the reporter saw

Turn **Legacy settings** off under Camera → Settings → Day & Night and *Gain multiple that means night* shows its thumb at **33** while the value is unset. The only tell is that no number appears beside the slider, so 33 reads as the current setting until you drag the thumb and back.

Reproduced on a hi3516ev300 with the key cleared, in Chrome:

```
{"value":"33","thumbPct":"50.8","min":"1","max":"64","show":"","resetDisabled":true}
```

An HTML range input has no empty state. Given `value=""` the browser parks the thumb at min + (max − min) / 2 — 32.5 for a 1–64 field, snapped up to 33 — and reports it back as if somebody had chosen it. The page already knew the value was not set (the widget reports `''` while the readout is empty, so dirty tracking and Save were honest); it never said so, and a blank readout is an absence rather than a statement.

**The same defect, unreported, on the Main stream page:** `video0.refEnhance` (0–3, no default) drew its handle at **2 of 3** — two thirds of the way across the track — with the same blank readout. Those two are the only bounded integers in the schema with no declared default.

## Why the value is not filled in instead

The issue asks whether the page should just write 33. It must not: an empty night gain multiple is a **different day/night trigger**, not a missing number. `night_policy_step()` branches on the key being absent — set, gain alone decides in both directions; unset, night begins when the AE cannot brighten the picture any further and the return to day consults that flag too. 33 is an artefact of the track's own arithmetic, and writing it would move the camera onto the other trigger without saying so.

## The change

**The display.** The widget keeps its own `chosen` flag instead of reading "is anything set" back out of the readout's text. Unset, the readout prints **Unset** — the word the resolution picker's *Auto · unset* entry already ends on — and the row takes `.mj-unset`, which takes the thumb off the track until hover, focus or a drag brings it back. The two engines' thumb pseudo-elements are separate CSS rules on purpose: an unrecognised pseudo-element invalidates the entire selector list, so grouping them would leave both browsers with no rule at all.

```
before   Gain multiple that means night          after   Gain multiple that means night
         ──────────●──────────   (blank)                 ─────────────────────  Unset
```

**The way back.** There was not one. The reset arrow was pre-disabled wherever the schema declares no default ("Server has no recorded default for this key"), on the assumption the camera would refuse it. It does not — `GET /api/v1/reset?key=nightMode.autoNightGain` answers 200 and removes the key, and a 404 now means the camera has no such setting at all. So the one control that could restore *when the exposure runs out* was the one control switched off, and a slider cannot be emptied by hand: one drag plus a Save made that mode unreachable for good. The arrow now **clears** such a key, asks a question that matches, and names the setting the way its own row does rather than by its dotted key. The 404 is still handled where the camera's answer arrives, tracked as a flag rather than by re-reading the button's own tooltip for its opening words.

This enables the arrow on every key the schema declares no default for — 26 visible rows on a hi3516ev300: the certificate paths, the TURN credentials, the unset pins, the raw sensor thresholds, both `videoN.enabled`. Clearing any of them is what the camera's own reset already does for a CLI caller; the confirm dialog is the guard. It also makes real a case the code already assumed: `syncLegacy()`'s comment allows for "a per-row reset of a threshold", which could not happen while those two rows had the arrow disabled.

## Testing

`npm test` passes; `tools/regen-bootstrap-css.sh` leaves `bootstrap.min.css` unchanged (`mj-unset` is not a Bootstrap class).

Checked in a real Chrome against a hi3516ev300 running this build:

- unset row reads `Unset`, row class `range mj-row mj-unset`, arrow enabled, not dirty, no save bar;
- drag to 12 → readout `12`, row `mj-dirty`, `mj-unset` gone;
- set 24 → press the arrow → the key is gone from a re-fetched `config.json` and the row is back to `Unset`;
- `video0.refEnhance` reads `Unset` where it drew a thumb at 2 of 3;
- a leaf this PR does not touch renders 8 rows and 31 nav entries with no console error;
- only the two `-webkit` rules survive CSS parsing in Chrome, which is what the split is for.

## Follow-up elsewhere

`video0.refEnhance`'s schema hint explained what 0 does and never what leaving the field alone does — 0 is a value the daemon programs into the encoder, unset is `INT_MIN` and both `HiSi_HAL_VENC_ApplyConfiguredRefParam()` and `mi_venc_set_ref()` return without touching the reference structure. A sentence saying so is queued on the daemon side for a nightly; it is what makes *Unset* mean something on that row.
