### PR TITLE
ircut: say how to see which coil is which, not which source says so

### DIFF
--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -433,10 +433,10 @@ group('run: it finds the pair, and only the pair');
 	// was inverted (#273).
 	//
 	// It is invisible by construction. A swapped label renders perfectly and
-	// reads plausibly; the only way to know is to watch a camera — switch it to
-	// night and irCutPin1 is the pad that goes high, while night is the filter
-	// swung out of the light path. So the check is written here, where the
-	// measurement is, rather than trusted to a reader of either file alone.
+	// reads plausibly; the only way to know is to watch a camera — with both
+	// coils assigned, switching to night raises irCutPin1, and night is the
+	// filter swung out of the light path. So the check is written here, where
+	// the measurement is, rather than trusted to a reader of either file alone.
 	function eleventh() {
 		group('the measured pad and the name on its field are one fact');
 		const map = require(path.join(__dirname, '..', 'www', 'a', 'ircut-map.js'));

--- a/tests/ircut-scan.test.js
+++ b/tests/ircut-scan.test.js
@@ -433,8 +433,8 @@ group('run: it finds the pair, and only the pair');
 	// was inverted (#273).
 	//
 	// It is invisible by construction. A swapped label renders perfectly and
-	// reads plausibly; the only way to know is majestic's own source, where
-	// double_ircut_set(night) raises pin1 for NIGHT, and night is the filter
+	// reads plausibly; the only way to know is to watch a camera — switch it to
+	// night and irCutPin1 is the pad that goes high, while night is the filter
 	// swung out of the light path. So the check is written here, where the
 	// measurement is, rather than trusted to a reader of either file alone.
 	function eleventh() {

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -61,10 +61,17 @@
 	// series set, so a pad and its row in the list always agree.
 	const ROLES = [
 		// Which coil is which is majestic's to say, not ours, and it is the
-		// opposite of what reads naturally from the key names. Switch a camera
-		// to night and the pad named irCutPin1 is the one that goes high —
-		// and night is the filter swung OUT of the light path. So irCutPin1 is
-		// the OPENING coil and irCutPin2 the closing one.
+		// opposite of what reads naturally from the key names. With BOTH coils
+		// assigned — the pair these two labels are about — switching a camera
+		// to night raises irCutPin1 and lowers irCutPin2, and night is the
+		// filter swung OUT of the light path. So irCutPin1 is the OPENING coil
+		// and irCutPin2 the closing one.
+		//
+		// Said of the PAIR deliberately. One assigned coil is a different mode:
+		// the camera then holds that single pad at a level, and the polarity
+		// chip beside it chooses which level means night — so on such a board
+		// night can hold irCutPin1 LOW. A blanket "night raises irCutPin1"
+		// would be false on exactly the cameras this map has to describe.
 		//
 		// Measured, not read, on the 85H50AI these were written against, whose
 		// config is irCutPin1=11 / irCutPin2=10: driving pad 11 high against 10

--- a/www/a/ircut-map.js
+++ b/www/a/ircut-map.js
@@ -61,13 +61,16 @@
 	// series set, so a pad and its row in the list always agree.
 	const ROLES = [
 		// Which coil is which is majestic's to say, not ours, and it is the
-		// opposite of what reads naturally from the key names. night.c drives
-		// pin1 high for NIGHT and pin2 high for DAY (double_ircut_set(night):
-		// set_gpio(pin1, night); set_gpio(pin2, !night)), and night is the
-		// filter swung OUT of the light path. So pin1 is the opening coil and
-		// pin2 the closing one. Measured on the 85H50AI these were written
-		// against: pad 11 driven high opens, pad 10 closes, and its config is
-		// irCutPin1=11 / irCutPin2=10.
+		// opposite of what reads naturally from the key names. Switch a camera
+		// to night and the pad named irCutPin1 is the one that goes high —
+		// and night is the filter swung OUT of the light path. So irCutPin1 is
+		// the OPENING coil and irCutPin2 the closing one.
+		//
+		// Measured, not read, on the 85H50AI these were written against, whose
+		// config is irCutPin1=11 / irCutPin2=10: driving pad 11 high against 10
+		// turns a daylight picture magenta, and driving pad 10 high against 11
+		// gives the colour back. Anyone can repeat that on their own camera,
+		// which is the point of writing it down this way round.
 		//
 		// They were the wrong way round here for a release. Nothing broke,
 		// because the labels only name what the fields already do -- but every


### PR DESCRIPTION
Pre-existing debt, found while checking a compliance finding on an earlier
change in this series.

Two comments had sat in the tree for months naming the daemon's IR-cut drive
routine and quoting two lines of it:

- `www/a/ircut-map.js` — named the source file, the routine, and quoted the two
  statements it makes
- `tests/ircut-scan.test.js` — *"the only way to know is majestic's own source,
  where …"*

That is compliance rule 1. This repository is public and the daemon's is not, so
the citation is a pointer the reader cannot follow, attached to internals they
were not meant to have — and it dates badly: rename the routine and the sentence
can no longer be checked by anyone at all.

Nothing had caught them because **the review bot reads a diff, and these were
already in**. They surfaced only when the same rule was raised against new text.

## What replaces them

The fact they were carrying is worth keeping, and it is observable from outside
the camera anyway — which is exactly what the rule's success criteria ask for:

> With **both coils assigned** — the pair these two labels are about — switching
> a camera to night raises `irCutPin1` and lowers `irCutPin2`, and night is the
> filter swung OUT of the light path. So `irCutPin1` is the OPENING coil and
> `irCutPin2` the closing one.

Stated of the **pair** deliberately. One assigned coil is a different mode: the
camera holds that single pad at a level and the polarity chip chooses which level
means night, so on such a board night can hold `irCutPin1` **low**. A blanket
"night raises `irCutPin1`" would be false on exactly the cameras this map has to
describe — and that is a live configuration, not a hypothetical.

The measured half stays as measured, now written so the next reader can repeat
it rather than take it on trust: driving pad 11 high against 10 turns a daylight
picture magenta, driving pad 10 high against 11 gives the colour back.

## No lint check comes with this, and that is a finding rather than an omission

I tried to add one to `tools/lint-templates.sh` and took it back out. **"Names a
C source file" is not the same predicate as "points into the private sibling
source."** The tree legitimately cites the public source of the logging daemon
whose timestamp format it parses, and of the vendor PTZ protocol one of the
shipped scripts was ported from — both followable by any reader, both exactly
what the rule permits. A first attempt also fired on `opts.h` and `m.b.h`, which
are ordinary JS properties.

The distinguishing fact — whether the repository being cited is private — is not
in the text, so a mechanical gate here fires on the citations the rule allows,
and a gate with false positives is one people learn to skip. The rule stays with
the reviewer, where `pr_compliance_checklist.yaml` puts it.

The narrow-and-clean half of that rule *is* already mechanised, in the check that
bans the deprecated config reader: it works because its legitimate count is
genuinely zero. This one's is not.

## Verified

Comments only — no behaviour change. Full suite green, `lint-templates.sh`
clean. A sweep for the other classes the rule names (private repository names,
tracker references that do not exist) comes back empty; the `OpenIPC/majestic`
issue references throughout are to the **public** tracker, which the rule
explicitly allows.
