### PR TITLE
update: let the flash progress bar span the card, not a 34rem strip (#426)

### DIFF
--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -6120,9 +6120,9 @@ dialog.mj-modal::backdrop {
 .mj-meter {
 	margin-top: 0.875rem;
 	/* No width cap: the bar spans the card, so the number it carries is easier
-	   to follow across a wide screen than a 34rem bar stranded mid-row was
-	   (#426). The step strip below sets the readable measure; the bar is a gauge,
-	   not prose, and wants the room. */
+	   to follow across a wide screen than a 34rem bar stranded mid-row was. The
+	   step strip below sets the readable measure; the bar is a gauge, not prose,
+	   and wants the room. */
 }
 
 .mj-meter-head {

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -6119,7 +6119,10 @@ dialog.mj-modal::backdrop {
    that keeps falling back to the start. */
 .mj-meter {
 	margin-top: 0.875rem;
-	max-width: 34rem;
+	/* No width cap: the bar spans the card, so the number it carries is easier
+	   to follow across a wide screen than a 34rem bar stranded mid-row was
+	   (#426). The step strip below sets the readable measure; the bar is a gauge,
+	   not prose, and wants the room. */
 }
 
 .mj-meter-head {


### PR DESCRIPTION
Follow-up to #426, addressing usa-'s suggestion: make the flash progress bar full-width.

The meter that carries the bar was capped at `max-width: 34rem`, so on a wide screen the bar sat mid-row at under half the width while the step strip and headline ran full width beside it — the gauge was the hardest thing on the page to follow.

Drop the cap. The bar is a gauge, not prose, so the readable-measure the step strip wants doesn't apply to it; it now fills the card, aligned under the headline. `.mj-meter` is used only on this page, so nothing else is affected.

(The bar sits in the hero text column, so it aligns with the headline rather than starting under the icon — a small left offset, which reads as intentional alignment. If edge-to-edge under the icon is wanted too, that's a one-line follow-up.)
