### PR TITLE
dashboard: show the deployed WebUI version, the way it shows majestic's

### DIFF
--- a/sbin/updatewebui
+++ b/sbin/updatewebui
@@ -39,6 +39,7 @@ LEGACY_SHARED='/usr/sbin/openwall /usr/sbin/setnetwork /usr/sbin/telegram
 
 branch=
 zip_url=
+resolved_sha=
 mode=install
 dry_run=0
 do_backup=1
@@ -233,7 +234,19 @@ fetch_tree() {
 	if [ -n "$zip_url" ]; then
 		source_name=$zip_url
 	else
-		zip_url="https://github.com/$REPO/archive/refs/heads/$branch.zip"
+		# Resolve the branch to its exact commit and fetch THAT commit's
+		# archive, so the tree installed and the version recorded for it are the
+		# same revision by construction: a branch that advances between the
+		# fetch and the stamp cannot leave them naming different trees. The
+		# branch zip is the fallback when the commit cannot be resolved
+		# (offline, rate limited), paired with a branch-only stamp.
+		resolved_sha=$(curl -fsSL --connect-timeout 10 "https://api.github.com/repos/$REPO/commits/$branch" 2>/dev/null |
+			grep -m1 '"sha"' | sed -n 's/.*"sha": *"\([0-9a-f]\{40\}\).*/\1/p')
+		if [ -n "$resolved_sha" ]; then
+			zip_url="https://github.com/$REPO/archive/$resolved_sha.zip"
+		else
+			zip_url="https://github.com/$REPO/archive/refs/heads/$branch.zip"
+		fi
 		source_name=$branch
 	fi
 	# Handed over, the download is already made and already reported; doing
@@ -700,17 +713,27 @@ hand_over() {
 write_version() {
 	when=$(date '+%Y-%m-%d %H:%M')
 	if [ -n "$zip_url_given" ]; then
-		stamp="$source_name, $when"
+		# A --url source can carry credentials or a signed query; persist and
+		# show neither. Drop any user:pass@ and any ?query, leaving the scheme,
+		# host and path -- enough to say where it came from.
+		safe=$(printf '%s' "$source_name" | sed -e 's#://[^/@]*@#://#' -e 's/[?].*$//')
+		stamp="$safe, $when"
 	else
-		# The branch head at install time, resolved from GitHub -- the branch
-		# zip carries no commit id of its own. One short call; the branch name
-		# alone is the honest answer when it cannot be made (offline, rate
-		# limited), never a guess.
-		sha=$(curl -fsSL --connect-timeout 10 "https://api.github.com/repos/$REPO/commits/$branch" 2>/dev/null |
-			grep -m1 '"sha"' | sed -n 's/.*"sha": *"\([0-9a-f]\{7\}\).*/\1/p')
-		if [ -n "$sha" ]; then stamp="$branch+$sha, $when"; else stamp="$branch, $when"; fi
+		# Prefer the commit fetch_tree resolved and installed by -- the tree and
+		# its stamp are then the same revision. Only if that was unavailable (or
+		# this is a handed-over run that copied the staged zip rather than
+		# fetching) ask the API for the branch head, and fall back to the branch
+		# name alone. Never a guessed id.
+		sha=$resolved_sha
+		[ -n "$sha" ] || sha=$(curl -fsSL --connect-timeout 10 "https://api.github.com/repos/$REPO/commits/$branch" 2>/dev/null |
+			grep -m1 '"sha"' | sed -n 's/.*"sha": *"\([0-9a-f]\{40\}\).*/\1/p')
+		if [ -n "$sha" ]; then stamp="$branch+$(echo "$sha" | cut -c1-7), $when"; else stamp="$branch, $when"; fi
 	fi
-	mkdir -p "$STATE_DIR" && printf '%s\n' "$stamp" >"$STATE_DIR/webui.version" ||
+	# Atomic: a truncated or interrupted write must not leave a partial file
+	# that still wins the Dashboard's non-empty check over the image's own stamp.
+	mkdir -p "$STATE_DIR" &&
+		printf '%s\n' "$stamp" >"$STATE_DIR/webui.version.tmp" &&
+		mv -f "$STATE_DIR/webui.version.tmp" "$STATE_DIR/webui.version" ||
 		echo "$scr_name: could not record the deployed version in $STATE_DIR/webui.version" >&2
 }
 
@@ -1126,8 +1149,10 @@ do_restore() {
 		echo "$scr_name: could not empty $MANIFEST" >&2
 	# The deployed-version record dies with the install: what shows through now
 	# is the firmware's own WebUI, whose version is its www/.version (or none),
-	# not what an install had put here.
-	rm -f "$STATE_DIR/webui.version"
+	# not what an install had put here. Drop the per-boot cache too, or the
+	# Dashboard keeps sourcing the removed version until something else
+	# regenerates it.
+	rm -f "$STATE_DIR/webui.version" /tmp/webui/sysinfo.txt
 	settle_view
 	restore_local
 	settle_view

--- a/sbin/updatewebui
+++ b/sbin/updatewebui
@@ -19,7 +19,7 @@
 # WebUI exactly as it was.
 
 scr_name=updatewebui
-scr_version=7
+scr_version=8
 
 REPO=openipc/majestic-webui
 STATE_DIR=/etc/webui
@@ -688,6 +688,32 @@ hand_over() {
 	die "cannot start installer v$newv, nothing has been changed"
 }
 
+# Record which WebUI this run deployed, so the Dashboard can show it -- there is
+# otherwise nothing on the camera that says which build is installed, and a
+# reporter cannot tell whether an install carried a given fix. It is written to
+# the state dir rather than into /var/www, and the Dashboard reads it in
+# preference to the image's own www/.version: an install hides that image copy
+# without replacing it (the fetched source tree carries none), so reading
+# /var/www/.version after an install would show the firmware's version, not
+# what was just deployed. Best-effort throughout -- a failure here never fails
+# an install that has otherwise succeeded. Format mirrors majestic's -v.
+write_version() {
+	when=$(date '+%Y-%m-%d %H:%M')
+	if [ -n "$zip_url_given" ]; then
+		stamp="$source_name, $when"
+	else
+		# The branch head at install time, resolved from GitHub -- the branch
+		# zip carries no commit id of its own. One short call; the branch name
+		# alone is the honest answer when it cannot be made (offline, rate
+		# limited), never a guess.
+		sha=$(curl -fsSL --connect-timeout 10 "https://api.github.com/repos/$REPO/commits/$branch" 2>/dev/null |
+			grep -m1 '"sha"' | sed -n 's/.*"sha": *"\([0-9a-f]\{7\}\).*/\1/p')
+		if [ -n "$sha" ]; then stamp="$branch+$sha, $when"; else stamp="$branch, $when"; fi
+	fi
+	mkdir -p "$STATE_DIR" && printf '%s\n' "$stamp" >"$STATE_DIR/webui.version" ||
+		echo "$scr_name: could not record the deployed version in $STATE_DIR/webui.version" >&2
+}
+
 do_install() {
 	fetch_tree
 	hand_over
@@ -698,6 +724,11 @@ do_install() {
 		echo
 		echo "Already up to date."
 		write_manifest
+		# Still record the version: an up-to-date tree may carry no stamp yet
+		# (the file matched /rom, or a prior install predates this record), and
+		# the Dashboard should show what is actually installed.
+		write_version
+		rm -f /tmp/webui/sysinfo.txt
 		return 0
 	fi
 	echo
@@ -708,6 +739,7 @@ do_install() {
 	settle_view
 	write_manifest
 	write_dirs
+	write_version
 	# The per-boot sysinfo cache was written by the release this one just
 	# replaced, and everything derived at detection time — PTZ backend and
 	# support, most visibly — stays frozen at the old release's answers until
@@ -1092,6 +1124,10 @@ do_restore() {
 	# tell your files from ours.
 	mkdir -p "$STATE_DIR" && : >"$MANIFEST" ||
 		echo "$scr_name: could not empty $MANIFEST" >&2
+	# The deployed-version record dies with the install: what shows through now
+	# is the firmware's own WebUI, whose version is its www/.version (or none),
+	# not what an install had put here.
+	rm -f "$STATE_DIR/webui.version"
 	settle_view
 	restore_local
 	settle_view

--- a/tools/build-dist.sh
+++ b/tools/build-dist.sh
@@ -23,6 +23,21 @@ cp -r www LICENSE "$PKG"/
 [ -d sbin ] && cp -r sbin "$PKG"/ || true
 [ -d bin ]  && cp -r bin  "$PKG"/ || true
 
+# Stamp the tree with its own version, so the Dashboard can show which WebUI is
+# deployed the way it shows majestic's -- there is otherwise nothing on the
+# camera that records it, and a reporter running an install cannot say which
+# build they are on. Best-effort: a build with no git checkout (buildroot
+# unpacking a release tarball) ships no stamp, and the Dashboard says "unknown"
+# rather than a wrong answer. Format mirrors majestic's -v: `<ref>+<sha>, <date>`.
+if git -C "$PWD" rev-parse --git-dir >/dev/null 2>&1; then
+	sha=$(git -C "$PWD" rev-parse --short HEAD 2>/dev/null)
+	when=$(git -C "$PWD" show -s --format=%cd --date=format:'%Y-%m-%d %H:%M' HEAD 2>/dev/null)
+	ref=${GITHUB_REF_NAME:-$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null)}
+	case $ref in '' | HEAD) stamp="$sha" ;; *) stamp="$ref+$sha" ;; esac
+	[ -n "$when" ] && stamp="$stamp, $when"
+	[ -n "$stamp" ] && printf '%s\n' "$stamp" >"$PKG/www/.version"
+fi
+
 # CGIs are exec'd directly by majestic, so a non-executable one 500s the page.
 # Guarantee the exec bit here even if a file was committed without it (a recurring
 # slip) — defence in depth on top of the repo's own modes. Same for sbin helpers.

--- a/tools/build-dist.sh
+++ b/tools/build-dist.sh
@@ -33,7 +33,11 @@ if git -C "$PWD" rev-parse --git-dir >/dev/null 2>&1; then
 	sha=$(git -C "$PWD" rev-parse --short HEAD 2>/dev/null)
 	when=$(git -C "$PWD" show -s --format=%cd --date=format:'%Y-%m-%d %H:%M' HEAD 2>/dev/null)
 	ref=${GITHUB_REF_NAME:-$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null)}
-	case $ref in '' | HEAD) stamp="$sha" ;; *) stamp="$ref+$sha" ;; esac
+	# The payload above is copied from the working tree, not from HEAD, so a
+	# tree with uncommitted or untracked changes to what ships must not
+	# advertise a clean commit. Judge only the paths that go into the package.
+	[ -n "$(git -C "$PWD" status --porcelain -- www sbin bin LICENSE 2>/dev/null)" ] && dirty="-dirty" || dirty=""
+	case $ref in '' | HEAD) stamp="$sha$dirty" ;; *) stamp="$ref+$sha$dirty" ;; esac
 	[ -n "$when" ] && stamp="$stamp, $when"
 	[ -n "$stamp" ] && printf '%s\n' "$stamp" >"$PKG/www/.version"
 fi

--- a/www/cgi-bin/dashboard.cgi
+++ b/www/cgi-bin/dashboard.cgi
@@ -266,6 +266,7 @@ done) %>
 				<dt>Firmware</dt><dd><% esc "${fw_version}-${fw_variant}" %></dd>
 				<dt>Build</dt><dd class="text-break"><% esc "$fw_build" %></dd>
 				<dt>Majestic</dt><dd><% esc "$mj_version" %></dd>
+				<dt>WebUI</dt><dd class="text-break"><% esc "${webui_version:-unknown}" %></dd>
 				<% if [ -n "$uboot_version" ]; then %>
 					<dt>U-Boot</dt><dd><% esc "$uboot_version" %></dd>
 				<% fi %>

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -584,6 +584,18 @@ update_caminfo() {
 
 	# WebUI
 	ui_password=$(grep root /etc/shadow | cut -d: -f2)
+	# The deployed WebUI's own version, shown on the Dashboard the way majestic's
+	# is. What updatewebui recorded wins over the image's own stamp: an install
+	# hides the image's www/.version without replacing it, so that file still
+	# reads as the firmware's version after a newer WebUI was laid over it. Empty
+	# on an image too old to carry either, which the Dashboard renders "unknown".
+	if [ -f /etc/webui/webui.version ]; then
+		webui_version=$(cat /etc/webui/webui.version)
+	elif [ -f /var/www/.version ]; then
+		webui_version=$(cat /var/www/.version)
+	else
+		webui_version=""
+	fi
 	# PTZ preview controls. The switch is the U-Boot ptz_control variable
 	# (#227): it names the method — "gpio" (gpio-motors, pins in ptz_gpio,
 	# with the legacy gpio_motors as an alias on both sides), "pelco-d"
@@ -687,7 +699,7 @@ update_caminfo() {
 
 	local variables="flash_size flash_type fw_build fw_variant fw_version mj_version network_address
 		network_gateway network_hostname network_interface network_macaddr overlay_root ptz_support
-		af_support ptz_backend ptz_caps sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password"
+		af_support ptz_backend ptz_caps sensor soc soc_family soc_has_temp soc_vendor tz_data tz_name uboot_version ui_password webui_version"
 	rm -f ${sysinfo_file}
 
 	local v

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -589,13 +589,18 @@ update_caminfo() {
 	# hides the image's www/.version without replacing it, so that file still
 	# reads as the firmware's version after a newer WebUI was laid over it. Empty
 	# on an image too old to carry either, which the Dashboard renders "unknown".
-	if [ -f /etc/webui/webui.version ]; then
+	if [ -s /etc/webui/webui.version ]; then
 		webui_version=$(cat /etc/webui/webui.version)
-	elif [ -f /var/www/.version ]; then
+	elif [ -s /var/www/.version ]; then
 		webui_version=$(cat /var/www/.version)
 	else
 		webui_version=""
 	fi
+	# This value is cached into the shell-sourced sysinfo file and shown on the
+	# Dashboard; keep it to characters that cannot break out of either. It is a
+	# version string, so a printable subset loses nothing real. Testing -s above
+	# (not -f) means a truncated or empty stamp falls through rather than winning.
+	webui_version=$(printf '%s' "$webui_version" | tr -cd 'A-Za-z0-9 .,:+/@()_-')
 	# PTZ preview controls. The switch is the U-Boot ptz_control variable
 	# (#227): it names the method — "gpio" (gpio-motors, pins in ptz_gpio,
 	# with the legacy gpio_motors as an alias on both sides), "pelco-d"


### PR DESCRIPTION
## What

Show the deployed **majestic-webui** version on the Dashboard, the way the Device panel already shows the firmware, the firmware build, majestic and U-Boot.

There was nothing on the camera that recorded which WebUI build was installed. `updatewebui` kept only a file manifest (paths + md5) with no ref, and the shipped tree carries no version file — so someone running `updatewebui` could not say which build they were on, and neither could we when triaging (this came up chasing whether an install had carried a specific fix).

## How

A WebUI is deployed two ways, and each now stamps a version:

- **Firmware image** — `tools/build-dist.sh` writes `www/.version` into the built payload from git (`<ref>+<sha>, <date>`), best-effort. A build with no git checkout ships no stamp, and the Dashboard says `unknown` rather than a wrong answer. The stamp is marked `-dirty` when the packaged paths differ from `HEAD`, since the payload is copied from the working tree.
- **`updatewebui`** — resolves the branch to its exact commit, fetches *that commit's* archive, and records the same commit (`<branch>+<sha>, <date>`), degrading to `<branch>, <date>` when the commit can't be resolved (offline, rate limited) — never a guessed SHA. A `--url` install records its source with any credentials/query stripped. Written to `/etc/webui/webui.version` (temp + rename, so a partial write can't win), on both the normal and "already up to date" install paths, and removed on `--restore` along with the per-boot cache.
- **`common.cgi`** reads it in `update_caminfo`, preferring `updatewebui`'s record over the image's own `www/.version` (an install hides the image copy without replacing it), testing it non-empty, and restricting it to a printable version-string subset before it is cached into the shell-sourced sysinfo file and rendered.
- **`dashboard.cgi`** adds a `WebUI` row to the Device panel, `unknown` when neither stamp exists.

`scr_version` is bumped 7→8 so the installer hand-over runs the new `write_version` step on the install that *delivers* it, rather than the run after.

## Verification

Exercised end-to-end on a lab HiSilicon camera deployed through `updatewebui`: the Device panel gains a `WebUI` row in the same `<ref>+<sha>, <date>` format as the Majestic line, and shows `unknown` when no stamp is present. The stamp block, the GitHub-API SHA resolution, the credential/query stripping, the injection-safe sanitiser, and the `-dirty` marker were each checked directly; `write_version` confirmed to run on the delivering install once the hand-over forwards to the bumped installer. `npm test` passes; template lint's structural checks pass.
