### PR TITLE
preview: the WebRTC signalling socket in a module of its own

### DIFF
--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -18,6 +18,9 @@ const vm = require('vm');
 const { check, group, done } = require('./assert');
 
 const SRC = path.join(__dirname, '..', 'www', 'a', 'preview-webrtc.js');
+// The signalling socket is a module of its own now (preview-signal.js),
+// loaded into the same context first, the way the pages load it.
+const SIG = path.join(__dirname, '..', 'www', 'a', 'preview-signal.js');
 
 // --- stubs ---------------------------------------------------------------
 function makeTrack(kind) {
@@ -103,6 +106,7 @@ function makeEnv(o) {
 	};
 	ctx.globalThis = ctx;
 	vm.createContext(ctx);
+	vm.runInContext(fs.readFileSync(SIG, 'utf8'), ctx);
 	vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
 	env.MajesticWebRTC = win.MajesticWebRTC;
 	env.video = { muted: true, volume: 1, srcObject: null, play: () => Promise.resolve() };

--- a/www/a/preview-signal.js
+++ b/www/a/preview-signal.js
@@ -1,0 +1,104 @@
+// The camera's WebRTC signalling socket, on its own.
+//
+// Two things offer over it now: the WebRTC media player (preview-webrtc.js)
+// and the data-channel feed that carries the /ws/video bitstream over an
+// RTCDataChannel (preview-datachannel.js). They share nothing else — one
+// negotiates a track and the other a byte pipe — but both open the same
+// socket, send the same `{req, data}` frames, and read the same replies, and
+// two copies of that would drift the way two copies of the transport rules
+// did (#402). So the socket lives here, and each caller supplies handlers.
+//
+// What it is NOT: a policy. Reconnects, attempts, fallback — every decision
+// stays with the caller, which is why each handler is a plain function the
+// caller binds to its own attempt. A socket only ever speaks to the handlers
+// it was opened with; close() detaches them before closing, so a late event
+// from a retired socket reaches nobody (the #298 hazard, one layer up).
+window.MajesticSignal = (function () {
+	'use strict';
+
+	function url(stream) {
+		const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+		return proto + '://' + location.host + '/ws/webrtc?stream=' + (stream | 0);
+	}
+
+	// Open one socket for `stream`. `on` maps what the camera sends to the
+	// caller's handlers, each optional:
+	//   open()                 the socket is up: offer now
+	//   answer(sdp)            the camera's SDP answer
+	//   candidate(line, mid)   a trickled ICE candidate and its m-line
+	//   stats(line)            the camera's own counters, once a second
+	//   served(reply)          which channel is served (#240), the whole reply
+	//   busy(text)             every session slot is taken — try again later
+	//   error(text)            the camera could not answer this offer
+	//   closed(text)           the session ended, with the camera's reason
+	//   close()                the socket closed, for any reason
+	// Returns a handle: send(req, data), close(), live(), and the socket
+	// itself for whoever needs to look at it.
+	function open(stream, on) {
+		on = on || {};
+		const sock = new WebSocket(url(stream));
+		sock.onopen = function () { if (on.open) on.open(); };
+		sock.onmessage = function (e) {
+			let m; try { m = JSON.parse(e.data); } catch (_) { return; }
+			if (!m || typeof m.reply !== 'string') return;
+			const h = on[m.reply];
+			if (typeof h !== 'function') return;
+			if (m.reply === 'candidate') h(m.data, m.mid);
+			else if (m.reply === 'served') h(m);
+			else h(m.data);
+		};
+		sock.onclose = function () { if (on.close) on.close(); };
+		sock.onerror = function () { try { sock.close(); } catch (e) {} };
+		return {
+			socket: sock,
+			send: function (req, data) {
+				if (sock.readyState !== 1) return false;
+				sock.send(JSON.stringify({ req: req, data: data === undefined ? '' : data }));
+				return true;
+			},
+			live: function () { return sock.readyState === 1; },
+			// Detach before closing: a socket closes asynchronously, and until
+			// it does its handlers are still live on a connection nobody wants
+			// any more — including the close that would start a reconnect on
+			// top of the attempt that replaced it.
+			close: function () {
+				try { sock.onopen = sock.onmessage = sock.onclose = sock.onerror = null; } catch (e) {}
+				try { sock.close(); } catch (e) {}
+			},
+		};
+	}
+
+	// The camera's stats line is `key=value` pairs separated by spaces, with
+	// a couple of composites (`rtcp=recv/rejected`, `pli=n(+suppressed)`).
+	// Split on the first `=` only and hand the values over as text: the page
+	// renders them, and inventing a schema here would mean changing two files
+	// every time the camera adds a counter.
+	function parseCam(line) {
+		const out = {};
+		(line || '').split(' ').forEach(function (kv) {
+			const i = kv.indexOf('=');
+			if (i > 0) out[kv.slice(0, i)] = kv.slice(i + 1);
+		});
+		return out;
+	}
+
+	// The port an SDP gives a media section (`m=<media> <port> ...`), or -1
+	// when the section is absent. Zero is how a camera declines a section it
+	// does not serve — the one fact a caller wants before applying an answer.
+	function sdpPort(sdp, media) {
+		const m = new RegExp('^m=' + media + '\\s+(\\d+)\\s', 'm').exec(sdp || '');
+		return m ? parseInt(m[1], 10) : -1;
+	}
+
+	// The ICE servers a caller was given: a list, or a function returning one
+	// (the page fetches the camera's list and the first attach can win the
+	// race against it, so it is read at every open rather than once).
+	function iceOf(opts) {
+		try {
+			const v = typeof opts.iceServers === 'function' ? opts.iceServers() : opts.iceServers;
+			return v || [];
+		} catch (e) { return []; }
+	}
+
+	return { open: open, url: url, parseCam: parseCam, sdpPort: sdpPort, iceOf: iceOf };
+})();

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -45,6 +45,11 @@ window.MajesticWebRTC = (function () {
 	// A browser without these cannot be helped by trying.
 	const rtcOk = typeof window.RTCPeerConnection === 'function';
 
+	// The signalling socket lives in preview-signal.js, shared with the
+	// data-channel feed. Resolved at every use rather than captured, the way
+	// the chain resolves its rules: a test may install it after this file.
+	const S = () => window.MajesticSignal;
+
 	function attach(video, opts) {
 		opts = opts || {};
 		const onState = opts.onState || function () {};
@@ -61,7 +66,9 @@ window.MajesticWebRTC = (function () {
 		const onServed = opts.onServed || function () {};
 		let stream = opts.stream | 0;
 
-		let pc = null, ws = null, statsTimer = null, signalTimer = null;
+		// `sig` is the signalling handle (preview-signal.js) for the current
+		// attempt; every handler it was opened with is bound to that attempt.
+		let pc = null, sig = null, statsTimer = null, signalTimer = null;
 		// Autoplay refused on a fresh document load with no user activation (Opera
 		// for Android, majestic-webui#317): the muted picture is ready but paused,
 		// and play() is never retried, so nothing shows until an in-app navigation
@@ -202,9 +209,7 @@ window.MajesticWebRTC = (function () {
 		}
 
 		function send(req, data) {
-			if (ws && ws.readyState === 1) {
-				ws.send(JSON.stringify({ req: req, data: data }));
-			}
+			if (sig) sig.send(req, data);
 		}
 
 		// Resolution and codec come from getStats rather than from the SDP:
@@ -225,7 +230,7 @@ window.MajesticWebRTC = (function () {
 			pc.getStats().then(function (report) {
 				if (!current(my)) return;
 				let codec = '', w = 0, h = 0, bytes = 0;
-				const s = { cam: parseCam(camLine) };
+				const s = { cam: S().parseCam(camLine) };
 				const codecs = {};
 				report.forEach(function (r) {
 					if (r.type === 'codec') codecs[r.id] = r;
@@ -339,20 +344,6 @@ window.MajesticWebRTC = (function () {
 		function rate(now, before) {
 			const d = now - before;
 			return d > 0 ? Math.round((d * 8) / STATS_MS) : 0;
-		}
-
-		// The camera's line is `key=value` pairs separated by spaces, with a
-		// couple of composites (`rtcp=recv/rejected`, `pli=n(+suppressed)`).
-		// Split on the first `=` only and hand the values over as text: the
-		// page renders them, and inventing a schema here would mean changing
-		// two files every time the camera adds a counter.
-		function parseCam(line) {
-			const out = {};
-			(line || '').split(' ').forEach(function (kv) {
-				const i = kv.indexOf('=');
-				if (i > 0) out[kv.slice(0, i)] = kv.slice(i + 1);
-			});
-			return out;
 		}
 
 		// ---- talkback ------------------------------------------------------
@@ -507,17 +498,14 @@ window.MajesticWebRTC = (function () {
 			lastCodec = ''; lastW = 0; lastH = 0;
 		}
 
-		// Detach before closing. A socket closes asynchronously, and until it
-		// does its handlers are still live on a connection nobody wants any
-		// more — including the onclose that would call reconnect() a second
-		// time and the one that would null out a socket the next attempt has
-		// already opened.
+		// The handle detaches its handlers before closing (see
+		// preview-signal.js), so a late close from a retired socket cannot
+		// start a reconnect on top of the attempt that replaced it.
 		function dropSocket() {
-			if (!ws) return;
-			const dead = ws;
-			ws = null;
-			try { dead.onopen = dead.onmessage = dead.onclose = dead.onerror = null; } catch (e) {}
-			try { dead.close(); } catch (e) {}
+			if (!sig) return;
+			const dead = sig;
+			sig = null;
+			dead.close();
 		}
 
 		function open() {
@@ -533,11 +521,7 @@ window.MajesticWebRTC = (function () {
 			// camera's config, the first attach can win a race against that
 			// fetch, and a reconnect should use the answer once it lands
 			// instead of repeating the empty list it started with.
-			let ice = [];
-			try {
-				ice = (typeof opts.iceServers === 'function'
-					? opts.iceServers() : opts.iceServers) || [];
-			} catch (e) { ice = []; }
+			const ice = S().iceOf(opts);
 
 			try {
 				pc = new RTCPeerConnection({ iceServers: ice });
@@ -625,40 +609,35 @@ window.MajesticWebRTC = (function () {
 				else if (s === 'disconnected') onState('error');
 			};
 
-			const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-			// Held in a local as well, so every handler below acts on the
-			// socket it was installed on rather than on whatever `ws` happens
-			// to point at by the time it fires.
-			const sock = new WebSocket(
-				proto + '://' + location.host + '/ws/webrtc?stream=' + stream);
-			ws = sock;
 			gotMedia = false;
-
-			sock.onopen = function () {
-				if (!current(my)) return;
-				backoff = 1000;
-				armSignalTimer(my);
-				pc.createOffer()
-					.then(function (offer) {
-						if (!current(my)) return;
-						return pc.setLocalDescription(offer).then(function () {
+			// Every handler is bound to this attempt, and the handle is held
+			// in a local as well, so a handler acts on the socket it was
+			// installed on rather than on whatever `sig` points at by the
+			// time it fires.
+			const handle = S().open(stream, {
+				open: function () {
+					if (!current(my)) return;
+					backoff = 1000;
+					armSignalTimer(my);
+					pc.createOffer()
+						.then(function (offer) {
 							if (!current(my)) return;
-							send('offer', pc.localDescription.sdp);
+							return pc.setLocalDescription(offer).then(function () {
+								if (!current(my)) return;
+								send('offer', pc.localDescription.sdp);
+							});
+						})
+						.catch(function () {
+							// A closed peer connection rejects whatever was in
+							// flight, so this fires on every ordinary teardown
+							// too. Only a live attempt has actually failed to
+							// offer.
+							if (current(my)) onState('fallback', 'offer failed');
 						});
-					})
-					.catch(function () {
-						// A closed peer connection rejects whatever was in
-						// flight, so this fires on every ordinary teardown too.
-						// Only a live attempt has actually failed to offer.
-						if (current(my)) onState('fallback', 'offer failed');
-					});
-			};
-			sock.onmessage = function (e) {
-				if (!current(my)) return;
-				let m; try { m = JSON.parse(e.data); } catch (_) { return; }
-				if (!m) return;
-				if (m.reply === 'answer') {
-					pc.setRemoteDescription({ type: 'answer', sdp: m.data })
+				},
+				answer: function (sdp) {
+					if (!current(my)) return;
+					pc.setRemoteDescription({ type: 'answer', sdp: sdp })
 						.then(function () {
 							if (!current(my)) return;
 							// Did the camera take the audio we offered to
@@ -703,7 +682,9 @@ window.MajesticWebRTC = (function () {
 						.catch(function () {
 							if (current(my)) onState('fallback', 'answer rejected');
 						});
-				} else if (m.reply === 'candidate') {
+				},
+				candidate: function (line, mid) {
+					if (!current(my)) return;
 					// Handed over without waiting for the answer to be applied,
 					// which is safe rather than sloppy: addIceCandidate chains
 					// onto the same operations queue as setRemoteDescription,
@@ -711,14 +692,18 @@ window.MajesticWebRTC = (function () {
 					// Measured on this camera — it trickles three candidates and
 					// one of them does arrive before the answer is installed;
 					// all three reach ICE.
-					pc.addIceCandidate({ candidate: m.data, sdpMid: m.mid })
+					pc.addIceCandidate({ candidate: line, sdpMid: mid })
 						.catch(function () {});
-				} else if (m.reply === 'stats') {
+				},
+				stats: function (line) {
+					if (!current(my)) return;
 					// The camera's own counters, once a second. Kept as text
 					// and parsed at the next poll, so the two sides are read
 					// out together rather than a tick apart.
-					camLine = m.data || '';
-				} else if (m.reply === 'served') {
+					camLine = line || '';
+				},
+				served: function (m) {
+					if (!current(my)) return;
 					// The camera says outright which channel this session
 					// serves — ?stream= was only ever a preference. Adopt it:
 					// setStream() no-ops when asked for the channel it thinks
@@ -737,30 +722,34 @@ window.MajesticWebRTC = (function () {
 								? m.reason : '',
 						});
 					}
-				} else if (m.reply === 'busy') {
+				},
+				busy: function (text) {
+					if (!current(my)) return;
 					// Full, not incapable — every slot is taken and this same
 					// offer would be answered once one frees. Same move as a
 					// refusal, MSE now rather than a frozen page, but reported
 					// apart from one so the caller does not conclude anything
 					// lasting about this browser. No retry either: hammering a
 					// camera that just said it is out of room helps nobody.
-					onState('busy', m.data || 'the camera is serving as many viewers as it can');
+					onState('busy', text || 'the camera is serving as many viewers as it can');
 					stop();
-				} else if (m.reply === 'error') {
+				},
+				error: function (text) {
+					if (!current(my)) return;
 					// The camera could not answer. Much the commonest cause is
 					// a profile this browser will not take — see
 					// docs/webrtc-browser-interop.md — and MSE has no such
 					// problem, so this is a reason to change transport rather
 					// than to keep retrying.
-					onState('fallback', m.data || 'the camera refused the offer');
+					onState('fallback', text || 'the camera refused the offer');
 					stop();
-				}
-			};
-			sock.onclose = function () {
-				if (ws === sock) ws = null;
-				if (current(my)) reconnect();
-			};
-			sock.onerror = function () { try { sock.close(); } catch (e) {} };
+				},
+				close: function () {
+					if (sig === handle) sig = null;
+					if (current(my)) reconnect();
+				},
+			});
+			sig = handle;
 
 			clearInterval(statsTimer);
 			statsTimer = setInterval(pollStats, STATS_MS);

--- a/www/cgi-bin/camera.cgi
+++ b/www/cgi-bin/camera.cgi
@@ -121,6 +121,7 @@ fi
 </div>
 
 <script src="/a/preview.js"></script>
+<script src="/a/preview-signal.js"></script>
 <script src="/a/preview-webrtc.js"></script>
 <script src="/a/preview-swap.js"></script>
 <script src="/a/preview-wasm.js"></script>

--- a/www/cgi-bin/live.cgi
+++ b/www/cgi-bin/live.cgi
@@ -34,6 +34,7 @@ hide_title=1; full_bleed=1
 <% fi %>
 
 <script src="/a/preview.js"></script>
+<script src="/a/preview-signal.js"></script>
 <script src="/a/preview-webrtc.js"></script>
 <script src="/a/preview-swap.js"></script>
 <script src="/a/preview-wasm.js"></script>


### PR DESCRIPTION
A pure refactor, ahead of #285's data-channel feed.

The socket the WebRTC player offers over (`/ws/webrtc?stream=N`, `{req, data}` out, the camera's `answer`/`candidate`/`stats`/`served`/`busy`/`error`/`closed` replies in) is about to get a second user: a feed that carries the live bitstream over an `RTCDataChannel` negotiates on the same socket. Two copies would drift the way two copies of the transport rules did (#402), so the socket moves to `www/a/preview-signal.js` (`MajesticSignal`): `open(stream, handlers)` returns a handle with `send`, `live` and `close`, the handlers each bound to the caller's own attempt, and `close()` detaches them before closing so a late event from a retired socket reaches nobody. `parseCam`, an m-line port reader (`sdpPort`) and the ICE-servers reader move with it.

`preview-webrtc.js` keeps every decision it had — attempts, reconnects, fallback, talkback — and only swaps its socket handling for the handle. Both pages load the module before the player. The talkback suite loads it into the same context and drives the same stub sockets through it; `npm test` is green.