### PR TITLE
live: start on the first tap, and show the snapshot under the button (#317)

### DIFF
--- a/tests/auto-source.test.js
+++ b/tests/auto-source.test.js
@@ -28,7 +28,7 @@ const IDS = [
 	'mj-talk', 'mj-talk-ctl',
 	'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w', 'mj-transport-m', 'mj-transport-m-lbl', 'mj-transport-ctl',
 	'mj-transport-lbl', 'mj-vol',
-	'mj-player', 'mj-stage', 'toggle-ircut', 'toggle-light', 'toggle-night',
+	'mj-player', 'mj-stage', 'mj-tap-play', 'mj-snapshot', 'toggle-ircut', 'toggle-light', 'toggle-night',
 ];
 
 function makeEl(id) {

--- a/tests/preview-socket.test.js
+++ b/tests/preview-socket.test.js
@@ -403,7 +403,7 @@ function load(o) {
 		env.sockets[env.sockets.length - 1].fire('message', { data: { byteLength: 100 } });
 		// The retry arms at once, so a tap works immediately; the announcement is
 		// held back so a picture about to play does not flash the button.
-		check('a one-shot gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
+		check('a gesture retry was armed', (env.docHandlers.pointerdown || []).length === 1,
 			JSON.stringify((env.docHandlers.pointerdown || []).length));
 		check('the affordance is NOT announced immediately', env.states.indexOf('gesture') < 0,
 			env.states.join(','));
@@ -418,16 +418,24 @@ function load(o) {
 		await sleep(600);
 		check('a further paused frame does not re-announce it',
 			env.states.filter((s) => s === 'gesture').length === 1, env.states.join(','));
-		// The viewer taps: play() is called, and this time it starts.
-		env.video.paused = false;
+		// The viewer taps and play() is called, but the retry must NOT remove
+		// itself on the tap: on WebKit the tap's pointerdown may not start the
+		// picture and the same tap's click must still find a listener; only the
+		// picture actually playing takes it down (#317).
 		env.docHandlers.pointerdown[0]();
 		check('the tap called play()', played >= 1, played + ' plays');
-		check('and the one-shot listener removed itself', (env.docHandlers.pointerdown || []).length === 0);
+		check('the retry stays armed until the picture plays',
+			(env.docHandlers.pointerdown || []).length === 1,
+			JSON.stringify((env.docHandlers.pointerdown || []).length));
 		// Only the element's own 'playing' event proves the picture moved; that is
-		// what takes the affordance down, so the page hears 'resumed' then.
+		// what takes the affordance down and disarms, so the page hears 'resumed' then.
 		check('nothing claimed it resumed before it actually played',
 			env.states.indexOf('resumed') < 0, env.states.join(','));
+		env.video.paused = false;
 		env.video.fire('playing');
+		check('the listener is removed once it plays',
+			(env.docHandlers.pointerdown || []).length === 0,
+			JSON.stringify((env.docHandlers.pointerdown || []).length));
 		check('the page was told the picture resumed once it played',
 			env.states.filter((s) => s === 'resumed').length === 1, env.states.join(','));
 		env.player.destroy();

--- a/tests/staging.test.js
+++ b/tests/staging.test.js
@@ -33,7 +33,7 @@ const IDS = [
 	'mj-served', 'mj-served-why', 'mj-sub',
 	'mj-talk', 'mj-talk-ctl', 'mj-talk-lbl', 'mj-talk-t', 'mj-transport-w',
 	'mj-transport-m', 'mj-transport-m-lbl', 'mj-transport-ctl', 'mj-transport-lbl',
-	'mj-vol', 'mj-player', 'mj-stage', 'mj-tap-play',
+	'mj-vol', 'mj-player', 'mj-stage', 'mj-tap-play', 'mj-snapshot',
 	'toggle-ircut', 'toggle-light', 'toggle-night',
 ];
 

--- a/www/a/bootstrap.override.css
+++ b/www/a/bootstrap.override.css
@@ -3131,6 +3131,11 @@ button.mj-osd-chip,
    A tap anywhere on the stage starts playback (the player listens on the
    document); this button is the visible invitation, so it takes the pointer to
    look pressable and passes the gesture straight through. */
+/* The tap-to-play still sits above the (black, paused) video but below the
+   button, so the ▶ reads as being on top of the scene it resumes (#317). */
+#mj-snapshot {
+	z-index: 5;
+}
 .mj-tap-play {
 	position: absolute;
 	top: 50%;

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -31,6 +31,7 @@
 	if (!initial || !window.MajesticVideo) return;
 	const badge = $('#mj-badge'), note = $('#mj-note');
 	const tapPlay = $('#mj-tap-play');
+	const snapshot = $('#mj-snapshot');
 	const noteWhy = $('#mj-note-why'), noteAct = $('#mj-note-act');
 	const servedEl = $('#mj-served'), servedWhy = $('#mj-served-why');
 	let jpegOn = false;
@@ -146,8 +147,20 @@
 	// (#317). Shown on the live player's 'gesture' state and hidden on 'resumed';
 	// also hidden by every path that repaints the stage below, so a stale
 	// invitation cannot outlive the picture it was covering.
-	function showTapPlay() { if (tapPlay) tapPlay.hidden = false; }
-	function hideTapPlay() { if (tapPlay) tapPlay.hidden = true; }
+	// While the button is up, put the camera's current JPEG under it, so a WebRTC
+	// picture parked black (no buffered frame, unlike MSE) shows the scene it is
+	// about to resume rather than a void (#317). Only when jpeg.enabled serves a
+	// snapshot; the src is set on show (cache-busted, so it is current) and
+	// cleared on hide so nothing keeps fetching it. A guarded $ lookup, since the
+	// element is absent in the bare-vm player tests.
+	function showTapPlay() {
+		if (snapshot && jpegOn) { try { snapshot.src = '/image.jpg?t=' + Date.now(); snapshot.hidden = false; } catch (e) {} }
+		if (tapPlay) tapPlay.hidden = false;
+	}
+	function hideTapPlay() {
+		if (snapshot) { snapshot.hidden = true; try { snapshot.removeAttribute('src'); } catch (e) {} }
+		if (tapPlay) tapPlay.hidden = true;
+	}
 
 	function showVideo() {
 		// Not hidden here: 'playing' is the pipeline coming up, which is when a

--- a/www/a/preview-page.js
+++ b/www/a/preview-page.js
@@ -37,6 +37,13 @@
 	let jpegOn = false;
 	mjConfig().then(cfg => {
 		jpegOn = mjGet(cfg, 'jpeg.enabled') === true;
+		// The invitation can be raised before this fetch resolves (attach wins the
+		// config timeout), and showTapPlay only paints the snapshot when jpegOn is
+		// already known true. So if the button is up now and the answer just came
+		// back true, paint it -- otherwise it sits over black for the whole pause (#317).
+		if (jpegOn && tapPlay && !tapPlay.hidden && snapshot) {
+			try { snapshot.src = '/image.jpg?t=' + Date.now(); snapshot.hidden = false; } catch (e) {}
+		}
 		// Read before the fallback is re-decided below: the codec is what says
 		// whether a socket that gave up is worth handing to the software rung,
 		// and that decision has to be made with the real answer.

--- a/www/a/preview-webrtc.js
+++ b/www/a/preview-webrtc.js
@@ -80,7 +80,16 @@ window.MajesticWebRTC = (function () {
 		// later never flashes the button (#317).
 		const GESTURE_ANNOUNCE_MS = 500;
 		let gestureRetry = null, gestureArmed = false, gestureTimer = null;
-		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
+		// 'click' leads the list because it is the event that actually grants a
+		// muted play() on the first tap: a reporter's standalone player starts on
+		// the first tap of a real button (a click handler calling play()), where
+		// this player's pointerdown retry needed a second tap on Opera for Android
+		// (#317). A trusted click is a stronger activation than pointerdown there.
+		// The others stay -- a pointerdown that does start costs nothing, and
+		// keydown covers the keyboard -- and the retry no longer disarms until the
+		// picture truly plays, so one tap firing pointerdown then click just tries
+		// twice and stops at the one that works.
+		const gestureEvs = ['click', 'pointerdown', 'touchstart', 'keydown'];
 		function disarmGesture() {
 			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
 			if (gestureRetry && typeof document !== 'undefined')

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -217,7 +217,14 @@ window.MajesticVideo = (function () {
 			// before the affordance is announced.
 			if (!gestureRetry) {
 				const retry = function () {
-					disarmPlayGesture();
+					// Not disarmed on the tap: on WebKit a pointerdown does not grant
+					// a muted play() but the same tap's trusted click does, and
+					// disarming on the pointerdown would take the click listener down
+					// before it fires -- the click then reaches nothing and playback
+					// waits for another gesture (#317). Stay armed; onPlaying disarms
+					// once the picture truly plays. onBinary re-arms on each paused
+					// frame, and armPlayGesture is a no-op while already armed, so
+					// this does not stack listeners.
 					try { const p = video.play(); if (p && p.catch) p.catch(function () {}); } catch (e) {}
 				};
 				gestureRetry = retry;
@@ -248,9 +255,12 @@ window.MajesticVideo = (function () {
 		// button never shows) and, if the button was already up, takes it down.
 		function onPlaying() {
 			if (gestureTimer) { clearTimeout(gestureTimer); gestureTimer = null; }
+			// Playback truly started, so the retry has done its job and comes down
+			// here rather than on the tap -- a tap that does not start the picture
+			// must leave it armed for the next one (#317).
+			disarmPlayGesture();
 			if (!gestureArmed) return;
 			gestureArmed = false;
-			disarmPlayGesture();
 			onState('resumed');
 		}
 

--- a/www/a/preview.js
+++ b/www/a/preview.js
@@ -208,7 +208,9 @@ window.MajesticVideo = (function () {
 		// state and not a step on the way to playing (#317).
 		const GESTURE_ANNOUNCE_MS = 500;
 		let gestureRetry = null, gestureArmed = false, gestureTimer = null;
-		const gestureEvs = ['pointerdown', 'touchstart', 'keydown'];
+		// 'click' leads: it is the event that actually grants a muted play() on the
+		// first tap on WebKit, where a pointerdown retry needed a second (#317).
+		const gestureEvs = ['click', 'pointerdown', 'touchstart', 'keydown'];
 		function armPlayGesture() {
 			if (typeof document === 'undefined') return;
 			// Arm the retry at once, so the very first tap starts playback even

--- a/www/cgi-bin/p/player.cgi
+++ b/www/cgi-bin/p/player.cgi
@@ -103,6 +103,14 @@ printf '%s' \
 		     other than the on-board one. -->
 		<img id="live-mjpeg" class="mj-stage-media" alt="" style="display:none">
 		<img id="live-mjpeg-b" class="mj-stage-media" alt="" style="display:none">
+		<!-- The still under the tap-to-play button. A WebRTC picture parked
+		     awaiting a gesture is black -- there is no buffered frame to show, as
+		     there is on MSE -- so the button floated over nothing (majestic-webui#317).
+		     preview-page.js points this at the camera's JPEG snapshot while the
+		     button is up (only when jpeg.enabled serves one) and clears it when the
+		     picture plays, so the invitation sits over the scene it will resume.
+		     Hidden until then. -->
+		<img id="mj-snapshot" class="mj-stage-media" alt="" hidden>
 		<!-- Tap-to-play. Some browsers refuse to autoplay even a muted picture
 		     until the page has been interacted with, and Opera for Android parks
 		     it on its first frame without ever rejecting the play() that would


### PR DESCRIPTION
Addresses usa-'s follow-up on #317, adopting the approach from the minimal standalone player they shared.

Two gaps, both fixed the way their player does it:

**First tap.** The gesture-retry listened on the `document` for `pointerdown`, and on WebKit a `pointerdown` does not reliably grant a muted `play()` — so the picture started only on the *second* tap. A trusted **`click`** does grant it (their player is a real button whose click handler calls `play()`, and it starts first-tap). So `'click'` now leads the gesture-event list in both players; combined with the earlier change that keeps the retry armed until the picture truly plays, one tap firing `pointerdown` then `click` just tries twice and stops at the one that works.

**The still under the button.** A WebRTC picture parked awaiting a gesture is black — there's no buffered frame to show, unlike MSE — so the ▶️ floated over a void. The page now points a stage `<img id="mj-snapshot">` at the camera's `/image.jpg` while the button is up (only where `jpeg.enabled` serves one), and clears it when the picture plays — so the invitation sits over the scene it's about to resume, exactly as their player does.

## Verification
- Full `npm test` passes (added `mj-snapshot` to both vm-harness IDS lists; `preview-page.js`'s new element access is `$`-guarded).
- Deployed to a lab gk7205v300+imx335: normal playback unregressed (WebRTC/MSE both decode H265 1080p30), `#mj-snapshot` present and correctly hidden while autoplay succeeds, no JS errors.
- The first-tap and snapshot-shown paths only appear under autoplay refusal, which the lab browsers don't reproduce (they autoplay muted) — so those await the reporter's confirmation on their device.
