### PR TITLE
live: keep the WebRTC tap-to-play retry armed until the picture actually plays (#317)

### DIFF
--- a/tests/talkback.test.js
+++ b/tests/talkback.test.js
@@ -279,9 +279,13 @@ async function playRetriesOnGesture() {
 	// first user gesture rather than leave it paused for ever.
 	const env = makeEnv();
 	let plays = 0, reject = true;
+	const vh = {};
 	const video = {
 		muted: true, volume: 1, srcObject: null,
 		play() { plays++; return reject ? Promise.reject({ name: 'NotAllowedError' }) : Promise.resolve(); },
+		addEventListener(ev, fn) { (vh[ev] = vh[ev] || []).push(fn); },
+		removeEventListener(ev, fn) { vh[ev] = (vh[ev] || []).filter((f) => f !== fn); },
+		fire(ev) { (vh[ev] || []).slice().forEach((f) => f({ target: this })); },
 	};
 	env.MajesticWebRTC.attach(video, {});
 	await tick();
@@ -290,7 +294,7 @@ async function playRetriesOnGesture() {
 	env.pcs[0].ontrack({ streams: [{}], track: { kind: 'video' } });
 	await tick();
 	check('play() was attempted and refused', plays === 1, plays + ' plays');
-	check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
+	check('a gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
 		JSON.stringify(Object.keys(env.docHandlers)));
 	// A second attempt (as a reconnect would make) is also refused: it must
 	// re-arm afresh, not be blocked by the first arming nor stack a second
@@ -300,22 +304,35 @@ async function playRetriesOnGesture() {
 	check('play() attempted again', plays === 2, plays + ' plays');
 	check('still exactly one retry (re-armed, not stacked or blocked)',
 		(env.docHandlers.pointerdown || []).length === 1);
-	// The viewer taps: play() is retried, and this time it is allowed.
+	// The viewer taps: play() is retried, and this time it is allowed. The retry
+	// is NOT removed on the tap -- only the picture actually starting takes it
+	// down, so a tap that does not start it (below) can be followed by another.
 	reject = false;
 	env.docHandlers.pointerdown[0]();
 	check('play() was retried on the gesture', plays === 3, plays + ' plays');
-	check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
+	check('the retry stays armed until the picture plays',
+		(env.docHandlers.pointerdown || []).length === 1);
+	video.fire('playing');
+	check('once it plays the listener is removed', (env.docHandlers.pointerdown || []).length === 0);
 }
 
 async function playResolvesButStaysPaused() {
-	group('a muted video whose play() resolves but stays paused still retries on a gesture (#317, Opera)');
+	group('a muted video whose play() resolves but stays paused keeps retrying across taps (#317, Opera)');
 	// Opera for Android resolves play() without starting playback: the .catch
-	// never runs, so only the paused-state observer can save it.
+	// never runs, so only the paused-state observer can save it -- and, the
+	// reporter's case, the TAP's play() no more starts the picture than autoplay
+	// did. A one-shot retry would remove itself on that first dead tap and leave
+	// every later tap doing nothing, the picture parked under an affordance it
+	// cannot dismiss. The retry must stay armed until the picture truly plays.
 	const env = makeEnv();
 	let plays = 0;
+	const vh = {};
 	const video = {
 		muted: true, volume: 1, srcObject: null, paused: true,
 		play() { plays++; return Promise.resolve(); },   // resolves, yet paused stays true
+		addEventListener(ev, fn) { (vh[ev] = vh[ev] || []).push(fn); },
+		removeEventListener(ev, fn) { vh[ev] = (vh[ev] || []).filter((f) => f !== fn); },
+		fire(ev) { (vh[ev] || []).slice().forEach((f) => f({ target: this })); },
 	};
 	env.MajesticWebRTC.attach(video, {});
 	await tick();
@@ -329,9 +346,21 @@ async function playResolvesButStaysPaused() {
 	check('a gesture retry armed from the observed paused state',
 		(env.docHandlers.pointerdown || []).length === 1,
 		JSON.stringify((env.docHandlers.pointerdown || []).length));
-	video.paused = false;
+	// The viewer taps, but the picture still does not start (paused stays true).
+	// The retry must NOT remove itself.
 	env.docHandlers.pointerdown[0]();
 	check('the tap retried play()', plays === 2, plays + ' plays');
+	check('and the retry is still armed for the next tap',
+		(env.docHandlers.pointerdown || []).length === 1,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
+	// A second tap retries again; when the picture finally starts, its own
+	// 'playing' event is what takes the retry down.
+	env.docHandlers.pointerdown[0]();
+	check('a second tap retried again', plays === 3, plays + ' plays');
+	video.paused = false;
+	video.fire('playing');
+	check('once it plays the retry is removed', (env.docHandlers.pointerdown || []).length === 0,
+		JSON.stringify((env.docHandlers.pointerdown || []).length));
 }
 
 async function playbackStartsArmsNothing() {

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -117,8 +117,18 @@ window.MajesticWebRTC = (function () {
 			// the listeners without ever playing -- leaving the picture paused.
 			disarmGesture();
 			const retry = function () {
-				disarmGesture();
-				if (alive && !alive()) return;
+				// A dead attempt's stale retry takes itself down; a live one does
+				// NOT disarm on the tap. On a browser that resolves play() without
+				// starting the picture -- Opera for Android, the same quirk the
+				// paused-state observer exists for -- the tap's play() no more
+				// starts it than autoplay did, and a one-shot retry would remove
+				// itself on that first dead tap and leave every later tap doing
+				// nothing, the picture parked under a ▶ affordance that cannot
+				// dismiss it (#317). Stay armed and keep retrying; the element's
+				// own 'playing' event (onPlaying) is what disarms, once the
+				// picture truly moves -- exactly as the MSE player re-tries on
+				// each frame until it plays.
+				if (alive && !alive()) { disarmGesture(); return; }
 				try { const p = v.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
 			};
 			gestureRetry = retry;
@@ -142,9 +152,13 @@ window.MajesticWebRTC = (function () {
 		// the button was already up, takes it down.
 		function onPlaying() {
 			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
+			// Playback truly started, so the gesture-retry has done its job and
+			// comes down here -- whether or not the affordance was ever announced.
+			// This, not the tap, is what disarms: a tap on a browser that does not
+			// start the picture must leave the retry armed for the next one (#317).
+			disarmGesture();
 			if (!gestureArmed) return;
 			gestureArmed = false;
-			disarmGesture();
 			onState('resumed');
 		}
 		try { video.addEventListener('playing', onPlaying); } catch (e) {}


### PR DESCRIPTION
Addresses the remaining WebRTC half of #317: after a reload, tapping the ▶️ affordance still didn't start the picture — the reporter's *"unsuccessfully tapping the ▶️ button instead of an empty area."*

## Cause

The gesture retry disarmed itself the instant it fired, **before** `play()` could be shown to have started:

```js
const retry = function () {
    disarmGesture();          // ← removes every listener on the tap
    if (alive && !alive()) return;
    try { v.play()... } catch (e) {}
};
```

On a browser that resolves `play()` without actually starting the muted picture — Opera for Android, the exact quirk the paused-state observer already exists for — the first tap removed all the listeners *and* failed to start playback. Every later tap then did nothing: the picture sat parked under a ▶️ affordance that could no longer dismiss it. (The MSE player never had this: a paused frame re-arms its retry every time until one plays.)

## Fix

Disarm on the element's own `'playing'` event, never on the tap. Each tap retries `play()`, and the listeners stay armed until the picture truly moves — the same shape the MSE player already uses. `onPlaying` now takes the listeners down whether or not the affordance was announced, so a picture that starts before the announce debounce leaves nothing armed either.

## Verification

A unit test models the resolves-but-stays-paused element and taps twice before it plays: both taps retry `play()`, the retry stays armed across the dead taps, and only the `'playing'` event disarms it. Existing gesture/`resumed`/no-flash/no-Chrome-regression tests still pass; full `npm test` green.

**Honest limitation:** I could not reproduce this in a lab browser — Chrome and desktop Safari always grant muted autoplay, so the parked state never arises there. The fix is proven by code inspection and the test that reproduces the documented Opera behavior, not a live Opera-Android run. I've asked the reporter to confirm on their device.
