### PR TITLE
preview: mark the live MSE source as endless so Safari stops flashing at the edge (#335)

### DIFF
--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -427,6 +427,24 @@ window.MajesticVideo = (function () {
 			ms.addEventListener('sourceopen', function () {
 				try { sb = ms.addSourceBuffer(mime); }
 				catch (e) { onState('mjpeg', 'mse-error'); stop(); return; }
+				// This is a live feed with no end. Say so, by setting the
+				// duration to Infinity: without it the source has no duration of
+				// its own, so the browser takes the end of the buffered range as
+				// the media's duration and moves it forward on every append. On
+				// Safari that finite, growing duration makes an unrecoverable
+				// trap at the live edge -- when the playhead reaches the last
+				// buffered frame (which it does at startup, on a 0.13 s buffer,
+				// and whenever a hardware decoder drains faster than fragments
+				// arrive) currentTime equals duration, the element fires 'ended'
+				// and rewinds to zero, and the picture flashes black until the
+				// next syncLive() seek jumps it back to the edge (#335). An
+				// infinite duration is never reached, so 'ended' never fires and
+				// the buffer's end stays what syncLive() seeks toward, not what
+				// the clock counts down to. Set once, before any append: a
+				// smaller value than what is already buffered would throw, and
+				// Infinity is above every finite append so the browser never
+				// lowers it back.
+				try { ms.duration = Infinity; } catch (e) {}
 				// Over the channel, frames can be lost and the fragment
 				// timeline then has holes: in 'segments' mode a hole is a
 				// stall until the playhead is seeked across it, in


### PR DESCRIPTION
## What

The Live player builds a `MediaSource` for the H.265 stream but never gives it a duration. The browser then derives one from the buffered range and moves it forward on every appended fragment. On Safari that finite, ever-growing duration is a trap at the live edge:

- Playback starts at `currentTime = 0` on a very short initial buffer (~0.13 s).
- When the playhead reaches the last buffered frame — at startup, and again whenever a hardware decoder drains faster than fragments arrive — `currentTime` equals `duration`.
- Safari treats that as the end of a finite asset: it fires `ended`, pauses, and rewinds toward zero.
- The picture flashes black until the next live-edge seek jumps it back to the edge.

This is the ~1–2 s flash reported in #335. It is not a decode error (no `MEDIA_ERR_DECODE`) and not a reconnect — the decoder keeps running throughout.

## Fix

Set `mediaSource.duration = Infinity` once the source opens, before any append. An endless source is never reached, so `ended` never fires; the buffer's end stays what the live-edge seek aims at rather than a clock counting down to it.

## Verification

Reproduced on an Intel Mac, Safari 26.1, against a gk7205v200 H.265 1080p30 stream driven through the real Live page:

- **Before:** 15/15 reloads fired `ended` and flashed. The event trace shows `durationchange` tracking the buffered end exactly, then `ended` at `currentTime == duration`, then a rewind to 0.
- **After:** 0/20 reloads fired `ended`; hardware decode intact throughout.

Apple Silicon never showed the flash because its decode timing does not catch the buffered tail the same way — consistent with the edge-trap mechanism above.

JS test suite passes.

Closes #335.
