### PR TITLE
live: stop the tap-to-play affordance flickering, keep the control bar reachable (#317)

### DIFF
--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -476,6 +476,33 @@ function load(o) {
 		env.player.destroy();
 	}
 
+	group('an announced gesture survives a reconnect and is still cleared when the picture plays (#317)');
+	{
+		// The page keeps the invitation up across a reconnect (it is still a
+		// parked picture), so the player must still emit 'resumed' when the
+		// reconnected picture plays — the rebuild must not forget it announced.
+		const env = load();
+		env.play();
+		env.video.muted = true;
+		env.video.paused = true;
+		env.video.play = () => Promise.resolve();
+		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		await sleep(600);
+		check('the affordance was announced', env.states.filter((s) => s === 'gesture').length === 1,
+			env.states.join(','));
+		// The socket fails; the player rebuilds and reconnects.
+		env.video.fire('error');
+		await sleep(1300);
+		check('a replacement session opened', env.sockets.length >= 2, env.sockets.length + '');
+		// The replacement's picture plays for real.
+		env.play();
+		env.video.paused = false;
+		env.video.fire('playing');
+		check('resumed is still emitted after the reconnect, so the button is taken down',
+			env.states.filter((s) => s === 'resumed').length === 1, env.states.join(','));
+		env.player.destroy();
+	}
+
 	// ---- the data-channel feed ----------------------------------------------
 	const frag = (withPrft) => {
 		const moof = new Uint8Array([0, 0, 0, 8, 0x6d, 0x6f, 0x6f, 0x66]); // an 8-byte moof

--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -397,15 +397,21 @@ function load(o) {
 		let played = 0;
 		env.video.play = () => { played++; return Promise.resolve(); };
 		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		// The retry arms at once, so a tap works immediately; the announcement is
+		// held back so a picture about to play does not flash the button.
 		check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
 			JSON.stringify((env.docHandlers.pointerdown || []).length));
-		// The page is told once that the picture is parked waiting for a tap, so
-		// it can raise the play affordance (#317).
+		check('the affordance is NOT announced immediately', env.states.indexOf('gesture') < 0,
+			env.states.join(','));
+		// Once the picture has stayed parked past the debounce, the page is told
+		// once that it is waiting for a tap.
+		await sleep(600);
 		check('the page was told the picture is waiting for a gesture',
 			env.states.filter((s) => s === 'gesture').length === 1, env.states.join(','));
 		// Another paused frame must not re-announce it: the affordance is up, and
 		// a second 'gesture' would be noise.
 		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		await sleep(600);
 		check('a further paused frame does not re-announce it',
 			env.states.filter((s) => s === 'gesture').length === 1, env.states.join(','));
 		// The viewer taps: play() is called, and this time it starts.
@@ -438,8 +444,35 @@ function load(o) {
 		// The element still fires 'playing' as it runs; with no gesture armed that
 		// must stay silent, or an ordinary autoplay start would emit 'resumed'.
 		env.video.fire('playing');
+		await sleep(600);
 		check('an ordinary playing element emits no resumed', env.states.indexOf('resumed') < 0,
 			env.states.join(','));
+		env.player.destroy();
+	}
+
+	group('a muted picture that plays shortly after parking never flashes the affordance (#317)');
+	{
+		// The reporter's flash: on Opera the picture is paused when the first
+		// frame arrives, then a moment later the browser grants muted autoplay
+		// (or a mode switch does). The button must not appear only to vanish.
+		const env = load();
+		env.play();
+		env.video.muted = true;
+		env.video.paused = true;
+		env.video.play = () => Promise.resolve();
+		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
+		check('the retry is armed at once (a tap would still work)',
+			(env.docHandlers.pointerdown || []).length === 1,
+			JSON.stringify((env.docHandlers.pointerdown || []).length));
+		// Playback begins before the debounce is out.
+		await sleep(200);
+		env.video.paused = false;
+		env.video.fire('playing');
+		await sleep(600);
+		check('the affordance never appeared — no flash',
+			env.states.indexOf('gesture') < 0, env.states.join(','));
+		check('and nothing was announced as resumed (it was never up)',
+			env.states.indexOf('resumed') < 0, env.states.join(','));
 		env.player.destroy();
 	}
 

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -345,10 +345,11 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 			env.el('mj-tap-play').hidden === true, String(env.el('mj-tap-play').hidden));
 	}
 
-	// The invitation belongs only to a picture parked on a still frame: any other
-	// state — a reconnect, an error — takes it down, and it returns only when the
-	// picture parks again (#317). A tap during a reconnect starts nothing anyway.
-	group('the invitation is tied to the parked state, not left stranded (#317)');
+	// Once raised, the invitation persists across the attempt's chatter — a
+	// reconnect, the pipeline's own 'playing' — and comes down only when the
+	// picture ACTUALLY plays ('resumed'). Toggling it on every transient state
+	// was the flicker the reporter saw on reload (#317).
+	group('the invitation persists across transient states, down only on real playback (#317)');
 	{
 		const env = load('mse');
 		await tick();
@@ -358,13 +359,29 @@ const tick = () => new Promise((r) => setTimeout(r, 1700));
 		check('a parked picture raises the invitation',
 			env.el('mj-tap-play').hidden === false, String(env.el('mj-tap-play').hidden));
 		live.say('connecting');
-		check('a reconnect takes it down', env.el('mj-tap-play').hidden === true,
+		check('a reconnect leaves it up', env.el('mj-tap-play').hidden === false,
 			String(env.el('mj-tap-play').hidden));
-		live.say('gesture');
-		check('it returns when the picture parks again',
-			env.el('mj-tap-play').hidden === false, String(env.el('mj-tap-play').hidden));
 		live.say('playing');
-		check('and a picture coming up takes it down for good',
+		check('the pipeline coming back up leaves it up', env.el('mj-tap-play').hidden === false,
+			String(env.el('mj-tap-play').hidden));
+		live.say('resumed');
+		check('it comes down only when the picture actually plays',
+			env.el('mj-tap-play').hidden === true, String(env.el('mj-tap-play').hidden));
+	}
+
+	// A different picture taking the stage clears a stale invitation, even
+	// though the picture that raised it never played (#317).
+	group('a different picture on the stage clears a stale invitation (#317)');
+	{
+		const env = load('mse');
+		await tick();
+		const first = env.made[0];
+		first.say('playing');
+		first.say('gesture');
+		env.el('mj-tap-play').hidden = false;   // the first picture parked, button up
+		pickWebRTC(env);
+		env.made[1].say('playing');   // the trial promotes and takes the stage
+		check('the incoming picture cleared the old invitation',
 			env.el('mj-tap-play').hidden === true, String(env.el('mj-tap-play').hidden));
 	}
 

--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -371,7 +371,13 @@ async function gestureAndResumedStates() {
 	env.MajesticWebRTC.attach(video, { onState: (s) => states.push(s) });
 	await tick();
 	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	// The paused-state observer arms at ~800ms; the announcement is then held
+	// back a further debounce, so a picture about to play does not flash it.
 	await tick(850);
+	check('the retry armed but the affordance is not announced yet',
+		(env.docHandlers.pointerdown || []).length === 1 && states.indexOf('gesture') < 0,
+		states.join(',') + ' | arms=' + (env.docHandlers.pointerdown || []).length);
+	await tick(600);
 	check('the page was told the picture is waiting for a gesture, once',
 		states.filter((s) => s === 'gesture').length === 1, states.join(','));
 	check('nothing claimed it resumed before it actually played',
@@ -403,11 +409,44 @@ async function pausedTimerClearedOnDestroy() {
 		JSON.stringify((env.docHandlers.pointerdown || []).length));
 }
 
+async function playsBeforeDebounceNoFlash() {
+	group('a WebRTC picture that plays right after a refused muted play() never flashes the affordance (#317)');
+	// The reject-path arms the retry at once so a tap works, but the
+	// announcement is debounced: a picture that then plays must not flash it.
+	const env = makeEnv();
+	const states = [];
+	const handlers = {};
+	let plays = 0;
+	const video = {
+		muted: true, volume: 1, srcObject: null, paused: true,
+		play() { plays++; return plays === 1 ? Promise.reject(new DOMException('x', 'NotAllowedError')) : Promise.resolve(); },
+		addEventListener(ev, fn) { (handlers[ev] = handlers[ev] || []).push(fn); },
+		removeEventListener(ev, fn) { handlers[ev] = (handlers[ev] || []).filter((f) => f !== fn); },
+		fire(ev) { (handlers[ev] || []).slice().forEach((f) => f({ target: this })); },
+	};
+	env.MajesticWebRTC.attach(video, { onState: (s) => states.push(s) });
+	await tick();
+	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
+	await tick();
+	check('the refused muted play() armed the retry at once',
+		(env.docHandlers.pointerdown || []).length === 1,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
+	check('but nothing is announced yet', states.indexOf('gesture') < 0, states.join(','));
+	// The picture plays before the debounce is out.
+	await tick(150);
+	video.paused = false;
+	video.fire('playing');
+	await tick(600);
+	check('no flash — the affordance never appeared', states.indexOf('gesture') < 0, states.join(','));
+	check('and nothing was announced as resumed (it was never up)',
+		states.indexOf('resumed') < 0, states.join(','));
+}
+
 (async () => {
 	for (const t of [reentrancy, cameraTakesMicButSendsNothing, destroyedDuringPrompt, cameraDeclines,
 		trackEndsOnItsOwn, destroyStopsMic, insecureContext, refused, playRetriesOnGesture,
 		playResolvesButStaysPaused, playbackStartsArmsNothing, gestureAndResumedStates,
-		pausedTimerClearedOnDestroy]) {
+		playsBeforeDebounceNoFlash, pausedTimerClearedOnDestroy]) {
 		await t();
 	}
 	done();

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -2969,9 +2969,11 @@ button.mj-osd-chip,
 	   visibly jumps size a second after it appeared. Sizing to the large,
 	   bar-collapsed height holds the picture the size it will be from the first
 	   frame; the cost is that the bottom of the stage sits under the URL bar until
-	   it collapses, where the control bar is overlaid and revealed on demand
-	   regardless. On every desktop browser lvh, dvh and vh are the same value, so
-	   nothing there changes. */
+	   it collapses. The control bar handles that itself -- it is lifted to the
+	   visible bottom by lvh - dvh (see .mj-bar) rather than left at the stage
+	   bottom -- so it stays reachable even where the URL bar never collapses. On
+	   every desktop browser lvh, dvh and vh are the same value, so nothing there
+	   changes. */
 	height: 100vh;
 	height: 100lvh;
 	display: flex;
@@ -3607,6 +3609,17 @@ button.mj-osd-chip,
 .mj-bar {
 	position: absolute;
 	inset: auto 0 0 0;
+	/* Pinned to the VISIBLE bottom, not the stage bottom. The stage is sized to
+	   the large (URL-bar-collapsed) viewport so the picture never reflows (see
+	   #page-live), but on a browser whose URL bar does not collapse -- a
+	   non-scrolling page in Opera for Android -- the stage bottom, and the bar
+	   with it, sit under that bar out of reach (majestic-webui#317). lvh - dvh
+	   is exactly how far the stage bottom is below the visible area right now, so
+	   lifting the bar by that much lands it on the visible bottom and follows the
+	   URL bar if it does move. Zero on every desktop browser and in fullscreen,
+	   where lvh and dvh are equal; a browser too old for the units keeps the
+	   inset's own bottom: 0. */
+	bottom: calc(100lvh - 100dvh);
 	z-index: 6;
 	display: flex;
 	flex-wrap: wrap;

--- a/www/a/mj-preview.js
+++ b/www/a/mj-preview.js
@@ -285,7 +285,6 @@ window.MajesticPreview = (function () {
 		function hideTapPlay() { if (tapPlay) tapPlay.hidden = true; }
 
 		function announcePlaying(kind) {
-			hideTapPlay();
 			if (announced === kind) return;
 			announced = kind;
 			if (opts.onPlaying) opts.onPlaying(kind);
@@ -450,6 +449,10 @@ window.MajesticPreview = (function () {
 			onPromoted: (kind, proven) => {
 				exhausted = false;
 				hideAlert();
+				// A different picture is taking the stage: any tap invitation the
+				// last one raised is for a picture that is gone, so take it down.
+				// The incoming picture raises its own if it too parks (#317).
+				hideTapPlay();
 				// The idle pair of the other kind is hidden by nobody — the swap
 				// only touches the slot it is using — so an empty <video> would
 				// sit visible under a painting canvas.
@@ -486,14 +489,14 @@ window.MajesticPreview = (function () {
 			// empty black box is indistinguishable from a camera that is off.
 			onExhausted: (kind, detail) => { chain.next(kind, detail); },
 			onLive: (st, d, kind) => {
-				// A muted picture parked on its first frame waiting for a tap
-				// (#317): raise the invitation. Any other state — it played, it
-				// reconnects, it failed — means the picture is no longer parked
-				// on a still frame, so the invitation comes down here and returns
-				// only when 'gesture' is next announced.
+				// A muted picture parked on its first frame is waiting for a tap
+				// (#317): raise the invitation on 'gesture', take it down on
+				// 'resumed' (the picture really played). Every other state is the
+				// attempt talking — connecting, a reconnect, its first bytes — and
+				// leaves the invitation alone; a different picture on the stage
+				// clears it through onPromoted, a lost one through showAlert.
 				if (st === 'gesture') { showTapPlay(); return; }
-				hideTapPlay();
-				if (st === 'resumed') return;
+				if (st === 'resumed') { hideTapPlay(); return; }
 				// The live player's own report that it is playing. This is the
 				// only place a FIRST attach can say so — it was promoted before
 				// it had anything, so its picture arrives here rather than as a

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -150,7 +150,11 @@
 	function hideTapPlay() { if (tapPlay) tapPlay.hidden = true; }
 
 	function showVideo() {
-		hideTapPlay();
+		// Not hidden here: 'playing' is the pipeline coming up, which is when a
+		// parked picture is about to raise the invitation, not a reason to take
+		// it down. A picture that genuinely replaces the one on screen clears it
+		// through onPromoted; a picture that actually plays clears it through
+		// 'resumed'. Hiding on every 'playing' was the flash on reload (#317).
 		const v = cur();
 		if (v) { v.style.display = ''; v.style.background = '#000'; }
 		if (note) note.style.display = 'none';
@@ -947,6 +951,10 @@
 					audio: audioOn, volume: vol },
 				handlersFor(id, onState))),
 		onPromoted: (kind, proven) => {
+			// A different picture is taking the stage, so any tap invitation the
+			// last one raised belongs to a picture that is gone; take it down. The
+			// incoming picture raises its own, once, if it too parks (#317).
+			hideTapPlay();
 			player = swap.player();
 			liveKind = kind;
 			liveEl = swap.element();
@@ -1091,20 +1099,15 @@
 			}
 			// Not while the fallback picture is being held: these describe the
 			// attempt, and the chip has to go on describing the stage.
-			// Anything else — connecting, reconnecting, an error — is the
-			// session no longer sitting on a parked frame, so the tap invitation
-			// comes down; it returns only when the picture parks again and the
-			// player re-announces 'gesture'. A tap during a reconnect could not
-			// start anything anyway (the player rebinds its gesture retry to the
-			// new attempt), so an invitation that stayed up would be one the
-			// viewer's tap fell through.
-			else {
-				hideTapPlay();
-				// Not while the fallback picture is being held: these describe the
-				// attempt, and the chip has to go on describing the stage.
-				if (badge && !holdingFallback) {
-					badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
-				}
+			// Anything else — connecting, reconnecting, an error — describes the
+			// attempt and only writes the chip. The tap invitation is left as it
+			// is: a picture parked over a brief reconnect is still a picture
+			// waiting for a tap, and taking the button down and putting it back
+			// on every transient was half of the flicker the reporter saw (#317).
+			// Not while the fallback picture is being held: these describe the
+			// attempt, and the chip has to go on describing the stage.
+			else if (badge && !holdingFallback) {
+				badge.textContent = (s === 'error') ? 'reconnecting…' : s + '…';
 			}
 		},
 	});

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -770,8 +770,12 @@ window.MajesticWebRTC = (function () {
 		function reconnect() {
 			// A new attempt begins here; drop any gesture retry bound to the old
 			// one so this attempt can arm its own if it too is refused autoplay.
+			// gestureArmed is NOT cleared: it records that the page is showing the
+			// invitation and is owed a 'resumed'. A reconnect keeps that debt, so
+			// the picture this attempt brings up still clears the button when it
+			// plays; clearing it here left the button stranded over a reconnected
+			// picture that played (#317). Only 'resumed' and destroy clear it.
 			disarmGesture();
-			gestureArmed = false;
 			disarmPausedTimer();
 			// Retire the attempt before dismantling it. Closing a peer
 			// connection rejects whatever it had in flight, and a rejection

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -75,9 +75,14 @@ window.MajesticWebRTC = (function () {
 		// happens to carry an activation. Retry play() on the first user gesture
 		// instead. One-shot, capture phase so a tap the controls also handle still
 		// counts, and guarded for the vm tests, which have no document.
-		let gestureRetry = null, gestureArmed = false;
+		// Announcing the affordance is held back this long after the picture is
+		// found parked, so a picture that goes on to play by itself a moment
+		// later never flashes the button (#317).
+		const GESTURE_ANNOUNCE_MS = 500;
+		let gestureRetry = null, gestureArmed = false, gestureTimer = null;
 		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
 		function disarmGesture() {
+			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
 			if (gestureRetry && typeof document !== 'undefined')
 				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
 			gestureRetry = null;
@@ -118,18 +123,25 @@ window.MajesticWebRTC = (function () {
 			};
 			gestureRetry = retry;
 			gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
-			// Tell the page that a muted picture is parked waiting for a tap, so it
-			// can offer the viewer somewhere to tap (#317). Once per arm: a
-			// reconnect re-arms through here, but the flag is cleared only when the
-			// picture actually plays or the attempt is torn down.
-			if (!gestureArmed) { gestureArmed = true; onState('gesture'); }
+			// Then wait out the debounce before telling the page the picture is
+			// waiting for a tap, so the button is offered only for a picture that
+			// really stays parked and never flashes on one about to play. Once
+			// per arm; the timer confirms the picture is still muted and paused.
+			if (!gestureArmed && !gestureTimer) {
+				gestureTimer = setTimeout(function () {
+					gestureTimer = null;
+					if (alive && !alive()) return;
+					if (!gestureArmed && v.muted && v.paused) { gestureArmed = true; onState('gesture'); }
+				}, GESTURE_ANNOUNCE_MS);
+			}
 		}
 		// The muted picture actually started moving. Only the element's own
 		// 'playing' event proves it — play() resolving does not, because Opera
-		// resolves it on a picture that never starts (#317) — so this is what
-		// takes the tap affordance down, and it ignores the event unless a gesture
-		// was armed so an ordinary autoplay start costs nothing.
+		// resolves it on a picture that never starts (#317). It cancels a pending
+		// announcement (the picture played before the debounce was out) and, if
+		// the button was already up, takes it down.
 		function onPlaying() {
+			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
 			if (!gestureArmed) return;
 			gestureArmed = false;
 			disarmGesture();

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -241,11 +241,15 @@ window.MajesticVideo = (function () {
 
 		function teardownMse() {
 			started = false; queue = [];
+			// The retry and the pending announcement go (disarmPlayGesture), but
+			// NOT gestureArmed: it records that the page is showing the invitation
+			// and is still owed a 'resumed' to take it back down. A rebuild -- a
+			// reconnect, a codec change -- keeps that debt, so when the picture
+			// this pipeline brings up finally plays, onPlaying still emits
+			// 'resumed'; clearing it here left the button stranded over a picture
+			// that reconnected and played (#317). It is cleared only by that
+			// 'resumed', and dies with the player on destroy.
 			disarmPlayGesture();
-			// The next pipeline re-arms and re-announces 'gesture' on its own if
-			// its picture is again parked; clear the flag so that emit is not
-			// suppressed by a stale one left from the pipeline being torn down.
-			gestureArmed = false;
 			if (pumpTimer) { clearTimeout(pumpTimer); pumpTimer = null; }
 			// The lag floor describes the pipeline being torn down; the next
 			// one learns its own.

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -187,33 +187,52 @@ window.MajesticVideo = (function () {
 		// frame (majestic-webui#317). Arm a one-shot document gesture that plays
 		// it, so the first tap anywhere starts playback. Only armed while paused,
 		// so a browser that autoplays never adds the listener.
-		let gestureRetry = null, gestureArmed = false;
+		// Announcing the affordance is held back until the picture has been
+		// parked this long. A picture that goes on to play by itself a moment
+		// later -- a browser that grants muted autoplay after a short delay, or
+		// the picture a transport switch brought up -- must never flash the
+		// button, so the announcement waits to see that the pause is the settled
+		// state and not a step on the way to playing (#317).
+		const GESTURE_ANNOUNCE_MS = 500;
+		let gestureRetry = null, gestureArmed = false, gestureTimer = null;
 		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
 		function armPlayGesture() {
-			if (typeof document === 'undefined' || gestureRetry) return;
-			const retry = function () {
-				disarmPlayGesture();
-				try { const p = video.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
-			};
-			gestureRetry = retry;
-			gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
-			// Tell the page that a muted picture is parked on its first frame
-			// waiting for a tap, so it can offer the viewer somewhere to tap
-			// (#317). Once per arm: the frame handler calls this on every frame
-			// while paused, but the gestureRetry guard above lets only the first
-			// through, so the page hears 'gesture' once and not on every frame.
-			if (!gestureArmed) { gestureArmed = true; onState('gesture'); }
+			if (typeof document === 'undefined') return;
+			// Arm the retry at once, so the very first tap starts playback even
+			// before the affordance is announced.
+			if (!gestureRetry) {
+				const retry = function () {
+					disarmPlayGesture();
+					try { const p = video.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
+				};
+				gestureRetry = retry;
+				gestureEvs.forEach(function (t) { try { document.addEventListener(t, retry, true); } catch (e) {} });
+			}
+			// Then wait out the debounce before telling the page the picture is
+			// waiting for a tap. The frame handler calls this on every paused
+			// frame; the timer is started once and confirms the picture is still
+			// muted and paused before it announces, so the page hears 'gesture'
+			// once and only for a picture that really is stuck.
+			if (!gestureArmed && !gestureTimer) {
+				gestureTimer = setTimeout(function () {
+					gestureTimer = null;
+					if (!gestureArmed && video.muted && video.paused) { gestureArmed = true; onState('gesture'); }
+				}, GESTURE_ANNOUNCE_MS);
+			}
 		}
 		function disarmPlayGesture() {
+			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
 			if (gestureRetry && typeof document !== 'undefined')
 				gestureEvs.forEach(function (t) { try { document.removeEventListener(t, gestureRetry, true); } catch (e) {} });
 			gestureRetry = null;
 		}
 		// The muted picture actually started moving. Only the element's own
 		// 'playing' event says so — play() resolving does not, because Opera
-		// resolves it on a picture that never starts (#317) — so this is the
-		// signal that takes the tap affordance back down, not the retry firing.
+		// resolves it on a picture that never starts (#317). It cancels a pending
+		// announcement (the picture played before the debounce was out, so the
+		// button never shows) and, if the button was already up, takes it down.
 		function onPlaying() {
+			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
 			if (!gestureArmed) return;
 			gestureArmed = false;
 			disarmPlayGesture();


### PR DESCRIPTION
Follow-up on #418, from the reporter's testing (#317). Two problems they saw once the affordance shipped, both from recent changes here.

## 1. The ▶️ flashed and vanished
It was announced the instant the picture was found paused, and taken back down on the pipeline's own `'playing'` state (which fires *before* real playback — at MSE `sourceopen` / the WebRTC first bytes) and on every reconnect. On a browser that grants muted autoplay a beat late (Opera for Android) it appeared and disappeared with no interaction; a transport switch flashed it too.

**Fix:**
- **Debounced announcement** (`preview.js`, `preview-webrtc.js`): the document tap-retry still arms the instant the picture parks, so the first tap always works — but `'gesture'` is announced only after the picture has stayed muted and paused past a short debounce, and a picture that starts playing cancels the pending announcement. A picture about to play never raises the button.
- **Stable latch** (`preview-page.js`, `mj-preview.js`): shown on `'gesture'`, taken down only when the picture *actually* plays (`'resumed'`, the element's own `playing` event) or a *different* picture takes the stage (`onPromoted`) or the picture is lost (no-signal / fallback). Not on the pipeline coming up, not on a reconnect. The distinction that makes this work: `onLive('playing')` is the same player's pipeline coming up (keep the button), `onPromoted` is a new picture on the stage (clear a stale one).

## 2. Stats and ⛶ were off the bottom of the screen
`#page-live` is sized to the large, URL-bar-collapsed viewport so the picture does not reflow when that bar collapses (#335). Where the URL bar never collapses — a non-scrolling page in Opera for Android — the stage bottom, and the bottom-anchored control bar with it (its last wrapped row is Stats and fullscreen), stay under the URL bar out of reach.

**Fix:** `.mj-bar { bottom: calc(100lvh - 100dvh) }` lifts the bar to the visible bottom — `lvh - dvh` is exactly how far the stage bottom sits below the visible area — and follows the URL bar if it moves. Zero on desktop and in fullscreen, where the two heights are equal; a browser too old for the units keeps the inset's own `bottom: 0`.

## Tests
`preview-socket.test.js`, `talkback.test.js`, `staging.test.js` gained cases driving the exact scenarios: a picture that plays before the debounce raises nothing (no flash); the invitation persists across a reconnect and the pipeline's own `'playing'`, coming down only on real playback; a new picture on the stage clears a stale invitation. Full suite green; dist build clean, the markup and CSS survive minification.

## Verification note
The flash is specific to browsers that block or delay muted autoplay: a lab Chrome always plays the muted picture, so the parked state — and the affordance — never engages there, and there is no dynamic URL bar to reproduce problem 2 either. The state machine is covered by the tests above; the mobile behaviour is best confirmed on the reporter's own Opera Android.