### PR TITLE
restart: ask on a GET, reboot only on a POST (#442)

### DIFF
--- a/tests/notice.test.js
+++ b/tests/notice.test.js
@@ -176,14 +176,22 @@ group('one vocabulary for the actions, wherever they are written');
 // like one: every action is a button, and the colour says what pressing costs.
 // btn-primary goes to the page that fixes the finding, btn-secondary is a
 // second diagnostic destination beside it, and btn-danger is the press that
-// acts on the camera rather than going anywhere — today one href, restart.cgi,
-// which reboots on GET.
+// acts on the camera rather than going anywhere — today one destination,
+// restart.cgi.
 //
 // btn-danger is the load-bearing one. main.js hangs its confirm() off
 // .btn-danger and .btn-warning, so wearing that class is a promise that
 // pressing does something worth asking about; the recordings banner wore it
 // over a plain navigation and came within one initAll() timing accident of
 // asking "Are you sure?" before letting somebody read a page.
+//
+// An acting action is also not an ANCHOR, and that half is newer (#442). A
+// confirm() on a `click` listener guards one gesture and not a link: a middle
+// click delivers `auxclick` and never `click`, and "Open link in new tab"
+// delivers nothing at all, so an acting anchor is followed without the
+// question by two things people do to menu items every day. Every acting
+// action submits a form instead, and restart.cgi refuses to reboot on
+// anything but a POST, so the two halves cannot disagree.
 //
 // The rule is worth a test rather than a paragraph because it is written in
 // three languages at once — a haserl argument, hand-written .mj-notice-acts
@@ -299,15 +307,27 @@ const groups = walk(WWW).flatMap((f) =>
 
 const found = [];
 groups.forEach((g) => {
-	const re = /<a\b([^>]*)>([\s\S]*?)<\/a>/g;
+	// Both shapes: a destination is an <a> naming its page in href, an action
+	// is a <button> whose page is the action of the form around it. Reading
+	// only anchors would leave the scan blind to every acting call site, which
+	// is the half of the rule it most needs to cover.
+	const re = /<(a|button)\b([^>]*)>([\s\S]*?)<\/\1>/g;
 	let a;
 	while ((a = re.exec(g.html))) {
-		const attrs = a[1], text = a[2].trim();
+		const tag = a[1], attrs = a[2], text = a[3].trim();
 		const cls = (/\bclass="([^"]*)"/.exec(attrs) || ['', ''])[1].split(/\s+/);
-		const href = (/\bhref="([^"]*)"/.exec(attrs) || ['', ''])[1];
-		const page = href.split(/[?#]/)[0].replace(/^.*\//, '');
+		let target;
+		if (tag === 'a') {
+			target = (/\bhref="([^"]*)"/.exec(attrs) || ['', ''])[1];
+		} else {
+			const open = g.html.lastIndexOf('<form', a.index);
+			target = open < 0 ? ''
+				: (/\baction="([^"]*)"/.exec(g.html.slice(open, a.index)) || ['', ''])[1];
+		}
+		const page = target.split(/[?#]/)[0].replace(/^.*\//, '');
 		const where = g.file + ': ' + a[0];
 		const has = (c) => cls.indexOf(c) >= 0;
+		const acts = ACTS_ON_CAMERA.has(page);
 		found.push(g.file + ' ' + page + ' "' + text + '"');
 
 		check(page + ' in ' + g.file + ' is a button', has('btn'),
@@ -315,10 +335,19 @@ groups.forEach((g) => {
 
 		// The confirm() class, spent only where pressing really does something.
 		check(page + ' in ' + g.file + ' asks before it acts, or does not claim to',
-			(has('btn-danger') || has('btn-warning')) === ACTS_ON_CAMERA.has(page),
-			ACTS_ON_CAMERA.has(page)
+			(has('btn-danger') || has('btn-warning')) === acts,
+			acts
 				? where + '\n    acts on the camera without the class that asks first'
 				: where + '\n    navigation wearing the class main.js hangs confirm() off');
+
+		// And it submits rather than links, so the gestures a click listener
+		// never hears cannot reach it either.
+		check(page + ' in ' + g.file + ' submits rather than links, or has nothing to submit',
+			(tag === 'button') === acts,
+			acts
+				? where + '\n    an acting anchor: middle-click and open-in-new-tab ' +
+					'follow it without the question'
+				: where + '\n    plain navigation written as a form submit');
 
 		// An arrow said what the button shape already says, so it went (#347).
 		// Pinned so it cannot creep back one banner at a time.

--- a/tests/video-check.test.js
+++ b/tests/video-check.test.js
@@ -140,15 +140,16 @@ group('what it does say');
 		hold(st, sample({ venc_empty_frames_run: 40 }), 2), null);
 	check('a stalled encoder is a finding', !!stall && stall.code === 'stall');
 	check('and it offers a restart', !!stall && /restart\.cgi/.test(stall.act.href));
-	// The banner this replaced carried .confirm + data-confirm, which main.js
-	// wires at load — and the anchor it lands on now is written at runtime, so
-	// that wiring would never see it. The prompt travels with the action
-	// instead, or one click restarts the camera.
-	check('and restarting asks first',
-		!!stall && typeof stall.act.confirm === 'string' &&
-		/Restart the camera/.test(stall.act.confirm));
-	check('while a settings link does not ask',
-		!!off && !off.act.confirm);
+	// A finding names a destination and nothing more. It used to carry the
+	// prompt too, because the anchor it lands on is written at runtime and
+	// main.js wires `.confirm` at load, so neither consumer could borrow that
+	// wiring — and a confirm() on a `click` listener guards one gesture rather
+	// than a link anyway. restart.cgi asks for itself now, refusing to reboot
+	// on anything but a POST (#442), so a prompt here would be a second
+	// question asked about the same press.
+	check('no finding carries a prompt of its own any more',
+		[stall, off].every((f) => !f || f.act.confirm === undefined),
+		'a finding still carries a confirm the destination now asks for itself');
 
 	const tr = vc.tracker();
 	const blind = vc.diagnose(BOTH_ON, sample(BLIND), hold(tr, sample(BLIND), 12), null);

--- a/www/a/dashboard.js
+++ b/www/a/dashboard.js
@@ -158,16 +158,11 @@
 			if (t) t.textContent = f.title;
 			if (d) d.textContent = f.detail;
 			if (a) {
+				// A destination and its words, and nothing else to wire: a
+				// finding's action no longer carries a prompt, because the one
+				// action that costs anything asks for itself on arrival (#442).
 				a.textContent = f.act.label;
 				a.href = f.act.href;
-				// Assigned, not added: this anchor is rewritten on every
-				// finding and addEventListener would stack a prompt per
-				// repaint. main.js cannot help here — it wires `.confirm` once
-				// at load and this link does not exist in its final form until
-				// long after.
-				a.onclick = f.act.confirm
-					? (ev) => { if (!confirm(f.act.confirm)) ev.preventDefault(); }
-					: null;
 			}
 			const h = $('#st-alert-novideo-h');
 			if (h) {

--- a/www/a/preview-health.js
+++ b/www/a/preview-health.js
@@ -107,14 +107,11 @@
 		if (!f) { alertEl.style.display = 'none'; return; }
 		if (alertWhy) alertWhy.textContent = f.title + ' — ' + f.detail;
 		if (alertAct) {
+			// A destination and its words. The prompt that used to be wired
+			// here went with the one in the Dashboard's copy: restart.cgi asks
+			// for itself now, on anything that is not a POST (#442).
 			alertAct.textContent = f.act.label + ' →';
 			alertAct.href = f.act.href;
-			// Assigned rather than added, so a repaint replaces the prompt
-			// instead of stacking another one. See the same line in status.js:
-			// main.js wires `.confirm` at load and this link is written later.
-			alertAct.onclick = f.act.confirm
-				? (ev) => { if (!confirm(f.act.confirm)) ev.preventDefault(); }
-				: null;
 		}
 		if (alertHelp) {
 			alertHelp.hidden = !f.help;

--- a/www/a/video-check.js
+++ b/www/a/video-check.js
@@ -179,18 +179,16 @@
 				title: 'The encoder has stopped',
 				detail: 'The camera is running, but the encoder has stopped ' +
 					'producing frames while everything else looks alive.',
-				// The confirmation travels WITH the action, because the anchor
-				// it lands on is written at runtime and main.js wired
-				// `.confirm` once at load — so the class the banner this
-				// replaced carried would never have been seen, and the link
-				// restarted the camera on one click. Whoever renders a finding
-				// is responsible for asking; both consumers do.
-				act: {
-					href: 'restart.cgi', label: 'Restart camera',
-					confirm: 'Restart the camera now?\n\nSettings are kept. ' +
-						'Video and recording stop for about half a minute ' +
-						'while it comes back.',
-				},
+				// No prompt travels with this action, and it used to. The
+				// anchor a finding lands on is written at runtime, long after
+				// main.js wired `.confirm` at load, so neither consumer could
+				// borrow that wiring and each carried its own confirm() —
+				// which covered a left click and none of the other ways a link
+				// gets followed. restart.cgi asks for itself now: reaching it
+				// with anything but a POST renders the question rather than
+				// rebooting (#442). A finding points at a destination; what
+				// that destination costs is the destination's to ask.
+				act: { href: 'restart.cgi', label: 'Restart camera' },
 				help: HELP,
 			};
 		}

--- a/www/cgi-bin/camera.cgi
+++ b/www/cgi-bin/camera.cgi
@@ -100,7 +100,7 @@ fi
     plain text rather than a link, about a daemon that has stopped. The log is
     where majestic says why it died -- and it is what an owner can screenshot
     for whoever sold them the camera -- and a restart is the thing to try. %>
-<% notice danger '<b>Majestic is not running</b> &mdash; the daemon that streams the video and answers for every setting on this page is stopped, so there is nothing here to configure.' '<a class="btn btn-sm btn-secondary" href="logs.cgi">Open the log</a><a class="btn btn-sm btn-danger" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. The camera is unreachable for about half a minute while it comes back.">Restart camera</a>' %>
+<% notice danger '<b>Majestic is not running</b> &mdash; the daemon that streams the video and answers for every setting on this page is stopped, so there is nothing here to configure.' '<a class="btn btn-sm btn-secondary" href="logs.cgi">Open the log</a><form method="post" action="restart.cgi" class="d-inline"><button type="submit" class="btn btn-sm btn-danger confirm" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. The camera is unreachable for about half a minute while it comes back.">Restart camera</button></form>' %>
 
 <% else %>
 

--- a/www/cgi-bin/p/common.cgi
+++ b/www/cgi-bin/p/common.cgi
@@ -379,10 +379,18 @@ log_create() {
 #
 # The last one is not decoration. main.js hangs its confirm() off .btn-danger
 # and .btn-warning, so that class is a promise that pressing does something
-# worth asking about; today exactly one href earns it, restart.cgi, which
-# reboots the camera on GET. Putting it on a link that merely navigates is how
-# the recordings banner came within one initAll() timing accident of asking
-# "Are you sure?" before letting somebody read a page.
+# worth asking about; today exactly one destination earns it, restart.cgi.
+# Putting it on a link that merely navigates is how the recordings banner came
+# within one initAll() timing accident of asking "Are you sure?" before letting
+# somebody read a page.
+#
+# An action that earns it is also written as a form submit rather than an
+# anchor, because that confirm() guards one gesture and not a link: a middle
+# click delivers `auxclick` and never `click`, and "Open link in new tab"
+# delivers nothing, so an acting anchor is followed without the question by two
+# things people do to menu items every day (#442). restart.cgi refuses to
+# reboot on anything but a POST, which is the half of that pair no markup here
+# can get wrong.
 #
 # The vocabulary drifted once already, because it is written in three languages
 # -- this argument, hand-written .mj-notice-acts markup, and an `acts:` literal

--- a/www/cgi-bin/p/header.cgi
+++ b/www/cgi-bin/p/header.cgi
@@ -322,7 +322,7 @@ if { [ -f /etc/crash/pending ] || [ -f /etc/crash/failsafe ]; } && [ "$pagename"
     where a flag would go on saying "waiting for a restart" about a change
     that had since been undone. %>
 <% if [ -e /tmp/system-reboot ] || [ -n "$restart_pending" ]; then %>
-<% notice warn '<b>Settings are waiting for a restart</b> &mdash; video and recording stop for about half a minute while the camera comes back.' '<a class="btn btn-sm btn-danger" href="restart.cgi" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</a>' %>
+<% notice warn '<b>Settings are waiting for a restart</b> &mdash; video and recording stop for about half a minute while the camera comes back.' '<form method="post" action="restart.cgi" class="d-inline"><button type="submit" class="btn btn-sm btn-danger confirm" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</button></form>' %>
 <% fi %>
 
 <% if [ -z "$hide_title" ]; then %><h2><%= $page_title %></h2><% fi %>

--- a/www/cgi-bin/restart.cgi
+++ b/www/cgi-bin/restart.cgi
@@ -4,7 +4,21 @@ Cache-Control: no-store
 Pragma: no-cache
 
 <!DOCTYPE html>
-<!-- Not escaped, and the include that would make escaping possible is not
+<!-- Two pages in one file, chosen by method. A POST reboots the camera and
+     renders the waiting screen below; anything else renders the question, with
+     a button that POSTs.
+
+     That split IS the protection, and nothing lighter was enough (#442). The
+     confirmation used to live entirely in the browser, as a confirm() main.js
+     hung off the `click` event of the links that offer this page -- which
+     covers a plain left click and nothing else. Measured in a real browser: a
+     middle click delivers `auxclick` and never `click`, and "Open link in new
+     tab" delivers no event at all, so both reached this page and rebooted the
+     camera without asking. A prefetcher, a crawler, a restored tab, a typed
+     URL and a client with JavaScript off all did the same. A GET cannot now
+     reach the reboot at all, whoever sends it and however it was sent.
+
+     Not escaped, and the include that would make escaping possible is not
      wanted here. This page carries no includes at all: it runs reboot below and
      has to render while the system is going down, so it pulls in no auth gate
      and sources nothing. That also means webui_theme is never set on this page
@@ -65,6 +79,23 @@ Pragma: no-cache
 		<h1>OpenIPC</h1>
 		<%# a plain heading on purpose: this page carries no includes, so the
 		    card_head helper does not exist here %>
+<% if [ "$REQUEST_METHOD" != "POST" ]; then %>
+		<%# The question. Answered with 200 rather than refused with 405: this
+		    is where an old bookmark, a shared link and every gesture that is
+		    not a plain click now arrive, and the useful thing to hand somebody
+		    who meant to restart the camera is the button, not an error. The
+		    ones that did not mean it -- a prefetch, a crawler -- read a page
+		    and leave, which is all they ever wanted. %>
+		<h3>Restart the camera?</h3>
+		<p class="lead">Settings are kept. Video and recording stop for about
+			half a minute while it comes back.</p>
+		<form method="post" action="restart.cgi">
+			<button type="submit" class="btn btn-danger btn-lg">Restart camera</button>
+		</form>
+	</main>
+</body>
+</html>
+<% exit 0; fi %>
 		<h3>Restarting. Please wait...</h3>
 		<progress max="20" value="0"></progress>
 	</main>

--- a/www/cgi-bin/wfb.cgi
+++ b/www/cgi-bin/wfb.cgi
@@ -409,7 +409,7 @@ update_wfbinfo
             </form>
             <hr class="my-3">
             <p class="small text-secondary mb-2">Reboot to apply new WFB settings.</p>
-            <a class="btn btn-sm btn-outline-secondary confirm" href="restart.cgi">Restart camera</a>
+            <form method="post" action="restart.cgi" class="d-inline"><button type="submit" class="btn btn-sm btn-outline-secondary confirm" data-confirm="Restart the camera now?&#10;&#10;Settings are kept. Video and recording stop for about half a minute while it comes back.">Restart camera</button></form>
         </div></div>
     </div>
 


### PR DESCRIPTION
Fixes #442.

## The problem

`restart.cgi` rebooted the camera while rendering, on **any** request method,
and the confirmation standing in front of it lived entirely in the browser — a
`confirm()` that `main.js` hangs off the `click` event of the links offering
the page.

That guards one gesture, not a link. Measured in a real browser against a
camera:

| how the link is followed | event delivered | reached the reboot |
|---|---|---|
| left click | `click` | no — asked first |
| **middle click** | `auxclick` | **yes, unasked** |
| **Open link in new tab** | none | **yes, unasked** |
| prefetch / crawler / restored tab / typed URL | none | **yes, unasked** |
| JavaScript unavailable | none | **yes, unasked** |

## What changed

The page is two pages chosen by method. A `POST` reboots and renders the
waiting screen it always did; anything else renders the question, with a button
that POSTs. **A GET cannot reach the reboot**, whoever sends it and however it
was sent.

It answers with **200 and a question rather than 405**, because of who arrives
there: old bookmarks, shared links, and every gesture that is not a plain left
click. The useful thing to hand somebody who meant to restart the camera is the
button. A prefetch reads a page and leaves, which is all it wanted.

## The call sites divide by what they are

**Buttons** submit a form now and keep their prompt, so the common paths stay
one click — the System menu entry, the pending-changes banner, the notice
`camera.cgi` raises when majestic is stopped, and the one under WFB's save
form.

**Actions written at runtime** stay plain links and land on the question. That
half deletes more than it adds: a `video-check.js` finding carried its own
`confirm` string, and `dashboard.js` and `preview-health.js` each wired it onto
an anchor by hand, because the anchor is written long after `main.js` wires
`.confirm` at load. None of it is needed once the destination asks for itself.
A finding names a destination; what the destination costs is the destination's
to ask.

## Tests

`notice.test.js` reads `<button>` actions as well as `<a>` — taking the page
from the form around them — and holds the other half of the rule: **an acting
action submits rather than links**. Reading only anchors would have left it
blind to every acting call site, which is the half it most needs to cover;
`nav-confirm.test.js` had the same trap when it was written.

`video-check.test.js`'s "and restarting asks first" becomes "no finding carries
a prompt of its own any more".

`p/common.cgi`'s action-vocabulary note said restart.cgi "reboots the camera on
GET", which is no longer true, and now carries the reason an acting action is a
form.

## Verified on a camera

In a real browser:

* `GET /cgi-bin/restart.cgi` renders **Restart the camera?** with a POST form
  and no progress bar — nothing in flight — and the uptime keeps climbing;
* `POST` reboots, uptime resets, the camera comes back;
* the Dashboard carries one restart **form** and zero restart **anchors**;
* pressing the menu entry and declining leaves you where you were;
* with the pending-restart flag set, the banner renders the form-and-button
  shape the test now expects.

Full suite green, no CSS drift, template lint clean.
