### PR TITLE
Day/Night: say what the lamp-down check found

### DIFF
--- a/tests/ircut-check.test.js
+++ b/tests/ircut-check.test.js
@@ -560,6 +560,136 @@ function runRest() {
 				!/day comes when/.test(unknown), unknown);
 	}
 
+	group('monitorView: the lamp-down check has a verdict, and it is said');
+	{
+		// The state the whole day probe exists for, and the one the page could
+		// not show: a room lit by the camera's own illuminator reads under the
+		// day threshold on every tick, the camera checks with the lamp down
+		// and correctly refuses, and every gauge on this page goes on
+		// promising a day that never comes (#370). The verdict is a gauge now,
+		// so the sentence can say what happened instead of leaving the
+		// countdown to be believed.
+		const lit = (extra) => ic.monitorView({ lightMonitor: true },
+			Object.assign({ night_mode_source: 4, night_enabled: 1,
+				night_auto_gain_milli: 1620 }, extra)).line;
+
+		const refused = lit({ night_probe_verdict: 0,
+			night_probe_gain_milli: 15500, night_probe_age_seconds: 120,
+			night_probe_wait_seconds: 300 });
+		check('a standing refusal is said, with what the scene needed',
+			/dropped the lamp 2 min ago and found 16x/.test(refused), refused);
+		check('...and named as the camera\'s own light',
+			/the light in view is the camera's own, so night holds/.test(refused),
+			refused);
+		check('...and says when it will look again',
+			/it looks again in 5 min/.test(refused), refused);
+
+		// A countdown under a standing refusal is a promise already broken
+		// once. The number is honest; what happens at the end of it is a
+		// check, not a switch.
+		const counting = lit({ night_auto_pending: 2,
+			night_auto_dwell_seconds: 60, night_auto_streak_seconds: 20,
+			night_probe_verdict: 0, night_probe_gain_milli: 15500,
+			night_probe_age_seconds: 30, night_probe_wait_seconds: 0 });
+		check('the countdown says what the camera will actually do',
+			/checking again in 40 s/.test(counting) &&
+				!/switching in/.test(counting), counting);
+
+		// Two explanations for one held night, and the refusal is the
+		// specific one: it says what is in view, where the ceiling clause
+		// only says the exposure has nothing left.
+		const both = lit({ isp_exposureismax: 1, night_probe_verdict: 0,
+			night_probe_gain_milli: 15500, night_probe_age_seconds: 30 });
+		check('the refusal silences the ceiling clause rather than joining it',
+			!/still at its ceiling/.test(both) &&
+				/the light in view is the camera's own/.test(both), both);
+		// And with no refusal standing the ceiling clause is still spoken —
+		// otherwise the check above passes on a sentence that never had one.
+		const ceiling = lit({ isp_exposureismax: 1 });
+		check('...and is otherwise still spoken',
+			/still at its ceiling/.test(ceiling), ceiling);
+
+		// The other direction needs no permission from the check: night is
+		// not what it stands between the camera and, and "checking again"
+		// under "Dark enough for night" describes a step that is not in that
+		// path.
+		const toNight = lit({ night_enabled: 0, night_auto_pending: 1,
+			night_auto_dwell_seconds: 15, night_auto_streak_seconds: 5,
+			night_probe_verdict: 0, night_probe_gain_milli: 15500,
+			night_probe_age_seconds: 30 });
+		check('the night countdown is left alone',
+			/switching in 10 s if it stays/.test(toNight), toNight);
+
+		// The camera that has never run one — no lamp, or a door that does not
+		// decide day on its own gain — publishes nothing, and an absence is
+		// not a refusal.
+		const quiet = lit({});
+		check('no check, nothing said', !/dropped the lamp/.test(quiet), quiet);
+
+		// A confirmation explains a switch that already happened. It is worth
+		// a line while it is what just happened, and by mid-afternoon it is
+		// an old sentence holding the space.
+		const dawn = lit({ night_enabled: 0, night_probe_verdict: 1,
+			night_probe_gain_milli: 1400, night_probe_age_seconds: 90 });
+		check('a fresh confirmation is said', /real daylight/.test(dawn), dawn);
+		const stale = lit({ night_enabled: 0, night_probe_verdict: 1,
+			night_probe_gain_milli: 1400, night_probe_age_seconds: 7200 });
+		check('a stale one is not', !/real daylight/.test(stale), stale);
+
+		const blind = lit({ night_probe_verdict: 2,
+			night_probe_gain_milli: -1, night_probe_age_seconds: 10 });
+		check('a check that could not read says that instead',
+			/could not read the sensor with the lamp down/.test(blind), blind);
+
+		// -1 is the camera saying it could not read the gain. Printing it as a
+		// gain, or as nothing at all, both invent a number it did not give.
+		const nogain = lit({ night_probe_verdict: 0,
+			night_probe_gain_milli: -1, night_probe_age_seconds: 30,
+			night_probe_wait_seconds: 0 });
+		check('a refusal with no readable gain still holds the night',
+			!/and found/.test(nogain) && /so night holds/.test(nogain), nogain);
+
+		// The countdown's projection measures time since the MONITOR's gauges
+		// last changed, which on a settled night is minutes — it exists
+		// because the streak only moves on the camera's own tick. These two
+		// are recomputed on every scrape, so reading them forward by that
+		// same number ages a check by however long the monitor sat still and
+		// floors the next one to nothing while its stand-off is still
+		// running. The camera's numbers, as given.
+		const settled = ic.monitorView({ lightMonitor: true },
+			{ night_mode_source: 4, night_enabled: 1,
+				night_auto_gain_milli: 1620, night_probe_verdict: 0,
+				night_probe_gain_milli: 15500, night_probe_age_seconds: 120,
+				night_probe_wait_seconds: 300 }, 240).line;
+		check('a monitor that has sat still does not age the check with it',
+			/dropped the lamp 2 min ago/.test(settled) &&
+				/looks again in 5 min/.test(settled), settled);
+
+		// A verdict with no age is half a verdict. The refusal survives it —
+		// it explains the night the camera is in now, whenever it was reached
+		// — but a confirmation is only worth saying while it is fresh, and an
+		// unageable one cannot be known to be. Neither may leave the gap where
+		// the time phrase would have gone.
+		const ageless = lit({ night_probe_verdict: 0,
+			night_probe_gain_milli: 15500 });
+		check('a refusal with no age still holds the night, and reads',
+			/dropped the lamp and found 16x/.test(ageless), ageless);
+		const agelessDay = lit({ night_enabled: 0, night_probe_verdict: 1,
+			night_probe_gain_milli: 1400 });
+		check('a confirmation that cannot be dated is not called fresh',
+			!/real daylight/.test(agelessDay), agelessDay);
+
+		// The legacy threshold pair goes through the same check — it is the
+		// door the report came from — so it gets the same sentence.
+		const thr = ic.monitorView(
+			{ lightMonitor: true, minThreshold: 2000, maxThreshold: 14000 },
+			{ night_mode_source: 2, night_enabled: 1, isp_again: 1500,
+				night_probe_verdict: 0, night_probe_gain_milli: 15500,
+				night_probe_age_seconds: 60 }).line;
+		check('the legacy door says it too',
+			/the light in view is the camera's own/.test(thr), thr);
+	}
+
 	group('monitorView: source 0 has two causes and says which');
 	{
 		// The same collision the finding above disentangles, in the panel's own

--- a/www/a/ircut-check.js
+++ b/www/a/ircut-check.js
@@ -882,13 +882,101 @@
 	//
 	// Spoken only while it is the thing in the way. "The exposure is off its
 	// ceiling" on every tick of every night is noise, and the chart is already
-	// showing what is then actually being waited for.
+	// showing what is then actually being waited for. A standing refusal is
+	// the thing in the way when there is one, and it is the more specific
+	// answer, so it silences this one rather than queueing behind it.
 	function stillPinned(v) {
 		if (!v || !('isp_exposureismax' in v)) return '';
 		return v.isp_exposureismax > 0
 			? ' The exposure is still at its ceiling, so day waits whatever ' +
 				'the gain does.'
 			: '';
+	}
+
+	// ── What the last lamp-down check found ────────────────────────────────
+	//
+	// A night spent under the camera's own illuminator argues for day on every
+	// tick: the lamp is most of what the gain is reading. majestic answers that
+	// by dropping the lamp for three seconds before it believes a day, and a
+	// refusal is the CORRECT outcome for a lit room that is not daylight — but
+	// it is invisible here. The gauges go on showing a gain under the day mark
+	// and a countdown that never arrives, which reads as a switch that is
+	// broken (OpenIPC/majestic-webui#370). The verdict lived in the daemon's
+	// log alone until it was published; this is it on the page that sets the
+	// thresholds it is about.
+	//
+	// Absent gauges mean no check has ever completed — no lamp, or a door that
+	// does not decide day on the camera's own gain — and then there is nothing
+	// to say, which is different from a check that said no.
+	const PROBE_REFUSED = 0, PROBE_CONFIRMED = 1, PROBE_UNREADABLE = 2;
+	// How long a confirmed day stays worth mentioning. A refusal explains the
+	// state the camera is in right now and is said for as long as it stands; a
+	// confirmation explains a switch that already happened, and by the middle
+	// of the afternoon "the last check found daylight" is just an old sentence
+	// taking up the line.
+	const PROBE_FRESH_S = 3600;
+
+	// Read as they arrive, and deliberately NOT projected forward the way the
+	// countdown beside them is. The projection the countdown uses measures
+	// time since the monitor's gauges last CHANGED — the streak only moves on
+	// the camera's own tick, which is slower than the poll, so it has to be
+	// read forward — and on a settled night those gauges do not change for
+	// minutes at a stretch. These two are recomputed by the camera on every
+	// scrape, so they are already current: adding that projection to them
+	// would age a check by however long the monitor happened to sit still,
+	// and floor "looks again in" to nothing while a stand-off was still
+	// running. Both are said coarsely enough that a poll period does not
+	// show.
+	function probeState(v) {
+		if (!v || typeof v.night_probe_verdict !== 'number') return null;
+		const milli = v.night_probe_gain_milli;
+		return {
+			verdict: v.night_probe_verdict,
+			// -1 is the camera saying it could not read the gain, which is not
+			// a gain of nothing.
+			gain: typeof milli === 'number' && milli >= 0 ? milli / 1000 : null,
+			age: typeof v.night_probe_age_seconds === 'number'
+				? Math.max(0, v.night_probe_age_seconds) : null,
+			wait: typeof v.night_probe_wait_seconds === 'number'
+				? Math.max(0, v.night_probe_wait_seconds) : 0,
+		};
+	}
+
+	const gainWord = (x) => (x >= 10 ? String(Math.round(x)) : x.toFixed(1)) + 'x';
+	// Coarse on purpose, and never zero: these are read while something is
+	// being decided somewhere else, and a number that ticks is a number that
+	// invites being watched instead of the picture.
+	function agoWord(s) {
+		if (s < 90) return 'a moment ago';
+		if (s < 3600) return Math.round(s / 60) + ' min ago';
+		return Math.round(s / 3600) + ' h ago';
+	}
+	function inWord(s) {
+		return s < 90 ? s + ' s' : Math.round(s / 60) + ' min';
+	}
+
+	function probeNote(p) {
+		if (!p) return '';
+		if (p.verdict === PROBE_UNREADABLE) {
+			return ' The last check could not read the sensor with the lamp ' +
+				'down, so night holds.';
+		}
+		// A camera that states a verdict without an age is stating half of
+		// one. The refusal survives it — it explains the night the camera is
+		// in right now, whenever it was reached — but a confirmation is only
+		// worth saying while it is fresh, and an unageable one cannot be
+		// known to be.
+		const when = p.age === null ? '' : ' ' + agoWord(p.age);
+		const found = p.gain === null ? '' : ' and found ' + gainWord(p.gain);
+		if (p.verdict === PROBE_CONFIRMED) {
+			if (p.age === null || p.age > PROBE_FRESH_S) return '';
+			return ' The last check dropped the lamp' + when +
+				found + ': real daylight.';
+		}
+		if (p.verdict !== PROBE_REFUSED) return '';
+		return ' The last check dropped the lamp' + when + found +
+			' — the light in view is the camera\'s own, so night holds' +
+			(p.wait > 0 ? '; it looks again in ' + inWord(p.wait) : '') + '.';
 	}
 
 	function monitorView(nm, v, ageS) {
@@ -968,8 +1056,21 @@
 			// repeating.
 			const left = typeof dwell === 'number' && streak !== null
 				? Math.max(0, Math.min(dwell, dwell - streak)) : null;
+			// With a refusal standing, "switching in 40 s" is a promise the
+			// camera has already broken once and will break again: what
+			// happens at the end of the dwell is another lamp-down check, and
+			// whether it ends the night is the scene's business, not the
+			// countdown's. Same number, said as what it is.
+			// Only on the way to day. The check stands between this camera
+			// and a DAY; night needs no permission from it, and "checking
+			// again" under "Dark enough for night" would describe a step that
+			// is not in that path at all.
+			const probe = probeState(v);
+			const refused = !!probe && probe.verdict === PROBE_REFUSED;
+			const stands = refused && pend === 2;
 			const inLeft = left === null ? '.' :
-				' — switching in ' + left + ' s if it stays.';
+				(stands ? ' — checking again in ' : ' — switching in ') +
+				left + ' s' + (stands ? '.' : ' if it stays.');
 			const line = pend === 1
 				? 'Dark enough for night' + inLeft
 				: pend === 2
@@ -986,7 +1087,7 @@
 							// the mechanism and claims neither.
 							: inNight === true
 								? '; day comes when the gain settles back ' +
-									'down.' + stillPinned(v)
+									'down.' + (refused ? '' : stillPinned(v))
 								: inNight === false
 									? '; night comes when the exposure runs ' +
 										'out.' + runOut(v)
@@ -994,7 +1095,7 @@
 			return {
 				mode: 'auto', chart: true,
 				value: gm != null && gm >= 0 ? gm / 1000 : null,
-				marks: marks, line: line + lampNote,
+				marks: marks, line: line + lampNote + probeNote(probe),
 				unit: 'x',
 			};
 		}
@@ -1043,7 +1144,7 @@
 					'Comparing raw sensor gain (vendor units) against the ' +
 					'thresholds. It switches on the first check past one, ' +
 					'every ' + everyS + ' s — so there is no countdown.' +
-					lampNote,
+					lampNote + probeNote(probeState(v)),
 				unit: '',
 			};
 		}


### PR DESCRIPTION
A camera whose night illuminator is the only light in the room reads
under the day threshold on every tick — the lamp is most of what the
gain is measuring. majestic answers that by dropping the lamp for three
seconds before it believes a day, and refusing when the scene turns out
to be night after all. That refusal is CORRECT, and this page could not
show it: the chart went on plotting a gain under the day mark, the
countdown went on promising a switch, and neither ever arrived. It reads
as a switch that is broken. It is what happened in #370, and the answer
had to be given by hand — go to Logs, filter for `lamp down`, read the
daemon's own sentence.

majestic publishes the verdict now, so the panel can say it:

    Night. Watching the sensor gain; day comes when the gain settles
    back down. Lamp at 100%. The last check dropped the lamp 2 min ago
    and found 16x — the light in view is the camera's own, so night
    holds; it looks again in 5 min.

The number is the whole of what a refusal has to say to an operator: it
is what the scene needs without the camera's own light, so it is both
the reason day was refused and the value "Gain multiple that means day
again" would have to reach for that room to count as day.

Three smaller things follow from having the verdict:

- While a refusal stands, a day countdown says "checking again in 40 s"
  rather than "switching in 40 s". What happens at the end of the dwell
  is another lamp-down check; whether it ends the night is the scene's
  business. The night countdown is untouched — night needs no permission
  from the check.
- A standing refusal silences the "the exposure is still at its ceiling"
  clause. Both explain a held night; the refusal explains it in terms of
  what is in view, which is the one the operator can act on.
- The legacy threshold pair gets the same sentence. It goes through the
  same check, and it is the door #370 was reported from.

Absent gauges say nothing at all. A camera with no lamp never runs a
check, and an older majestic publishes no verdict; neither is a refusal.
A confirmation is spoken only while it is FRESH and only while it can be
dated — it explains a switch that already happened, and by mid-afternoon
"the last check found daylight" is an old sentence holding the line, so
a verdict arriving without its age cannot be known to be worth saying. A
refusal survives the same gap, because it explains the night the camera
is in now whenever it was reached.

These two readings are used as the camera gives them, and deliberately
not read forward the way the countdown beside them is. That projection
measures time since the MONITOR's gauges last changed — the streak moves
only on the camera's own tick, slower than the poll, so it has to be
projected — and on a settled night those gauges do not change for
minutes at a stretch. The probe's age and wait are recomputed on every
scrape and are already current; adding that number to them would age a
check by however long the monitor happened to sit still and floor "looks
again in" to nothing while a stand-off was still running. Both phrases
are coarse enough that a poll period does not show.

Tests: sixteen checks in tests/ircut-check.test.js — the refusal and its
three parts, the countdown's wording in each direction, the ceiling
clause silenced and otherwise not, a camera that has never run a check,
a confirmation fresh and stale, an unreadable check, a refusal whose
gain the camera could not state, a verdict with no age at all on both
doors, a settled monitor not ageing the check with it, and the legacy
threshold pair.
