### PR TITLE
update: name the flash steps apart from the bar's own passes (#426)

### DIFF
--- a/www/cgi-bin/update.cgi
+++ b/www/cgi-bin/update.cgi
@@ -425,16 +425,23 @@
 						<div id="fw-bar" class="progress" role="progressbar"
 						     aria-valuemin="0" aria-valuemax="100"><div class="progress-bar"></div></div>
 					</div>
-					<%# "Erasing settings" is the overlay wipe, and it is here because
-					    the bar now reports it: without a row of its own the strip
-					    would say "Rebooting" while the bar said the overlay was
-					    being erased. update.js hides it unless this run asked for
-					    the wipe. %>
+					<%# The step names deliberately avoid the words the bar's own
+					    passes use -- "Erasing", "Writing", "Verifying" -- so the
+					    strip and the bar under it never show the same word meaning
+					    two different things: a step "Writing kernel" above a bar
+					    reading "Writing 40%" read as one thing said twice (#426).
+					    So the flash steps say "Update", and the pre-flash image
+					    check is "Checking image" rather than a second "Verifying".
+					    "Erasing settings" is the overlay wipe, here because the bar
+					    now reports it: without a row of its own the strip would say
+					    "Rebooting" while the bar said the overlay was being erased;
+					    it names what is erased, which the bar's bare "Erasing" does
+					    not. update.js hides it unless this run asked for the wipe. %>
 					<ol id="fw-steps" class="mj-steps">
 						<li data-step="download">Downloading</li>
-						<li data-step="verify">Verifying</li>
-						<li data-step="kernel">Writing kernel</li>
-						<li data-step="rootfs">Writing rootfs</li>
+						<li data-step="verify">Checking image</li>
+						<li data-step="kernel">Update kernel</li>
+						<li data-step="rootfs">Update rootfs</li>
 						<li data-step="overlay">Erasing settings</li>
 						<li data-step="reboot">Rebooting</li>
 					</ol>


### PR DESCRIPTION
Follow-up to the progress display (#426), addressing usa-'s feedback on the step names.

The progress strip and the bar beneath it could show the **same word meaning two different things**:

- the step **"Writing kernel"** sat above a bar reading **"Writing kernel 40%"**, and
- the step **"Verifying"** (the pre-flash image check) shared its word with the bar's per-partition **"Verifying"** pass.

Read together, they looked like one thing said twice.

## Change

Name each step for the whole phase it covers, not the pass currently in flight:

| step | before | after |
|---|---|---|
| verify | Verifying | **Checking image** |
| kernel | Writing kernel | **Update kernel** |
| rootfs | Writing rootfs | **Update rootfs** |

The bar keeps reporting the pass it is actually running (`Erasing` / `Writing` / `Verifying`), now unambiguous beneath a step that no longer echoes it. Downloading, "Erasing settings" (the overlay wipe — it names *what* is erased, unlike the bar's bare "Erasing") and Rebooting are unchanged.

On usa-'s question about the check step: it's the pre-flash image validation and is worth keeping — renaming it to **"Checking image"** both says what it does and stops it colliding with the flash-verify pass. I kept the nested step→bar structure rather than flattening to nine rows, since the grouping is what tells you which partition a pass belongs to.

The step names are display-only — progression keys on `data-step` — so nothing in the driver changes.
