### PR TITLE
live: play H.265 on iPhone Safari via ManagedMediaSource instead of falling to MJPEG (#335)

### DIFF
--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -79,6 +79,10 @@ function makeVideo(env) {
 function load(o) {
 	const env = { sockets: [], states: [], dc: o && o.dc };
 	const video = makeVideo(env);
+	// iPhone Safari has ONLY window.ManagedMediaSource; drive the same stub
+	// through that global (and no window.MediaSource) to exercise the managed
+	// path — constructor selection, disableRemotePlayback, streaming gate.
+	const managed = !!(o && o.mms);
 
 	const MediaSourceStub = function () {
 		const ms = {
@@ -102,7 +106,7 @@ function load(o) {
 	};
 	MediaSourceStub.isTypeSupported = () => true;
 
-	const win = { MediaSource: MediaSourceStub };
+	const win = managed ? { ManagedMediaSource: MediaSourceStub } : { MediaSource: MediaSourceStub };
 	// The data-channel feed, stubbed: a WebSocket-shaped object the test
 	// drives by hand, and an eligibility the test sets. Installed only when
 	// asked, so every existing case sees the player exactly as before.
@@ -132,7 +136,7 @@ function load(o) {
 			addEventListener(t, fn) { (env.docHandlers[t] = env.docHandlers[t] || []).push(fn); },
 			removeEventListener(t, fn) { env.docHandlers[t] = (env.docHandlers[t] || []).filter((f) => f !== fn); },
 		},
-		MediaSource: MediaSourceStub,
+		MediaSource: managed ? undefined : MediaSourceStub,
 		WebSocket: makeSockets(env),
 		URL: { createObjectURL: () => 'blob:stub', revokeObjectURL() {} },
 		location: { protocol: 'http:', host: 'camera' },
@@ -593,6 +597,34 @@ function load(o) {
 		await sleep(1100);
 		const st = env.stats[env.stats.length - 1];
 		check('feed is the websocket, no dc block, no lag', st && st.feed === 'websocket' && st.dc === undefined && st.lag === undefined);
+		env.player.destroy();
+	}
+
+	group('iPhone ManagedMediaSource: constructed, remote playback off, appends gated on streaming (#335)');
+	{
+		// Only window.ManagedMediaSource exists (no window.MediaSource), as on
+		// iPhone Safari. The player must pick it, opt the element out of remote
+		// playback, and feed only while the source says it is streaming.
+		const env = load({ mms: true });
+		env.play();   // open + init + sourceopen -> managed source built, buffer ready
+		check('a managed source was constructed', (env.msCount || 0) >= 1, String(env.msCount));
+		check('remote playback was disabled (proves the managed branch ran)',
+			env.video.disableRemotePlayback === true, String(env.video.disableRemotePlayback));
+		const s = env.sockets[env.sockets.length - 1];
+		// A media frame while streaming (the default) is appended.
+		s.fire('message', { data: { byteLength: 100 } });
+		check('appends while the source is streaming', env.sb.appends >= 1, String(env.sb.appends));
+		// endstreaming: the source asks the page to hold — further frames queue,
+		// not append. This is the freeze the guard on the source protects.
+		env.ms.listeners.endstreaming();
+		const held = env.sb.appends;
+		s.fire('message', { data: { byteLength: 100 } });
+		check('endstreaming holds further appends', env.sb.appends === held,
+			env.sb.appends + ' vs ' + held);
+		// startstreaming: resume, and the frame held back goes in.
+		env.ms.listeners.startstreaming();
+		check('startstreaming resumes appends', env.sb.appends > held,
+			env.sb.appends + ' vs ' + held);
 		env.player.destroy();
 	}
 

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -414,9 +414,14 @@ window.MajesticVideo = (function () {
 			// MediaSource, which has neither the events nor the property to mind.
 			mmsStreaming = true;
 			if (usingMMS) {
+				// Bound to THIS source: a rebuild makes a new one, and a delayed
+				// endstreaming from the retired source must not lower the gate on
+				// its replacement and wedge every later append. `ms === src` is
+				// false once ms has moved on, so a stale event does nothing.
+				const src = ms;
 				try { video.disableRemotePlayback = true; } catch (e) {}
-				ms.addEventListener('startstreaming', function () { mmsStreaming = true; pump(); });
-				ms.addEventListener('endstreaming', function () { mmsStreaming = false; });
+				src.addEventListener('startstreaming', function () { if (ms === src) { mmsStreaming = true; pump(); } });
+				src.addEventListener('endstreaming', function () { if (ms === src) mmsStreaming = false; });
 			}
 			video.src = objUrl;
 			ms.addEventListener('sourceopen', function () {

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -15,6 +15,15 @@ window.MajesticVideo = (function () {
 	// carries the camera's offset; the spread is exact.
 	const LAG_KEEP = 240;
 	const DC = () => window.MajesticDataChannel;
+	// The buffered-video API the browser exposes. iPhone Safari has ONLY
+	// ManagedMediaSource — window.MediaSource is undefined there — and it decodes
+	// H.265 all the same, so use whichever exists rather than treating the iPhone
+	// as a browser with no player and dropping it to MJPEG (majestic-webui#335).
+	// Managed Media Source is fed the same way, with two additions handled below:
+	// the element opts out of remote playback, and appends are gated on the
+	// source's streaming state (it tells the page when to feed and when to hold).
+	const MSImpl = window.MediaSource || window.ManagedMediaSource;
+	const usingMMS = !!MSImpl && MSImpl !== window.MediaSource;
 	// Safari wedges its MSE SourceBuffer on high-frequency per-frame appendBuffer
 	// calls for HEVC: /ws/video delivers one fMP4 fragment per frame (~20-30/s),
 	// and appending each on its own froze Safari after a few seconds with NO
@@ -47,9 +56,9 @@ window.MajesticVideo = (function () {
 	// prefers whichever of these it is already encoding.
 	const AUDIO_CODECS = ['opus', 'mp4a.40.2'];
 	const audioPrefs = (function () {
-		if (!('MediaSource' in window)) return '';
+		if (!MSImpl) return '';
 		return AUDIO_CODECS.filter(function (c) {
-			return MediaSource.isTypeSupported('audio/mp4; codecs="' + c + '"');
+			return MSImpl.isTypeSupported('audio/mp4; codecs="' + c + '"');
 		}).join(',');
 	})();
 
@@ -125,7 +134,11 @@ window.MajesticVideo = (function () {
 		// whether play() has been refused since the pipeline was built.
 		let lagFloor = 0, lagLearn = true, lastCt = null, playRefused = false;
 
-		const mseOk = ('MediaSource' in window);
+		const mseOk = !!MSImpl;
+		// ManagedMediaSource only accepts appends while it is "streaming"; it
+		// raises and lowers this through start/endstreaming events (below). Plain
+		// MediaSource has no such notion, so this stays true and gates nothing.
+		let mmsStreaming = true;
 		const NO_SIGNAL_MS = 4000;
 
 		function armSignalTimer() {
@@ -137,7 +150,7 @@ window.MajesticVideo = (function () {
 		function markSignal() { gotSignal = true; clearTimeout(signalTimer); }
 
 		function pump() {
-			if (!sb || sb.updating || !queue.length) return;
+			if (!sb || sb.updating || !queue.length || !mmsStreaming) return;
 			// H.264 keeps its per-frame append. HEVC coalesces: wait briefly for a
 			// full batch (bounded by APPEND_MAX_WAIT so a slow/ending stream still
 			// plays), then append the batch as one buffer.
@@ -151,7 +164,7 @@ window.MajesticVideo = (function () {
 		}
 		function flushAppend() {
 			if (pumpTimer) { clearTimeout(pumpTimer); pumpTimer = null; }
-			if (!sb || sb.updating || !queue.length) return;
+			if (!sb || sb.updating || !queue.length || !mmsStreaming) return;
 			const n = hevc ? Math.min(queue.length, APPEND_BATCH) : 1;
 			let buf;
 			if (n === 1) {
@@ -358,7 +371,7 @@ window.MajesticVideo = (function () {
 			// would have produced.
 			if (wantAudio && !info.audioCodec) { wantAudio = false; video.muted = true; }
 			const newMime = info.mime || ('video/mp4; codecs="' + info.codecString + '"');
-			if (!mseOk || !MediaSource.isTypeSupported(newMime)) {
+			if (!mseOk || !MSImpl.isTypeSupported(newMime)) {
 				onState('mjpeg', 'undecodable ' + info.codec);
 				stop();
 				return;
@@ -393,8 +406,18 @@ window.MajesticVideo = (function () {
 			lastW = info.width | 0;
 			lastH = info.height | 0;
 			teardownMse();
-			ms = new MediaSource();
+			ms = new MSImpl();
 			objUrl = URL.createObjectURL(ms);
+			// Managed Media Source: a fresh source starts able to stream, and the
+			// element must opt out of remote playback or the source can be handed
+			// to AirPlay and stop feeding. Harmless (and skipped) on plain
+			// MediaSource, which has neither the events nor the property to mind.
+			mmsStreaming = true;
+			if (usingMMS) {
+				try { video.disableRemotePlayback = true; } catch (e) {}
+				ms.addEventListener('startstreaming', function () { mmsStreaming = true; pump(); });
+				ms.addEventListener('endstreaming', function () { mmsStreaming = false; });
+			}
 			video.src = objUrl;
 			ms.addEventListener('sourceopen', function () {
 				try { sb = ms.addSourceBuffer(mime); }


### PR DESCRIPTION
## The gap
iPhone Safari exposes **no `window.MediaSource`** — only `window.ManagedMediaSource` — and it decodes H.265 just the same. The live player only ever checked `('MediaSource' in window)` and called `new MediaSource()`, so on **every iPhone** it reported `no-mse` and dropped straight to MJPEG, even though the device can play the H.265 stream. That's the "This browser has no Media Source Extensions… showing the MJPEG stream" an iPhone user sees on the Live page.

## The change (`www/a/preview.js`)
- `const MSImpl = window.MediaSource || window.ManagedMediaSource` — use whichever the browser has, and route `isTypeSupported` / `mseOk` / `new`‑source through it.
- Managed Media Source needs two things a plain `MediaSource` doesn't, both no‑ops where it's absent:
  - the `<video>` opts out of remote playback (`disableRemotePlayback`), or the source can be handed to AirPlay and stop feeding;
  - appends are gated on the source's **streaming state** (`startstreaming` / `endstreaming`) — feed when asked, hold when told; the existing live‑edge trim keeps it at the edge.

Desktop/Android/iPad are unchanged: they have `window.MediaSource`, so `MSImpl` resolves to it and the MMS branches never run.

## Verified on a physical iPhone
Driven on a real iPhone (Safari 26.6.1) against a gk7205v200 serving the exact stream from the report (`hvc1.1.6.L123.B0`, 1920×1080, 30 fps):

```
before: badge "…no Media Source Extensions… MJPEG"
after:  badge "H265 1920×1080 · 30 fps"   decoded 38→462 frames over 15s (~30 fps)
        currentTime real-time, no flash, no MJPEG fallback
        window.MediaSource=undefined  window.ManagedMediaSource=function
```

Notably the iPhone's ManagedMediaSource does **not** wedge on per‑frame HEVC appends the way desktop Safari's MediaSource does — it played this exact stream cleanly. So this is the iPhone‑H.265 gap; the desktop‑Safari flash in #335 is a separate MediaSource issue.

## Tests
Existing MSE suites (`preview-socket`, `preview-live-edge`, `talkback`, `staging`, `mj-preview`, `preview-chain`, `transport`) pass unchanged — the vm stub resolves `MSImpl` to its `MediaSource` stub, so the MMS branches stay dormant there. Full suite green; minified dist builds clean.